### PR TITLE
Docs: update PR template and remove python destination as accepted contributions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,17 @@
+<!--
+Thanks for your contribution! 
+Before you submit the pull request, 
+I'd like to kindly remind you to take a moment and read through our guidelines
+to ensure that your contribution aligns with the type of contributions our project accepts.
+All the information you need can be found here:
+   https://docs.airbyte.com/contributing-to-airbyte/
+
+We truly appreciate your interest in contributing to Airbyte,
+and we're excited to see what you have to offer! 
+
+If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
+-->
+
 ## What
 *Describe what the change is solving*
 *It helps to add screenshots if it affects the frontend.*

--- a/docs/connector-development/tutorials/building-a-python-destination.md
+++ b/docs/connector-development/tutorials/building-a-python-destination.md
@@ -1,8 +1,9 @@
 # Building a Python Destination
 
 :::warning
-Airbyte has a simple Python Destination CDK but currently the project is not accepting new Python Destination in the official catalog.
-You can still build the connector and use for your projects locally or import in Airbyte Cloud.
+Airbyte has a Python Destination CDK that allows you to create quick and simple destinations for particular use cases. 
+Currently, the project is not accepting new Python Destinations in the official catalog.
+However, you can still build the connector and use it for your projects locally or import it into Airbyte Cloud.
 :::
 
 ## Summary

--- a/docs/connector-development/tutorials/building-a-python-destination.md
+++ b/docs/connector-development/tutorials/building-a-python-destination.md
@@ -1,6 +1,6 @@
 # Building a Python Destination
 
-:::warn
+:::warning
 Airbyte has a simple Python Destination CDK but currently the project is not accepting new Python Destination in the official catalog.
 You can still build the connector and use for your projects locally or import in Airbyte Cloud.
 :::

--- a/docs/connector-development/tutorials/building-a-python-destination.md
+++ b/docs/connector-development/tutorials/building-a-python-destination.md
@@ -1,5 +1,10 @@
 # Building a Python Destination
 
+:::warn
+Airbyte has a simple Python Destination CDK but currently the project is not accepting new Python Destination in the official catalog.
+You can still build the connector and use for your projects locally or import in Airbyte Cloud.
+:::
+
 ## Summary
 
 This article provides a checklist for how to create a Python destination. Each step in the checklist has a link to a more detailed explanation below.

--- a/docs/contributing-to-airbyte/README.md
+++ b/docs/contributing-to-airbyte/README.md
@@ -20,7 +20,7 @@ A great place to start looking will be our GitHub projects for:
 Due to project priorities, we may not be able to accept all contributions at this time. 
 We are prioritizing the following contributions: 
 * Bug fixes, features, and enhancements to existing API source connectors
-* New connector sources and destinations built with the Python CDK, with a preference for low and no-code CDK, as these connectors are easier to maintain
+* New connector sources built with the Low-Code CDK and Connector Builder, as these connectors are easier to maintain.
 * Bug fixes, features, and enhancements to the following database sources: MongoDB, Postgres, MySQL, MSSQL
 * Bug fixes to the following destinations: BigQuery, Snowflake, Redshift, S3, and Postgres
 * Helm Charts features, bug fixes, and other platform bug fixes


### PR DESCRIPTION
## What
* Update the PR template to link to Airbyte's contribution documentation;
* Added in Python Destination CDK a warning the project is not accepting that type of destination (there a few recent ones trying to add Reverse ETL connectors and most of them are very simplistic implementation with append only method)
* Remove Source and Destination Python CDK as accepted in Contribution guidelines. (In favor only for low-code and connector builder ones)