### PR TITLE
connectors-ci: extend nightly build timeout

### DIFF
--- a/.github/workflows/connectors_nightly_build.yml
+++ b/.github/workflows/connectors_nightly_build.yml
@@ -19,7 +19,7 @@ run-name: "Test connectors: ${{ inputs.test-connectors-options || 'nightly build
 jobs:
   test_connectors:
     name: "Test connectors: ${{ inputs.test-connectors-options || 'nightly build for GA and Beta connectors' }} - on ${{ inputs.runs-on || 'conn-nightly-xlarge-runner' }}"
-    timeout-minutes: 480 # 8 hours
+    timeout-minutes: 720 # 12 hours
     runs-on: ${{ inputs.runs-on || 'conn-nightly-xlarge-runner' }}
     steps:
       - name: Checkout Airbyte


### PR DESCRIPTION
## What
Nightly build are running longer now that we have potentially fixed transient failure in https://github.com/airbytehq/airbyte/pull/28656 , I want to increase the time out value.
