### PR TITLE
connectors-ci: revert system deps changes introduced for langchain

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -51,8 +51,6 @@ def with_python_base(context: PipelineContext, python_image_name: str = "python:
     base_container = (
         context.dagger_client.container()
         .from_(python_image_name)
-        .with_exec(["apt-get", "update"])
-        .with_exec(["apt-get", "install", "-y", "build-essential", "cmake", "g++", "libffi-dev", "libstdc++6"])
         .with_mounted_cache("/root/.cache/pip", pip_cache)
         .with_exec(["pip", "install", "pip==23.1.2"])
     )

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from ci_connector_ops.pipelines.contexts import ConnectorContext, PipelineContext
 
 
-def with_python_base(context: PipelineContext) -> Container:
+def with_python_base(context: PipelineContext, python_image_name: str = "python:3.9-slim") -> Container:
     """Build a Python container with a cache volume for pip cache.
 
     Args:
@@ -44,14 +44,15 @@ def with_python_base(context: PipelineContext) -> Container:
     Returns:
         Container: The python base environment container.
     """
-
+    if not python_image_name.startswith("python:3"):
+        raise ValueError("You have to use a python image to build the python base environment")
     pip_cache: CacheVolume = context.dagger_client.cache_volume("pip_cache")
 
     base_container = (
         context.dagger_client.container()
-        .from_("python:3.9-slim")
+        .from_(python_image_name)
         .with_exec(["apt-get", "update"])
-        .with_exec(["apt-get", "install", "-y", "build-essential", "cmake", "g++", "libffi-dev", "libstdc++6", "git"])
+        .with_exec(["apt-get", "install", "-y", "build-essential", "cmake", "g++", "libffi-dev", "libstdc++6"])
         .with_mounted_cache("/root/.cache/pip", pip_cache)
         .with_exec(["pip", "install", "pip==23.1.2"])
     )
@@ -368,9 +369,10 @@ async def with_ci_connector_ops(context: PipelineContext) -> Container:
     Returns:
         Container: A python environment container with ci_connector_ops installed.
     """
-    python_base_environment: Container = with_python_base(context)
+    python_base_environment: Container = with_python_base(context, "python:3-alpine")
+    python_with_git = with_alpine_packages(python_base_environment, ["gcc", "libffi-dev", "musl-dev", "git"])
 
-    return await with_installed_python_package(context, python_base_environment, CI_CONNECTOR_OPS_SOURCE_PATH)
+    return await with_installed_python_package(context, python_with_git, CI_CONNECTOR_OPS_SOURCE_PATH)
 
 
 def with_global_dockerd_service(dagger_client: Client) -> Container:
@@ -568,7 +570,7 @@ def with_poetry(context: PipelineContext) -> Container:
     Returns:
         Container: A python environment with poetry installed.
     """
-    python_base_environment: Container = with_python_base(context)
+    python_base_environment: Container = with_python_base(context, "python:3.9")
     python_with_git = with_debian_packages(python_base_environment, ["git"])
     python_with_poetry = with_pip_packages(python_with_git, ["poetry"])
 


### PR DESCRIPTION
## What
I introduced sys dep changes on Python connectors to unblock @flash1293 in the development on the langchain connector in https://github.com/airbytehq/airbyte/pull/26184 . 
I believe this change is not working correctly on AMD64 and currently lead to errors in thetest pipeline for Python connectors: https://github.com/airbytehq/airbyte/actions/runs/5580779554


## How
Revert the change.
@flash1293 I'll try to implement a workaround for langchain.

