### PR TITLE
pin stripe version in cloud to 3.13.0

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -14,7 +14,7 @@ data:
   registries:
     cloud:
       enabled: true
-      dockerImageTag: 3.13.0
+      dockerImageTag: 3.13.0  # https://github.com/airbytehq/oncall/issues/2578
     oss:
       enabled: true
   releaseStage: generally_available

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -14,6 +14,7 @@ data:
   registries:
     cloud:
       enabled: true
+      dockerImageTag: 3.13.0
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
Roll back stripe in cloud due to https://github.com/airbytehq/oncall/issues/2578