### PR TITLE
🐛 Source Mongo: fix potential npe when collecting stats

### DIFF
--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/mongodb/MongoDatabase.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/mongodb/MongoDatabase.java
@@ -38,7 +38,7 @@ import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MongoDatabase extends AbstractDatabase implements AutoCloseable {
+public class    MongoDatabase extends AbstractDatabase implements AutoCloseable {
 
   public static final String COLLECTION_COUNT_KEY = "collectionCount";
   public static final String COLLECTION_STORAGE_SIZE_KEY = "collectionStorageSize";
@@ -137,12 +137,18 @@ public class MongoDatabase extends AbstractDatabase implements AutoCloseable {
   public Map<String, Object> getCollectionStats(final String collectionName) {
     try {
       final Document collectionStats = getDatabase().runCommand(new BsonDocument("collStats", new BsonString(collectionName)));
-      return Map.of(COLLECTION_COUNT_KEY, collectionStats.get("count"),
-          COLLECTION_STORAGE_SIZE_KEY, collectionStats.get("storageSize"));
-    } catch (final MongoCommandException e) {
-      LOGGER.warn("Unable to retrieve collection statistics", e);
-      return Map.of();
+      final var count = collectionStats.get("count");
+      final var storageSize = collectionStats.get("storageSize");
+
+      if (count != null && storageSize != null) {
+        return Map.of(COLLECTION_COUNT_KEY, collectionStats.get("count"),
+            COLLECTION_STORAGE_SIZE_KEY, collectionStats.get("storageSize"));
+      }
+    } catch (final Exception e) {
+      LOGGER.warn("Unable to retrieve collection statistics - {}", e.getMessage(), e);
     }
+
+    return Map.of();
   }
 
   public String getServerType() {

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/mongodb/MongoDatabase.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/mongodb/MongoDatabase.java
@@ -38,7 +38,7 @@ import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class    MongoDatabase extends AbstractDatabase implements AutoCloseable {
+public class MongoDatabase extends AbstractDatabase implements AutoCloseable {
 
   public static final String COLLECTION_COUNT_KEY = "collectionCount";
   public static final String COLLECTION_STORAGE_SIZE_KEY = "collectionStorageSize";

--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/Dockerfile
@@ -24,5 +24,5 @@ ENV APPLICATION source-mongodb-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.3
+LABEL io.airbyte.version=0.2.4
 LABEL io.airbyte.name=airbyte/source-mongodb-strict-encrypt

--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   dockerRepository: airbyte/source-mongodb-strict-encrypt
   githubIssueLabel: source-mongodb-v2
   icon: mongodb.svg

--- a/airbyte-integrations/connectors/source-mongodb-v2/Dockerfile
+++ b/airbyte-integrations/connectors/source-mongodb-v2/Dockerfile
@@ -24,5 +24,5 @@ ENV APPLICATION source-mongodb-v2
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.4
 LABEL io.airbyte.name=airbyte/source-mongodb-v2

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   dockerRepository: airbyte/source-mongodb-v2
   githubIssueLabel: source-mongodb-v2
   icon: mongodb.svg
@@ -10,7 +10,7 @@ data:
   name: MongoDb
   registries:
     cloud:
-      dockerImageTag: 0.2.3
+      dockerImageTag: 0.2.4
       dockerRepository: airbyte/source-mongodb-strict-encrypt
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io.airbyte.integrations.source.mongodb/MongoDbSource.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io.airbyte.integrations.source.mongodb/MongoDbSource.java
@@ -265,8 +265,7 @@ public class MongoDbSource extends AbstractDbSource<BsonType, MongoDatabase> {
   public void close() {}
 
   private void recordStatistics(final MongoDatabase database, final String collectionName) {
-    final Map<String, Object> data = new HashMap<>();
-    data.putAll(database.getCollectionStats(collectionName));
+    final Map<String, Object> data = new HashMap<>(database.getCollectionStats(collectionName));
     data.put("version", database.getServerVersion());
     data.put("type", database.getServerType());
     LOGGER.info(Jsons.serialize(data));

--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -101,7 +101,8 @@ For more information regarding configuration parameters, please see [MongoDb Doc
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                   |
-|:--------|:-----------| :------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------|
+|:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
+| 0.2.4   | 2023-07-26 | [28760](https://github.com/airbytehq/airbyte/pull/28760) | Fix bug preventing some syncs from succeeding when collecting stats                                       |
 | 0.2.3   | 2023-07-26 | [28733](https://github.com/airbytehq/airbyte/pull/28733) | Fix bug preventing syncs from discovering field types                                                     |
 | 0.2.2   | 2023-07-25 | [28692](https://github.com/airbytehq/airbyte/pull/28692) | Fix bug preventing statistics retrieval from views                                                        |
 | 0.2.1   | 2023-07-21 | [28527](https://github.com/airbytehq/airbyte/pull/28527) | Log server information                                                                                    |


### PR DESCRIPTION
## What
- avoid NPE in `getCollectionStats` call
   ```
   Caused by: java.lang.NullPointerException
        at java.util.Objects.requireNonNull(Objects.java:208) ~[?:?]
        at java.util.ImmutableCollections$MapN.<init>(ImmutableCollections.java:1186) ~[?:?]</init>
        at java.util.Map.of(Map.java:1373) ~[?:?]
        at io.airbyte.db.mongodb.MongoDatabase.getCollectionStats(MongoDatabase.java:140) ~[io.airbyte.airbyte-db-db-lib-24.0.2.jar:?]
   ```
- update version; `0.2.3` -> `0.2.4`

## How
- ensure values pulled from `collectionStats` `Document` are not `null` before calling `Map.of`
- update `catch` statement in `getCollectionStats` to catch all exceptions, not only `MongoCommandException`
    - an failure to collect these stats should not result in a sync failing 

## Recommended reading order
1. `MongoDatabase.java`
2. everything else

