### PR TITLE
Langchain destination: Add Chroma support

### DIFF
--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim as base
+FROM python:3.10-slim as base
 
 # build and load all requirements
 FROM base as builder

--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -42,5 +42,5 @@ COPY destination_langchain ./destination_langchain
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.4
+LABEL io.airbyte.version=0.0.5
 LABEL io.airbyte.name=airbyte/destination-langchain

--- a/airbyte-integrations/connectors/destination-langchain/README.md
+++ b/airbyte-integrations/connectors/destination-langchain/README.md
@@ -8,7 +8,7 @@ For information about how to use this connector within Airbyte, see [the documen
 ### Prerequisites
 **To iterate on this connector, make sure to complete this prerequisites section.**
 
-#### Minimum Python version required `= 3.9.0`
+#### Minimum Python version required `= 3.10.0`
 
 #### Build & Activate Virtual Environment and install dependencies
 From this connector directory, create a virtual environment:

--- a/airbyte-integrations/connectors/destination-langchain/bootstrap.md
+++ b/airbyte-integrations/connectors/destination-langchain/bootstrap.md
@@ -23,4 +23,8 @@ You can use the `test_pinecone.py` file to check whether the pipeline works as e
 
 The DocArrayHnswSearch integration is storing the vector metadata in a local file in the local root (`/local` in the container, `/tmp/airbyte_local` on the host). It's not possible to dedupe records, so only full refresh syncs are supported. DocArrayHnswSearch uses hnswlib under the hood, but the integration is fully relying on the langchain abstraction.
 
+## Chroma integration
+
+The Chroma integration is storing the vector metadata in a local file in the local root (`/local` in the container, `/tmp/airbyte_local` on the host), similar to the DocArrayHnswSearch. This is called the "persistent client" mode in Chroma. The integration is mostly using langchains abstraction, but it can also dedupe records and reset streams independently.
+
 You can use the `test_local.py` file to check whether the pipeline works as expected.

--- a/airbyte-integrations/connectors/destination-langchain/destination_langchain/config.py
+++ b/airbyte-integrations/connectors/destination-langchain/destination_langchain/config.py
@@ -68,6 +68,27 @@ class PineconeIndexingModel(BaseModel):
         }
 
 
