### PR TITLE
connectors-ci: per connector dockerd

### DIFF
--- a/airbyte-integrations/connectors/source-openweather/setup.py
+++ b/airbyte-integrations/connectors/source-openweather/setup.py
@@ -27,3 +27,6 @@ setup(
         "tests": TEST_REQUIREMENTS,
     },
 )
+
+
+colinmayar = "yolo"

--- a/airbyte-integrations/connectors/source-openweather/setup.py
+++ b/airbyte-integrations/connectors/source-openweather/setup.py
@@ -27,6 +27,3 @@ setup(
         "tests": TEST_REQUIREMENTS,
     },
 )
-
-
-colinmayar = "yolo"


### PR DESCRIPTION
## What
Closes #27867 

https://github.com/airbytehq/airbyte/pull/28000 is our best bet at reducing reliance on dockerd and its potential over caching issues. But it's currently blocked because I'm looking for advices from the Dagger team for the dagger-in-dagger usecase.

This PR is an alternative approach to try to increase isolation in CAT run:
* Create a docker daemon as a side car container for each connector
We originally had one global docker daemon shared accross containers and we suspect it to be the root cause dubious connector command output in CAT causing transient CAT failures.

Having a per-connector dockerd was not the recommended approach by the Dagger team as it creates a lot of overhead and services to manage for the engine. But we're trying this approach again to see if the original issues we had persist / have been solved in the latest Dagger version.
 
# Tests
A "nightly build" on all GA connectors is running [here](https://github.com/airbytehq/airbyte/actions/runs/5623577981)
