### PR TITLE
[Source-Mysql] Set default cursor value for cdc mode

### DIFF
--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
@@ -43,6 +43,7 @@ public abstract class SourceAcceptanceTest extends AbstractSourceConnectorTest {
   public static final String CDC_DELETED_AT = "_ab_cdc_deleted_at";
   public static final String CDC_LOG_FILE = "_ab_cdc_log_file";
   public static final String CDC_LOG_POS = "_ab_cdc_log_pos";
+  public static final String CDC_DEFAULT_CURSOR = "_ab_cdc_cursor";
   public static final String CDC_EVENT_SERIAL_NO = "_ab_cdc_event_serial_no";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SourceAcceptanceTest.class);
@@ -359,6 +360,7 @@ public abstract class SourceAcceptanceTest extends AbstractSourceConnectorTest {
     ((ObjectNode) clone.getData()).remove(CDC_UPDATED_AT);
     ((ObjectNode) clone.getData()).remove(CDC_DELETED_AT);
     ((ObjectNode) clone.getData()).remove(CDC_EVENT_SERIAL_NO);
+    ((ObjectNode) clone.getData()).remove(CDC_DEFAULT_CURSOR);
     return clone;
   }
 

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/Dockerfile
@@ -24,6 +24,6 @@ ENV APPLICATION source-mysql-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=2.1.2
+LABEL io.airbyte.version=3.0.0
 
 LABEL io.airbyte.name=airbyte/source-mysql-strict-encrypt

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 2.1.2
+  dockerImageTag: 3.0.0
   dockerRepository: airbyte/source-mysql-strict-encrypt
   githubIssueLabel: source-mysql
   icon: mysql.svg

--- a/airbyte-integrations/connectors/source-mysql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql/Dockerfile
@@ -24,6 +24,6 @@ ENV APPLICATION source-mysql
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=2.1.2
+LABEL io.airbyte.version=3.0.0
 
 LABEL io.airbyte.name=airbyte/source-mysql

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -23,6 +23,11 @@ data:
   tags:
     - language:java
     - language:python