+class ChromaLocalIndexingModel(BaseModel):
+    mode: Literal["chroma_local"] = Field("chroma_local", const=True)
+    destination_path: str = Field(
+        ...,
+        title="Destination Path",
+        description="Path to the directory where chroma files will be written. The files will be placed inside that local mount.",
+        examples=["/local/my_chroma_db"],
+    )
+    collection_name: str = Field(
+        title="Collection Name",
+        description="Name of the collection to use.",
+        default="langchain",
+    )
+
+    class Config:
+        title = "Chroma (In-memory with persistance)"
+        schema_extra = {
+            "description": "Chroma is a popular vector store that can be used to store and retrieve embeddings. It will build its index in memory and persist it to disk by the end of the sync."
+        }
+
+
 class DocArrayHnswSearchIndexingModel(BaseModel):
     mode: Literal["DocArrayHnswSearch"] = Field("DocArrayHnswSearch", const=True)
     destination_path: str = Field(
@@ -89,7 +110,7 @@ class ConfigModel(BaseModel):
     embedding: Union[OpenAIEmbeddingConfigModel, FakeEmbeddingConfigModel] = Field(
         ..., title="Embedding", description="Embedding configuration", discriminator="mode", group="embedding", type="object"
     )
-    indexing: Union[PineconeIndexingModel, DocArrayHnswSearchIndexingModel] = Field(
+    indexing: Union[PineconeIndexingModel, DocArrayHnswSearchIndexingModel, ChromaLocalIndexingModel] = Field(
         ..., title="Indexing", description="Indexing configuration", discriminator="mode", group="indexing", type="object"
     )
 

--- a/airbyte-integrations/connectors/destination-langchain/destination_langchain/config.py
+++ b/airbyte-integrations/connectors/destination-langchain/destination_langchain/config.py
@@ -83,7 +83,7 @@ class ChromaLocalIndexingModel(BaseModel):
     )
 
     class Config:
-        title = "Chroma (In-memory with persistance)"
+        title = "Chroma (local persistance)"
         schema_extra = {
             "description": "Chroma is a popular vector store that can be used to store and retrieve embeddings. It will build its index in memory and persist it to disk by the end of the sync."
         }

--- a/airbyte-integrations/connectors/destination-langchain/destination_langchain/destination.py
+++ b/airbyte-integrations/connectors/destination-langchain/destination_langchain/destination.py
@@ -21,12 +21,12 @@ from destination_langchain.batcher import Batcher
 from destination_langchain.config import ConfigModel
 from destination_langchain.document_processor import DocumentProcessor
 from destination_langchain.embedder import Embedder, FakeEmbedder, OpenAIEmbedder
-from destination_langchain.indexer import DocArrayHnswSearchIndexer, Indexer, PineconeIndexer
+from destination_langchain.indexer import ChromaLocalIndexer, DocArrayHnswSearchIndexer, Indexer, PineconeIndexer
 from langchain.document_loaders.base import Document
 
 BATCH_SIZE = 128
 
-indexer_map = {"pinecone": PineconeIndexer, "DocArrayHnswSearch": DocArrayHnswSearchIndexer}
+indexer_map = {"pinecone": PineconeIndexer, "DocArrayHnswSearch": DocArrayHnswSearchIndexer, "chroma_local": ChromaLocalIndexer}
 
 embedder_map = {"openai": OpenAIEmbedder, "fake": FakeEmbedder}
 

--- a/airbyte-integrations/connectors/destination-langchain/destination_langchain/indexer.py
+++ b/airbyte-integrations/connectors/destination-langchain/destination_langchain/indexer.py
@@ -165,7 +165,15 @@ class ChromaLocalIndexer(Indexer):
     def index(self, document_chunks, delete_ids):
         for delete_in in delete_ids:
             self.vectorstore._collection.delete(where={METADATA_RECORD_ID_FIELD: {"$eq": delete_in}})
+        for chunk in document_chunks:
+            self._normalize_metadata(chunk)
         self.vectorstore.add_documents(document_chunks)
+
+    def _normalize_metadata(self, document: Document):
+        for key, value in document.metadata.items():
+            # check bool separately because isinstance(True, int) == True
+            if not isinstance(value, (str, float, int)) or isinstance(value, bool):
+                document.metadata[key] = str(value)
 
     def check(self) -> Optional[str]:
         try:

--- a/airbyte-integrations/connectors/destination-langchain/integration_tests/base_integration_test.py
+++ b/airbyte-integrations/connectors/destination-langchain/integration_tests/base_integration_test.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import shutil
+import tempfile
 import unittest
 from typing import Any, Dict
 
@@ -40,3 +42,11 @@ class BaseIntegrationTest(unittest.TestCase):
         return AirbyteMessage(
             type=Type.RECORD, record=AirbyteRecordMessage(stream=stream, data={"str_col": str_value, "int_col": int_value}, emitted_at=0)
         )
+
+
+class LocalIntegrationTest(BaseIntegrationTest):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)

