### PR TITLE
Revert "source-postgres: enable ctid+cdc implementation (#28044)"

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -414,9 +414,80 @@ public class PostgresSource extends AbstractJdbcSource<PostgresType> implements 
     final JsonNode sourceConfig = database.getSourceConfig();
     final CtidFeatureFlags ctidFeatureFlags = new CtidFeatureFlags(sourceConfig);
     if (PostgresUtils.isCdc(sourceConfig) && shouldUseCDC(catalog)) {
-      LOGGER.info("Using ctid + CDC");
-      return cdcCtidIteratorsCombined(database, catalog, tableNameToTable, stateManager, emittedAt, getQuoteString(),
-          getReplicationSlot(database, sourceConfig).get(0));
+      if (sourceConfig.has("cdc_via_ctid") && sourceConfig.get("cdc_via_ctid").asBoolean()) {
+        LOGGER.info("Using ctid + CDC");
+        return cdcCtidIteratorsCombined(database, catalog, tableNameToTable, stateManager, emittedAt, getQuoteString(),
+            getReplicationSlot(database, sourceConfig).get(0));
+      }
+      final Duration firstRecordWaitTime = PostgresUtils.getFirstRecordWaitTime(sourceConfig);
+      final OptionalInt queueSize = OptionalInt.of(PostgresUtils.getQueueSize(sourceConfig));
+      LOGGER.info("First record waiting time: {} seconds", firstRecordWaitTime.getSeconds());
+      LOGGER.info("Queue size: {}", queueSize.getAsInt());
+
+      final PostgresDebeziumStateUtil postgresDebeziumStateUtil = new PostgresDebeziumStateUtil();
+      final JsonNode state =
+          (stateManager.getCdcStateManager().getCdcState() == null ||
+              stateManager.getCdcStateManager().getCdcState().getState() == null) ? null
+                  : Jsons.clone(stateManager.getCdcStateManager().getCdcState().getState());
+
+      final OptionalLong savedOffset = postgresDebeziumStateUtil.savedOffset(
+          Jsons.clone(PostgresCdcProperties.getDebeziumDefaultProperties(database)),
+          catalog,
+          state,
+          sourceConfig);
+
+      // We should always be able to extract offset out of state if it's not null
+      if (state != null && savedOffset.isEmpty()) {
+        throw new RuntimeException(
+            "Unable extract the offset out of state, State mutation might not be working. " + state.asText());
+      }
+
+      final boolean savedOffsetAfterReplicationSlotLSN = postgresDebeziumStateUtil.isSavedOffsetAfterReplicationSlotLSN(
+          // We can assume that there will be only 1 replication slot cause before the sync starts for
+          // Postgres CDC,
+          // we run all the check operations and one of the check validates that the replication slot exists
+          // and has only 1 entry
+          getReplicationSlot(database, sourceConfig).get(0),
+          savedOffset);
+
+      if (!savedOffsetAfterReplicationSlotLSN) {
+        LOGGER.warn("Saved offset is before Replication slot's confirmed_flush_lsn, Airbyte will trigger sync from scratch");
+      } else if (PostgresUtils.shouldFlushAfterSync(sourceConfig)) {
+        postgresDebeziumStateUtil.commitLSNToPostgresDatabase(database.getDatabaseConfig(),
+            savedOffset,
+            sourceConfig.get("replication_method").get("replication_slot").asText(),
+            sourceConfig.get("replication_method").get("publication").asText(),
+            PostgresUtils.getPluginValue(sourceConfig.get("replication_method")));
+      }
+
+      final AirbyteDebeziumHandler<Long> handler = new AirbyteDebeziumHandler<>(sourceConfig,
+          PostgresCdcTargetPosition.targetPosition(database),
+          false,
+          firstRecordWaitTime,
+          queueSize);
+      final PostgresCdcStateHandler postgresCdcStateHandler = new PostgresCdcStateHandler(stateManager);
+      final List<ConfiguredAirbyteStream> streamsToSnapshot = identifyStreamsToSnapshot(catalog, stateManager);
+      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier =
+          () -> handler.getIncrementalIterators(catalog,
+              new PostgresCdcSavedInfoFetcher(
+                  savedOffsetAfterReplicationSlotLSN ? stateManager.getCdcStateManager().getCdcState()
+                      : null),
+              postgresCdcStateHandler,
+              new PostgresCdcConnectorMetadataInjector(),
+              PostgresCdcProperties.getDebeziumDefaultProperties(database),
+              emittedAt,
+              false);
+      if (!savedOffsetAfterReplicationSlotLSN || streamsToSnapshot.isEmpty()) {
+        return Collections.singletonList(incrementalIteratorSupplier.get());
+      }
+
+      final AutoCloseableIterator<AirbyteMessage> snapshotIterator = handler.getSnapshotIterators(
+          new ConfiguredAirbyteCatalog().withStreams(streamsToSnapshot), new PostgresCdcConnectorMetadataInjector(),
+          PostgresCdcProperties.getSnapshotProperties(database), postgresCdcStateHandler, emittedAt);
+      return Collections.singletonList(
+          AutoCloseableIterators.concatWithEagerClose(AirbyteTraceMessageUtility::emitStreamStatusTrace, snapshotIterator,
+              AutoCloseableIterators.lazyIterator(incrementalIteratorSupplier, null)));
+
     }
 
     if (isIncrementalSyncMode(catalog) && PostgresUtils.isXmin(sourceConfig)) {

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSourceOperations.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSourceOperations.java
@@ -361,7 +361,7 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
     final ArrayNode arrayNode = Jsons.arrayNode();
     final ResultSet arrayResultSet = resultSet.getArray(colIndex).getResultSet();
     while (arrayResultSet.next()) {
-      arrayNode.add(DataTypeUtils.returnNullIfInvalid(() -> arrayResultSet.getDouble(2), Double::isFinite));
+      arrayNode.add(DataTypeUtils.returnNullIfInvalid(() -> arrayResultSet.getDouble(colIndex), Double::isFinite));
     }
     node.set(columnName, arrayNode);
   }
