### PR TITLE
source-sftp-bulk: make integration test pass in `airbyte-ci`

### DIFF
--- a/airbyte-integrations/connectors/source-sftp-bulk/setup.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/setup.py
@@ -13,7 +13,7 @@ MAIN_REQUIREMENTS = [
     "pandas==1.5.0",
 ]
 
-TEST_REQUIREMENTS = ["pytest~=6.1", "connector-acceptance-test", "docker==5.0.3"]
+TEST_REQUIREMENTS = ["pytest~=6.1", "connector-acceptance-test", "docker==5.0.3", "pytest-docker"]
 
 setup(
     name="source_sftp_bulk",

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
@@ -267,6 +267,7 @@ class PytestStep(Step, ABC):
         """
         test_config = "pytest.ini" if await check_path_in_workdir(connector_under_test, "pytest.ini") else "/" + PYPROJECT_TOML_FILE_PATH
         if await check_path_in_workdir(connector_under_test, test_directory):
+            print("GOOOBERSSSSSS")
             tester = connector_under_test.with_exec(
                 [
                     "python",
@@ -278,6 +279,7 @@ class PytestStep(Step, ABC):
                     test_directory,
                     "-c",
                     test_config,
+                    
                 ]
             )
             logs = await tester.stdout()

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
@@ -267,7 +267,6 @@ class PytestStep(Step, ABC):
         """
         test_config = "pytest.ini" if await check_path_in_workdir(connector_under_test, "pytest.ini") else "/" + PYPROJECT_TOML_FILE_PATH
         if await check_path_in_workdir(connector_under_test, test_directory):
-            print("GOOOBERSSSSSS")
             tester = connector_under_test.with_exec(
                 [
                     "python",
@@ -279,7 +278,6 @@ class PytestStep(Step, ABC):
                     test_directory,
                     "-c",
                     test_config,
-                    
                 ]
             )
             logs = await tester.stdout()

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
@@ -267,8 +267,8 @@ class PytestStep(Step, ABC):
         """
         test_config = "pytest.ini" if await check_path_in_workdir(connector_under_test, "pytest.ini") else "/" + PYPROJECT_TOML_FILE_PATH
         if await check_path_in_workdir(connector_under_test, test_directory):
-            docker_daemon = self.context.dagger_client.host().unix_socket("/var/run/docker.sock")
-            tester = connector_under_test.with_unix_socket("/var/run/docker/sock", docker_daemon).with_exec(
+            print("GOOOBERSSSSSS")
+            tester = connector_under_test.with_exec(
                 [
                     "python",
                     "-m",

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
@@ -267,8 +267,8 @@ class PytestStep(Step, ABC):
         """
         test_config = "pytest.ini" if await check_path_in_workdir(connector_under_test, "pytest.ini") else "/" + PYPROJECT_TOML_FILE_PATH
         if await check_path_in_workdir(connector_under_test, test_directory):
-            print("GOOOBERSSSSSS")
-            tester = connector_under_test.with_exec(
+            docker_daemon = self.context.dagger_client.host().unix_socket("/var/run/docker.sock")
+            tester = connector_under_test.with_unix_socket("/var/run/docker/sock", docker_daemon).with_exec(
                 [
                     "python",
                     "-m",


### PR DESCRIPTION
Trying to fix the integration tests in #28579 which pass when I run `python -m pytest -s integration_tests` but not when I run `airbyte-ci connectors --name source-sftp-bulk test`