--- a/airbyte-integrations/connectors/destination-langchain/integration_tests/chroma_integration_test.py
+++ b/airbyte-integrations/connectors/destination-langchain/integration_tests/chroma_integration_test.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import json
+import logging
+
+import chromadb
+from airbyte_cdk.models import DestinationSyncMode, Status
+from chromadb.api.types import QueryResult
+from destination_langchain.destination import DestinationLangchain
+from destination_langchain.embedder import OPEN_AI_VECTOR_SIZE
+from integration_tests.base_integration_test import LocalIntegrationTest
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import Chroma
+
+
+class ChromaLocalIntegrationTest(LocalIntegrationTest):
+    def setUp(self):
+        super().setUp()
+        with open("secrets/config.json", "r") as f:
+            self.config = json.loads(f.read())
+        self.config["indexing"] = {
+            "destination_path": self.temp_dir,
+            "mode": "chroma_local",
+        }
+        self.chroma_client = chromadb.PersistentClient(path=self.temp_dir)
+
+    def test_check_valid_config(self):
+        outcome = DestinationLangchain().check(logging.getLogger("airbyte"), self.config)
+        assert outcome.status == Status.SUCCEEDED
+
+    def test_write(self):
+        catalog = self._get_configured_catalog(DestinationSyncMode.overwrite)
+        first_state_message = self._state({"state": "1"})
+        first_record_chunk = [self._record("mystream", f"Dogs are number {i}", i) for i in range(5)]
+
+        # initial sync
+        destination = DestinationLangchain()
+        list(destination.write(self.config, catalog, [*first_record_chunk, first_state_message]))
+        assert self.chroma_client.get_collection("langchain").count() == 5
+
+        # incrementalally update a doc
+        incremental_catalog = self._get_configured_catalog(DestinationSyncMode.append_dedup)
+        list(destination.write(self.config, incremental_catalog, [self._record("mystream", "Cats are nice", 2), first_state_message]))
+        chroma_result: QueryResult = self.chroma_client.get_collection("langchain").query(
+            query_embeddings=[0] * OPEN_AI_VECTOR_SIZE, n_results=10, where={"_record_id": "2"}, include=["documents"]
+        )
+        assert len(chroma_result["documents"][0]) == 1
+        assert chroma_result["documents"][0] == ["str_col: Cats are nice"]
+
+        # test langchain integration
+        embeddings = OpenAIEmbeddings(openai_api_key=self.config["embedding"]["openai_key"])
+        vector_store = Chroma(embedding_function=embeddings, persist_directory=self.temp_dir)
+        result = vector_store.similarity_search("feline animals", 1)
+        assert result[0].metadata["_record_id"] == "2"

--- a/airbyte-integrations/connectors/destination-langchain/integration_tests/docarray_integration_test.py
+++ b/airbyte-integrations/connectors/destination-langchain/integration_tests/docarray_integration_test.py
@@ -3,30 +3,23 @@
 #
 
 import logging
-import os
-import tempfile
 
 from airbyte_cdk.models import DestinationSyncMode, Status
 from destination_langchain.destination import DestinationLangchain
 from destination_langchain.embedder import OPEN_AI_VECTOR_SIZE
-from integration_tests.base_integration_test import BaseIntegrationTest
+from integration_tests.base_integration_test import LocalIntegrationTest
 from langchain.embeddings import FakeEmbeddings
 from langchain.vectorstores import DocArrayHnswSearch
 
 
-class LocalIntegrationTest(BaseIntegrationTest):
+class DocArrayIntegrationTest(LocalIntegrationTest):
     def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
+        super().setUp()
         self.config = {
             "processing": {"text_fields": ["str_col"], "chunk_size": 1000},
             "embedding": {"mode": "fake"},
             "indexing": {"mode": "DocArrayHnswSearch", "destination_path": self.temp_dir},
         }
-
-    def tearDown(self):
-        for file in os.listdir(self.temp_dir):
-            os.remove(os.path.join(self.temp_dir, file))
-        os.removedirs(self.temp_dir)
 
     def test_check_valid_config(self):
         outcome = DestinationLangchain().check(logging.getLogger("airbyte"), self.config)

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: cf98d52c-ba5a-4dfd-8ada-c1baebfa6e73
-  dockerImageTag: 0.0.4
+  dockerImageTag: 0.0.5
   dockerRepository: airbyte/destination-langchain
   githubIssueLabel: destination-langchain
   icon: langchain.svg

--- a/airbyte-integrations/connectors/destination-langchain/setup.py
+++ b/airbyte-integrations/connectors/destination-langchain/setup.py
@@ -17,7 +17,7 @@ MAIN_REQUIREMENTS = [
     "typing_extensions==4.5.0",
     "pydantic==1.10.8",
     "pandas==1.4.2",
-    "chromadb",
+    "chromadb==0.4.3",
 ]
 
 TEST_REQUIREMENTS = ["pytest~=6.2"]

--- a/airbyte-integrations/connectors/destination-langchain/setup.py
+++ b/airbyte-integrations/connectors/destination-langchain/setup.py
@@ -17,6 +17,7 @@ MAIN_REQUIREMENTS = [
     "typing_extensions==4.5.0",
     "pydantic==1.10.8",
     "pandas==1.4.2",
+    "chromadb",
 ]
 
 TEST_REQUIREMENTS = ["pytest~=6.2"]

