### PR TITLE
✨ Source Surveymonkey: Stream `survey_responses` add field metadata.respondent.language

### DIFF
--- a/airbyte-integrations/connectors/source-surveymonkey/source_surveymonkey/schemas/survey_responses.json
+++ b/airbyte-integrations/connectors/source-surveymonkey/source_surveymonkey/schemas/survey_responses.json
@@ -35,6 +35,20 @@
     "metadata": {
       "type": ["object", "null"],
       "properties": {
+        "respondent": {
+          "type": ["object", "null"],
+          "properties": {
+            "language": {
+              "type": ["object", "null"],
+              "properties": {
+                "type": {
+                  "type": ["string", "null"],
+                  "value": ["string", "null"]
+                }
+              }
+            }
+          }
+        },
         "contact": {
           "type": ["object", "null"]
         }

--- a/airbyte-integrations/connectors/source-surveymonkey/source_surveymonkey/schemas/survey_responses.json
+++ b/airbyte-integrations/connectors/source-surveymonkey/source_surveymonkey/schemas/survey_responses.json
@@ -42,8 +42,10 @@
               "type": ["object", "null"],
               "properties": {
                 "type": {
-                  "type": ["string", "null"],
-                  "value": ["string", "null"]
+                  "type": ["string", "null"]
+                },
+                "value": {
+                  "type": ["string", "null"]
                 }
               }
             }


### PR DESCRIPTION
## What
Sychronizing field `metadata.respondent.language` inside stream `survey_responses`

Example values returned from API request `https://api.surveymonkey.com/v3/surveys/{survey_id}/responses/{response_id}`

![image](https://github.com/airbytehq/airbyte/assets/67712864/3242a627-7222-4bdc-bfdc-232202acb789)


## How
Expanding the schema definitino for stream `survey_responses`

## 🚨 User Impact 🚨
Extension of schema fields, no breaking changes.

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
