### PR TITLE
handle case where migrationDocumentationUrl is None (by default)

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -67,7 +67,7 @@ def calculate_migration_documentation_url(releases_or_breaking_change: dict, doc
     base_url = f"{documentation_url}-migrations"
     default_migration_documentation_url = f"{base_url}#{version}" if version is not None else base_url
 
-    return releases_or_breaking_change.get("migrationDocumentationUrl", default_migration_documentation_url)
+    return releases_or_breaking_change.get("migrationDocumentationUrl", None) or default_migration_documentation_url
 
 
 @deep_copy_params

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -325,7 +325,7 @@ def test_migration_documentation_url_default():
             "definitionId": "test-id",
             "documentationUrl": "test-doc-url",
             "registries": {"oss": {"enabled": True}},
-            "releases": {"breakingChanges": {"1.0.0": {}}},
+            "releases": {"migrationDocumentationUrl": None, "breakingChanges": {"1.0.0": {"migrationDocumentationUrl": None}}},
         }
     }
 


### PR DESCRIPTION
Close #28549 

By default, the object created by our pydantic models (I think) sets `migrationDocumentationUrl` to `None`. This means that if you use `releases_or_breaking_change.get("migrationDocumentationUrl", default_migration_documentation_url)`, it returns `None`, since that is the value at that key. 

Instead, return the value of the key, (or default None), and then or it with the default in order to apply the default if the value is `None`. 