### PR TITLE
fix(sec): upgrade certifi to 

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/tools/acceptance_test_config_migration/requirements.txt
+++ b/airbyte-integrations/bases/connector-acceptance-test/tools/acceptance_test_config_migration/requirements.txt
@@ -3,7 +3,7 @@ appdirs==1.4.4
 attrs==22.1.0
 backoff==2.2.1
 cattrs==22.2.0
-certifi==2022.9.24
+certifi==2022.12.07
 charset-normalizer==2.1.1
 coverage==6.5.0
 dataclasses-jsonschema==2.15.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.9.24
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2022.9.24 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS