### PR TITLE
fix: publish strict-encrypt connectors before regular variant

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/publish.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/publish.py
@@ -307,8 +307,6 @@ def reorder_contexts(contexts: List[PublishConnectorContext]) -> List[PublishCon
     Non strict-encrypt variant reference the strict-encrypt variant in their metadata file for cloud.
     So if we publish the non strict-encrypt variant first, the metadata upload will fail if the strict-encrypt variant is not published yet.
     As strict-encrypt variant are often modified in the same PR as the non strict-encrypt variant, we want to publish them first.
-    This is an hacky approach: as connector names with -strict-encrypt/secure prefix are longer,
-    they will be sorted first with our reverse sort below.
     """
 
-    return sorted(contexts, key=lambda context: context.connector.technical_name, reverse=True)
+    return sorted(contexts, key=lambda context: ("strict-encrypt" in context.connector.technical_name, context.connector.technical_name), reverse=True)

--- a/airbyte-ci/connectors/pipelines/pipelines/publish.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/publish.py
@@ -309,4 +309,8 @@ def reorder_contexts(contexts: List[PublishConnectorContext]) -> List[PublishCon
     As strict-encrypt variant are often modified in the same PR as the non strict-encrypt variant, we want to publish them first.
     """
 
-    return sorted(contexts, key=lambda context: ("strict-encrypt" in context.connector.technical_name, context.connector.technical_name), reverse=True)
+    def has_secure_variant(context: PublishConnectorContext) -> bool:
+        SECURE_VARIANT_KEYS = ["secure", "strict-encrypt"]
+        return any(key in context.connector.technical_name for key in SECURE_VARIANT_KEYS)
+
+    return sorted(contexts, key=lambda context: (has_secure_variant(context), context.connector.technical_name), reverse=True)


### PR DESCRIPTION
## What

We had a special case come up with mongodb which didn't work with our reverse alphabetic sorting since the regular connector is called `source-mongodb-v2` and the secure variant is `source-mongodb-strict-encrypt`.

This fixes the issue by explicitly checking if `strict-encrypt` is in the name.

## How

Use python tuple sorting to check for strict encrypt. This works since tuples are sorted by each element, and when sorting booleans, `False` comes before `True`. Note that we're still reversing the list, so in practice `True` comes before `False`.