@@ -370,7 +370,7 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
     final ArrayNode arrayNode = Jsons.arrayNode();
     final ResultSet arrayResultSet = resultSet.getArray(colIndex).getResultSet();
     while (arrayResultSet.next()) {
-      final String moneyValue = parseMoneyValue(arrayResultSet.getString(2));
+      final String moneyValue = parseMoneyValue(arrayResultSet.getString(colIndex));
       arrayNode.add(DataTypeUtils.returnNullIfInvalid(() -> DataTypeUtils.returnNullIfInvalid(() -> Double.valueOf(moneyValue), Double::isFinite)));
     }
     node.set(columnName, arrayNode);

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/ctid/CtidFeatureFlags.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/ctid/CtidFeatureFlags.java
@@ -10,11 +10,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 // One for each type: CDC and standard cursor based
 public class CtidFeatureFlags {
 
+  public static final String CDC_VIA_CTID = "cdc_via_ctid";
   public static final String CURSOR_VIA_CTID = "cursor_via_ctid";
   private final JsonNode sourceConfig;
 
   public CtidFeatureFlags(final JsonNode sourceConfig) {
     this.sourceConfig = sourceConfig;
+  }
+
+  public boolean isCdcSyncEnabled() {
+    return getFlagValue(CDC_VIA_CTID);
   }
 
   public boolean isCursorSyncEnabled() {

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractPostgresSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractPostgresSourceDatatypeTest.java
@@ -588,13 +588,6 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
             .addExpectedValues("(\"fuzzy dice\",42,1.99)", null)
             .build());
 
-    addHstoreTest();
-    addTimeWithTimeZoneTest();
-    addArraysTestData();
-    addMoneyTest();
-  }
-
-  protected void addHstoreTest() {
     addDataTypeTestData(
         TestDataHolder.builder()
             .sourceType("hstore")
@@ -609,6 +602,10 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
                 {"ISBN-13":"978-1449370000","weight":"11.2 ounces","paperback":"243","publisher":"postgresqltutorial.com","language":"English"}""",
                 null)
             .build());
+
+    addTimeWithTimeZoneTest();
+    addArraysTestData();
+    addMoneyTest();
   }
 
   protected void addMoneyTest() {

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcInitialSnapshotPostgresSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcInitialSnapshotPostgresSourceDatatypeTest.java
@@ -6,26 +6,18 @@ package io.airbyte.integrations.io.airbyte.integration_tests.sources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
-import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.Database;
 import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.DatabaseDriver;
 import io.airbyte.db.jdbc.JdbcUtils;
-import io.airbyte.integrations.standardtest.source.TestDataHolder;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
 import io.airbyte.integrations.util.HostPortResolver;
-import io.airbyte.protocol.models.JsonSchemaType;
 import java.util.List;
 import org.jooq.SQLDialect;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.MountableFile;
-import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
-import uk.org.webcompere.systemstubs.jupiter.SystemStub;
-import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-@ExtendWith(SystemStubsExtension.class)
 public class CdcInitialSnapshotPostgresSourceDatatypeTest extends AbstractPostgresSourceDatatypeTest {
 
   private static final String SCHEMA_NAME = "test";
@@ -33,12 +25,9 @@ public class CdcInitialSnapshotPostgresSourceDatatypeTest extends AbstractPostgr
   private static final String PUBLICATION = "publication";
   private static final int INITIAL_WAITING_SECONDS = 30;
 
-  @SystemStub
-  private EnvironmentVariables environmentVariables;
-
   @Override
   protected Database setupDatabase() throws Exception {
-    environmentVariables.set(EnvVariableFeatureFlags.USE_STREAM_CAPABLE_STATE, "true");
+
     container = new PostgreSQLContainer<>("postgres:14-alpine")
         .withCopyFileToContainer(MountableFile.forClasspathResource("postgresql.conf"),
             "/etc/postgresql/postgresql.conf")
@@ -66,6 +55,7 @@ public class CdcInitialSnapshotPostgresSourceDatatypeTest extends AbstractPostgr
         .put("replication_method", replicationMethod)
         .put("is_test", true)
         .put(JdbcUtils.SSL_KEY, false)
+        .put("snapshot_mode", "initial_only")
         .build());
 
     dslContext = DSLContextFactory.create(
@@ -109,21 +99,4 @@ public class CdcInitialSnapshotPostgresSourceDatatypeTest extends AbstractPostgr
     return true;
   }
 
-  @Override
-  protected void addHstoreTest() {
-    addDataTypeTestData(
-        TestDataHolder.builder()
-            .sourceType("hstore")
-            .airbyteType(JsonSchemaType.STRING)
-            .addInsertValues("""
-                '"paperback" => "243","publisher" => "postgresqltutorial.com",
-                "language"  => "English","ISBN-13" => "978-1449370000",
-                "weight"    => "11.2 ounces"'
-                """, null)
-            .addExpectedValues(
-                //
-                "\"weight\"=>\"11.2 ounces\", \"ISBN-13\"=>\"978-1449370000\", \"language\"=>\"English\", \"paperback\"=>\"243\", \"publisher\"=>\"postgresqltutorial.com\"",
-                null)
-            .build());
-  }
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcWalLogsPostgresSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcWalLogsPostgresSourceDatatypeTest.java
@@ -6,7 +6,6 @@ package io.airbyte.integrations.io.airbyte.integration_tests.sources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
-import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.Database;
 import io.airbyte.db.factory.DSLContextFactory;
@@ -20,18 +19,12 @@ import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteStateMessage;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.jooq.SQLDialect;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.MountableFile;
-import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
-import uk.org.webcompere.systemstubs.jupiter.SystemStub;
-import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-@ExtendWith(SystemStubsExtension.class)
 public class CdcWalLogsPostgresSourceDatatypeTest extends AbstractPostgresSourceDatatypeTest {
 
   private static final String SCHEMA_NAME = "test";
@@ -39,9 +32,6 @@ public class CdcWalLogsPostgresSourceDatatypeTest extends AbstractPostgresSource
   private static final String PUBLICATION = "publication";
   private static final int INITIAL_WAITING_SECONDS = 30;
   private JsonNode stateAfterFirstSync;
-
-  @SystemStub
-  private EnvironmentVariables environmentVariables;
 
   @Override
   protected List<AirbyteMessage> runRead(final ConfiguredAirbyteCatalog configuredCatalog) throws Exception {
@@ -67,11 +57,14 @@ public class CdcWalLogsPostgresSourceDatatypeTest extends AbstractPostgresSource
     catalog.getStreams().add(dummyTableWithData);
 
     final List<AirbyteMessage> allMessages = super.runRead(catalog);
+    if (allMessages.size() != 2) {
+      throw new RuntimeException("First sync should only generate 2 records");
+    }
     final List<AirbyteStateMessage> stateAfterFirstBatch = extractStateMessages(allMessages);
     if (stateAfterFirstBatch == null || stateAfterFirstBatch.isEmpty()) {
       throw new RuntimeException("stateAfterFirstBatch should not be null or empty");
     }
-    stateAfterFirstSync = Jsons.jsonNode(Collections.singletonList(stateAfterFirstBatch.get(stateAfterFirstBatch.size() - 1)));
+    stateAfterFirstSync = Jsons.jsonNode(stateAfterFirstBatch);
     if (stateAfterFirstSync == null) {
       throw new RuntimeException("stateAfterFirstSync should not be null");
     }
@@ -85,7 +78,7 @@ public class CdcWalLogsPostgresSourceDatatypeTest extends AbstractPostgresSource
 
   @Override
   protected Database setupDatabase() throws Exception {
-    environmentVariables.set(EnvVariableFeatureFlags.USE_STREAM_CAPABLE_STATE, "true");
+
     container = new PostgreSQLContainer<>("postgres:14-alpine")
         .withCopyFileToContainer(MountableFile.forClasspathResource("postgresql.conf"),
             "/etc/postgresql/postgresql.conf")

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/XminPostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/XminPostgresSourceAcceptanceTest.java
@@ -81,6 +81,22 @@ public class XminPostgresSourceAcceptanceTest extends AbstractPostgresSourceAcce
     }
   }
 
+  private JsonNode getConfig(final String username, final String password, final List<String> schemas) {
+    final JsonNode replicationMethod = Jsons.jsonNode(ImmutableMap.builder()
+        .put("method", "Standard")
+        .build());
+    return Jsons.jsonNode(ImmutableMap.builder()
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
+        .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
+        .put(JdbcUtils.SCHEMAS_KEY, Jsons.jsonNode(schemas))
+        .put(JdbcUtils.USERNAME_KEY, username)
+        .put(JdbcUtils.PASSWORD_KEY, password)
+        .put(JdbcUtils.SSL_KEY, false)
+        .put("replication_method", replicationMethod)
+        .build());
+  }
+
   private JsonNode getXminConfig(final String username, final String password, final List<String> schemas) {
     final JsonNode replicationMethod = Jsons.jsonNode(ImmutableMap.builder()
         .put("method", "Xmin")
@@ -115,6 +131,40 @@ public class XminPostgresSourceAcceptanceTest extends AbstractPostgresSourceAcce
   @Override
   protected boolean supportsPerStream() {
     return true;
+  }
+
+  private ConfiguredAirbyteCatalog getCommonConfigCatalog() {
+    return new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
+        new ConfiguredAirbyteStream()
+            .withSyncMode(SyncMode.INCREMENTAL)
+            .withCursorField(Lists.newArrayList("id"))
+            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+            .withStream(CatalogHelpers.createAirbyteStream(
+                    STREAM_NAME, SCHEMA_NAME,
+                    Field.of("id", JsonSchemaType.NUMBER),
+                    Field.of("name", JsonSchemaType.STRING))
+                .withSupportedSyncModes(Lists.newArrayList(SyncMode.INCREMENTAL))
+                .withSourceDefinedPrimaryKey(List.of(List.of("id")))),
+        new ConfiguredAirbyteStream()
+            .withSyncMode(SyncMode.INCREMENTAL)
+            .withCursorField(Lists.newArrayList("id"))
+            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+            .withStream(CatalogHelpers.createAirbyteStream(
+                    STREAM_NAME2, SCHEMA_NAME,
+                    Field.of("id", JsonSchemaType.NUMBER),
+                    Field.of("name", JsonSchemaType.STRING))
+                .withSupportedSyncModes(Lists.newArrayList(SyncMode.INCREMENTAL))
+                .withSourceDefinedPrimaryKey(List.of(List.of("id")))),
+        new ConfiguredAirbyteStream()
+            .withSyncMode(SyncMode.INCREMENTAL)
+            .withCursorField(Lists.newArrayList("id"))
+            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+            .withStream(CatalogHelpers.createAirbyteStream(
+                    STREAM_NAME_MATERIALIZED_VIEW, SCHEMA_NAME,
+                    Field.of("id", JsonSchemaType.NUMBER),
+                    Field.of("name", JsonSchemaType.STRING))
+                .withSupportedSyncModes(Lists.newArrayList(SyncMode.INCREMENTAL))
+                .withSourceDefinedPrimaryKey(List.of(List.of("id"))))));
   }
 
   private ConfiguredAirbyteCatalog getXminCatalog() {

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
@@ -7,10 +7,8 @@ package io.airbyte.integrations.source.postgres;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_DELETED_AT;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_LSN;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_UPDATED_AT;
-import static io.airbyte.integrations.source.postgres.ctid.CtidStateManager.STATE_TYPE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,7 +18,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Streams;
 import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
@@ -44,27 +41,19 @@ import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.protocol.models.v0.AirbyteCatalog;
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus;
-import io.airbyte.protocol.models.v0.AirbyteGlobalState;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.AirbyteStateMessage;
-import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
 import io.airbyte.protocol.models.v0.AirbyteStream;
-import io.airbyte.protocol.models.v0.AirbyteStreamState;
 import io.airbyte.protocol.models.v0.CatalogHelpers;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
-import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
-import io.airbyte.protocol.models.v0.StreamDescriptor;
 import io.airbyte.protocol.models.v0.SyncMode;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.SQLException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
@@ -242,252 +231,6 @@ public class CdcPostgresSourceTest extends CdcSourceTest {
 
   @Override
   protected void assertExpectedStateMessages(final List<AirbyteStateMessage> stateMessages) {
-    assertEquals(7, stateMessages.size());
-    assertStateTypes(stateMessages, 4);
-  }
-
-  @Override
-  protected void assertExpectedStateMessagesForRecordsProducedDuringAndAfterSync(final List<AirbyteStateMessage> stateAfterFirstBatch) {
-    assertEquals(27, stateAfterFirstBatch.size());
-    assertStateTypes(stateAfterFirstBatch, 24);
-  }
-
-  private void assertStateTypes(final List<AirbyteStateMessage> stateMessages, final int indexTillWhichExpectCtidState) {
-    JsonNode sharedState = null;
-    for (int i = 0; i < stateMessages.size(); i++) {
-      final AirbyteStateMessage stateMessage = stateMessages.get(i);
-      assertEquals(AirbyteStateType.GLOBAL, stateMessage.getType());
-      final AirbyteGlobalState global = stateMessage.getGlobal();
-      assertNotNull(global.getSharedState());
-      if (Objects.isNull(sharedState)) {
-        sharedState = global.getSharedState();
-      } else {
-        assertEquals(sharedState, global.getSharedState());
-      }
-      assertEquals(1, global.getStreamStates().size());
-      final AirbyteStreamState streamState = global.getStreamStates().get(0);
-      if (i <= indexTillWhichExpectCtidState) {
-        assertTrue(streamState.getStreamState().has(STATE_TYPE_KEY));
-        assertEquals("ctid", streamState.getStreamState().get(STATE_TYPE_KEY).asText());
-      } else {
-        assertFalse(streamState.getStreamState().has(STATE_TYPE_KEY));
-      }
-    }
-  }
-
-  @Override
-  protected void assertStateMessagesForNewTableSnapshotTest(final List<AirbyteStateMessage> stateMessages,
-      final AirbyteStateMessage stateMessageEmittedAfterFirstSyncCompletion) {
-    assertEquals(7, stateMessages.size());
-    for (int i = 0; i <= 4; i++) {
-      final AirbyteStateMessage stateMessage = stateMessages.get(i);
-      assertEquals(AirbyteStateMessage.AirbyteStateType.GLOBAL, stateMessage.getType());
-      assertEquals(stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getSharedState(),
-          stateMessage.getGlobal().getSharedState());
-      final Set<StreamDescriptor> streamsInSnapshotState = stateMessage.getGlobal().getStreamStates()
-          .stream()
-          .map(AirbyteStreamState::getStreamDescriptor)
-          .collect(Collectors.toSet());
-      assertEquals(2, streamsInSnapshotState.size());
-      assertTrue(
-          streamsInSnapshotState.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME + "_random").withNamespace(randomTableSchema())));
-      assertTrue(streamsInSnapshotState.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA)));
-
-      stateMessage.getGlobal().getStreamStates().forEach(s -> {
-        final JsonNode streamState = s.getStreamState();
-        if (s.getStreamDescriptor().equals(new StreamDescriptor().withName(MODELS_STREAM_NAME + "_random").withNamespace(randomTableSchema()))) {
-          assertEquals("ctid", streamState.get(STATE_TYPE_KEY).asText());
-        } else if (s.getStreamDescriptor().equals(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA))) {
-          assertFalse(streamState.has(STATE_TYPE_KEY));
-        } else {
-          throw new RuntimeException("Unknown stream");
-        }
-      });
-    }
-
-    final AirbyteStateMessage secondLastSateMessage = stateMessages.get(5);
-    assertEquals(AirbyteStateMessage.AirbyteStateType.GLOBAL, secondLastSateMessage.getType());
-    assertEquals(stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getSharedState(),
-        secondLastSateMessage.getGlobal().getSharedState());
-    final Set<StreamDescriptor> streamsInSnapshotState = secondLastSateMessage.getGlobal().getStreamStates()
-        .stream()
-        .map(AirbyteStreamState::getStreamDescriptor)
-        .collect(Collectors.toSet());
-    assertEquals(2, streamsInSnapshotState.size());
-    assertTrue(
-        streamsInSnapshotState.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME + "_random").withNamespace(randomTableSchema())));
-    assertTrue(streamsInSnapshotState.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA)));
-    secondLastSateMessage.getGlobal().getStreamStates().forEach(s -> {
-      final JsonNode streamState = s.getStreamState();
-      assertFalse(streamState.has(STATE_TYPE_KEY));
-    });
-
-    final AirbyteStateMessage stateMessageEmittedAfterSecondSyncCompletion = stateMessages.get(6);
-    assertEquals(AirbyteStateMessage.AirbyteStateType.GLOBAL, stateMessageEmittedAfterSecondSyncCompletion.getType());
-    assertNotEquals(stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getSharedState(),
-        stateMessageEmittedAfterSecondSyncCompletion.getGlobal().getSharedState());
-    final Set<StreamDescriptor> streamsInSyncCompletionState = stateMessageEmittedAfterSecondSyncCompletion.getGlobal().getStreamStates()
-        .stream()
-        .map(AirbyteStreamState::getStreamDescriptor)
-        .collect(Collectors.toSet());
-    assertEquals(2, streamsInSnapshotState.size());
-    assertTrue(
-        streamsInSyncCompletionState.contains(
-            new StreamDescriptor().withName(MODELS_STREAM_NAME + "_random").withNamespace(randomTableSchema())));
-    assertTrue(streamsInSyncCompletionState.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA)));
-    assertNotNull(stateMessageEmittedAfterSecondSyncCompletion.getData());
-  }
-
-  @Test
-  public void testTwoStreamSync() throws Exception {
-    final ConfiguredAirbyteCatalog configuredCatalog = Jsons.clone(CONFIGURED_CATALOG);
-
-    final List<JsonNode> MODEL_RECORDS_2 = ImmutableList.of(
-        Jsons.jsonNode(ImmutableMap.of(COL_ID, 110, COL_MAKE_ID, 1, COL_MODEL, "Fiesta-2")),
-        Jsons.jsonNode(ImmutableMap.of(COL_ID, 120, COL_MAKE_ID, 1, COL_MODEL, "Focus-2")),
-        Jsons.jsonNode(ImmutableMap.of(COL_ID, 130, COL_MAKE_ID, 1, COL_MODEL, "Ranger-2")),
-        Jsons.jsonNode(ImmutableMap.of(COL_ID, 140, COL_MAKE_ID, 2, COL_MODEL, "GLA-2")),
-        Jsons.jsonNode(ImmutableMap.of(COL_ID, 150, COL_MAKE_ID, 2, COL_MODEL, "A 220-2")),
-        Jsons.jsonNode(ImmutableMap.of(COL_ID, 160, COL_MAKE_ID, 2, COL_MODEL, "E 350-2")));
-
-    createTable(MODELS_SCHEMA, MODELS_STREAM_NAME + "_2",
-        columnClause(ImmutableMap.of(COL_ID, "INTEGER", COL_MAKE_ID, "INTEGER", COL_MODEL, "VARCHAR(200)"), Optional.of(COL_ID)));
-
-    for (final JsonNode recordJson : MODEL_RECORDS_2) {
-      writeRecords(recordJson, MODELS_SCHEMA, MODELS_STREAM_NAME + "_2", COL_ID,
-          COL_MAKE_ID, COL_MODEL);
-    }
-
-    final ConfiguredAirbyteStream airbyteStream = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(
-                MODELS_STREAM_NAME + "_2",
-                MODELS_SCHEMA,
-                Field.of(COL_ID, JsonSchemaType.INTEGER),
-                Field.of(COL_MAKE_ID, JsonSchemaType.INTEGER),
-                Field.of(COL_MODEL, JsonSchemaType.STRING))
-            .withSupportedSyncModes(
-                Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
-            .withSourceDefinedPrimaryKey(List.of(List.of(COL_ID))));
-    airbyteStream.setSyncMode(SyncMode.INCREMENTAL);
-
-    final List<ConfiguredAirbyteStream> streams = configuredCatalog.getStreams();
-    streams.add(airbyteStream);
-    configuredCatalog.withStreams(streams);
-
-    final AutoCloseableIterator<AirbyteMessage> read1 = getSource()
-        .read(getConfig(), configuredCatalog, null);
-    final List<AirbyteMessage> actualRecords1 = AutoCloseableIterators.toListAndClose(read1);
-
-    final Set<AirbyteRecordMessage> recordMessages1 = extractRecordMessages(actualRecords1);
-    final List<AirbyteStateMessage> stateMessages1 = extractStateMessages(actualRecords1);
-    assertEquals(13, stateMessages1.size());
-    JsonNode sharedState = null;
-    StreamDescriptor firstStreamInState = null;
-    for (int i = 0; i < stateMessages1.size(); i++) {
-      final AirbyteStateMessage stateMessage = stateMessages1.get(i);
-      assertEquals(AirbyteStateType.GLOBAL, stateMessage.getType());
-      final AirbyteGlobalState global = stateMessage.getGlobal();
-      assertNotNull(global.getSharedState());
-      if (Objects.isNull(sharedState)) {
-        sharedState = global.getSharedState();
-      } else {
-        assertEquals(sharedState, global.getSharedState());
-      }
-
-      if (Objects.isNull(firstStreamInState)) {
-        assertEquals(1, global.getStreamStates().size());
-        firstStreamInState = global.getStreamStates().get(0).getStreamDescriptor();
-      }
-
-      if (i <= 4) {
-        // First 4 state messages are ctid state
-        assertEquals(1, global.getStreamStates().size());
-        final AirbyteStreamState streamState = global.getStreamStates().get(0);
-        assertTrue(streamState.getStreamState().has(STATE_TYPE_KEY));
-        assertEquals("ctid", streamState.getStreamState().get(STATE_TYPE_KEY).asText());
-      } else if (i == 5) {
-        // 5th state message is the final state message emitted for the stream
-        assertEquals(1, global.getStreamStates().size());
-        final AirbyteStreamState streamState = global.getStreamStates().get(0);
-        assertFalse(streamState.getStreamState().has(STATE_TYPE_KEY));
-      } else if (i <= 10) {
-        // 6th to 10th is the ctid state message for the 2nd stream but final state message for 1st stream
-        assertEquals(2, global.getStreamStates().size());
-        final StreamDescriptor finalFirstStreamInState = firstStreamInState;
-        global.getStreamStates().forEach(c -> {
-          if (c.getStreamDescriptor().equals(finalFirstStreamInState)) {
-            assertFalse(c.getStreamState().has(STATE_TYPE_KEY));
-          } else {
-            assertTrue(c.getStreamState().has(STATE_TYPE_KEY));
-            assertEquals("ctid", c.getStreamState().get(STATE_TYPE_KEY).asText());
-          }
-        });
-      } else {
-        // last 2 state messages don't contain ctid info cause ctid sync should be complete
-        assertEquals(2, global.getStreamStates().size());
-        global.getStreamStates().forEach(c -> assertFalse(c.getStreamState().has(STATE_TYPE_KEY)));
-      }
-    }
-
-    final Set<String> names = new HashSet<>(STREAM_NAMES);
-    names.add(MODELS_STREAM_NAME + "_2");
-    assertExpectedRecords(Streams.concat(MODEL_RECORDS_2.stream(), MODEL_RECORDS.stream())
-            .collect(Collectors.toSet()),
-        recordMessages1,
-        names,
-        names,
-        MODELS_SCHEMA);
-
-    assertEquals(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA), firstStreamInState);
-
-    // Triggering a sync with a ctid state for 1 stream and complete state for other stream
-    final AutoCloseableIterator<AirbyteMessage> read2 = getSource()
-        .read(getConfig(), configuredCatalog, Jsons.jsonNode(Collections.singletonList(stateMessages1.get(6))));
-    final List<AirbyteMessage> actualRecords2 = AutoCloseableIterators.toListAndClose(read2);
-
-    final List<AirbyteStateMessage> stateMessages2 = extractStateMessages(actualRecords2);
-
-    assertEquals(6, stateMessages2.size());
-    for (int i = 0; i < stateMessages2.size(); i++) {
-      final AirbyteStateMessage stateMessage = stateMessages2.get(i);
-      assertEquals(AirbyteStateType.GLOBAL, stateMessage.getType());
-      final AirbyteGlobalState global = stateMessage.getGlobal();
-      assertNotNull(global.getSharedState());
-      assertEquals(2, global.getStreamStates().size());
-
-      if (i <= 3) {
-        final StreamDescriptor finalFirstStreamInState = firstStreamInState;
-        global.getStreamStates().forEach(c -> {
-          // First 4 state messages are ctid state for the stream that didn't complete ctid sync the first time
-          if (c.getStreamDescriptor().equals(finalFirstStreamInState)) {
-            assertFalse(c.getStreamState().has(STATE_TYPE_KEY));
-          } else {
-            assertTrue(c.getStreamState().has(STATE_TYPE_KEY));
-            assertEquals("ctid", c.getStreamState().get(STATE_TYPE_KEY).asText());
-          }
-        });
-      } else {
-        // last 2 state messages don't contain ctid info cause ctid sync should be complete
-        global.getStreamStates().forEach(c -> assertFalse(c.getStreamState().has(STATE_TYPE_KEY)));
-      }
-    }
-
-    final Set<AirbyteRecordMessage> recordMessages2 = extractRecordMessages(actualRecords2);
-    assertEquals(5, recordMessages2.size());
-    assertExpectedRecords(new HashSet<>(MODEL_RECORDS_2.subList(1, MODEL_RECORDS_2.size())),
-        recordMessages2,
-        names,
-        names,
-        MODELS_SCHEMA);
-  }
-
-  @Override
-  protected void assertExpectedStateMessagesForNoData(final List<AirbyteStateMessage> stateMessages) {
-    assertEquals(2, stateMessages.size());
-  }
-
-  @Override
-  protected void assertExpectedStateMessagesFromIncrementalSync(final List<AirbyteStateMessage> stateMessages) {
     assertEquals(1, stateMessages.size());
     assertNotNull(stateMessages.get(0).getData());
   }
@@ -726,8 +469,7 @@ public class CdcPostgresSourceTest extends CdcSourceTest {
   }
 
   protected void assertStateForSyncShouldHandlePurgedLogsGracefully(final List<AirbyteStateMessage> stateMessages) {
-    assertEquals(28, stateMessages.size());
-    assertStateTypes(stateMessages, 25);
+    assertExpectedStateMessages(stateMessages);
   }
 
   @Test
@@ -849,11 +591,11 @@ public class CdcPostgresSourceTest extends CdcSourceTest {
   protected void assertLsnPositionForSyncShouldIncrementLSN(final Long lsnPosition1,
       final Long lsnPosition2, final int syncNumber) {
     if (syncNumber == 1) {
-      assertEquals(1, lsnPosition2.compareTo(lsnPosition1));
+      assertEquals(lsnPosition1, lsnPosition2);
     } else if (syncNumber == 2) {
-      assertEquals(0, lsnPosition2.compareTo(lsnPosition1));
+      assertEquals(1, lsnPosition2.compareTo(lsnPosition1));
     } else {
-      throw new RuntimeException("Unknown sync number " + syncNumber);
+      throw new RuntimeException("unknown sync number " + syncNumber);
     }
   }
 

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CtidEnabledCdcPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CtidEnabledCdcPostgresSourceTest.java
@@ -1,0 +1,320 @@
+package io.airbyte.integrations.source.postgres;
+
+import static io.airbyte.integrations.source.postgres.ctid.CtidFeatureFlags.CDC_VIA_CTID;
+import static io.airbyte.integrations.source.postgres.ctid.CtidStateManager.STATE_TYPE_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.util.AutoCloseableIterator;
+import io.airbyte.commons.util.AutoCloseableIterators;
+import io.airbyte.protocol.models.Field;
+import io.airbyte.protocol.models.JsonSchemaType;
+import io.airbyte.protocol.models.v0.AirbyteGlobalState;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
+import io.airbyte.protocol.models.v0.AirbyteStreamState;
+import io.airbyte.protocol.models.v0.CatalogHelpers;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import io.airbyte.protocol.models.v0.SyncMode;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class CtidEnabledCdcPostgresSourceTest extends CdcPostgresSourceTest {
+
+  @Override
+  protected void assertStateForSyncShouldHandlePurgedLogsGracefully(final List<AirbyteStateMessage> stateMessages) {
+    assertEquals(28, stateMessages.size());
+    assertStateTypes(stateMessages, 25);
+  }
+
+  @Override
+  protected void assertLsnPositionForSyncShouldIncrementLSN(final Long lsnPosition1,
+      final Long lsnPosition2, final int syncNumber) {
+    if (syncNumber == 1) {
+      assertEquals(1, lsnPosition2.compareTo(lsnPosition1));
+    } else if (syncNumber == 2) {
+      assertEquals(0, lsnPosition2.compareTo(lsnPosition1));
+    } else {
+      throw new RuntimeException("Unknown sync number " + syncNumber);
+    }
+  }
+
+  @Override
+  protected void assertExpectedStateMessages(final List<AirbyteStateMessage> stateMessages) {
+    assertEquals(7, stateMessages.size());
+    assertStateTypes(stateMessages, 4);
+  }
+
+  @Override
+  protected JsonNode getConfig() {
+    JsonNode config = super.getConfig();
+    ((ObjectNode) config).put(CDC_VIA_CTID, true);
+    return config;
+  }
+
+  @Override
+  protected void assertExpectedStateMessagesFromIncrementalSync(final List<AirbyteStateMessage> stateMessages) {
+    super.assertExpectedStateMessages(stateMessages);
+  }
+
+  @Override
+  protected void assertExpectedStateMessagesForRecordsProducedDuringAndAfterSync(final List<AirbyteStateMessage> stateAfterFirstBatch) {
+    assertEquals(27, stateAfterFirstBatch.size());
+    assertStateTypes(stateAfterFirstBatch, 24);
+  }
+
+  @Override
+  protected void assertExpectedStateMessagesForNoData(final List<AirbyteStateMessage> stateMessages) {
+    assertEquals(2, stateMessages.size());
+  }
+
+  private void assertStateTypes(final List<AirbyteStateMessage> stateMessages, final int indexTillWhichExpectCtidState) {
+    JsonNode sharedState = null;
+    for (int i = 0; i < stateMessages.size(); i++) {
+      final AirbyteStateMessage stateMessage = stateMessages.get(i);
+      assertEquals(AirbyteStateType.GLOBAL, stateMessage.getType());
+      final AirbyteGlobalState global = stateMessage.getGlobal();
+      assertNotNull(global.getSharedState());
+      if (Objects.isNull(sharedState)) {
+        sharedState = global.getSharedState();
+      } else {
+        assertEquals(sharedState, global.getSharedState());
+      }
+      assertEquals(1, global.getStreamStates().size());
+      final AirbyteStreamState streamState = global.getStreamStates().get(0);
+      if (i <= indexTillWhichExpectCtidState) {
+        assertTrue(streamState.getStreamState().has(STATE_TYPE_KEY));
+        assertEquals("ctid", streamState.getStreamState().get(STATE_TYPE_KEY).asText());
+      } else {
+        assertFalse(streamState.getStreamState().has(STATE_TYPE_KEY));
+      }
+    }
+  }
+
+  @Override
+  protected void assertStateMessagesForNewTableSnapshotTest(final List<AirbyteStateMessage> stateMessages,
+      final AirbyteStateMessage stateMessageEmittedAfterFirstSyncCompletion) {
+    assertEquals(7, stateMessages.size());
+    for (int i = 0; i <= 4; i++) {
+      final AirbyteStateMessage stateMessage = stateMessages.get(i);
+      assertEquals(AirbyteStateMessage.AirbyteStateType.GLOBAL, stateMessage.getType());
+      assertEquals(stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getSharedState(),
+          stateMessage.getGlobal().getSharedState());
+      final Set<StreamDescriptor> streamsInSnapshotState = stateMessage.getGlobal().getStreamStates()
+          .stream()
+          .map(AirbyteStreamState::getStreamDescriptor)
+          .collect(Collectors.toSet());
+      assertEquals(2, streamsInSnapshotState.size());
+      assertTrue(
+          streamsInSnapshotState.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME + "_random").withNamespace(randomTableSchema())));
+      assertTrue(streamsInSnapshotState.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA)));
+
+      stateMessage.getGlobal().getStreamStates().forEach(s -> {
+        final JsonNode streamState = s.getStreamState();
+        if (s.getStreamDescriptor().equals(new StreamDescriptor().withName(MODELS_STREAM_NAME + "_random").withNamespace(randomTableSchema()))) {
+          assertEquals("ctid", streamState.get(STATE_TYPE_KEY).asText());
+        } else if (s.getStreamDescriptor().equals(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA))) {
+          assertFalse(streamState.has(STATE_TYPE_KEY));
+        } else {
+          throw new RuntimeException("Unknown stream");
+        }
+      });
+    }
+
+    final AirbyteStateMessage secondLastSateMessage = stateMessages.get(5);
+    assertEquals(AirbyteStateMessage.AirbyteStateType.GLOBAL, secondLastSateMessage.getType());
+    assertEquals(stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getSharedState(),
+        secondLastSateMessage.getGlobal().getSharedState());
+    final Set<StreamDescriptor> streamsInSnapshotState = secondLastSateMessage.getGlobal().getStreamStates()
+        .stream()
+        .map(AirbyteStreamState::getStreamDescriptor)
+        .collect(Collectors.toSet());
+    assertEquals(2, streamsInSnapshotState.size());
+    assertTrue(
+        streamsInSnapshotState.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME + "_random").withNamespace(randomTableSchema())));
+    assertTrue(streamsInSnapshotState.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA)));
+    secondLastSateMessage.getGlobal().getStreamStates().forEach(s -> {
+      final JsonNode streamState = s.getStreamState();
+      assertFalse(streamState.has(STATE_TYPE_KEY));
+    });
+
+    final AirbyteStateMessage stateMessageEmittedAfterSecondSyncCompletion = stateMessages.get(6);
+    assertEquals(AirbyteStateMessage.AirbyteStateType.GLOBAL, stateMessageEmittedAfterSecondSyncCompletion.getType());
+    assertNotEquals(stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getSharedState(),
+        stateMessageEmittedAfterSecondSyncCompletion.getGlobal().getSharedState());
+    final Set<StreamDescriptor> streamsInSyncCompletionState = stateMessageEmittedAfterSecondSyncCompletion.getGlobal().getStreamStates()
+        .stream()
+        .map(AirbyteStreamState::getStreamDescriptor)
+        .collect(Collectors.toSet());
+    assertEquals(2, streamsInSnapshotState.size());
+    assertTrue(
+        streamsInSyncCompletionState.contains(
+            new StreamDescriptor().withName(MODELS_STREAM_NAME + "_random").withNamespace(randomTableSchema())));
+    assertTrue(streamsInSyncCompletionState.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA)));
+    assertNotNull(stateMessageEmittedAfterSecondSyncCompletion.getData());
+  }
+
+  @Test
+  public void testTwoStreamSync() throws Exception {
+    final ConfiguredAirbyteCatalog configuredCatalog = Jsons.clone(CONFIGURED_CATALOG);
+
+    final List<JsonNode> MODEL_RECORDS_2 = ImmutableList.of(
+        Jsons.jsonNode(ImmutableMap.of(COL_ID, 110, COL_MAKE_ID, 1, COL_MODEL, "Fiesta-2")),
+        Jsons.jsonNode(ImmutableMap.of(COL_ID, 120, COL_MAKE_ID, 1, COL_MODEL, "Focus-2")),
+        Jsons.jsonNode(ImmutableMap.of(COL_ID, 130, COL_MAKE_ID, 1, COL_MODEL, "Ranger-2")),
+        Jsons.jsonNode(ImmutableMap.of(COL_ID, 140, COL_MAKE_ID, 2, COL_MODEL, "GLA-2")),
+        Jsons.jsonNode(ImmutableMap.of(COL_ID, 150, COL_MAKE_ID, 2, COL_MODEL, "A 220-2")),
+        Jsons.jsonNode(ImmutableMap.of(COL_ID, 160, COL_MAKE_ID, 2, COL_MODEL, "E 350-2")));
+
+    createTable(MODELS_SCHEMA, MODELS_STREAM_NAME + "_2",
+        columnClause(ImmutableMap.of(COL_ID, "INTEGER", COL_MAKE_ID, "INTEGER", COL_MODEL, "VARCHAR(200)"), Optional.of(COL_ID)));
+
+    for (final JsonNode recordJson : MODEL_RECORDS_2) {
+      writeRecords(recordJson, MODELS_SCHEMA, MODELS_STREAM_NAME + "_2", COL_ID,
+          COL_MAKE_ID, COL_MODEL);
+    }
+
+    final ConfiguredAirbyteStream airbyteStream = new ConfiguredAirbyteStream()
+        .withStream(CatalogHelpers.createAirbyteStream(
+                MODELS_STREAM_NAME + "_2",
+                MODELS_SCHEMA,
+                Field.of(COL_ID, JsonSchemaType.INTEGER),
+                Field.of(COL_MAKE_ID, JsonSchemaType.INTEGER),
+                Field.of(COL_MODEL, JsonSchemaType.STRING))
+            .withSupportedSyncModes(
+                Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+            .withSourceDefinedPrimaryKey(List.of(List.of(COL_ID))));
+    airbyteStream.setSyncMode(SyncMode.INCREMENTAL);
+
+    final List<ConfiguredAirbyteStream> streams = configuredCatalog.getStreams();
+    streams.add(airbyteStream);
+    configuredCatalog.withStreams(streams);
+
+    final AutoCloseableIterator<AirbyteMessage> read1 = getSource()
+        .read(getConfig(), configuredCatalog, null);
+    final List<AirbyteMessage> actualRecords1 = AutoCloseableIterators.toListAndClose(read1);
+
+    final Set<AirbyteRecordMessage> recordMessages1 = extractRecordMessages(actualRecords1);
+    final List<AirbyteStateMessage> stateMessages1 = extractStateMessages(actualRecords1);
+    assertEquals(13, stateMessages1.size());
+    JsonNode sharedState = null;
+    StreamDescriptor firstStreamInState = null;
+    for (int i = 0; i < stateMessages1.size(); i++) {
+      final AirbyteStateMessage stateMessage = stateMessages1.get(i);
+      assertEquals(AirbyteStateType.GLOBAL, stateMessage.getType());
+      final AirbyteGlobalState global = stateMessage.getGlobal();
+      assertNotNull(global.getSharedState());
+      if (Objects.isNull(sharedState)) {
+        sharedState = global.getSharedState();
+      } else {
+        assertEquals(sharedState, global.getSharedState());
+      }
+
+      if (Objects.isNull(firstStreamInState)) {
+        assertEquals(1, global.getStreamStates().size());
+        firstStreamInState = global.getStreamStates().get(0).getStreamDescriptor();
+      }
+
+      if (i <= 4) {
+        // First 4 state messages are ctid state
+        assertEquals(1, global.getStreamStates().size());
+        final AirbyteStreamState streamState = global.getStreamStates().get(0);
+        assertTrue(streamState.getStreamState().has(STATE_TYPE_KEY));
+        assertEquals("ctid", streamState.getStreamState().get(STATE_TYPE_KEY).asText());
+      } else if (i == 5) {
+        // 5th state message is the final state message emitted for the stream
+        assertEquals(1, global.getStreamStates().size());
+        final AirbyteStreamState streamState = global.getStreamStates().get(0);
+        assertFalse(streamState.getStreamState().has(STATE_TYPE_KEY));
+      } else if (i <= 10) {
+        // 6th to 10th is the ctid state message for the 2nd stream but final state message for 1st stream
+        assertEquals(2, global.getStreamStates().size());
+        final StreamDescriptor finalFirstStreamInState = firstStreamInState;
+        global.getStreamStates().forEach(c -> {
+          if (c.getStreamDescriptor().equals(finalFirstStreamInState)) {
+            assertFalse(c.getStreamState().has(STATE_TYPE_KEY));
+          } else {
+            assertTrue(c.getStreamState().has(STATE_TYPE_KEY));
+            assertEquals("ctid", c.getStreamState().get(STATE_TYPE_KEY).asText());
+          }
+        });
+      } else {
+        // last 2 state messages don't contain ctid info cause ctid sync should be complete
+        assertEquals(2, global.getStreamStates().size());
+        global.getStreamStates().forEach(c -> assertFalse(c.getStreamState().has(STATE_TYPE_KEY)));
+      }
+    }
+
+    final Set<String> names = new HashSet<>(STREAM_NAMES);
+    names.add(MODELS_STREAM_NAME + "_2");
+    assertExpectedRecords(Streams.concat(MODEL_RECORDS_2.stream(), MODEL_RECORDS.stream())
+            .collect(Collectors.toSet()),
+        recordMessages1,
+        names,
+        names,
+        MODELS_SCHEMA);
+
+    assertEquals(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA), firstStreamInState);
+
+    // Triggering a sync with a ctid state for 1 stream and complete state for other stream
+    final AutoCloseableIterator<AirbyteMessage> read2 = getSource()
+        .read(getConfig(), configuredCatalog, Jsons.jsonNode(Collections.singletonList(stateMessages1.get(6))));
+    final List<AirbyteMessage> actualRecords2 = AutoCloseableIterators.toListAndClose(read2);
+
+    final List<AirbyteStateMessage> stateMessages2 = extractStateMessages(actualRecords2);
+
+    assertEquals(6, stateMessages2.size());
+    for (int i = 0; i < stateMessages2.size(); i++) {
+      final AirbyteStateMessage stateMessage = stateMessages2.get(i);
+      assertEquals(AirbyteStateType.GLOBAL, stateMessage.getType());
+      final AirbyteGlobalState global = stateMessage.getGlobal();
+      assertNotNull(global.getSharedState());
+      assertEquals(2, global.getStreamStates().size());
+
+      if (i <= 3) {
+        final StreamDescriptor finalFirstStreamInState = firstStreamInState;
+        global.getStreamStates().forEach(c -> {
+          // First 4 state messages are ctid state for the stream that didn't complete ctid sync the first time
+          if (c.getStreamDescriptor().equals(finalFirstStreamInState)) {
+            assertFalse(c.getStreamState().has(STATE_TYPE_KEY));
+          } else {
+            assertTrue(c.getStreamState().has(STATE_TYPE_KEY));
+            assertEquals("ctid", c.getStreamState().get(STATE_TYPE_KEY).asText());
+          }
+        });
+      } else {
+        // last 2 state messages don't contain ctid info cause ctid sync should be complete
+        global.getStreamStates().forEach(c -> assertFalse(c.getStreamState().has(STATE_TYPE_KEY)));
+      }
+    }
+
+    final Set<AirbyteRecordMessage> recordMessages2 = extractRecordMessages(actualRecords2);
+    assertEquals(5, recordMessages2.size());
+    assertExpectedRecords(new HashSet<>(MODEL_RECORDS_2.subList(1, MODEL_RECORDS_2.size())),
+        recordMessages2,
+        names,
+        names,
+        MODELS_SCHEMA);
+  }
+
+}


### PR DESCRIPTION
This reverts commit 886ab6b09b95ec64ac24d5a0688ab08c931bd938.

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
