### PR TITLE
connectors-ci: pin Dagger CLI to new version

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -60,7 +60,7 @@ inputs:
   dagger_cli_commit:
     description: "Commit SHA of dagger-cli to use"
     required: false
-    default: "6ed6264f1c4efbf84d310a104b57ef1bc57d57b0"
+    default: "c7a440a47f8bde4c552962114bcf608a60809972"
   ci_job_key:
     description: "CI job key"
     required: false


### PR DESCRIPTION
## What
Closes #28299 

## How
[The Dagger team fixed the bug](https://discord.com/channels/707636530424053791/1072668966151004290/1130578708827217990) that can relate to abusive caching, the new Dagger CLI version to use is `c7a440a47f8bde4c552962114bcf608a60809972`, in combination of engine `registry.dagger.io/engine:main@sha256:2d71c49aa491db8fd68bfd11af40f42523bcad01a37691a33eb53844352e3528`

Engine version bump in https://github.com/airbytehq/airbyte-infra/pull/48 