### PR TITLE
add a stub to test a java cdk workflow

### DIFF
--- a/.github/workflows/java_cdk.yml
+++ b/.github/workflows/java_cdk.yml
@@ -1,0 +1,13 @@
+name: "Java CDK CI"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+    paths:
+      - '.github/workflows/java_cdk.yml'
+      - 'airbyte-ci/java-cdk/**'
+      - 'airbyte-ci/java/**'
+  workflow_dispatch:


### PR DESCRIPTION
## What
Due to somewhat arbitrary github actions limitations, in order to iterate on a workflow in a pull request, it has to already exist as a barebones stub on the main branch, or else it won't show up in the UI and wont' be available to kick off with

## How
Add a stub
