### PR TITLE
fix pyyaml/cython dependency issue when building base-normalization

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -15,6 +15,11 @@ COPY dbt-project-template/ ./dbt-template/
 
 # Install python dependencies
 WORKDIR /airbyte/base_python_structs
+
+# workaround for https://github.com/yaml/pyyaml/issues/601
+# this should be fixed in the airbyte/base-airbyte-protocol-python image
+RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation
+
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code

--- a/airbyte-integrations/bases/base-normalization/clickhouse.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/clickhouse.Dockerfile
@@ -14,6 +14,11 @@ COPY dbt-project-template/ ./dbt-template/
 
 # Install python dependencies
 WORKDIR /airbyte/base_python_structs
+
+# workaround for https://github.com/yaml/pyyaml/issues/601
+# this should be fixed in the airbyte/base-airbyte-protocol-python image
+RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation
+
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code

--- a/airbyte-integrations/bases/base-normalization/duckdb.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/duckdb.Dockerfile
@@ -15,6 +15,11 @@ COPY dbt-project-template/ ./dbt-template/
 
 # Install python dependencies
 WORKDIR /airbyte/base_python_structs
+
+# workaround for https://github.com/yaml/pyyaml/issues/601
+# this should be fixed in the airbyte/base-airbyte-protocol-python image
+RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation
+
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code

--- a/airbyte-integrations/bases/base-normalization/mssql.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/mssql.Dockerfile
@@ -49,6 +49,11 @@ COPY dbt-project-template-mssql/* ./dbt-template/
 
 # Install python dependencies
 WORKDIR /airbyte/base_python_structs
+
+# workaround for https://github.com/yaml/pyyaml/issues/601
+# this should be fixed in the airbyte/base-airbyte-protocol-python image
+RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation
+
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code

--- a/airbyte-integrations/bases/base-normalization/mysql.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/mysql.Dockerfile
@@ -16,6 +16,11 @@ COPY dbt-project-template-mysql/* ./dbt-template/
 
 # Install python dependencies
 WORKDIR /airbyte/base_python_structs
+
+# workaround for https://github.com/yaml/pyyaml/issues/601
+# this should be fixed in the airbyte/base-airbyte-protocol-python image
+RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation
+
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code

--- a/airbyte-integrations/bases/base-normalization/oracle.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/oracle.Dockerfile
@@ -34,6 +34,11 @@ COPY dbt-project-template/ ./dbt-template/
 COPY dbt-project-template-oracle/* ./dbt-template/
 
 WORKDIR /airbyte/base_python_structs
+
+# workaround for https://github.com/yaml/pyyaml/issues/601
+# this should be fixed in the airbyte/base-airbyte-protocol-python image
+RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation
+
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code

--- a/airbyte-integrations/bases/base-normalization/redshift.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/redshift.Dockerfile
@@ -16,6 +16,11 @@ COPY dbt-project-template-redshift/* ./dbt-template/
 
 # Install python dependencies
 WORKDIR /airbyte/base_python_structs
+
+# workaround for https://github.com/yaml/pyyaml/issues/601
+# this should be fixed in the airbyte/base-airbyte-protocol-python image
+RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation
+
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code

--- a/airbyte-integrations/bases/base-normalization/snowflake.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/snowflake.Dockerfile
@@ -16,6 +16,11 @@ COPY dbt-project-template-snowflake/* ./dbt-template/
 
 # Install python dependencies
 WORKDIR /airbyte/base_python_structs
+
+# workaround for https://github.com/yaml/pyyaml/issues/601
+# this should be fixed in the airbyte/base-airbyte-protocol-python image
+RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation
+
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code

--- a/airbyte-integrations/bases/base-normalization/tidb.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/tidb.Dockerfile
@@ -15,6 +15,11 @@ COPY dbt-project-template/ ./dbt-template/
 
 # Install python dependencies
 WORKDIR /airbyte/base_python_structs
+
+# workaround for https://github.com/yaml/pyyaml/issues/601
+# this should be fixed in the airbyte/base-airbyte-protocol-python image
+RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation
+
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code


### PR DESCRIPTION
## What

Applies a workaround for https://github.com/yaml/pyyaml/issues/601

This error is introduced by `COPY --from=airbyte/base-airbyte-protocol-python:0.1.1 /airbyte /airbyte`. When we get to installing dependencies in the dockerfile for this image here:

```
# Install python dependencies
WORKDIR /airbyte/base_python_structs
RUN pip install .
```

We error out with the `cython_sources` error. 

airbyte/base-airbyte-protocol-python has only been published once, 2 years ago. It is unclear where this image comes from, what's in it, and how it was built. This isn't a great spot to be in, but we can workaround it for now with this fix until we know more. 
