### PR TITLE
destination-langchain: fix build

### DIFF
--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -5,9 +5,10 @@ FROM base as builder
 WORKDIR /airbyte/integration_code
 
 # upgrade pip to the latest version
-RUN apk --no-cache upgrade \
+
+RUN apt-get update \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base swig libffi-dev libstdc++
+    && apt-get install -y --no-cache build-essential cmake g++ libffi-dev libstdc++6
 
 COPY setup.py ./
 

--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -13,7 +13,9 @@ COPY setup.py ./
 
 RUN pip install --upgrade pip
 
-## Workaround for https://github.com/yaml/pyyaml/issues/601
+# This is required because the current connector dependency is not compatible with the CDK version
+# An older CDK version will be used, which depends on pyYAML 5.4, for which we need to pin Cython to <3.0
+# As of today the CDK version that satisfies the main dependency requirements, is 0.1.80 ...
 RUN pip install --prefix=/install "Cython<3.0" "pyyaml~=5.4" --no-build-isolation
 
 # install necessary packages to a temporary folder

--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /airbyte/integration_code
 
 RUN apt-get update \
     && pip install --upgrade pip \
-    && apt-get install -y --no-cache build-essential cmake g++ libffi-dev libstdc++6
+    && apt-get install -y build-essential cmake g++ libffi-dev libstdc++6
 
 COPY setup.py ./
 
@@ -33,7 +33,7 @@ COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
 # bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+RUN apt-get install bash
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM nickgryg/alpine-pandas:3.9.12 as base
+FROM python:3.9-slim as base
 
 # build and load all requirements
 FROM base as builder

--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -42,5 +42,5 @@ COPY destination_langchain ./destination_langchain
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.2
+LABEL io.airbyte.version=0.0.3
 LABEL io.airbyte.name=airbyte/destination-langchain

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: cf98d52c-ba5a-4dfd-8ada-c1baebfa6e73
-  dockerImageTag: 0.0.2
+  dockerImageTag: 0.0.3
   dockerRepository: airbyte/destination-langchain
   githubIssueLabel: destination-langchain
   icon: langchain.svg

--- a/airbyte-integrations/connectors/destination-langchain/setup.py
+++ b/airbyte-integrations/connectors/destination-langchain/setup.py
@@ -16,6 +16,7 @@ MAIN_REQUIREMENTS = [
     "typing-inspect==0.8.0",
     "typing_extensions==4.5.0",
     "pydantic==1.10.8",
+    "pandas==1.4.2",
 ]
 
 TEST_REQUIREMENTS = ["pytest~=6.2"]

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -98,5 +98,6 @@ qa = RetrievalQA.from_chain_type(llm=OpenAI(temperature=0), chain_type="stuff", 
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.0.3   | 2023-07-20 | [#28509](https://github.com/airbytehq/airbyte/pull/28509)     | Change the base image to python:3.9-slim to fix build  |
 | 0.0.2   | 2023-07-18 | [#26184](https://github.com/airbytehq/airbyte/pull/28398)     | Adjust python dependencies and release on cloud  |
 | 0.0.1   | 2023-07-12 | [#26184](https://github.com/airbytehq/airbyte/pull/26184)     | Initial release  |


### PR DESCRIPTION
## What
The connector build was failing with `.buildkit_qemu_emulator: /bin/sh: Invalid ELF image for this architecture`
We believe this is due to an unusual alpine image being used as a base image.

## How
Use python:3.9-slim as the base image