### PR TITLE
Remove invalid public field from metadata.yaml

### DIFF
--- a/airbyte-integrations/connectors/source-shopify-oauth/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify-oauth/metadata.yaml
@@ -8,7 +8,6 @@ data:
   icon: shopify.svg
   license: ELv2
   name: Shopify
-  public: false
   registries:
     cloud:
       enabled: true


### PR DESCRIPTION
## What
Removes `public: true` from shopify oauth as its invalid