### PR TITLE
remove connectors ci checklist item

### DIFF
--- a/airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
+++ b/airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
@@ -8,5 +8,4 @@ paths:
     - All documentation files are up to date. (README.md, bootstrap.md, docs.md, etc...)
     - Changelog updated in `docs/integrations/<source or destination>/<name>.md` with an entry for the new version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
     - Migration guide updated in `docs/integrations/<source or destination>/<name>-migrations.md` with an entry for the new version, if the version is a breaking change. See migration guide [example](https://docs.airbyte.io/integrations/sources/faker-migrations)
-    - The connector tests are passing in CI
     - If set, you've ensured the icon is present in the `platform-internal` repo. ([Docs](https://docs.airbyte.com/connector-development/connector-metadata-file/#the-icon-field))


### PR DESCRIPTION
Connector tests are now a required PR check. Can we remove them from the checklist?