### PR TITLE
🤖 Cloud Availability updater: new connectors to deploy [20230724]

### DIFF
--- a/airbyte-integrations/connectors/source-gainsight-px/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gainsight-px/metadata.yaml
@@ -4,7 +4,7 @@ data:
       - api.aptrinsic.com/v1
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   connectorSubtype: api


### PR DESCRIPTION
The Cloud Availability Updater decided that it's the right time to make the following 1 connectors available on Cloud!

# Promoted connectors
|connector_technical_name|connector_version|      connector_definition_id       |
|------------------------|-----------------|------------------------------------|
|source-gainsight-px     |0.1.0            |0da3b186-8879-4e94-8738-55b48762f1e8|

# Excluded but eligible connectors
|connector_technical_name|connector_version|connector_definition_id|
|------------------------|-----------------|-----------------------|

 ☝️ These eligible connectors are already in the definitions masks. They might have been explicitly pinned or excluded. We're not adding these for safety.