### PR TITLE
connectors-ci: fix full dagger python connector dagger build

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
@@ -8,25 +8,25 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import toml
 import re
 import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Optional
 
+import toml
 import yaml
+from dagger import CacheVolume, Client, Container, DaggerError, Directory, File, Platform, Secret
+from dagger.engine._version import CLI_VERSION as dagger_engine_version
 from pipelines import consts
 from pipelines.consts import (
-    CONNECTOR_OPS_SOURCE_PATHSOURCE_PATH,
     CI_CREDENTIALS_SOURCE_PATH,
+    CONNECTOR_OPS_SOURCE_PATHSOURCE_PATH,
     CONNECTOR_TESTING_REQUIREMENTS,
     LICENSE_SHORT_FILE_PATH,
     PYPROJECT_TOML_FILE_PATH,
 )
 from pipelines.utils import get_file_contents
-from dagger import CacheVolume, Client, Container, DaggerError, Directory, File, Platform, Secret
-from dagger.engine._version import CLI_VERSION as dagger_engine_version
 
 if TYPE_CHECKING:
     from pipelines.contexts import ConnectorContext, PipelineContext
@@ -980,7 +980,7 @@ async def with_airbyte_python_connector_full_dagger(context: ConnectorContext, b
         .with_mounted_cache("/root/.cache/pip", pip_cache)
         .with_exec(["pip", "install", "--upgrade", "pip"])
         .with_exec(["apt-get", "install", "-y", "tzdata"])
-        .with_file("setup.py", await context.get_connector_dir(include="setup.py").file("setup.py"))
+        .with_file("setup.py", (await context.get_connector_dir(include="setup.py")).file("setup.py"))
     )
 
     for dependency_path in setup_dependencies_to_mount:
@@ -995,8 +995,8 @@ async def with_airbyte_python_connector_full_dagger(context: ConnectorContext, b
         .with_file("/usr/localtime", builder.file("/usr/share/zoneinfo/Etc/UTC"))
         .with_new_file("/etc/timezone", "Etc/UTC")
         .with_exec(["apt-get", "install", "-y", "bash"])
-        .with_file("main.py", await context.get_connector_dir(include="main.py").file("main.py"))
-        .with_directory(snake_case_name, await context.get_connector_dir(include=snake_case_name).directory(snake_case_name))
+        .with_file("main.py", (await context.get_connector_dir(include="main.py")).file("main.py"))
+        .with_directory(snake_case_name, (await context.get_connector_dir(include=snake_case_name)).directory(snake_case_name))
         .with_env_variable("AIRBYTE_ENTRYPOINT", " ".join(entrypoint))
         .with_entrypoint(entrypoint)
         .with_label("io.airbyte.version", context.metadata["dockerImageTag"])


### PR DESCRIPTION
Closes #28778
Fix a typo in the async code to build python connectors with dagger.
`source-file-secure` is the single connector built this way, because it has a dependency on `source-file`.