### PR TITLE
connector-acceptance-tests: Bump PyYaml to 6.0

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/setup.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/setup.py
@@ -8,7 +8,7 @@ import setuptools
 MAIN_REQUIREMENTS = [
     "airbyte-cdk~=0.2",
     "docker~=5.0.3",
-    "PyYAML~=5.4",
+    "PyYAML~=6.0",
     "icdiff~=1.9",
     "inflection~=0.5",
     "pdbpp~=0.10",

--- a/airbyte-integrations/connectors/source-stripe/setup.py
+++ b/airbyte-integrations/connectors/source-stripe/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk", "stripe==2.56.0", "pendulum==2.1.2"]
+MAIN_REQUIREMENTS = ["airbyte-cdk==0.46.0", "stripe==2.56.0", "pendulum==2.1.2"]
 
 TEST_REQUIREMENTS = [
     "pytest~=6.1",

--- a/airbyte-integrations/connectors/source-stripe/setup.py
+++ b/airbyte-integrations/connectors/source-stripe/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk==0.46.0", "stripe==2.56.0", "pendulum==2.1.2"]
+MAIN_REQUIREMENTS = ["airbyte-cdk", "stripe==2.56.0", "pendulum==2.1.2"]
 
 TEST_REQUIREMENTS = [
     "pytest~=6.1",


### PR DESCRIPTION
## What
* Upgrade pyyaml to 6.0 to solve the [cython dependency issue](https://github.com/yaml/pyyaml/issues/601)