### PR TITLE
Update documentation related to data residency

### DIFF
--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -207,17 +207,6 @@ Depending on your [data residency](https://docs.airbyte.com/cloud/managing-airby
 * 34.106.225.141
 
 ### European Union
-
-#### GCP region: us-west3
-* 34.106.109.131
-* 34.106.196.165
-* 34.106.60.246
-* 34.106.229.69
-* 34.106.127.139
-* 34.106.218.58
-* 34.106.115.240
-* 34.106.225.141
-
 #### AWS region: eu-west-3
 * 13.37.4.46
 * 13.37.142.60

--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -208,12 +208,6 @@ Depending on your [data residency](https://docs.airbyte.com/cloud/managing-airby
 
 ### European Union
 
-:::note 
-
-Some workflows still run in the US, even when the data residency is in the EU. If you use the EU as a data residency, you must allowlist the following IP addresses from both GCP us-west3 and AWS eu-west-3.
-
-:::
-
 #### GCP region: us-west3
 * 34.106.109.131
 * 34.106.196.165

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -103,6 +103,7 @@ For individual connections, you can choose a data residency that is different fr
 :::note 
 
 While the data is processed in a data plane in the chosen residency, the cursor and primary key data is stored in the US control plane. If you have data that cannot be stored in the US, do not use it as a cursor or primary key.
+All your account information such as the name and email addresses of the Airbyte users are stored in the US as well.
 
 :::
 


### PR DESCRIPTION
This brings two clarifications related to data residency:

 * Whitelisting US IP is no longer necessary for users that set their data residency to EU. All connection operation now run in the region chosen as data residency.
 * Airbyte users email and name are always stored in the US. The data residency setting only affects replication operation location.
