### PR TITLE
connectors-ci: bust cache on java connector build

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/java_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/java_connectors.py
@@ -51,7 +51,9 @@ class BuildConnectorImage(BuildConnectorImageBase):
 
     async def _run(self, distribution_tar: File) -> StepResult:
         try:
-            java_connector = await environments.with_airbyte_java_connector(self.context, distribution_tar, self.build_platform)
+            java_connector = await environments.with_airbyte_java_connector(
+                self.context, distribution_tar, self.build_platform, bust_cache=True
+            )
             spec_exit_code = await with_exit_code(java_connector.with_exec(["spec"]))
             if spec_exit_code != 0:
                 return StepResult(

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
@@ -279,6 +279,7 @@ async def run_connector_publish_pipeline(context: PublishConnectorContext, semap
                 return create_connector_report(results)
 
             built_connector_platform_variants = list(build_connector_results.output_artifact.values())
+
             push_connector_image_results = await PushConnectorImageToRegistry(context).run(built_connector_platform_variants)
             results.append(push_connector_image_results)
 


### PR DESCRIPTION
## What
Relates to https://github.com/airbytehq/airbyte/issues/28299

We observe that some java connectors are occasionally built with stale code.


## How
* Bust the cache on connector container build by introducing a cache buster env var.
* Use `with_new_file` to copy the connector tar archive to the container