--- a/airbyte-integrations/connectors/destination-langchain/test_local.py
+++ b/airbyte-integrations/connectors/destination-langchain/test_local.py
@@ -5,12 +5,12 @@
 from langchain.chains import RetrievalQA
 from langchain.embeddings import OpenAIEmbeddings
 from langchain.llms import OpenAI
-from langchain.vectorstores import DocArrayHnswSearch
+from langchain.vectorstores import Chroma
 
 # Run with OPENAI_API_KEY set in the environment
 
 embeddings = OpenAIEmbeddings()
-vector_store = DocArrayHnswSearch.from_params(embeddings, "/tmp/airbyte_local/special_path", 1536)
+vector_store = Chroma(embedding_function=embeddings, persist_directory="/tmp/airbyte_local/my_chroma_db")
 
 # print(vector_store.similarity_search("python", 1))
 

--- a/airbyte-integrations/connectors/destination-langchain/unit_tests/chroma_local_indexer_test.py
+++ b/airbyte-integrations/connectors/destination-langchain/unit_tests/chroma_local_indexer_test.py
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+from unittest.mock import MagicMock, call
+
+from airbyte_cdk.models import ConfiguredAirbyteCatalog
+from destination_langchain.config import ChromaLocalIndexingModel
+from destination_langchain.indexer import ChromaLocalIndexer
+from langchain.document_loaders.base import Document
+
+
+def create_chroma_local_indexer():
+    config = ChromaLocalIndexingModel(mode="chroma_local", destination_path="/test", collection_name="myindex")
+    embedder = MagicMock()
+    indexer = ChromaLocalIndexer(config, embedder)
+
+    indexer.vectorstore = MagicMock()
+    indexer.vectorstore._collection = MagicMock()
+    indexer.vectorstore._collection.delete = MagicMock()
+    indexer.embed_fn = MagicMock(return_value=[[1, 2, 3], [4, 5, 6]])
+    indexer.vectorstore.add_documents = MagicMock()
+    return indexer
+
+
+def test_chroma_local_index_upsert_and_delete():
+    indexer = create_chroma_local_indexer()
+    docs = [
+        Document(page_content="test", metadata={"_airbyte_stream": "abc"}),
+        Document(page_content="test2", metadata={"_airbyte_stream": "abc"}),
+    ]
+    indexer.index(
+        docs,
+        ["delete_id1", "delete_id2"],
+    )
+    indexer.vectorstore._collection.delete.assert_has_calls(
+        [
+            call(where={"_record_id": {"$eq": "delete_id1"}}),
+            call(where={"_record_id": {"$eq": "delete_id2"}}),
+        ]
+    )
+    indexer.vectorstore.add_documents.assert_called_with(docs)
+
+
+def test_chroma_local_index_empty_batch():
+    indexer = create_chroma_local_indexer()
+    indexer.index(
+        [],
+        [],
+    )
+    indexer.vectorstore._collection.delete.assert_not_called()
+    indexer.vectorstore.add_documents.assert_called_with([])
+
+
+def test_chroma_local_pre_sync():
+    indexer = create_chroma_local_indexer()
+    indexer._init_vectorstore = MagicMock()
+    indexer.pre_sync(
+        ConfiguredAirbyteCatalog.parse_obj(
+            {
+                "streams": [
+                    {
+                        "stream": {
+                            "name": "example_stream",
+                            "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
+                            "supported_sync_modes": ["full_refresh", "incremental"],
+                            "source_defined_cursor": False,
+                            "default_cursor_field": ["column_name"],
+                        },
+                        "primary_key": [["id"]],
+                        "sync_mode": "incremental",
+                        "destination_sync_mode": "append_dedup",
+                    },
+                    {
+                        "stream": {
+                            "name": "example_stream2",
+                            "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
+                            "supported_sync_modes": ["full_refresh", "incremental"],
+                            "source_defined_cursor": False,
+                            "default_cursor_field": ["column_name"],
+                        },
+                        "primary_key": [["id"]],
+                        "sync_mode": "full_refresh",
+                        "destination_sync_mode": "overwrite",
+                    },
+                ]
+            }
+        )
+    )
+    indexer._init_vectorstore.assert_called()
+    indexer.vectorstore._collection.delete.assert_called_with(where={"_airbyte_stream": {"$eq": "example_stream2"}})