+  releases:
+    breakingChanges:
+      3.0.0:
+        message: "Add default cursor for cdc"
+        upgradeDeadline: "2023-08-17"
   ab_internal:
     sl: 300
     ql: 300

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 2.1.2
+  dockerImageTag: 3.0.0
   dockerRepository: airbyte/source-mysql
   githubIssueLabel: source-mysql
   icon: mysql.svg

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class MySqlCdcConnectorMetadataInjector implements CdcMetadataInjector<MysqlDebeziumStateAttributes> {
 
   private final long emittedAtNano;
+  // This now makes this class stateful. Please make sure to use the same instance within a sync
   private final AtomicLong recordCounter = new AtomicLong(1);
   private static final long ONE_HUNDRED_MILLION = 100_000_000;
 

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
@@ -6,6 +6,7 @@ package io.airbyte.integrations.source.mysql;
 
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_DELETED_AT;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_UPDATED_AT;
+import static io.airbyte.integrations.source.mysql.MySqlSource.CDC_DEFAULT_CURSOR;
 import static io.airbyte.integrations.source.mysql.MySqlSource.CDC_LOG_FILE;
 import static io.airbyte.integrations.source.mysql.MySqlSource.CDC_LOG_POS;
 
@@ -13,13 +14,23 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.integrations.debezium.CdcMetadataInjector;
 import io.airbyte.integrations.debezium.internals.mysql.MySqlDebeziumStateUtil.MysqlDebeziumStateAttributes;
+import java.time.Instant;
 
 public class MySqlCdcConnectorMetadataInjector implements CdcMetadataInjector<MysqlDebeziumStateAttributes> {
 
+  final Instant emittedAt;
+
+  public MySqlCdcConnectorMetadataInjector(final Instant emittedAt) {
+    this.emittedAt = emittedAt;
+  }
+
   @Override
   public void addMetaData(final ObjectNode event, final JsonNode source) {
+    final String cdcDefaultCursor =
+        String.format("%s_%s_%s", emittedAt.toString(), source.get("file").asText(), source.get("pos").asText());
     event.put(CDC_LOG_FILE, source.get("file").asText());
     event.put(CDC_LOG_POS, source.get("pos").asLong());
+    event.put(CDC_DEFAULT_CURSOR, cdcDefaultCursor);
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
@@ -19,13 +19,13 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class MySqlCdcConnectorMetadataInjector implements CdcMetadataInjector<MysqlDebeziumStateAttributes> {
 
-  private final long emittedAtNano;
+  private final long emittedAt;
   // This now makes this class stateful. Please make sure to use the same instance within a sync
   private final AtomicLong recordCounter = new AtomicLong(1);
   private static final long ONE_HUNDRED_MILLION = 100_000_000;
 
   public MySqlCdcConnectorMetadataInjector(final Instant emittedAt) {
-    this.emittedAtNano = emittedAt.getEpochSecond() * ONE_HUNDRED_MILLION;
+    this.emittedAt = emittedAt.getEpochSecond() * ONE_HUNDRED_MILLION;
   }
 
   @Override
@@ -51,7 +51,7 @@ public class MySqlCdcConnectorMetadataInjector implements CdcMetadataInjector<My
   }
 
   private Long getCdcDefaultCursor() {
-    return this.emittedAtNano + recordCounter.getAndIncrement();
+    return this.emittedAt + recordCounter.getAndIncrement();
   }
 
 }

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
@@ -18,7 +18,7 @@ import java.time.Instant;
 
 public class MySqlCdcConnectorMetadataInjector implements CdcMetadataInjector<MysqlDebeziumStateAttributes> {
 
-  final Instant emittedAt;
+  private final Instant emittedAt;
 
   public MySqlCdcConnectorMetadataInjector(final Instant emittedAt) {
     this.emittedAt = emittedAt;

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
@@ -29,10 +29,9 @@ public class MySqlCdcConnectorMetadataInjector implements CdcMetadataInjector<My
 
   @Override
   public void addMetaData(final ObjectNode event, final JsonNode source) {
-    final Long cdcDefaultCursor = this.emittedAtNano + recordCounter.getAndIncrement();
     event.put(CDC_LOG_FILE, source.get("file").asText());
     event.put(CDC_LOG_POS, source.get("pos").asLong());
-    event.put(CDC_DEFAULT_CURSOR, cdcDefaultCursor);
+    event.put(CDC_DEFAULT_CURSOR, getCdcDefaultCursor());
   }
 
   @Override
@@ -42,11 +41,16 @@ public class MySqlCdcConnectorMetadataInjector implements CdcMetadataInjector<My
     record.put(CDC_LOG_FILE, debeziumStateAttributes.binlogFilename());
     record.put(CDC_LOG_POS, debeziumStateAttributes.binlogPosition());
     record.put(CDC_DELETED_AT, (String) null);
+    record.put(CDC_DEFAULT_CURSOR, getCdcDefaultCursor());
   }
 
   @Override
   public String namespace(final JsonNode source) {
     return source.get("db").asText();
+  }
+
+  private Long getCdcDefaultCursor() {
+    return this.emittedAtNano + recordCounter.getAndIncrement();
   }
 
 }

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
@@ -62,7 +62,7 @@ public class MySqlCdcConnectorMetadataInjector implements CdcMetadataInjector<My
   }
 
   private Long getCdcDefaultCursor() {
-    return emittedAtConverted + this.recordCounter.getAndIncrement();
+    return this.emittedAtConverted + this.recordCounter.getAndIncrement();
   }
 
 }

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
@@ -18,19 +18,21 @@ import java.time.Instant;
 
 public class MySqlCdcConnectorMetadataInjector implements CdcMetadataInjector<MysqlDebeziumStateAttributes> {
 
-  private final Instant emittedAt;
+  private final long emittedAtNano;
+  private long recordCounter = 1;
+  private static final long ONE_BILLION = 1_000_000_000;
 
   public MySqlCdcConnectorMetadataInjector(final Instant emittedAt) {
-    this.emittedAt = emittedAt;
+    this.emittedAtNano = emittedAt.getEpochSecond() * ONE_BILLION;
   }
 
   @Override
   public void addMetaData(final ObjectNode event, final JsonNode source) {
-    final String cdcDefaultCursor =
-        String.format("%s_%s_%s", emittedAt.toString(), source.get("file").asText(), source.get("pos").asText());
+    final Long cdcDefaultCursor = this.emittedAtNano + recordCounter;
     event.put(CDC_LOG_FILE, source.get("file").asText());
     event.put(CDC_LOG_POS, source.get("pos").asLong());
     event.put(CDC_DEFAULT_CURSOR, cdcDefaultCursor);
+    recordCounter++;
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -149,7 +149,9 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
    * airbyte [emittedAt(converted to nano seconds)] + [sync wide record counter]
    */
   private static AirbyteStream setDefaultCursorFieldForCdc(final AirbyteStream stream) {
-    stream.setDefaultCursorField(ImmutableList.of(CDC_DEFAULT_CURSOR));
+    if (stream.getSupportedSyncModes().contains(SyncMode.INCREMENTAL)) {
+      stream.setDefaultCursorField(ImmutableList.of(CDC_DEFAULT_CURSOR));
+    }
     return stream;
   }
 
@@ -350,7 +352,7 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
       final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getIncrementalIterators(catalog,
           new MySqlCdcSavedInfoFetcher(cdcState.orElse(null)),
           new MySqlCdcStateHandler(stateManager),
-          new MySqlCdcConnectorMetadataInjector(emittedAt),
+          mySqlCdcConnectorMetadataInjector,
           MySqlCdcProperties.getDebeziumProperties(database),
           emittedAt,
           false);

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -108,7 +108,7 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
   public static final String DRIVER_CLASS = DatabaseDriver.MYSQL.getDriverClassName();
   public static final String CDC_LOG_FILE = "_ab_cdc_log_file";
   public static final String CDC_LOG_POS = "_ab_cdc_log_pos";
-  public static final String CDC_DEFAULT_CURSOR = "_ab_cdc_default_cursor";
+  public static final String CDC_DEFAULT_CURSOR = "_ab_cdc_cursor";
   public static final List<String> SSL_PARAMETERS = List.of(
       "useSSL=true",
       "requireSSL=true");
@@ -146,8 +146,7 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
 
   /*
    * To prepare for Destination v2, cdc streams must have a default cursor field
-   * Cursor format is [emitted_at]_[_ab_cdc_log_file]_[_ab_cdc_log_pos].
-   * The emitted_at timestamp is used as a proxy for a run id allowing the cursor to be sortable
+   * Cursor format: the airbyte [emittedAt(converted to nano seconds)] + [sync wide record counter]
    */
   private static AirbyteStream setDefaultCursorFieldForCdc(final AirbyteStream stream) {
     stream.setDefaultCursorField(ImmutableList.of(CDC_DEFAULT_CURSOR));
@@ -165,7 +164,7 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
     properties.set(CDC_LOG_POS, numberType);
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
-    properties.set(CDC_DEFAULT_CURSOR, stringType);
+    properties.set(CDC_DEFAULT_CURSOR, numberType);
 
     return stream;
   }

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -145,8 +145,8 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
   }
 
   /*
-   * To prepare for Destination v2, cdc streams must have a default cursor field
-   * Cursor format: the airbyte [emittedAt(converted to nano seconds)] + [sync wide record counter]
+   * To prepare for Destination v2, cdc streams must have a default cursor field Cursor format: the
+   * airbyte [emittedAt(converted to nano seconds)] + [sync wide record counter]
    */
   private static AirbyteStream setDefaultCursorFieldForCdc(final AirbyteStream stream) {
     stream.setDefaultCursorField(ImmutableList.of(CDC_DEFAULT_CURSOR));
@@ -159,12 +159,13 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
     final ObjectNode properties = (ObjectNode) jsonSchema.get("properties");
 
     final JsonNode numberType = Jsons.jsonNode(ImmutableMap.of("type", "number"));
+    final JsonNode airbyteIntegerType = Jsons.jsonNode(ImmutableMap.of("type", "number", "airbyte_type", "integer"));
     final JsonNode stringType = Jsons.jsonNode(ImmutableMap.of("type", "string"));
     properties.set(CDC_LOG_FILE, stringType);
     properties.set(CDC_LOG_POS, numberType);
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
-    properties.set(CDC_DEFAULT_CURSOR, numberType);
+    properties.set(CDC_DEFAULT_CURSOR, airbyteIntegerType);
 
     return stream;
   }

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -344,7 +344,7 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
           new AirbyteDebeziumHandler<>(sourceConfig, MySqlCdcTargetPosition.targetPosition(database), true, firstRecordWaitTime, OptionalInt.empty());
 
       final MySqlCdcStateHandler mySqlCdcStateHandler = new MySqlCdcStateHandler(stateManager);
-      final MySqlCdcConnectorMetadataInjector mySqlCdcConnectorMetadataInjector = new MySqlCdcConnectorMetadataInjector(emittedAt);
+      final MySqlCdcConnectorMetadataInjector mySqlCdcConnectorMetadataInjector = MySqlCdcConnectorMetadataInjector.getInstance(emittedAt);
 
       final List<ConfiguredAirbyteStream> streamsToSnapshot = identifyStreamsToSnapshot(catalog, stateManager);
       final Optional<CdcState> cdcState = Optional.ofNullable(stateManager.getCdcStateManager().getCdcState());

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/initialsync/MySqlInitialReadUtil.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/initialsync/MySqlInitialReadUtil.java
@@ -106,18 +106,20 @@ public class MySqlInitialReadUtil {
         || stateManager.getCdcStateManager().getCdcState().getState() == null)) ? new CdcState().withState(initialDebeziumState)
         : stateManager.getCdcStateManager().getCdcState();
 
