### PR TITLE
Source S3: basic structure using file-based CDK

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/remote_file.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/remote_file.py
@@ -3,9 +3,15 @@
 #
 
 from datetime import datetime
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel
+
+
+class FileReadMode(Enum):
+    READ = "r"
+    READ_BINARY = "rb"
 
 
 class RemoteFile(BaseModel):

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/remote_file.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/remote_file.py
@@ -3,15 +3,9 @@
 #
 
 from datetime import datetime
-from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel
-
-
-class FileReadMode(Enum):
-    READ = "r"
-    READ_BINARY = "rb"
 
 
 class RemoteFile(BaseModel):

--- a/airbyte-integrations/connectors/source-s3/Dockerfile
+++ b/airbyte-integrations/connectors/source-s3/Dockerfile
@@ -17,5 +17,5 @@ COPY source_s3 ./source_s3
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=3.1.1
+LABEL io.airbyte.version=3.1.2
 LABEL io.airbyte.name=airbyte/source-s3

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
-  dockerImageTag: 3.1.1
+  dockerImageTag: 3.1.2
   dockerRepository: airbyte/source-s3
   githubIssueLabel: source-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/source-s3/setup.py
+++ b/airbyte-integrations/connectors/source-s3/setup.py
@@ -19,7 +19,7 @@ MAIN_REQUIREMENTS = [
 TEST_REQUIREMENTS = [
     "pytest~=6.1",
     "connector-acceptance-test",
-    "pandas==1.3.1",
+    "pandas==2.0.3",
     "psutil",
     "pytest-order",
     "netifaces~=0.11.0",

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/__init__.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+from .config import Config
+from .stream_reader import SourceS3StreamReader
+
+__all__ = ["Config", "SourceS3StreamReader"]

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+from typing import Optional
+
+from airbyte_cdk.sources.file_based.config.abstract_file_based_spec import AbstractFileBasedSpec
+from pydantic import AnyUrl, Field, ValidationError, root_validator
+
+
+class Config(AbstractFileBasedSpec):
+    config_version: str = "0.1"
+
+    @classmethod
+    def documentation_url(cls) -> AnyUrl:
+        return AnyUrl("https://docs.airbyte.com/integrations/sources/s3", scheme="https")
+
+    bucket: str = Field(title="Bucket", description="Name of the S3 bucket where the file(s) exist.", order=0)
+
+    aws_access_key_id: Optional[str] = Field(
+        title="AWS Access Key ID",
+        default=None,
+        description="In order to access private Buckets stored on AWS S3, this connector requires credentials with the proper "
+        "permissions. If accessing publicly available data, this field is not necessary.",
+        airbyte_secret=True,
+        order=1,
+    )
+
+    aws_secret_access_key: Optional[str] = Field(
+        title="AWS Secret Access Key",
+        default=None,
+        description="In order to access private Buckets stored on AWS S3, this connector requires credentials with the proper "
+        "permissions. If accessing publicly available data, this field is not necessary.",
+        airbyte_secret=True,
+        order=2,
+    )
+
+    endpoint: Optional[str] = Field(
+        "", title="Endpoint", description="Endpoint to an S3 compatible service. Leave empty to use AWS.", order=4
+    )
+
+    @root_validator
+    def validate_optional_args(cls, values):
+        aws_access_key_id = values.get("aws_access_key_id")
+        aws_secret_access_key = values.get("aws_secret_access_key")
+        endpoint = values.get("endpoint")
+        if aws_access_key_id or aws_secret_access_key:
+            if not (aws_access_key_id and aws_secret_access_key):
+                raise ValidationError(
+                    "`aws_access_key_id` and `aws_secret_access_key` are both required to authenticate with AWS.", model=Config
+                )
+            if endpoint:
+                raise ValidationError(
+                    "Either `aws_access_key_id` and `aws_secret_access_key` or `endpoint` must be set, but not both.", model=Config
+                )
+        return values

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
@@ -10,8 +10,8 @@ from typing import Iterable, List, Optional, Set
 import boto3.session
 import smart_open
 from airbyte_cdk.sources.file_based.exceptions import ErrorListingFiles, FileBasedSourceError
-from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader
-from airbyte_cdk.sources.file_based.remote_file import FileReadMode, RemoteFile
+from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader, FileReadMode
+from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from botocore.client import BaseClient
 from botocore.client import Config as ClientConfig
 from source_s3.v4.config import Config
@@ -145,27 +145,14 @@ class SourceS3StreamReader(AbstractFileBasedStreamReader):
                 break
 
 
-# Used to specify anonymous (unsigned) request signature
-class UNSIGNED:
-    def __copy__(self):
-        return self
-
-    def __deepcopy__(self, memodict):
-        return self
-
-
 def _get_s3_compatible_client_args(config: Config) -> dict:
     """
     Returns map of args used for creating s3 boto3 client.
     """
-    client_config = ClientConfig(signature_version=UNSIGNED())
-    client_kv_args = {"config": client_config}
-    client_kv_args.update(
-        {
-            "endpoint_url": config.endpoint,
-            "use_ssl": True,
-            "verify": True,
-            "config": ClientConfig(s3={"addressing_style": "auto"}),
-        }
-    )
+    client_kv_args = {
+        "config": ClientConfig(s3={"addressing_style": "auto"}),
+        "endpoint_url": config.endpoint,
+        "use_ssl": True,
+        "verify": True,
+    }
     return client_kv_args

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
@@ -1,0 +1,171 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import logging
+from contextlib import contextmanager
+from io import IOBase
+from typing import Iterable, List, Optional, Set
+
+import boto3.session
+import smart_open
+from airbyte_cdk.sources.file_based.exceptions import ErrorListingFiles, FileBasedSourceError
+from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader
+from airbyte_cdk.sources.file_based.remote_file import FileReadMode, RemoteFile
+from botocore.client import BaseClient
+from botocore.client import Config as ClientConfig
+from source_s3.v4.config import Config
+
+
+class SourceS3StreamReader(AbstractFileBasedStreamReader):
+    def __init__(self):
+        super().__init__()
+        self._s3_client = None
+
+    @property
+    def config(self) -> Config:
+        return self._config
+
+    @config.setter
+    def config(self, value: Config):
+        """
+        FileBasedSource reads the config from disk and parses it, and once parsed, the source sets the config on its StreamReader.
+
+        Note: FileBasedSource only requires the keys defined in the abstract config, whereas concrete implementations of StreamReader
+        will require keys that (for example) allow it to authenticate with the 3rd party.
+
+        Therefore, concrete implementations of AbstractFileBasedStreamReader's config setter should assert that `value` is of the correct
+        config type for that type of StreamReader.
+        """
+        assert isinstance(value, Config)
+        self._config = value
+
+    @property
+    def s3_client(self) -> BaseClient:
+        if self.config is None:
+            # We shouldn't hit this; config should always get set before attempting to
+            # list or read files.
+            raise ValueError("Source config is missing; cannot create the S3 client.")
+        if self._s3_client is None:
+            if self.config.endpoint:
+                client_kv_args = _get_s3_compatible_client_args(self.config)
+                self._s3_client = boto3.client("s3", **client_kv_args)
+            else:
+                self._s3_client = boto3.client(
+                    "s3",
+                    aws_access_key_id=self.config.aws_access_key_id,
+                    aws_secret_access_key=self.config.aws_secret_access_key,
+                )
+        return self._s3_client
+
+    def get_matching_files(self, globs: List[str], logger: logging.Logger) -> Iterable[RemoteFile]:
+        """
+        Get all files matching the specified glob patterns.
+        """
+        s3 = self.s3_client
+        prefixes = self.get_prefixes_from_globs(globs)
+        seen = set()
+        total_n_keys = 0
+
+        try:
+            if prefixes:
+                for prefix in prefixes:
+                    for remote_file in self._page(s3, globs, self.config.bucket, prefix, seen, logger):
+                        total_n_keys += 1
+                        yield remote_file
+            else:
+                for remote_file in self._page(s3, globs, self.config.bucket, None, seen, logger):
+                    total_n_keys += 1
+                    yield remote_file
+
+            logger.info(f"Finished listing objects from S3. Found {total_n_keys} objects total ({len(seen)} unique objects).")
+        except Exception as exc:
+            raise ErrorListingFiles(
+                FileBasedSourceError.ERROR_LISTING_FILES,
+                source="s3",
+                bucket=self.config.bucket,
+                globs=globs,
+                endpoint=self.config.endpoint,
+            ) from exc
+
+    @contextmanager
+    def open_file(self, file: RemoteFile, mode: FileReadMode, logger: logging.Logger) -> IOBase:
+        try:
+            params = {"client": self.s3_client}
+        except Exception as exc:
+            raise exc
+
+        logger.debug(f"try to open {file.uri}")
+        try:
+            result = smart_open.open(f"s3://{self.config.bucket}/{file.uri}", transport_params=params, mode=mode.value)
+        except OSError:
+            logger.warning(
+                f"We don't have access to {file.uri}. The file appears to have become unreachable during sync."
+                f"Check whether key {file.uri} exists in `{self.config.bucket}` bucket and/or has proper ACL permissions"
+            )
+        # see https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager for why we do this
+        try:
+            yield result
+        finally:
+            result.close()
+
+    @staticmethod
+    def _is_folder(file) -> bool:
+        return file["Key"].endswith("/")
+
+    def _page(
+        self, s3: BaseClient, globs: List[str], bucket: str, prefix: Optional[str], seen: Set[str], logger: logging.Logger
+    ) -> Iterable[RemoteFile]:
+        """
+        Page through lists of S3 objects.
+        """
+        total_n_keys_for_prefix = 0
+        kwargs = {"Bucket": bucket}
+        while True:
+            response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix) if prefix else s3.list_objects_v2(Bucket=bucket)
+            key_count = response.get("KeyCount")
+            total_n_keys_for_prefix += key_count
+            logger.info(f"Received {key_count} objects from S3 for prefix '{prefix}'.")
+
+            if "Contents" in response:
+                for file in response["Contents"]:
+                    if self._is_folder(file):
+                        continue
+                    remote_file = RemoteFile(uri=file["Key"], last_modified=file["LastModified"])
+                    if self.file_matches_globs(remote_file, globs) and remote_file.uri not in seen:
+                        seen.add(remote_file.uri)
+                        yield remote_file
+            else:
+                logger.warning(f"Invalid response from S3; missing 'Contents' key. kwargs={kwargs}.")
+
+            if next_token := response.get("NextContinuationToken"):
+                kwargs["ContinuationToken"] = next_token
+            else:
+                logger.info(f"Finished listing objects from S3 for prefix={prefix}. Found {total_n_keys_for_prefix} objects.")
+                break
+
+
+# Used to specify anonymous (unsigned) request signature
+class UNSIGNED:
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memodict):
+        return self
+
+
+def _get_s3_compatible_client_args(config: Config) -> dict:
+    """
+    Returns map of args used for creating s3 boto3 client.
+    """
+    client_config = ClientConfig(signature_version=UNSIGNED())
+    client_kv_args = {"config": client_config}
+    client_kv_args.update(
+        {
+            "endpoint_url": config.endpoint,
+            "use_ssl": True,
+            "verify": True,
+            "config": ClientConfig(s3={"addressing_style": "auto"}),
+        }
+    )
+    return client_kv_args

