### PR TITLE
Source Google Ads: fix timezone

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-ads/Dockerfile
@@ -13,5 +13,5 @@ COPY main.py ./
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.7.2
+LABEL io.airbyte.version=0.7.3
 LABEL io.airbyte.name=airbyte/source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: 0.7.2
+  dockerImageTag: 0.7.3
   dockerRepository: airbyte/source-google-ads
   githubIssueLabel: source-google-ads
   icon: google-adwords.svg

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -58,12 +58,12 @@ def chunk_date_range(
     Currently this method returns `start_date` and `end_date` with `range_days` difference which is 15 days in most cases.
     """
     today = pendulum.today(tz=time_zone)
-    end_date = min(pendulum.parse(end_date), today) if end_date else today
-    start_date = pendulum.parse(start_date)
+    end_date = min(pendulum.parse(end_date, tz=time_zone), today) if end_date else today
+    start_date = pendulum.parse(start_date, tz=time_zone)
 
     # For some metrics we can only get data not older than N days, it is Google Ads policy
     if days_of_data_storage:
-        start_date = max(start_date, pendulum.now().subtract(days=days_of_data_storage - conversion_window))
+        start_date = max(start_date, pendulum.now(tz=time_zone).subtract(days=days_of_data_storage - conversion_window))
 
     # As in to return some state when state in abnormal
     if start_date > end_date:

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py
@@ -92,7 +92,7 @@ def test_interval_chunking():
         {"start_date": "2021-07-27", "end_date": "2021-08-05"},
         {"start_date": "2021-08-06", "end_date": "2021-08-10"},
     ]
-    intervals = list(chunk_date_range("2021-07-01", 14, "2021-08-10", range_days=10))
+    intervals = list(chunk_date_range("2021-07-01", 14, "2021-08-10", range_days=10, time_zone="UTC"))
     assert mock_intervals == intervals
 
 

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
@@ -111,7 +111,7 @@ def test_chunk_date_range_without_end_date():
     start_date_str = "2022-01-24"
     conversion_window = 0
     slices = list(chunk_date_range(
-        start_date=start_date_str, conversion_window=conversion_window, end_date=None, days_of_data_storage=None, range_days=1
+        start_date=start_date_str, conversion_window=conversion_window, end_date=None, days_of_data_storage=None, range_days=1, time_zone="UTC"
     ))
     expected_response = [
         {"start_date": "2022-01-24", "end_date": "2022-01-24"},
@@ -129,7 +129,7 @@ def test_chunk_date_range():
     start_date = "2021-03-04"
     end_date = "2021-05-04"
     conversion_window = 14
-    slices = list(chunk_date_range(start_date, conversion_window, end_date, range_days=10))
+    slices = list(chunk_date_range(start_date, conversion_window, end_date, range_days=10, time_zone="UTC"))
     assert [
         {"start_date": "2021-02-18", "end_date": "2021-02-27"},
         {"start_date": "2021-02-28", "end_date": "2021-03-09"},

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -167,6 +167,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version  | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:---------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| `0.7.3`  | 2023-07-24 | [28510](https://github.com/airbytehq/airbyte/pull/28510) | Set dates with client's timezone                                                                                                     |
 | `0.7.2`  | 2023-07-20 | [28535](https://github.com/airbytehq/airbyte/pull/28535) | UI improvement: Make the query field in custom reports a multi-line string field                                                                    |
 | `0.7.1`  | 2023-07-17 | [28365](https://github.com/airbytehq/airbyte/pull/28365) | 0.3.1 and 0.3.2 follow up: make today the end date, not yesterday                                                                    |
 | `0.7.0`  | 2023-07-12 | [28246](https://github.com/airbytehq/airbyte/pull/28246) | Add new streams: labels, criterions, biddig strategies                                                                               |


### PR DESCRIPTION
## What
- https://github.com/airbytehq/oncall/issues/2460

## How
*The problem was in wrong date comparison in different timezone. Set same timezone for start/end/now dates*
