### PR TITLE
write build scan url to a local file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ gha-creds-*.json
 
 # Legacy pipeline reports path
 tools/ci_connector_ops/pipeline_reports/
+
+# ignore local build scan uri output
+scan-journal.log

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,6 @@
+import com.gradle.scan.plugin.PublishedBuildScan
+
+
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -28,8 +31,13 @@ gradleEnterprise {
     buildScan {
         termsOfServiceUrl = "https://gradle.com/terms-of-service"
         termsOfServiceAgree = "yes"
+        buildScanPublished { PublishedBuildScan scan ->
+            file("scan-journal.log") << "${new Date()} - ${scan.buildScanId} - ${scan.buildScanUri}\n"
+        }
     }
 }
+
+
 
 ext.isCiServer = System.getenv().containsKey("CI")
 


### PR DESCRIPTION
## What
This is for usage in downstream automation and reporting of test results

## How
Write the build scan url to a file called scan-journal.log, which is gitignored