--- a/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_config.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_config.py
@@ -1,0 +1,26 @@
+
+import logging
+
+import pytest
+from pydantic import ValidationError
+from source_s3.v4.config import Config
+
+logger = logging.Logger("")
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected_error",
+    [
+        pytest.param({"bucket": "test", "streams": []}, None, id="required-fields"),
+        pytest.param({"bucket": "test", "streams": [], "aws_access_key_id": "access_key", "aws_secret_access_key": "secret_access_key"}, None, id="config-created-with-aws-info"),
+        pytest.param({"bucket": "test", "streams": [], "endpoint": "http://test.com"}, None, id="config-created-with-endpoint"),
+        pytest.param({"bucket": "test", "streams": [], "aws_access_key_id": "access_key", "aws_secret_access_key": "secret_access_key", "endpoint": "http://test.com"}, ValidationError, id="cannot-have-endpoint-and-aws-info"),
+        pytest.param({"streams": []}, ValidationError, id="missing-bucket"),
+    ]
+)
+def test_config(kwargs, expected_error):
+    if expected_error:
+        with pytest.raises(expected_error):
+            Config(**kwargs)
+    else:
+        Config(**kwargs)

--- a/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_stream_reader.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_stream_reader.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, List, Optional, Set
 import pytest
 from airbyte_cdk.sources.file_based.config.abstract_file_based_spec import AbstractFileBasedSpec
 from airbyte_cdk.sources.file_based.exceptions import ErrorListingFiles, FileBasedSourceError
