### PR TITLE
Update the cloud dockerfile when publishing the cdk

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -294,6 +294,7 @@ jobs:
         run: |
           PREVIOUS_VERSION=$(cat oss/airbyte-connector-builder-resources/CDK_VERSION)
           sed -i "s/${PREVIOUS_VERSION}/${{needs.bump-version.outputs.new_cdk_version}}/g" oss/airbyte-connector-builder-server/Dockerfile
+          sed -i "s/${PREVIOUS_VERSION}/${{needs.bump-version.outputs.new_cdk_version}}/g" airbyte-connector-builder-server-wrapped/Dockerfile
           sed -i "s/airbyte-cdk==${PREVIOUS_VERSION}/airbyte-cdk==${{needs.bump-version.outputs.new_cdk_version}}/g" oss/airbyte-connector-builder-server/requirements.in
           echo ${{needs.bump-version.outputs.new_cdk_version}} > oss/airbyte-connector-builder-resources/CDK_VERSION
           cd oss/airbyte-connector-builder-server


### PR DESCRIPTION
## What
* A quickfix so the connector builder image on cloud is also updated when we publish a new version
* This is a hotfix, it's not great that we need to keep referencing the CDK version
* This depends on merging in https://github.com/airbytehq/airbyte-platform-internal/pull/7985 which removes the extra CDK_VERSION and requirements.txt files

## How
* Update the cloud dockerfile 

## Recommended reading order
1. `.github/workflows/publish-cdk-command-manually.yml`