### PR TITLE
Source Twitter : add all available fields

### DIFF
--- a/airbyte-integrations/connectors/source-twitter/source_twitter/manifest.yaml
+++ b/airbyte-integrations/connectors/source-twitter/source_twitter/manifest.yaml
@@ -13,7 +13,7 @@ definitions:
       api_token: "{{ config.api_key }}"
     request_parameters:
       query: "{{ config['query'] }}"
-      tweet.fields: "author_id,conversation_id,created_at,in_reply_to_user_id,lang"
+      tweet.fields: "attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,in_reply_to_user_id,lang,possibly_sensitive,referenced_tweets,reply_settings,source,withheld"
   retriever:
     record_selector:
       $ref: "#/definitions/selector"

--- a/airbyte-integrations/connectors/source-twitter/source_twitter/schemas/tweets.json
+++ b/airbyte-integrations/connectors/source-twitter/source_twitter/schemas/tweets.json
@@ -2,33 +2,63 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "edit_history_tweet_ids": {
-      "type": ["null", "array"],
-      "items": {
-        "type": "string"
-      }
+    "attachments": {
+      "type": ["null", "object"]
     },
-    "id": {
+    "author_id": {
       "type": ["null", "string"]
     },
-    "text": {
+    "context_annotations": {
+      "type": ["null", "object"]
+    },
+    "conversation_id": {
       "type": ["null", "string"]
     },
     "created_at": {
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "lang": {
+    "edit_controls": {
+      "type": ["null", "object"]
+    },
+    "edit_history_tweet_ids": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "entities": {
+      "type": ["null", "object"]
+    },
+    "geo": {
       "type": ["null", "string"]
     },
-    "author_id": {
-      "type": ["null", "string"]
-    },
-    "conversation_id": {
+    "id": {
       "type": ["null", "string"]
     },
     "in_reply_to_user_id": {
       "type": ["null", "string"]
+    },
+    "lang": {
+      "type": ["null", "string"]
+    },
+    "possibly_sensitive": {
+      "type": ["null", "string"]
+    },
+    "referenced_tweets": {
+      "type": ["null", "array"]
+    },
+    "reply_settings": {
+      "type": ["null", "string"]
+    },
+    "source": {
+      "type": ["null", "string"]
+    },
+    "text": {
+      "type": ["null", "string"]
+    },
+    "withheld": {
+      "type": ["null", "object"]
     }
   }
 }

--- a/docs/integrations/sources/twitter.md
+++ b/docs/integrations/sources/twitter.md
@@ -38,6 +38,7 @@ Rate limiting is mentioned in the API [documentation](https://developer.twitter.
 
 | Version | Date       | Pull Request                                             | Subject                                           |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------|
+| 0.1.3   | 2023-07-26 | [28736](https://github.com/airbytehq/airbyte/pull/28736) | add all available fields                                               |
 | 0.1.2   | 2023-03-06 | [23749](https://github.com/airbytehq/airbyte/pull/23749) | Spec and docs are improved for beta certification |
 | 0.1.1   | 2023-03-03 | [23661](https://github.com/airbytehq/airbyte/pull/23661) | Incremental added for the "tweets" stream         |
 | 0.1.0   | 2022-11-01 | [18883](https://github.com/airbytehq/airbyte/pull/18858) | 🎉 New Source: Twitter                            |


### PR DESCRIPTION
## What
*Retrieve all available fields from the search tweets API 

## How
*In the previous version only mandatory fields (id, text...) were configured in the manifest in this version several fields have been added as entities, attachments, reply_settings.