### PR TITLE
Replace deprecated dagger APIs

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -555,7 +555,7 @@ async def load_image_to_docker_host(context: ConnectorContext, tar_file: File, i
     # Not tagged images only have a sha256 id the load output shares.
     if "sha256:" in image_load_output:
         image_id = image_load_output.replace("\n", "").replace("Loaded image ID: sha256:", "")
-        await docker_cli.with_exec(["docker", "tag", image_id, image_tag]).exit_code()
+        await docker_cli.with_exec(["docker", "tag", image_id, image_tag])
     image_sha = json.loads(await docker_cli.with_exec(["docker", "inspect", image_tag]).stdout())[0].get("Id")
     return image_sha
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/remote_storage.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/remote_storage.py
@@ -7,7 +7,7 @@ import uuid
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from ci_connector_ops.pipelines.utils import get_exec_result, secret_host_env_variable, with_exit_code
+from ci_connector_ops.pipelines.utils import get_exec_result, secret_host_variable, with_exit_code
 from dagger import Client, File, Secret
 
 GOOGLE_CLOUD_SDK_TAG = "425.0.0-slim"
@@ -31,9 +31,9 @@ async def upload_to_s3(dagger_client: Client, file_to_upload_path: Path, key: st
         dagger_client.container()
         .from_("amazon/aws-cli:latest")
         .with_file(str(file_to_upload_path), file_to_upload)
-        .with_(secret_host_env_variable(dagger_client, "AWS_ACCESS_KEY_ID"))
-        .with_(secret_host_env_variable(dagger_client, "AWS_SECRET_ACCESS_KEY"))
-        .with_(secret_host_env_variable(dagger_client, "AWS_DEFAULT_REGION"))
+        .with_(secret_host_variable(dagger_client, "AWS_ACCESS_KEY_ID"))
+        .with_(secret_host_variable(dagger_client, "AWS_SECRET_ACCESS_KEY"))
+        .with_(secret_host_variable(dagger_client, "AWS_DEFAULT_REGION"))
         .with_exec(["s3", "cp", str(file_to_upload_path), s3_uri])
     )
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/remote_storage.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/remote_storage.py
@@ -7,8 +7,7 @@ import uuid
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-import asyncer
-from ci_connector_ops.pipelines.utils import with_exit_code, with_stderr, with_stdout
+from ci_connector_ops.pipelines.utils import get_exec_result, secret_host_env_variable, with_exit_code
 from dagger import Client, File, Secret
 
 GOOGLE_CLOUD_SDK_TAG = "425.0.0-slim"
@@ -28,16 +27,13 @@ async def upload_to_s3(dagger_client: Client, file_to_upload_path: Path, key: st
     """
     s3_uri = f"s3://{bucket}/{key}"
     file_to_upload: File = dagger_client.host().directory(".", include=[str(file_to_upload_path)]).file(str(file_to_upload_path))
-    aws_access_key_id: Secret = dagger_client.host().env_variable("AWS_ACCESS_KEY_ID").secret()
-    aws_secret_access_key: Secret = dagger_client.host().env_variable("AWS_SECRET_ACCESS_KEY").secret()
-    aws_region: Secret = dagger_client.host().env_variable("AWS_DEFAULT_REGION").secret()
     return await with_exit_code(
         dagger_client.container()
         .from_("amazon/aws-cli:latest")
         .with_file(str(file_to_upload_path), file_to_upload)
-        .with_secret_variable("AWS_ACCESS_KEY_ID", aws_access_key_id)
-        .with_secret_variable("AWS_SECRET_ACCESS_KEY", aws_secret_access_key)
-        .with_secret_variable("AWS_DEFAULT_REGION", aws_region)
+        .with_(secret_host_env_variable(dagger_client, "AWS_ACCESS_KEY_ID"))
+        .with_(secret_host_env_variable(dagger_client, "AWS_SECRET_ACCESS_KEY"))
+        .with_(secret_host_env_variable(dagger_client, "AWS_DEFAULT_REGION"))
         .with_exec(["s3", "cp", str(file_to_upload_path), s3_uri])
     )
 
@@ -86,9 +82,4 @@ async def upload_to_gcs(
         gcloud_auth_container = gcloud_container.with_exec(["gcloud", "auth", "activate-service-account", "--key-file", "credentials.json"])
 
     gcloud_cp_container = gcloud_auth_container.with_exec(cp_command)
-
-    async with asyncer.create_task_group() as task_group:
-        soon_exit_code = task_group.soonify(with_exit_code)(gcloud_cp_container)
-        soon_stderr = task_group.soonify(with_stderr)(gcloud_cp_container)
-        soon_stdout = task_group.soonify(with_stdout)(gcloud_cp_container)
-    return soon_exit_code.value, soon_stdout.value, soon_stderr.value
+    return await get_exec_result(gcloud_cp_container)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/secrets.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/secrets.py
@@ -9,7 +9,7 @@ import datetime
 from typing import TYPE_CHECKING
 
 from ci_connector_ops.pipelines.actions import environments
-from ci_connector_ops.pipelines.utils import get_file_contents, get_secret_host_env_variable
+from ci_connector_ops.pipelines.utils import get_file_contents, get_secret_host_variable
 from dagger import Secret
 
 if TYPE_CHECKING:
@@ -42,7 +42,7 @@ async def download(context: ConnectorContext, gcp_gsm_env_variable_name: str = "
     Returns:
         Directory: A directory with the downloaded secrets.
     """
-    gsm_secret = get_secret_host_env_variable(context.dagger_client, gcp_gsm_env_variable_name)
+    gsm_secret = get_secret_host_variable(context.dagger_client, gcp_gsm_env_variable_name)
     secrets_path = f"/{context.connector.code_directory}/secrets"
     ci_credentials = await environments.with_ci_credentials(context, gsm_secret)
     with_downloaded_secrets = (
@@ -73,7 +73,7 @@ async def upload(context: ConnectorContext, gcp_gsm_env_variable_name: str = "GC
     Returns:
         int: The exit code of the ci-credentials update-secrets command.
     """
-    gsm_secret = get_secret_host_env_variable(context.dagger_client, gcp_gsm_env_variable_name)
+    gsm_secret = get_secret_host_variable(context.dagger_client, gcp_gsm_env_variable_name)
     secrets_path = f"/{context.connector.code_directory}/secrets"
 
     ci_credentials = await environments.with_ci_credentials(context, gsm_secret)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/secrets.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/secrets.py
@@ -71,7 +71,10 @@ async def upload(context: ConnectorContext, gcp_gsm_env_variable_name: str = "GC
         gcp_gsm_env_variable_name (str, optional): The name of the environment variable holding credentials to connect to Google Secret Manager. Defaults to "GCP_GSM_CREDENTIALS".
 
     Returns:
-        int: The exit code of the ci-credentials update-secrets command.
+        container (Container): The executed ci-credentials update-secrets command.
+
+    Raises:
+        ExecError: If the command returns a non-zero exit code.
     """
     gsm_secret = get_secret_host_variable(context.dagger_client, gcp_gsm_env_variable_name)
     secrets_path = f"/{context.connector.code_directory}/secrets"

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/java_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/java_connectors.py
@@ -7,7 +7,6 @@ from ci_connector_ops.pipelines.bases import StepResult, StepStatus
 from ci_connector_ops.pipelines.builds.common import BuildConnectorImageBase, BuildConnectorImageForAllPlatformsBase
 from ci_connector_ops.pipelines.contexts import ConnectorContext
 from ci_connector_ops.pipelines.gradle import GradleTask
-from ci_connector_ops.pipelines.utils import with_exit_code
 from dagger import ExecError, File, QueryError
 
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/java_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/java_connectors.py
@@ -8,7 +8,7 @@ from ci_connector_ops.pipelines.builds.common import BuildConnectorImageBase, Bu
 from ci_connector_ops.pipelines.contexts import ConnectorContext
 from ci_connector_ops.pipelines.gradle import GradleTask
 from ci_connector_ops.pipelines.utils import with_exit_code
-from dagger import File, QueryError
+from dagger import ExecError, File, QueryError
 
 
 class BuildConnectorDistributionTar(GradleTask):
@@ -52,8 +52,9 @@ class BuildConnectorImage(BuildConnectorImageBase):
     async def _run(self, distribution_tar: File) -> StepResult:
         try:
             java_connector = await environments.with_airbyte_java_connector(self.context, distribution_tar, self.build_platform)
-            spec_exit_code = await with_exit_code(java_connector.with_exec(["spec"]))
-            if spec_exit_code != 0:
+            try:
+                await java_connector.with_exec(["spec"])
+            except ExecError:
                 return StepResult(
                     self, StepStatus.FAILURE, stderr=f"Failed to run spec on the connector built for platform {self.build_platform}."
                 )

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -19,7 +19,7 @@ from ci_connector_ops.pipelines.github import update_global_commit_status_check_
 from ci_connector_ops.pipelines.pipelines.connectors import run_connectors_pipelines
 from ci_connector_ops.pipelines.publish import reorder_contexts, run_connector_publish_pipeline
 from ci_connector_ops.pipelines.tests import run_connector_test_pipeline
-from ci_connector_ops.pipelines.utils import DaggerPipelineCommand, get_modified_connectors, get_modified_metadata_files
+from ci_connector_ops.pipelines.utils import DaggerPipelineCommand, get_modified_connectors
 from ci_connector_ops.utils import ConnectorLanguage, console, get_all_released_connectors
 from rich.table import Table
 from rich.text import Text

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/format/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/format/__init__.py
@@ -89,7 +89,7 @@ async def run_connectors_format_pipelines(
         dockerd_service = environments.with_global_dockerd_service(dagger_client)
         async with anyio.create_task_group() as tg_main:
             if requires_dind:
-                tg_main.start_soon(dockerd_service.exit_code)
+                tg_main.start_soon(dockerd_service.sync)
                 await anyio.sleep(10)  # Wait for the docker service to be ready
             for context in contexts:
                 context.dagger_client = dagger_client.pipeline(f"Format - {context.connector.technical_name}")

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/gradle.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/gradle.py
@@ -135,6 +135,5 @@ class GradleTask(Step, ABC):
                     f"{consts.GRADLE_READ_ONLY_DEPENDENCY_CACHE_PATH}/modules-2/",
                 ]
             )
-            await with_cache.exit_code()
-            return with_cache
+            return await with_cache
         return gradle_container

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/connectors.py
@@ -87,7 +87,7 @@ async def run_connectors_pipelines(
         # See https://github.com/airbytehq/airbyte/issues/27233
         dockerd_service = environments.with_global_dockerd_service(dagger_client)
         async with anyio.create_task_group() as tg_main:
-            tg_main.start_soon(dockerd_service.exit_code)
+            tg_main.start_soon(dockerd_service.sync)
             await anyio.sleep(10)  # Wait for the docker service to be ready
             async with anyio.create_task_group() as tg_connectors:
                 for context in contexts:

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
@@ -1,6 +1,8 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
+import functools
+import os
 import uuid
 from pathlib import Path
 from typing import Optional, Set
@@ -10,7 +12,7 @@ from ci_connector_ops.pipelines.actions.environments import with_pip_packages, w
 from ci_connector_ops.pipelines.bases import Report, Step, StepResult
 from ci_connector_ops.pipelines.contexts import PipelineContext
 from ci_connector_ops.pipelines.helpers.steps import run_steps
-from ci_connector_ops.pipelines.utils import DAGGER_CONFIG, METADATA_FILE_NAME, METADATA_ICON_FILE_NAME, execute_concurrently
+from ci_connector_ops.pipelines.utils import DAGGER_CONFIG, METADATA_FILE_NAME, METADATA_ICON_FILE_NAME, execute_concurrently, get_secret_host_env_variable
 
 METADATA_DIR = "airbyte-ci/connectors/metadata_service"
 METADATA_LIB_MODULE_PATH = "lib"
@@ -125,7 +127,10 @@ class DeployOrchestrator(Step):
         python_base = with_python_base(self.context)
         python_with_dependencies = with_pip_packages(python_base, ["dagster-cloud==1.2.6", "pydantic==1.10.6", "poetry2setup==1.1.0"])
         dagster_cloud_api_token_secret: dagger.Secret = (
-            self.context.dagger_client.host().env_variable("DAGSTER_CLOUD_METADATA_API_TOKEN").secret()
+            self.context.dagger_client.set_secret(
+                "DAGSTER_CLOUD_METADATA_API_TOKEN",
+                os.environ.get("DAGSTER_CLOUD_METADATA_API_TOKEN"),
+            )
         )
 
         container_to_run = (
@@ -282,17 +287,14 @@ async def run_metadata_upload_pipeline(
     async with dagger.Connection(DAGGER_CONFIG) as dagger_client:
         pipeline_context.dagger_client = dagger_client.pipeline(pipeline_context.pipeline_name)
         async with pipeline_context:
-            gcs_credentials_secret: dagger.Secret = pipeline_context.dagger_client.host().env_variable("GCS_CREDENTIALS").secret()
-            docker_hub_username_secret: dagger.Secret = pipeline_context.dagger_client.host().env_variable("DOCKER_HUB_USERNAME").secret()
-            docker_hub_password_secret: dagger.Secret = pipeline_context.dagger_client.host().env_variable("DOCKER_HUB_PASSWORD").secret()
-
+            get_secret = functools.partial(get_secret_host_env_variable, pipeline_context.dagger_client)
             results = await execute_concurrently(
                 [
                     MetadataUpload(
                         context=pipeline_context,
-                        metadata_service_gcs_credentials_secret=gcs_credentials_secret,
-                        docker_hub_username_secret=docker_hub_username_secret,
-                        docker_hub_password_secret=docker_hub_password_secret,
+                        metadata_service_gcs_credentials_secret=get_secret("GCS_CREDENTIALS"),
+                        docker_hub_username_secret=get_secret("DOCKER_HUB_USERNAME"),
+                        docker_hub_password_secret=get_secret("DOCKER_HUB_PASSWORD"),
                         metadata_bucket_name=gcs_bucket_name,
                         metadata_path=metadata_path,
                     ).run

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -7,14 +7,13 @@ from __future__ import annotations
 
 import datetime
 import json
+import os
 import re
 import sys
 import unicodedata
 from glob import glob
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set, Tuple, Union
-
-from gitdb.util import os
 
 import anyio
 import asyncer

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -128,8 +128,8 @@ async def get_container_output(container: Container) -> Tuple[str, str]:
         ExecError: If the container exit code is not 0.
     """
     async with asyncer.create_task_group() as task_group:
-        soon_stdout = task_group.soonify(container.stdout)
-        soon_stderr = task_group.soonify(container.stderr)
+        soon_stdout = task_group.soonify(container.stdout)()
+        soon_stderr = task_group.soonify(container.stderr)()
     return soon_stdout.value, soon_stderr.value
 
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -12,7 +12,9 @@ import sys
 import unicodedata
 from glob import glob
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, List, NamedTuple, Optional, Set, Tuple, Union
+
+from gitdb.util import os
 
 import anyio
 import asyncer
@@ -21,7 +23,7 @@ import git
 from ci_connector_ops.pipelines import consts, main_logger
 from ci_connector_ops.pipelines.consts import GCS_PUBLIC_DOMAIN
 from ci_connector_ops.utils import get_all_released_connectors, get_changed_connectors
-from dagger import Config, Connection, Container, DaggerError, File, ImageLayerCompression, QueryError
+from dagger import Config, Connection, Client, Container, DaggerError, ExecError, File, ImageLayerCompression, QueryError, Secret
 from google.cloud import storage
 from google.oauth2 import service_account
 from more_itertools import chunked
@@ -57,6 +59,20 @@ async def check_path_in_workdir(container: Container, path: str) -> bool:
     else:
         return False
 
+def secret_host_variable(client: Client, name: str, default: str = ""):
+    """Add a host environment variable as a secret in a container."""
+    def _secret_host_variable(container: Container):
+        return container.with_secret_variable(
+            name,
+            get_secret_host_variable(client, name, default)
+        )
+    return _secret_host_variable
+
+
+def get_secret_host_variable(client: Client, name: str, default: str = "") -> Secret:
+    """Creates a dagger.Secret from a host environment variable."""
+    return client.set_secret(name, os.environ.get(name, default))
+
 
 # This utils will probably be redundant once https://github.com/dagger/dagger/issues/3764 is implemented
 async def get_file_contents(container: Container, path: str) -> Optional[str]:
@@ -73,18 +89,27 @@ async def get_file_contents(container: Container, path: str) -> Optional[str]:
         return await container.file(path).contents()
     except QueryError as e:
         if "no such file or directory" not in str(e):
-            # this is the hicky bit of the stopgap because
             # this error could come from a network issue
             raise
     return None
 
 
-# This is a stop-gap solution to capture non 0 exit code on Containers
-# The original issue is tracked here https://github.com/dagger/dagger/issues/3192
+async def get_container_output(container: Container) -> Tuple[str, str]:
+    async with asyncer.create_task_group() as task_group:
+        soon_stdout = task_group.soonify(container.stdout)
+        soon_stderr = task_group.soonify(container.stderr)
+    return soon_stdout.value, soon_stderr.value
+
+
+async def get_exec_result(container: Container) -> Tuple[int, str, str]:
+    try:
+        return 0, *(await get_container_output(container))
+    except ExecError as e:
+        return e.exit_code, e.stdout, e.stderr
+
+
 async def with_exit_code(container: Container) -> int:
     """Read the container exit code.
-
-    If the exit code is not 0 a QueryError is raised. We extract the non-zero exit code from the QueryError message.
 
     Args:
         container (Container): The container from which you want to read the exit code.
@@ -93,37 +118,26 @@ async def with_exit_code(container: Container) -> int:
         int: The exit code.
     """
     try:
-        await container.exit_code()
-    except QueryError as e:
-        error_message = str(e)
-        if "exit code: " in error_message:
-            exit_code = re.search(r"exit code: (\d+)", error_message)
-            if exit_code:
-                return int(exit_code.group(1))
-            else:
-                return 1
-        raise
+        await container
+    except ExecError as e:
+        return e.exit_code
     return 0
 
 
-# This is a stop-gap solution to capture non 0 exit code on Containers
-# The original issue is tracked here https://github.com/dagger/dagger/issues/3192
 async def with_stderr(container: Container) -> str:
-    """Retrieve the stderr of a container and handle unexpected errors."""
+    """Retrieve the stderr of a container even on execution error."""
     try:
         return await container.stderr()
-    except QueryError as e:
-        return str(e)
+    except ExecError as e:
+        return e.stderr
 
 
-# This is a stop-gap solution to capture non 0 exit code on Containers
-# The original issue is tracked here https://github.com/dagger/dagger/issues/3192
 async def with_stdout(container: Container) -> str:
-    """Retrieve the stdout of a container and handle unexpected errors."""
+    """Retrieve the stdout of a container even on execution error."""
     try:
         return await container.stdout()
-    except QueryError as e:
-        return str(e)
+    except ExecError as e:
+        return e.stdout
 
 
 def get_current_git_branch() -> str:  # noqa D103


### PR DESCRIPTION
## What
This change replaces deprecated dagger usage with more current solutions since they will be removed soon, in https://github.com/dagger/dagger/issues/5479. It needs Python SDK >0.6.0 because of `ExecError`.

## How
Only two methods needed to be replaced. The following sections describe the minimum changes that need to be taken, however I took the opportunity to add some convenience functions to reduce boilerplate and modernized the error handling in a few cases.

### `HostVariable.secret`

The simplest change is to replace:
```python
client.host().env_variable("MY_SECRET").secret()
```
With:
```python
import os
client.set_secret("can-be-different", os.environ.get("MY_SECRET", ""))
```
Notice the default of `""`. Without it, if the var doesn't exist in the host, it'll default to `None`, which fails validation on the required `str` for the secret's plaintext.

### `Container.exit_code` and `stdout`/`stderr` from error

The simplest change is to use my modifications on `with_exit_code`, `with_stdout` and `with_stderr`, and replace any usage of `container.exit_code()` with `container.sync()`.

In addition to that, I recommend not to care about the exit code value if it's just to check if `exit_code != 0`. Just capture `ExecError` and handle the exception instead.

## Recommended reading order
1. `tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py` for the changes in `with_exit_code` and `with_stderr`, then the added convenience functions
2. `tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py` for a good example on replacing `if exit_code != 0:` with `try...except ExecError`


## 🚨 User Impact 🚨

There should be no breaking changes, unless one of the functions that changed is being used outside of this repo which I have no awareness of. See https://github.com/airbytehq/airbyte/pull/28450#discussion_r1267959386. 

I'm also not sure if the change from `str(e)` to `e.stderr` in `with_stderr` (same in `with_stdout`) breaks anything. It shouldn't but the error message is no longer there. See  https://github.com/airbytehq/airbyte/pull/28450#discussion_r1268023744.

Usually the error message is just `process "....." did not complete successfully: exit code: 1` or something like that. The more relevant information is usually in `stderr`, but better check.

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*