### PR TITLE
Improve file identification for mypy

### DIFF
--- a/airbyte-cdk/python/bin/run-mypy-on-modified-files.sh
+++ b/airbyte-cdk/python/bin/run-mypy-on-modified-files.sh
@@ -1,3 +1,3 @@
 set -e
 # TODO change this to include unit_tests as well once it's in a good state
-{ git diff --name-only --relative ':(exclude)unit_tests'; git diff --name-only master... --relative ':(exclude)unit_tests'; } | grep -E '\.py$' | xargs .venv/bin/python -m mypy --config-file mypy.ini --install-types --non-interactive
+{ git diff --name-only --relative ':(exclude)unit_tests'; git diff --name-only --staged --relative ':(exclude)unit_tests'; git diff --name-only master... --relative ':(exclude)unit_tests'; } | grep -E '\.py$' | sort | uniq | xargs .venv/bin/python -m mypy --config-file mypy.ini --install-types --non-interactive

--- a/airbyte-cdk/python/bin/run-mypy-on-modified-files.sh
+++ b/airbyte-cdk/python/bin/run-mypy-on-modified-files.sh
@@ -1,3 +1,3 @@
 set -e
 # TODO change this to include unit_tests as well once it's in a good state
-git diff --name-only master... ':(exclude)unit_tests' | xargs -I '{}' realpath --relative-to=. $(git rev-parse --show-toplevel)/'{}' | grep -E '\.py$' | xargs .venv/bin/python -m mypy --config-file mypy.ini --install-types --non-interactive
+{ git diff --name-only --relative ':(exclude)unit_tests'; git diff --name-only master... --relative ':(exclude)unit_tests'; } | grep -E '\.py$' | xargs .venv/bin/python -m mypy --config-file mypy.ini --install-types --non-interactive

--- a/airbyte-cdk/python/bin/run-mypy-on-modified-files.sh
+++ b/airbyte-cdk/python/bin/run-mypy-on-modified-files.sh
@@ -1,3 +1,3 @@
 set -e
 # TODO change this to include unit_tests as well once it's in a good state
-git diff --name-only --relative --diff-filter=d remotes/origin/master -- . ':(exclude)unit_tests' | grep -E '\.py$' | xargs .venv/bin/python -m mypy --config-file mypy.ini --install-types --non-interactive
+git diff --name-only master... ':(exclude)unit_tests' | xargs -I '{}' realpath --relative-to=. $(git rev-parse --show-toplevel)/'{}' | grep -E '\.py$' | xargs .venv/bin/python -m mypy --config-file mypy.ini --install-types --non-interactive


### PR DESCRIPTION
## What
The current mypy script flags any file that is different from master. When there is a change to a file on master and you haven't merge master into your branch, it'll prevent you from merging even though there are no conflicts.

Here is an example where I was doing changes to the CATs but got a CI failure:
```
(.venv) python% git diff --name-only --relative --diff-filter=d remotes/origin/master -- . ':(exclude)unit_tests' | grep -E '\.py$'
airbyte_cdk/connector_builder/message_grouper.py
airbyte_cdk/sources/declarative/models/declarative_component_schema.py
airbyte_cdk/sources/declarative/requesters/http_requester.py
airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
airbyte_cdk/sources/file_based/config/file_based_stream_config.py
airbyte_cdk/sources/file_based/file_types/avro_parser.py
airbyte_cdk/sources/message/repository.py
airbyte_cdk/sources/streams/core.py
airbyte_cdk/sources/streams/http/http.py
airbyte_cdk/sources/streams/http/rate_limiting.py
setup.py
```

## How
Concatenate the following commands:
* `git diff --name-only --relative ':(exclude)unit_tests'`: unstaged files
* `git diff --name-only --staged --relative ':(exclude)unit_tests';`: staged files
* `git diff --name-only master... --relative ':(exclude)unit_tests'; }`: commit files

After that, grep and filter out duplicates