### PR TITLE
🐛 Source Mongo: Ignore internal collections in discover

### DIFF
--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/mongodb/MongoUtils.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/mongodb/MongoUtils.java
@@ -320,7 +320,7 @@ public class MongoUtils {
     LOGGER.debug("Fetching types for field '{}'...", name);
     final AggregateIterable<Document> output = collection.aggregate(Arrays.asList(
         new Document("$limit", DISCOVER_LIMIT),
-        new Document("$project", new Document(ID, 0).append("fieldType", new Document("$type", name))),
+        new Document("$project", new Document(ID, 0).append("fieldType", new Document("$type", "$" + name))),
         new Document("$group", new Document(ID, new Document("fieldType", "$fieldType"))
             .append("count", new Document("$sum", 1)))));
     final var listOfTypes = new ArrayList<String>();

--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/Dockerfile
@@ -24,5 +24,5 @@ ENV APPLICATION source-mongodb-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.4
+LABEL io.airbyte.version=0.2.5
 LABEL io.airbyte.name=airbyte/source-mongodb-strict-encrypt

--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
-  dockerImageTag: 0.2.4
+  dockerImageTag: 0.2.5
   dockerRepository: airbyte/source-mongodb-strict-encrypt
   githubIssueLabel: source-mongodb-v2
   icon: mongodb.svg

--- a/airbyte-integrations/connectors/source-mongodb-v2/Dockerfile
+++ b/airbyte-integrations/connectors/source-mongodb-v2/Dockerfile
@@ -24,5 +24,5 @@ ENV APPLICATION source-mongodb-v2
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.4
+LABEL io.airbyte.version=0.2.5
 LABEL io.airbyte.name=airbyte/source-mongodb-v2

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
-  dockerImageTag: 0.2.4
+  dockerImageTag: 0.2.5
   dockerRepository: airbyte/source-mongodb-v2
   githubIssueLabel: source-mongodb-v2
   icon: mongodb.svg
@@ -10,7 +10,7 @@ data:
   name: MongoDb
   registries:
     cloud:
-      dockerImageTag: 0.2.4
+      dockerImageTag: 0.2.5
       dockerRepository: airbyte/source-mongodb-strict-encrypt
       enabled: true
     oss:

--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -102,6 +102,7 @@ For more information regarding configuration parameters, please see [MongoDb Doc
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
+| 0.2.5   | 2023-07-27 | [28799](https://github.com/airbytehq/airbyte/pull/28799) | Filter out internal collections from discover                                                             |
 | 0.2.4   | 2023-07-26 | [28760](https://github.com/airbytehq/airbyte/pull/28760) | Fix bug preventing some syncs from succeeding when collecting stats                                       |
 | 0.2.3   | 2023-07-26 | [28733](https://github.com/airbytehq/airbyte/pull/28733) | Fix bug preventing syncs from discovering field types                                                     |
 | 0.2.2   | 2023-07-25 | [28692](https://github.com/airbytehq/airbyte/pull/28692) | Fix bug preventing statistics retrieval from views                                                        |


### PR DESCRIPTION
## What
* Prevent discover failures due to Mongo restriction on access to certain system-level collections.

## How
* Filter out system-level collections when discovering schema

## Recommended reading order
1. `MongoDbSource.java`