### PR TITLE
improve DX of releasing breaking changes (docs, logs, bugfix)

### DIFF
--- a/airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
+++ b/airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
@@ -1,7 +1,7 @@
 paths:
   "airbyte-integrations/connectors/**":
     - PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#pull-request-title-convention)
-    - "[Breaking changes are considered](https://docs.airbyte.com/contributing-to-airbyte/#breaking-changes-to-connectors). If a **Breaking Change** is being introduced, ensure an Airbyte engineer has created a Breaking Change Plan and you've followed all steps in the [Breaking Changes Checklist](https://docs.airbyte.com/contributing-to-airbyte/#checklist-for-contributors)"
+    - "[Breaking changes are considered](https://docs.airbyte.com/contributing-to-airbyte/change-cdk-connector/#breaking-changes-to-connectors). If a **Breaking Change** is being introduced, ensure an Airbyte engineer has created a Breaking Change Plan and you've followed all steps in the [Breaking Changes Checklist](https://docs.airbyte.com/contributing-to-airbyte/#checklist-for-contributors)"
     - Connector version has been incremented in the Dockerfile and metadata.yaml according to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines
     - You've updated the connector's `metadata.yaml` file any other relevant changes, including a `breakingChanges` entry for major version bumps. See [metadata.yaml docs](https://docs.airbyte.com/connector-development/connector-metadata-file/)
     - Secrets in the connector's spec are annotated with `airbyte_secret`

--- a/airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
+++ b/airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
@@ -1,7 +1,7 @@
 paths:
   "airbyte-integrations/connectors/**":
     - PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#pull-request-title-convention)
-    - "[Breaking changes are considered](https://docs.airbyte.com/contributing-to-airbyte/change-cdk-connector/#breaking-changes-to-connectors). If a **Breaking Change** is being introduced, ensure an Airbyte engineer has created a Breaking Change Plan and you've followed all steps in the [Breaking Changes Checklist](https://docs.airbyte.com/contributing-to-airbyte/#checklist-for-contributors)"
+    - "[Breaking changes are considered](https://docs.airbyte.com/contributing-to-airbyte/change-cdk-connector/#breaking-changes-to-connectors). If a **Breaking Change** is being introduced, ensure an Airbyte engineer has created a Breaking Change Plan."
     - Connector version has been incremented in the Dockerfile and metadata.yaml according to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#semantic-versioning-for-connectors) guidelines
     - You've updated the connector's `metadata.yaml` file any other relevant changes, including a `breakingChanges` entry for major version bumps. See [metadata.yaml docs](https://docs.airbyte.com/connector-development/connector-metadata-file/)
     - Secrets in the connector's spec are annotated with `airbyte_secret`

--- a/airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
+++ b/airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
@@ -2,10 +2,11 @@ paths:
   "airbyte-integrations/connectors/**":
     - PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#pull-request-title-convention)
     - "[Breaking changes are considered](https://docs.airbyte.com/contributing-to-airbyte/change-cdk-connector/#breaking-changes-to-connectors). If a **Breaking Change** is being introduced, ensure an Airbyte engineer has created a Breaking Change Plan and you've followed all steps in the [Breaking Changes Checklist](https://docs.airbyte.com/contributing-to-airbyte/#checklist-for-contributors)"
-    - Connector version has been incremented in the Dockerfile and metadata.yaml according to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines
+    - Connector version has been incremented in the Dockerfile and metadata.yaml according to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#semantic-versioning-for-connectors) guidelines
     - You've updated the connector's `metadata.yaml` file any other relevant changes, including a `breakingChanges` entry for major version bumps. See [metadata.yaml docs](https://docs.airbyte.com/connector-development/connector-metadata-file/)
     - Secrets in the connector's spec are annotated with `airbyte_secret`
     - All documentation files are up to date. (README.md, bootstrap.md, docs.md, etc...)
     - Changelog updated in `docs/integrations/<source or destination>/<name>.md` with an entry for the new version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
+    - Migration guide updated in `docs/integrations/<source or destination>/<name>-migrations.md` with an entry for the new version, if the version is a breaking change. See migration guide [example](https://docs.airbyte.io/integrations/sources/faker-migrations)
     - The connector tests are passing in CI
     - If set, you've ensured the icon is present in the `platform-internal` repo. ([Docs](https://docs.airbyte.com/connector-development/connector-metadata-file/#the-icon-field))

--- a/docs/connector-development/connector-metadata-file.md
+++ b/docs/connector-development/connector-metadata-file.md
@@ -98,3 +98,29 @@ You may notice a `icon.svg` file in the connectors folder.
 This is because we are transitioning away from icons being stored in the `platform-internal` repository. Instead, we will be storing them in the connector folder itself. This will allow us to have a single source of truth for all connector-related information.
 
 This transition is currently in progress. Once it is complete, the `icon` field in the `metadata.yaml` file will be removed, and the `icon.svg` file will be used instead.
+
+## The `releases` Section
+The `releases` section contains extra information about certain types of releases. The current types of releases are:
+* `breakingChanges`
+
+### `breakingChanges`
+
+The `breakingChanges` section of `releases` contains a dictionary of version numbers (usually major versions, i.e. `1.0.0`) and information about
+their associated breaking changes. Each entry must contain the following parameters:
+* `message`: A description of the breaking change, written in a user-friendly format. This message should briefly describe
+  * What the breaking change is
+  * How it affects the user (or which users it will affect)
+  * What the user should do to fix the issue
+* `upgradeDeadline`: (`YYYY-MM-DD`) The date by which the user should upgrade to the new version.
+
+Note that the `message` should be brief no matter how involved the fix is - the user will be redirected to the migration documentation for the
+full upgrade/migration instructions.
+
+Here is an example:
+```yaml
+releases:
+  breakingChanges:
+    1.0.0:
+      message: "This version changes the connector’s authentication by removing ApiKey authentication, which is now deprecated by the [upstream source](upsteam-docs-url.com). Users currently using ApiKey auth will need to reauthenticate with OAuth after upgrading to continue syncing."
+      upgradeDeadline: "2023-12-31"  # The date that the upstream API stops support for ApiKey authentication
+```

--- a/docs/contributing-to-airbyte/change-cdk-connector.md
+++ b/docs/contributing-to-airbyte/change-cdk-connector.md
@@ -58,7 +58,9 @@ When we review, we look at:
 Often times, changes to connectors can be made without impacting the user experience.  However, there are some changes that will require users to take action before they can continue to sync data.  These changes are considered **Breaking Changes** and require a
 
 1. A **Major Version** increase 
-2. An Airbyte Engineer to follow the  [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) before merging.
+2. A [`breakingChanges` entry](https://docs.airbyte.com/connector-development/connector-metadata-file/) in the `releases` section of the `metadata.yaml` file
+3. A migration guide which details steps that users should take to resolve the change
+4. An Airbyte Engineer to follow the  [Connector Breaking Change Release Playbook](https://docs.google.com/document/u/0/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit) before merging.
 
 ### Types of Breaking Changes
 A breaking change is any change that will require users to take action before they can continue to sync data. The following are examples of breaking changes:

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/common.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/common.py
@@ -145,6 +145,7 @@ class QaChecks(Step):
         include = [
             str(self.context.connector.code_directory),
             str(self.context.connector.documentation_file_path),
+            str(self.context.connector.migration_guide_file_path),
             str(self.context.connector.icon_path),
         ]
         if (

--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -20,7 +20,7 @@ def check_migration_guide(connector: Connector) -> bool:
 
     migration_guide_file_path = connector.migration_guide_file_path
     if not migration_guide_file_path.exists():
-        print(f"Migration guide file is missing for {connector.name}.")
+        print(f"Migration guide file is missing for {connector.name}. Please create a {connector.migration_guide_file_name} file in the docs folder.")
         return False
 
     # Check that the migration guide begins with # {connector name} Migration Guide
@@ -29,7 +29,7 @@ def check_migration_guide(connector: Connector) -> bool:
     with open(migration_guide_file_path) as f:
         first_line = f.readline().strip()
         if not first_line == expected_title:
-            print(f"Migration guide file for {connector.name} does not start with the correct header.")
+            print(f"Migration guide file for {connector.name} does not start with the correct header. Expected '{expected_title}', got '{first_line}'")
             return False
 
         # Check that the migration guide contains a section for each breaking change key ## Upgrading to {version}

--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -50,7 +50,8 @@ def check_migration_guide(connector: Connector) -> bool:
                 ordered_heading_versions.append(version)
 
         if ordered_breaking_changes != ordered_heading_versions:
-            print(f"Migration guide file for {connector.name} has missing or misordered version headings.")
+            print(f"Migration guide file for {connector.name} has incorrect version headings.")
+            print(f"Check for missing, extra, or misordered headings, or headers with typos.")
             print(f"Expected headings: {ordered_expected_headings}")
             return False
 

--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -40,6 +40,8 @@ def check_migration_guide(connector: Connector) -> bool:
         # We also have to check that the headings are in the breaking changes dict
 
         ordered_breaking_changes = sorted(breaking_changes.keys(), reverse=True)
+        ordered_expected_headings = [f"{expected_version_header_start}{version}" for version in ordered_breaking_changes]
+
         ordered_heading_versions = []
         for line in f:
             stripped_line = line.strip()
@@ -49,8 +51,7 @@ def check_migration_guide(connector: Connector) -> bool:
 
         if ordered_breaking_changes != ordered_heading_versions:
             print(f"Migration guide file for {connector.name} has missing or misordered version headings.")
-            print(f"Expected: {ordered_breaking_changes}")
-            print(f"Actual: {ordered_heading_versions}")
+            print(f"Expected headings: {ordered_expected_headings}")
             return False
 
     return True

--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -24,12 +24,12 @@ def check_migration_guide(connector: Connector) -> bool:
         return False
 
     # Check that the migration guide begins with # {connector name} Migration Guide
-    expected_title = f"# {connector.name} Migration Guide"
+    expected_title = f"# {connector.name_from_metadata} Migration Guide"
     expected_version_header_start = f"## Upgrading to "
     with open(migration_guide_file_path) as f:
         first_line = f.readline().strip()
         if not first_line == expected_title:
-            print(f"Migration guide file for {connector.name} does not start with the correct header. Expected '{expected_title}', got '{first_line}'")
+            print(f"Migration guide file for {connector.technical_name} does not start with the correct header. Expected '{expected_title}', got '{first_line}'")
             return False
 
         # Check that the migration guide contains a section for each breaking change key ## Upgrading to {version}

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -269,6 +269,10 @@ class Connector:
         )
 
     @property
+    def name_from_metadata(self) -> Optional[str]:
+        return self.metadata.get("name") if self.metadata else None
+
+    @property
     def release_stage(self) -> Optional[str]:
         return self.metadata.get("releaseStage") if self.metadata else None
 

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -207,9 +207,12 @@ class Connector:
         return self.documentation_directory / readme_file_name
 
     @property
+    def migration_guide_file_name(self) -> str:
+        return f"{self.name}-migrations.md"
+
+    @property
     def migration_guide_file_path(self) -> Path:
-        migration_guide_file_name = f"{self.name}-migrations.md"
-        return self.documentation_directory / migration_guide_file_name
+        return self.documentation_directory / self.migration_guide_file_name
 
     @property
     def icon_path(self) -> Path:

--- a/tools/ci_connector_ops/tests/test_migration_files/bad-header.md
+++ b/tools/ci_connector_ops/tests/test_migration_files/bad-header.md
@@ -1,0 +1,9 @@
+# Foobar Migration Guide
+
+## 2.0.0
+
+This is something else
+
+## 1.0.0
+
+This is something

--- a/tools/ci_connector_ops/tests/test_migration_files/bad-title.md
+++ b/tools/ci_connector_ops/tests/test_migration_files/bad-title.md
@@ -1,0 +1,9 @@
+# source-foobar Migration Guide
+
+## Upgrading to 2.0.0
+
+This is something else
+
+## Upgrading to 1.0.0
+
+This is something

--- a/tools/ci_connector_ops/tests/test_migration_files/extra-header.md
+++ b/tools/ci_connector_ops/tests/test_migration_files/extra-header.md
@@ -1,0 +1,13 @@
+# Foobar Migration Guide
+
+## Upgrading to 2.0.0
+
+This is something else
+
+## Upgrading to 1.0.0
+
+This is something
+
+## Upgrading to 1.0.0
+
+This is extra

--- a/tools/ci_connector_ops/tests/test_migration_files/missing-entry.md
+++ b/tools/ci_connector_ops/tests/test_migration_files/missing-entry.md
@@ -1,0 +1,5 @@
+# Foobar Migration Guide
+
+## Upgrading to 1.0.0
+
+This is something

--- a/tools/ci_connector_ops/tests/test_migration_files/out-of-order.md
+++ b/tools/ci_connector_ops/tests/test_migration_files/out-of-order.md
@@ -1,0 +1,9 @@
+# Foobar Migration Guide
+
+## Upgrading to 1.0.0
+
+This is something
+
+## Upgrading to 2.0.0
+
+This is something else


### PR DESCRIPTION
## What
* close #28497
* metadata-only changes from https://github.com/airbytehq/airbyte/pull/28414
* Update checklist to reference breaking changes steps
* Update docs to reference breaking changes steps
* Improve logging for migration guide checking so users better understand what they have to do 
* Change the expected name for migration guides 
* Fix an issue where the migration guide wasn't getting added to the context