-from airbyte_cdk.sources.file_based.remote_file import FileReadMode, RemoteFile
+from airbyte_cdk.sources.file_based.file_based_stream_reader import FileReadMode
+from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from botocore.stub import Stubber
 from pydantic import AnyUrl
 from source_s3.v4.config import Config

--- a/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_stream_reader.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_stream_reader.py
@@ -1,0 +1,186 @@
+
+import logging
+from datetime import datetime
+from itertools import product
+from typing import Any, Dict, List, Optional, Set
+
+import pytest
+from airbyte_cdk.sources.file_based.config.abstract_file_based_spec import AbstractFileBasedSpec
+from airbyte_cdk.sources.file_based.exceptions import ErrorListingFiles, FileBasedSourceError
+from airbyte_cdk.sources.file_based.remote_file import FileReadMode, RemoteFile
+from botocore.stub import Stubber
+from pydantic import AnyUrl
+from source_s3.v4.config import Config
+from source_s3.v4.stream_reader import SourceS3StreamReader
+
+logger = logging.Logger("")
+
+endpoint_values = ["http://fake.com", None]
+_get_matching_files_cases = [
+    pytest.param([], [], False, set(), id="no-files-match-if-no-globs"),
+    pytest.param(
+        ["**"],
+        [
+            {"Key": "file1.csv", "LastModified": datetime.now()},
+            {"Key": "a/file2.csv", "LastModified": datetime.now()},
+            {"Key": "a/b/file3.csv", "LastModified": datetime.now()},
+            {"Key": "a/b/c/file4.csv", "LastModified": datetime.now()},
+        ],
+        False,
+        {"file1.csv", "a/file2.csv", "a/b/file3.csv", "a/b/c/file4.csv"},
+        id="all-files-match-single-page",
+    ),
+    pytest.param(
+        ["**"],
+        [
+            {"Key": "file1.csv", "LastModified": datetime.now()},
+            {"Key": "a/file2.csv", "LastModified": datetime.now()},
+            {"Key": "a/b/file3.csv", "LastModified": datetime.now()},
+            {"Key": "a/b/c/file4.csv", "LastModified": datetime.now()},
+        ],
+        True,
+        {"file1.csv", "a/file2.csv", "a/b/file3.csv", "a/b/c/file4.csv"},
+        id="all-files-match-multiple-pages",
+    ),
+    pytest.param(
+        ["**/*.csv"],
+        [
+            {"Key": "file1.csv", "LastModified": datetime.now()},
+            {"Key": "a/file2.csv", "LastModified": datetime.now()},
+            {"Key": "a/b/file3.jsonl", "LastModified": datetime.now()},
+            {"Key": "a/b/c/file4.jsonl", "LastModified": datetime.now()},
+        ],
+        True,
+        {"file1.csv", "a/file2.csv"},
+        id="nonmatching-files-are-filtered",
+    ),
+    pytest.param(
+        ["a/*.csv", "a/*.jsonl"],
+        [
+            {"Key": "file1.csv", "LastModified": datetime.now()},
+            {"Key": "file2.jsonl", "LastModified": datetime.now()},
+            {"Key": "a/file3.csv", "LastModified": datetime.now()},
+            {"Key": "a/file4.jsonl", "LastModified": datetime.now()},
+        ],
+        True,
+        {"a/file3.csv", "a/file4.jsonl"},
+        id="nonmatching-files-are-filtered-multiple-prefixes",
+    ),
+    pytest.param(
+        ["**", "a/*.jsonl"],
+        [
+            {"Key": "file1.csv", "LastModified": datetime.now()},
+            {"Key": "file2.jsonl", "LastModified": datetime.now()},
+            {"Key": "a/file3.csv", "LastModified": datetime.now()},
+            {"Key": "a/file4.jsonl", "LastModified": datetime.now()},
+        ],
+        True,
+        {"file1.csv", "file2.jsonl", "a/file3.csv", "a/file4.jsonl"},
+        id="files-matching-multiple-prefixes-only-listed-once",
+    ),
+    pytest.param(
+        ["**"],
+        [
+            {"Key": "file1.csv", "LastModified": datetime.now()},
+            {"Key": "file2.jsonl", "LastModified": datetime.now()},
+            {"Key": "file3.csv", "LastModified": datetime.now()},
+            {"Key": "file3.csv", "LastModified": datetime.now()},
+        ],
+        True,
+        {"file1.csv", "file2.jsonl", "file3.csv"},
+        id="duplicate-files-only-listed-once",
+    ),
+]
+
+get_matching_files_cases = []
+for original_case, endpoint_value in product(_get_matching_files_cases, endpoint_values):
+    params = list(original_case.values) + [endpoint_value]
+    test_case = pytest.param(*params, id=original_case.id + f"-endpoint-{endpoint_value}")
+    get_matching_files_cases.append(test_case)
+
+
+@pytest.mark.parametrize(
+    "globs,mocked_response,multiple_pages,expected_uris,endpoint",
+    get_matching_files_cases
+)
+def test_get_matching_files(globs: List[str], mocked_response: List[Dict[str, Any]], multiple_pages: bool, expected_uris: Set[str], endpoint: Optional[str]):
+    reader = SourceS3StreamReader()
+    try:
+        aws_access_key_id = aws_secret_access_key = None if endpoint else "test"
+        reader.config = Config(
+            bucket="test",
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            streams=[],
+            endpoint=endpoint,
+        )
+    except Exception as exc:
+        raise exc
+
+    stub = set_stub(reader, mocked_response, multiple_pages)
+    files = list(reader.get_matching_files(globs, logger))
+    stub.deactivate()
+    assert set(f.uri for f in files) == expected_uris
+
+
+def test_get_matching_files_exception():
+    reader = SourceS3StreamReader()
+    reader.config = Config(bucket="test", aws_access_key_id="test", aws_secret_access_key="test", streams=[])
+    stub = Stubber(reader.s3_client)
+    stub.add_client_error("list_objects_v2")
+    stub.activate()
+    with pytest.raises(ErrorListingFiles) as exc:
+        list(reader.get_matching_files(["*"], logger))
+    stub.deactivate()
+    assert FileBasedSourceError.ERROR_LISTING_FILES.value in exc.value.args[0]
+
+
+def test_get_matching_files_without_config_raises_exception():
+    with pytest.raises(ValueError):
+        next(SourceS3StreamReader().get_matching_files([], logger))
+
+
+def test_open_file_without_config_raises_exception():
+    with pytest.raises(ValueError):
+        with SourceS3StreamReader().open_file(RemoteFile(uri="", last_modified=datetime.now()), FileReadMode.READ, logger) as fp:
+            fp.read()
+
+
+def test_get_s3_client_without_config_raises_exception():
+    with pytest.raises(ValueError):
+        SourceS3StreamReader().s3_client
+
+
+def test_cannot_set_wrong_config_type():
+    stream_reader = SourceS3StreamReader()
+
+    class OtherConfig(AbstractFileBasedSpec):
+        def documentation_url(cls) -> AnyUrl:
+            return AnyUrl("https://fake.com", scheme="https")
+
+    other_config = OtherConfig(streams=[])
+    with pytest.raises(AssertionError):
+        stream_reader.config = other_config
+
+
+def set_stub(reader: SourceS3StreamReader, contents: List[Dict[str, Any]], multiple_pages: bool) -> Stubber:
+    s3_stub = Stubber(reader.s3_client)
+    split_contents_idx = int(len(contents) / 2) if multiple_pages else -1
+    page1, page2 = contents[:split_contents_idx], contents[split_contents_idx:]
+    resp = {
+        "KeyCount": len(page1),
+        "Contents": page1,
+    }
+    if page2:
+        resp["NextContinuationToken"] = "token"
+    s3_stub.add_response("list_objects_v2", resp)
+    if page2:
+        s3_stub.add_response(
+            "list_objects_v2",
+            {
+                "KeyCount": len(page2),
+                "Contents": page2,
+            },
+        )
+    s3_stub.activate()
+    return s3_stub