+    final MySqlCdcConnectorMetadataInjector metadataInjector = new MySqlCdcConnectorMetadataInjector(emittedAt);
+
     // If there are streams to sync via primary key load, build the relevant iterators.
     if (!initialLoadStreams.streamsForInitialLoad().isEmpty()) {
-
       LOGGER.info("Streams to be synced via primary key : {}", initialLoadStreams.streamsForInitialLoad().size());
       LOGGER.info("Streams: {}", prettyPrintConfiguredAirbyteStreamList(initialLoadStreams.streamsForInitialLoad()));
       final MySqlInitialLoadStateManager initialLoadStateManager =
           new MySqlInitialLoadGlobalStateManager(initialLoadStreams, initPairToPrimaryKeyInfoMap(initialLoadStreams, tableNameToTable),
               stateToBeUsed, catalog);
       final MysqlDebeziumStateAttributes stateAttributes = MySqlDebeziumStateUtil.getStateAttributesFromDB(database);
+
       final MySqlInitialLoadSourceOperations sourceOperations =
           new MySqlInitialLoadSourceOperations(
-              Optional.of(new CdcMetadataInjector(emittedAt.toString(), stateAttributes, new MySqlCdcConnectorMetadataInjector(emittedAt))));
+              Optional.of(new CdcMetadataInjector(emittedAt.toString(), stateAttributes, metadataInjector)));
 
       final MySqlInitialLoadHandler initialLoadHandler = new MySqlInitialLoadHandler(sourceConfig, database,
           sourceOperations,
@@ -140,7 +142,7 @@ public class MySqlInitialReadUtil {
     final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getIncrementalIterators(catalog,
         new MySqlCdcSavedInfoFetcher(stateToBeUsed),
         new MySqlCdcStateHandler(stateManager),
-        new MySqlCdcConnectorMetadataInjector(emittedAt),
+        metadataInjector,
         MySqlCdcProperties.getDebeziumProperties(database),
         emittedAt,
         false);

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/initialsync/MySqlInitialReadUtil.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/initialsync/MySqlInitialReadUtil.java
@@ -117,7 +117,7 @@ public class MySqlInitialReadUtil {
       final MysqlDebeziumStateAttributes stateAttributes = MySqlDebeziumStateUtil.getStateAttributesFromDB(database);
       final MySqlInitialLoadSourceOperations sourceOperations =
           new MySqlInitialLoadSourceOperations(
-              Optional.of(new CdcMetadataInjector(emittedAt.toString(), stateAttributes, new MySqlCdcConnectorMetadataInjector())));
+              Optional.of(new CdcMetadataInjector(emittedAt.toString(), stateAttributes, new MySqlCdcConnectorMetadataInjector(emittedAt))));
 
       final MySqlInitialLoadHandler initialLoadHandler = new MySqlInitialLoadHandler(sourceConfig, database,
           sourceOperations,
@@ -140,7 +140,7 @@ public class MySqlInitialReadUtil {
     final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getIncrementalIterators(catalog,
         new MySqlCdcSavedInfoFetcher(stateToBeUsed),
         new MySqlCdcStateHandler(stateManager),
-        new MySqlCdcConnectorMetadataInjector(),
+        new MySqlCdcConnectorMetadataInjector(emittedAt),
         MySqlCdcProperties.getDebeziumProperties(database),
         emittedAt,
         false);

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/initialsync/MySqlInitialReadUtil.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/initialsync/MySqlInitialReadUtil.java
@@ -106,7 +106,7 @@ public class MySqlInitialReadUtil {
         || stateManager.getCdcStateManager().getCdcState().getState() == null)) ? new CdcState().withState(initialDebeziumState)
         : stateManager.getCdcStateManager().getCdcState();
 
-    final MySqlCdcConnectorMetadataInjector metadataInjector = new MySqlCdcConnectorMetadataInjector(emittedAt);
+    final MySqlCdcConnectorMetadataInjector metadataInjector = MySqlCdcConnectorMetadataInjector.getInstance(emittedAt);
 
     // If there are streams to sync via primary key load, build the relevant iterators.
     if (!initialLoadStreams.streamsForInitialLoad().isEmpty()) {

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
@@ -195,7 +195,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     properties.set(CDC_LOG_POS, numberType);
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
-    properties.set(CDC_DEFAULT_CURSOR, stringType);
+    properties.set(CDC_DEFAULT_CURSOR, numberType);
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
@@ -188,14 +188,14 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     final ObjectNode jsonSchema = (ObjectNode) stream.getJsonSchema();
     final ObjectNode properties = (ObjectNode) jsonSchema.get("properties");
 
+    final JsonNode airbyteIntegerType = Jsons.jsonNode(ImmutableMap.of("type", "number", "airbyte_type", "integer"));
     final JsonNode numberType = Jsons.jsonNode(ImmutableMap.of("type", "number"));
-
     final JsonNode stringType = Jsons.jsonNode(ImmutableMap.of("type", "string"));
     properties.set(CDC_LOG_FILE, stringType);
     properties.set(CDC_LOG_POS, numberType);
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
-    properties.set(CDC_DEFAULT_CURSOR, numberType);
+    properties.set(CDC_DEFAULT_CURSOR, airbyteIntegerType);
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
@@ -8,6 +8,7 @@ import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_UPDATED_AT;
 import static io.airbyte.integrations.debezium.internals.mysql.MySqlDebeziumStateUtil.MYSQL_CDC_OFFSET;
 import static io.airbyte.integrations.debezium.internals.mysql.MySqlDebeziumStateUtil.MYSQL_DB_HISTORY;
+import static io.airbyte.integrations.source.mysql.MySqlSource.CDC_DEFAULT_CURSOR;
 import static io.airbyte.integrations.source.mysql.MySqlSource.CDC_LOG_FILE;
 import static io.airbyte.integrations.source.mysql.MySqlSource.CDC_LOG_POS;
 import static io.airbyte.integrations.source.mysql.MySqlSource.DRIVER_CLASS;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.json.Jsons;
@@ -156,6 +158,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     assertNull(data.get(CDC_LOG_POS));
     assertNull(data.get(CDC_UPDATED_AT));
     assertNull(data.get(CDC_DELETED_AT));
+    assertNull(data.get(CDC_DEFAULT_CURSOR));
   }
 
   @Override
@@ -163,6 +166,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     assertNotNull(data.get(CDC_LOG_FILE));
     assertNotNull(data.get(CDC_LOG_POS));
     assertNotNull(data.get(CDC_UPDATED_AT));
+    assertNotNull(data.get(CDC_DEFAULT_CURSOR));
     if (deletedAtNull) {
       assertTrue(data.get(CDC_DELETED_AT).isNull());
     } else {
@@ -176,6 +180,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     data.remove(CDC_LOG_POS);
     data.remove(CDC_UPDATED_AT);
     data.remove(CDC_DELETED_AT);
+    data.remove(CDC_DEFAULT_CURSOR);
   }
 
   @Override
@@ -190,11 +195,12 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     properties.set(CDC_LOG_POS, numberType);
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
+    properties.set(CDC_DEFAULT_CURSOR, stringType);
   }
 
   @Override
   protected void addCdcDefaultCursorField(final AirbyteStream stream) {
-    // Leaving empty until cdc default cursor is implemented for MySQL
+    stream.setDefaultCursorField(ImmutableList.of(CDC_DEFAULT_CURSOR));
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.util.AutoCloseableIterator;
@@ -34,15 +35,21 @@ import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.debezium.CdcSourceTest;
 import io.airbyte.integrations.debezium.internals.mysql.MySqlCdcTargetPosition;
+import io.airbyte.protocol.models.Field;
+import io.airbyte.protocol.models.JsonSchemaType;
+import io.airbyte.protocol.models.v0.AirbyteCatalog;
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus.Status;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.AirbyteStateMessage;
 import io.airbyte.protocol.models.v0.AirbyteStream;
+import io.airbyte.protocol.models.v0.CatalogHelpers;
+import io.airbyte.protocol.models.v0.SyncMode;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.jooq.SQLDialect;
@@ -303,6 +310,48 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
 
   protected void assertStateForSyncShouldHandlePurgedLogsGracefully(final List<AirbyteStateMessage> stateMessages, final int syncNumber) {
     assertExpectedStateMessages(stateMessages);
+  }
+
+  @Override
+  protected AirbyteCatalog expectedCatalogForDiscover() {
+    final AirbyteCatalog expectedCatalog = Jsons.clone(CATALOG);
+
+    createTable(MODELS_SCHEMA, MODELS_STREAM_NAME + "_2",
+                columnClause(ImmutableMap.of(COL_ID, "INTEGER", COL_MAKE_ID, "INTEGER", COL_MODEL, "VARCHAR(200)"), Optional.empty()));
+
+    final List<AirbyteStream> streams = expectedCatalog.getStreams();
+    // stream with PK
+    streams.get(0).setSourceDefinedCursor(true);
+    addCdcMetadataColumns(streams.get(0));
+    addCdcDefaultCursorField(streams.get(0));
+
+    final AirbyteStream streamWithoutPK = CatalogHelpers.createAirbyteStream(
+        MODELS_STREAM_NAME + "_2",
+        MODELS_SCHEMA,
+        Field.of(COL_ID, JsonSchemaType.INTEGER),
+        Field.of(COL_MAKE_ID, JsonSchemaType.INTEGER),
+        Field.of(COL_MODEL, JsonSchemaType.STRING));
+    streamWithoutPK.setSourceDefinedPrimaryKey(Collections.emptyList());
+    streamWithoutPK.setSupportedSyncModes(List.of(SyncMode.FULL_REFRESH));
+    addCdcMetadataColumns(streamWithoutPK);
+
+    final AirbyteStream randomStream = CatalogHelpers.createAirbyteStream(
+            MODELS_STREAM_NAME + "_random",
+            randomTableSchema(),
+            Field.of(COL_ID + "_random", JsonSchemaType.INTEGER),
+            Field.of(COL_MAKE_ID + "_random", JsonSchemaType.INTEGER),
+            Field.of(COL_MODEL + "_random", JsonSchemaType.STRING))
+        .withSourceDefinedCursor(true)
+        .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+        .withSourceDefinedPrimaryKey(List.of(List.of(COL_ID + "_random")));
+
+    addCdcDefaultCursorField(randomStream);
+    addCdcMetadataColumns(randomStream);
+
+    streams.add(streamWithoutPK);
+    streams.add(randomStream);
+    expectedCatalog.withStreams(streams);
+    return expectedCatalog;
   }
 
 }

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -264,6 +264,7 @@ WHERE actor_definition_id ='435bb9a5-7887-4809-aa58-28c27df0d7ad' AND (configura
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                         |
 | :------ | :--------- | :--------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.0.0   | 2023-08-08 | [28756](https://github.com/airbytehq/airbyte/pull/28756)   | Set a default cursor for Cdc mode                                                                                                               |
 | 2.1.2   | 2023-08-08 | [29220](https://github.com/airbytehq/airbyte/pull/29220)   | Add indicator that CDC is the recommended update method                                                                                         |
 | 2.1.1   | 2023-07-31 | [28882](https://github.com/airbytehq/airbyte/pull/28882)   | Improve replication method labels and descriptions                                                                                              |
 | 2.1.0   | 2023-06-26 | [27737](https://github.com/airbytehq/airbyte/pull/27737)   | License Update: Elv2                                                                                                                            |


### PR DESCRIPTION
## What
[27340](https://app.zenhub.com/workspaces/db--dw-source-connectors-6333360e0a41155061efbcbd/issues/gh/airbytehq/airbyte/27340)
To prepare for Destination v2, Cdc-enabled DB sources need to have a pre-defined cursor for normalization to operate properly. 
## How
![image](https://github.com/airbytehq/airbyte/assets/24193788/9cea7632-2743-4934-b63c-47e01b5c84d7)
During the discover phase, `source_defined_cursor` is set to `true`, and a new composite cursor column called `_ab_cdc_cursor` is selected as the predefined cursor. This column is constructed from:

1. Converting the emittedAt timestamp , generated at the [read step](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/AbstractDbSource.java#L143), to epoch seconds.
2. Convert that to nanoseconds.
3. Initialize a threadsafe recordCounter = 1
4. Add the recordCounter to the converted timestamp
5. Increment the counter

The numeric cursor value will be computed for every record and allows for fast comparison in tie-breaking scenarios for records with the same Primary Key.
```
Updated Streamstate
[
    {
      "streamDescriptor": {
        "name": "users",
        "namespace": "1gb"
      },
      "streamState": {
        "stream_name": "users",
        "cursor_field": [
          "_ab_cdc_cursor"
        ],
        "stream_namespace": "1gb"
      }
    }
  ]
```

## Recommended reading order
1. `MySqlSource.java`
6. `MySqlCdcConnectorMetadataInjector.java`
7.  All the test files

## 🚨 User Impact 🚨
New CDC syncs that have refreshed their source schema will see this cursor field be chosen.
This update requires that users do a full reset **OR** drop their SCD tables to ensure that syncs continue operating normally
Customers who reset their data will continue to see old behavior until their source goes through the `discover()` phase again.
