### PR TITLE
Source Greenhouse: fixed unittest

### DIFF
--- a/airbyte-integrations/connectors/source-greenhouse/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-greenhouse/unit_tests/test_streams.py
@@ -139,7 +139,7 @@ def test_parse_response_expected_response(applications_stream):
     """
     response._content = response_content
     parsed_response = applications_stream.retriever.parse_response(response, stream_state={})
-    records = [record for record in parsed_response]
+    records = [dict(record) for record in parsed_response]
 
     assert records == json.loads(response_content)
 


### PR DESCRIPTION
## What
test_parse_response_expected_response failed due to incorrect comparison between dict and airbyte record types.

## How
Added casting type from airbyte record type to dict in test for correct comparison.