--- a/airbyte-integrations/connectors/source-s3/v4_main.py
+++ b/airbyte-integrations/connectors/source-s3/v4_main.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+
+import sys
+
+from airbyte_cdk.entrypoint import AirbyteEntrypoint, launch
+from airbyte_cdk.sources.file_based.file_based_source import FileBasedSource
+from source_s3.v4 import Config, SourceS3StreamReader
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    catalog_path = AirbyteEntrypoint.extract_catalog(args)
+    source = FileBasedSource(SourceS3StreamReader(), Config, catalog_path)
+    launch(source, args)

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -281,7 +281,8 @@ Be cautious when raising this value too high, as it may result in Out Of Memory 
 ## Changelog
 
 | Version | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
-| :------ | :--------- | :-------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------- |
+|:--------|:-----------| :-------------------------------------------------------------------------------------------------------------- |:---------------------------------------------------------------------------------------------------------------------|
+| 3.1.2   | 2023-07-29 | [28786](https://github.com/airbytehq/airbyte/pull/28786)                                                        | Add a codepath for using the file-based CDK                                                                          |
 | 3.1.1   | 2023-07-26 | [28730](https://github.com/airbytehq/airbyte/pull/28730)                                                        | Add human readable error message and improve validation for encoding field when it empty                             |
 | 3.1.0   | 2023-06-26 | [27725](https://github.com/airbytehq/airbyte/pull/27725)                                                        | License Update: Elv2                                                                                                 |
 | 3.0.3   | 2023-06-23 | [27651](https://github.com/airbytehq/airbyte/pull/27651)                                                        | Handle Bucket Access Errors                                                                                          |


### PR DESCRIPTION
## What
Adds the basic structure for using the file-based CDK for syncing data from S3:
- S3 implementation of the `AbstractFileBasedStreamReader`
- S3-specific config

This includes a few changes to the file-based CDK. 
- I've removed the `file_type` attribute on `RemoteFile` because we don't actually know the type of the `RemoteFile` when we create it. We could theoretically guess based on the stream config, but there's no need to.
- The `AbstractFileBasedStreamReader`'s `open_file` method now takes in a `mode` argument. This is passed in by the parser that's calling `open_file`, which knows its associated file read mode.

The S3 integration tests will be updated in a separate phase, which will verify that both the old and new config work.

## Recommended reading order
1. file-based CDK changes
2. S3-specific changes