### PR TITLE
connectors-ci: copy metadata with `with_new_file` instead of `with_file`

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
@@ -76,10 +76,10 @@ class MetadataUpload(PoetryRun):
         super().__init__(context, title, METADATA_DIR, METADATA_LIB_MODULE_PATH)
 
         # Ensure the icon file is included in the upload
-        base_container = self.poetry_run_container.with_file(METADATA_FILE_NAME, get_metadata_file_from_path(context, metadata_path))
+        base_container = self.poetry_run_container.with_new_file(METADATA_FILE_NAME, get_metadata_file_from_path(context, metadata_path))
         metadata_icon_path = metadata_path.parent / METADATA_ICON_FILE_NAME
         if metadata_icon_path.exists():
-            base_container = base_container.with_file(
+            base_container = base_container.with_new_file(
                 METADATA_ICON_FILE_NAME, get_metadata_icon_file_from_path(context, metadata_icon_path)
             )
 


### PR DESCRIPTION
## What
Relates to #28299
Some publish pipeline skip metadata upload because the pipeline is using an old version of the file that was already updated:
> On investigation the logs show that the step was trying to publish the previous metadata file.

The dagger SDK API has two function to copy a file to a container: 
* [`with_file`:  _Retrieves this container plus the contents of the given file copied to the given path._](https://dagger-io.readthedocs.io/en/sdk-python-v0.5.4/api.html#dagger.api.gen.Container.with_file)
* [`with_new_file`: _Retrieves this container plus a new file written at the given path._ ](https://dagger-io.readthedocs.io/en/sdk-python-v0.5.4/api.html#dagger.api.gen.Container.with_new_file)

I [asked the dagger team ](https://discord.com/channels/707636530424053791/1129454621044252772/1130513188887220254) to deblur the behavior of these two functions.
## How
The existing metadata pipeline uses `with_file`. I suggest trying `with_new_file`. It might force a write operation to the container while `with_file` might be cached?
