### PR TITLE
connectors-ci: fix reported sentry tags

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/sentry_utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/sentry_utils.py
@@ -14,14 +14,6 @@ def initialize():
             dsn=os.environ.get("SENTRY_DSN"),
             release=f"pipelines@{importlib.metadata.version('pipelines')}",
         )
-        set_global_tags()
-
-
-def set_global_tags():
-    if "pull_request_number" in os.environ:
-        sentry_sdk.set_tag("pull_request", os.environ.get("pull_request_number"))
-    if "ci_job_key" in os.environ:
-        sentry_sdk.set_tag("ci_job", os.environ.get("ci_job_key"))
 
 
 def with_step_context(func):


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

These tags were being marked as invalid by sentry because I guess they're reported as empty strings

<img width="521" alt="image" src="https://github.com/airbytehq/airbyte/assets/4368928/27b9a1ab-42b8-4336-aaca-e5816baa4bae">

## How

Fix the issue by instead using values from the context which seem more reliable
