### PR TITLE
connectors-ci: fix error handling

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -153,7 +153,7 @@ async def get_exec_result(container: Container) -> Tuple[int, str, str]:
     """
     try:
         return 0, *(await get_container_output(container))
-    except (ExecError) as e:
+    except ExecError as e:
         return e.exit_code, e.stdout, e.stderr
 
 


### PR DESCRIPTION
## What
I believe https://github.com/airbytehq/airbyte/pull/28450 introduce a slight regression in our error handling logic:
When we run `.stdout` or `.stderr` in a task group and one of this task is raising an `ExecError` `anyio` wraps it in an `ExceptionGroup`. Downstream code is not handling `ExceptionGroup` but `ExecError`, which makes unhandled `ExceptionGroup` errors to be raised.

## How
Handle `ExceptionGroup` in `get_container_output` and raise an `ExecError` if the first member of the `ExceptionGroup` is an `ExecError`