--- a/airbyte-integrations/connectors/destination-langchain/unit_tests/chroma_local_indexer_test.py
+++ b/airbyte-integrations/connectors/destination-langchain/unit_tests/chroma_local_indexer_test.py
@@ -42,6 +42,20 @@ def test_chroma_local_index_upsert_and_delete():
     indexer.vectorstore.add_documents.assert_called_with(docs)
 
 
+def test_chroma_local_normalize_metadata():
+    indexer = create_chroma_local_indexer()
+    docs = [
+        Document(page_content="test", metadata={"_airbyte_stream": "abc", "a_boolean_value": True}),
+    ]
+    indexer.index(
+        docs,
+        [],
+    )
+    indexer.vectorstore.add_documents.assert_called_with([
+        Document(page_content="test", metadata={"_airbyte_stream": "abc", "a_boolean_value": "True"}),
+    ])
+
+
 def test_chroma_local_index_empty_batch():
     indexer = create_chroma_local_indexer()
     indexer.index(

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -73,7 +73,7 @@ from langchain.vectorstores import Chroma
 from langchain.embeddings import OpenAIEmbeddings
 
 embeddings = OpenAIEmbeddings()
-vector_store = Chroma.from_params(embedding_function=embeddings, persist_directory="/tmp/airbyte_local/<your configured directory>")
+vector_store = Chroma(embedding_function=embeddings, persist_directory="/tmp/airbyte_local/<your configured directory>")
 
 qa = RetrievalQA.from_chain_type(llm=OpenAI(temperature=0), chain_type="stuff", retriever=vector_store.as_retriever())
 ```
@@ -133,7 +133,7 @@ Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a M
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.0.5   | 2023-07-25 | [#28556](https://github.com/airbytehq/airbyte/pull/28556)     | Add Chroma support  |
+| 0.0.5   | 2023-07-25 | [#28605](https://github.com/airbytehq/airbyte/pull/28605)     | Add Chroma support  |
 | 0.0.4   | 2023-07-21 | [#28556](https://github.com/airbytehq/airbyte/pull/28556)     | Correctly dedupe records with composite and nested primary keys  |
 | 0.0.3   | 2023-07-20 | [#28509](https://github.com/airbytehq/airbyte/pull/28509)     | Change the base image to python:3.9-slim to fix build  |
 | 0.0.2   | 2023-07-18 | [#26184](https://github.com/airbytehq/airbyte/pull/28398)     | Adjust python dependencies and release on cloud  |

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -30,6 +30,63 @@ For testing purposes, it's also possible to use the [Fake embeddings](https://py
 
 ### Indexing
 
+#### Pinecone vector store
+
+For production use, use the pinecone vector store. Use the Pinecone web UI or API to create a project and an index before running the destination. All streams will be indexed into the same index, the `_airbyte_stream` metadata field is used to distinguish between streams. Overall, the size of the metadata fields is limited to 30KB per document. Both OpenAI and Fake embeddings are produced with 1536 vector dimensions, make sure to configure the index accordingly.
+
+To initialize a langchain QA chain based on the indexed data, use the following code (set the open API key and pinecone key and environment as `OPENAI_API_KEY`, `PINECONE_KEY` and `PINECONE_ENV` env variables):
+
+```python
+from langchain import OpenAI
+from langchain.chains import RetrievalQA
+from langchain.llms import OpenAI
+from langchain.vectorstores import Pinecone
+from langchain.embeddings import OpenAIEmbeddings
+import pinecone
+import os
+
+embeddings = OpenAIEmbeddings()
+pinecone.init(api_key=os.environ["PINECONE_KEY"], environment=os.environ["PINECONE_ENV"])
+index = pinecone.Index("<your pinecone index name>")
+vector_store = Pinecone(index, embeddings.embed_query, "text")
+
+qa = RetrievalQA.from_chain_type(llm=OpenAI(temperature=0), chain_type="stuff", retriever=vector_store.as_retriever())
+```
+
+#### Chroma vector store
+
+The [Chroma vector store](https://trychroma.com) is running the Chroma embedding database as persistent client and stores the vectors in a local file.
+
+The `destination_path` has to start with `/local`. Any directory nesting within local will be mapped onto the local mount.
+
+By default, the `LOCAL_ROOT` env variable in the `.env` file is set `/tmp/airbyte_local`.
+
+The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` is substituted by `/tmp/airbyte_local` by default.
+
+To initialize a langchain QA chain based on the indexed data, use the following code (set the openai API key as `OPENAI_API_KEY` env variable):
+
+```python
+from langchain import OpenAI
+from langchain.chains import RetrievalQA
+from langchain.llms import OpenAI
+from langchain.vectorstores import Chroma
+from langchain.embeddings import OpenAIEmbeddings
+
+embeddings = OpenAIEmbeddings()
+vector_store = Chroma.from_params(embedding_function=embeddings, persist_directory="/tmp/airbyte_local/<your configured directory>")
+
+qa = RetrievalQA.from_chain_type(llm=OpenAI(temperature=0), chain_type="stuff", retriever=vector_store.as_retriever())
+```
+
+:::caution
+
+Chroma is meant to be used on a local workstation and won't work on Kubernetes.
+
+Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a MacOS, as /tmp has a symlink that points to /private. It will not work otherwise). You allow it with "File sharing" in `Settings -> Resources -> File sharing -> add the one or two above folder` and hit the "Apply & restart" button.
+
+:::
+
+
 #### DocArrayHnswSearch vector store
 
 For local testing, the [DocArrayHnswSearch](https://python.langchain.com/docs/modules/data_connection/vectorstores/integrations/docarray_hnsw) is recommended - it stores the vectors in a local file with a sqlite database for metadata. It is not suitable for production use, but it is the easiest to set up for testing and development purposes.
@@ -71,33 +128,12 @@ Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a M
 
 :::
 
-#### Pinecone vector store
-
-For production use, use the pinecone vector store. Use the Pinecone web UI or API to create a project and an index before running the destination. All streams will be indexed into the same index, the `_airbyte_stream` metadata field is used to distinguish between streams. Overall, the size of the metadata fields is limited to 30KB per document. Both OpenAI and Fake embeddings are produced with 1536 vector dimensions, make sure to configure the index accordingly.
-
-To initialize a langchain QA chain based on the indexed data, use the following code (set the open API key and pinecone key and environment as `OPENAI_API_KEY`, `PINECONE_KEY` and `PINECONE_ENV` env variables):
-
-```python
-from langchain import OpenAI
-from langchain.chains import RetrievalQA
-from langchain.llms import OpenAI
-from langchain.vectorstores import Pinecone
-from langchain.embeddings import OpenAIEmbeddings
-import pinecone
-import os
-
-embeddings = OpenAIEmbeddings()
-pinecone.init(api_key=os.environ["PINECONE_KEY"], environment=os.environ["PINECONE_ENV"])
-index = pinecone.Index("<your pinecone index name>")
-vector_store = Pinecone(index, embeddings.embed_query, "text")
-
-qa = RetrievalQA.from_chain_type(llm=OpenAI(temperature=0), chain_type="stuff", retriever=vector_store.as_retriever())
-```
 
 ## CHANGELOG
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.0.5   | 2023-07-25 | [#28556](https://github.com/airbytehq/airbyte/pull/28556)     | Add Chroma support  |
 | 0.0.4   | 2023-07-21 | [#28556](https://github.com/airbytehq/airbyte/pull/28556)     | Correctly dedupe records with composite and nested primary keys  |
 | 0.0.3   | 2023-07-20 | [#28509](https://github.com/airbytehq/airbyte/pull/28509)     | Change the base image to python:3.9-slim to fix build  |
 | 0.0.2   | 2023-07-18 | [#26184](https://github.com/airbytehq/airbyte/pull/28398)     | Adjust python dependencies and release on cloud  |


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/28516

## How

Adds a new indexing option for [Chroma](https://www.trychroma.com/). This is similar to the docarray option as it's saving the vector db in a local file.


I had to switch the base image to python 3.10, because the sqlite version would be too old for chroma to work properly otherwise.