### PR TITLE
File-based CDK: allow null values for all inferred columns

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/schema_helpers.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/schema_helpers.py
@@ -176,7 +176,9 @@ def conforms_to_schema(record: Mapping[str, Any], schema: Mapping[str, Any]) -> 
         value = record.get(column)
 
         if value is not None:
-            if expected_type == "object":
+            if isinstance(expected_type, list):
+                return any(is_equal_or_narrower_type(value, e) for e in expected_type)
+            elif expected_type == "object":
                 return isinstance(value, dict)
             elif expected_type == "array":
                 if not isinstance(value, list):

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py
@@ -139,17 +139,17 @@ _decimal_as_float_avro_format = AvroFormat(decimal_as_float=True)
                      id="test_decimal_missing_precision"),
         pytest.param(_default_avro_format, {"type": "bytes", "logicalType": "decimal", "precision": 9}, None, ValueError,
                      id="test_decimal_missing_scale"),
-        pytest.param(_default_avro_format, {"type": "bytes", "logicalType": "uuid"}, {"type": "string"}, None, id="test_uuid"),
-        pytest.param(_default_avro_format, {"type": "int", "logicalType": "date"}, {"type": "string", "format": "date"}, None,
+        pytest.param(_default_avro_format, {"type": "bytes", "logicalType": "uuid"}, {"type": ["null", "string"]}, None, id="test_uuid"),
+        pytest.param(_default_avro_format, {"type": "int", "logicalType": "date"}, {"type": ["null", "string"], "format": "date"}, None,
                      id="test_date"),
-        pytest.param(_default_avro_format, {"type": "int", "logicalType": "time-millis"}, {"type": "integer"}, None, id="test_time_millis"),
-        pytest.param(_default_avro_format, {"type": "long", "logicalType": "time-micros"}, {"type": "integer"}, None,
+        pytest.param(_default_avro_format, {"type": "int", "logicalType": "time-millis"}, {"type": ["null", "integer"]}, None, id="test_time_millis"),
+        pytest.param(_default_avro_format, {"type": "long", "logicalType": "time-micros"}, {"type": ["null", "integer"]}, None,
                      id="test_time_micros"),
         pytest.param(
             _default_avro_format,
-            {"type": "long", "logicalType": "timestamp-millis"}, {"type": "string", "format": "date-time"}, None, id="test_timestamp_millis"
+            {"type": "long", "logicalType": "timestamp-millis"}, {"type": ["null", "string"], "format": "date-time"}, None, id="test_timestamp_millis"
         ),
-        pytest.param(_default_avro_format, {"type": "long", "logicalType": "timestamp-micros"}, {"type": "string"}, None,
+        pytest.param(_default_avro_format, {"type": "long", "logicalType": "timestamp-micros"}, {"type": ["null", "string"]}, None,
                      id="test_timestamp_micros"),
         pytest.param(
             _default_avro_format,

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py
@@ -243,8 +243,8 @@ single_avro_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col1": {"type": "string"},
-                            "col2": {"type": "integer"},
+                            "col1": {"type": ["null", "string"]},
+                            "col2": {"type": ["null", "integer"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -327,19 +327,19 @@ multiple_avro_combine_schema_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col_double": {"type": "string"},
-                            "col_string": {"type": "string"},
+                            "col_double": {"type": ["null", "string"]},
+                            "col_string": {"type": ["null", "string"]},
                             "col_album": {
                                 "properties": {
-                                    "album": {"type": "string"},
+                                    "album": {"type": ["null", "string"]},
                                 },
-                                "type": "object",
+                                "type": ["null", "object"],
                             },
                             "col_song": {
                                 "properties": {
-                                    "title": {"type": "string"},
+                                    "title": {"type": ["null", "string"]},
                                 },
-                                "type": "object",
+                                "type": ["null", "object"],
                             },
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
@@ -422,28 +422,28 @@ avro_all_types_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col_array": {"items": {"type": "string"}, "type": "array"},
-                            "col_bool": {"type": "boolean"},
-                            "col_bytes": {"type": "string"},
-                            "col_double": {"type": "string"},
-                            "col_enum": {"enum": ["POP_ROCK", "INDIE_ROCK", "ALTERNATIVE_ROCK"], "type": "string"},
-                            "col_fixed": {"pattern": "^[0-9A-Fa-f]{8}$", "type": "string"},
-                            "col_float": {"type": "number"},
-                            "col_int": {"type": "integer"},
-                            "col_long": {"type": "integer"},
-                            "col_map": {"additionalProperties": {"type": "string"}, "type": "object"},
+                            "col_array": {"items": {"type": ["null", "string"]}, "type": ["null", "array"]},
+                            "col_bool": {"type": ["null", "boolean"]},
+                            "col_bytes": {"type": ["null", "string"]},
+                            "col_double": {"type": ["null", "string"]},
+                            "col_enum": {"enum": ["POP_ROCK", "INDIE_ROCK", "ALTERNATIVE_ROCK"], "type": ["null", "string"]},
+                            "col_fixed": {"pattern": "^[0-9A-Fa-f]{8}$", "type": ["null", "string"]},
+                            "col_float": {"type": ["null", "number"]},
+                            "col_int": {"type": ["null", "integer"]},
+                            "col_long": {"type": ["null", "integer"]},
+                            "col_map": {"additionalProperties": {"type": ["null", "string"]}, "type": ["null", "object"]},
                             "col_record": {
-                                "properties": {"artist": {"type": "string"}, "song": {"type": "string"}, "year": {"type": "integer"}},
-                                "type": "object",
+                                "properties": {"artist": {"type": ["null", "string"]}, "song": {"type": ["null", "string"]}, "year": {"type": ["null", "integer"]}},
+                                "type": ["null", "object"],
                             },
-                            "col_string": {"type": "string"},
-                            "col_decimal": {"pattern": "^-?\\d{(1, 5)}(?:\\.\\d(1, 5))?$", "type": "string"},
-                            "col_uuid": {"type": "string"},
-                            "col_date": {"format": "date", "type": "string"},
-                            "col_time_millis": {"type": "integer"},
-                            "col_time_micros": {"type": "integer"},
-                            "col_timestamp_millis": {"format": "date-time", "type": "string"},
-                            "col_timestamp_micros": {"type": "string"},
+                            "col_string": {"type": ["null", "string"]},
+                            "col_decimal": {"pattern": "^-?\\d{(1, 5)}(?:\\.\\d(1, 5))?$", "type": ["null", "string"]},
+                            "col_uuid": {"type": ["null", "string"]},
+                            "col_date": {"format": "date", "type": ["null", "string"]},
+                            "col_time_millis": {"type": ["null", "integer"]},
+                            "col_time_micros": {"type": ["null", "integer"]},
+                            "col_timestamp_millis": {"format": "date-time", "type": ["null", "string"]},
+                            "col_timestamp_micros": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -587,10 +587,10 @@ multiple_streams_avro_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col_title": {"type": "string"},
-                            "col_album": {"type": "string", "enum": ["SUMMERS_GONE", "IN_RETURN", "A_MOMENT_APART", "THE_LAST_GOODBYE"]},
-                            "col_year": {"type": "integer"},
-                            "col_vocals": {"type": "boolean"},
+                            "col_title": {"type": ["null", "string"]},
+                            "col_album": {"type": ["null", "string"], "enum": ["SUMMERS_GONE", "IN_RETURN", "A_MOMENT_APART", "THE_LAST_GOODBYE"]},
+                            "col_year": {"type": ["null", "integer"]},
+                            "col_vocals": {"type": ["null", "boolean"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -604,12 +604,12 @@ multiple_streams_avro_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col_name": {"type": "string"},
+                            "col_name": {"type": ["null", "string"]},
                             "col_location": {
-                                "properties": {"country": {"type": "string"}, "state": {"type": "string"}, "city": {"type": "string"}},
-                                "type": "object",
+                                "properties": {"country": {"type": ["null", "string"]}, "state": {"type": ["null", "string"]}, "city": {"type": ["null", "string"]}},
+                                "type": ["null", "object"],
                             },
-                            "col_attendance": {"type": "integer"},
+                            "col_attendance": {"type": ["null", "integer"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -698,19 +698,19 @@ avro_file_with_decimal_as_float_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col_double": {"type": "number"},
-                            "col_string": {"type": "string"},
+                            "col_double": {"type": ["null", "number"]},
+                            "col_string": {"type": ["null", "string"]},
                             "col_album": {
                                 "properties": {
-                                    "album": {"type": "string"},
+                                    "album": {"type": ["null", "string"]},
                                 },
-                                "type": "object",
+                                "type": ["null", "object"],
                             },
                             "col_song": {
                                 "properties": {
-                                    "title": {"type": "string"},
+                                    "title": {"type": ["null", "string"]},
                                 },
-                                "type": "object",
+                                "type": ["null", "object"],
                             },
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -236,8 +236,8 @@ single_csv_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col1": {"type": "string"},
-                            "col2": {"type": "string"},
+                            "col1": {"type": ["null", "string"]},
+                            "col2": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -317,9 +317,9 @@ multi_csv_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col1": {"type": "string"},
-                            "col2": {"type": "string"},
-                            "col3": {"type": "string"},
+                            "col1": {"type": ["null", "string"]},
+                            "col2": {"type": ["null", "string"]},
+                            "col3": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -419,8 +419,8 @@ multi_csv_stream_n_file_exceeds_limit_for_inference = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col1": {"type": "string"},
-                            "col2": {"type": "string"},
+                            "col1": {"type": ["null", "string"]},
+                            "col2": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -514,8 +514,8 @@ invalid_csv_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col1": {"type": "string"},
-                            "col2": {"type": "string"},
+                            "col1": {"type": ["null", "string"]},
+                            "col2": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -583,8 +583,8 @@ csv_single_stream_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col1": {"type": "string"},
-                            "col2": {"type": "string"},
+                            "col1": {"type": ["null", "string"]},
+                            "col2": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -670,9 +670,9 @@ csv_multi_stream_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col1": {"type": "string"},
-                            "col2": {"type": "string"},
-                            "col3": {"type": "string"},
+                            "col1": {"type": ["null", "string"]},
+                            "col2": {"type": ["null", "string"]},
+                            "col3": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -686,7 +686,7 @@ csv_multi_stream_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col3": {"type": "string"},
+                            "col3": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -787,13 +787,13 @@ csv_custom_format_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
@@ -895,13 +895,13 @@ csv_legacy_format_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
@@ -1021,13 +1021,13 @@ multi_stream_custom_format = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
@@ -1043,7 +1043,7 @@ multi_stream_custom_format = (
                         "type": "object",
                         "properties": {
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
@@ -1139,8 +1139,8 @@ empty_schema_inference_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col1": {"type": "string"},
-                            "col2": {"type": "string"},
+                            "col1": {"type": ["null", "string"]},
+                            "col2": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -1339,7 +1339,7 @@ schemaless_csv_multi_stream_scenario = (
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col3": {"type": "string"},
+                            "col3": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },
@@ -1513,7 +1513,7 @@ schemaless_with_user_input_schema_fails_connection_check_multi_stream_scenario =
                     "json_schema": {
                         "type": "object",
                         "properties": {
-                            "col3": {"type": "string"},
+                            "col3": {"type": ["null", "string"]},
                             "_ab_source_file_last_modified": {"type": "string"},
                             "_ab_source_file_url": {"type": "string"},
                         },

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/incremental_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/incremental_scenarios.py
@@ -71,9 +71,9 @@ single_csv_input_state_is_earlier_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             }, "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -154,9 +154,9 @@ single_csv_file_is_skipped_if_same_modified_at_as_in_history = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             }, "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -239,9 +239,9 @@ single_csv_file_is_synced_if_modified_at_is_more_recent_than_in_history = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             }, "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -297,9 +297,9 @@ single_csv_no_input_state_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             }, "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -376,13 +376,13 @@ multi_csv_same_timestamp_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -460,9 +460,9 @@ single_csv_input_state_is_later_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             }, "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -551,13 +551,13 @@ multi_csv_different_timestamps_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -656,13 +656,13 @@ multi_csv_per_timestamp_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -767,13 +767,13 @@ multi_csv_skip_file_if_already_in_history = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -887,13 +887,13 @@ multi_csv_include_missing_files_within_history_range = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -1001,13 +1001,13 @@ multi_csv_remove_old_files_if_history_is_full_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -1145,13 +1145,13 @@ multi_csv_same_timestamp_more_files_than_history_size_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -1262,13 +1262,13 @@ multi_csv_sync_recent_files_if_history_is_incomplete_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -1378,13 +1378,13 @@ multi_csv_sync_files_within_time_window_if_history_is_incomplete__different_time
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -1500,13 +1500,13 @@ multi_csv_sync_files_within_history_time_window_if_history_is_incomplete_differe
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/jsonl_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/jsonl_scenarios.py
@@ -42,16 +42,16 @@ single_jsonl_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         },
                     },
@@ -116,19 +116,19 @@ multi_jsonl_with_different_keys_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             },
                             "col2": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         }
                     },
@@ -197,15 +197,15 @@ multi_jsonl_stream_n_file_exceeds_limit_for_inference = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             }, "col2": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         }
                     },
@@ -275,15 +275,15 @@ multi_jsonl_stream_n_bytes_exceeds_limit_for_inference = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             }, "col2": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         }
                     },
@@ -346,13 +346,13 @@ invalid_jsonl_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         }
                     },
@@ -429,19 +429,19 @@ jsonl_multi_stream_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "integer"
+                                "type": ["null", "integer"]
                             },
                             "col2": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             },
                             "col3": {
-                                "type": "number"
+                                "type": ["null", "number"]
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         },
                     },
@@ -455,13 +455,13 @@ jsonl_multi_stream_scenario = (
                         "type": "object",
                         "properties": {
                             "col3": {
-                                "type": "number"
+                                "type": ["null", "number"]
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         },
                     },
@@ -539,10 +539,10 @@ schemaless_jsonl_scenario = (
                                 "type": "object"
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         }
                     },
@@ -620,10 +620,10 @@ schemaless_jsonl_multi_stream_scenario = (
                                 "type": "object"
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         },
                     },
@@ -637,13 +637,13 @@ schemaless_jsonl_multi_stream_scenario = (
                         "type": "object",
                         "properties": {
                             "col3": {
-                                "type": "number"
+                                "type": ["null", "number"]
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         },
                     },
@@ -709,13 +709,13 @@ jsonl_user_input_schema_scenario = (
                                 "type": "integer"
                             },
                             "col2": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         },
                     },

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/parquet_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/parquet_scenarios.py
@@ -185,10 +185,10 @@ single_parquet_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string"
+                                "type": ["null", "string"]
                             },
                             "col2": {
-                                "type": "string"
+                                "type": ["null", "string"]
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -233,13 +233,13 @@ multi_parquet_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string"
+                                "type": ["null", "string"]
                             },
                             "col2": {
-                                "type": "string"
+                                "type": ["null", "string"]
                             },
                             "col3": {
-                                "type": "string"
+                                "type": ["null", "string"]
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -296,80 +296,80 @@ parquet_various_types_scenario = (
                         "type": "object",
                         "properties": {
                             "col_bool": {
-                                "type": "boolean"
+                                "type": ["null", "boolean"],
                             },
                             "col_int8": {
-                                "type": "integer"
+                                "type": ["null", "integer"],
                             },
                             "col_int16": {
-                                "type": "integer"
+                                "type": ["null", "integer"],
                             },
                             "col_int32": {
-                                "type": "integer"
+                                "type": ["null", "integer"],
                             },
                             "col_uint8": {
-                                "type": "integer"
+                                "type": ["null", "integer"],
                             },
                             "col_uint16": {
-                                "type": "integer"
+                                "type": ["null", "integer"],
                             },
                             "col_uint32": {
-                                "type": "integer"
+                                "type": ["null", "integer"],
                             },
                             "col_uint64": {
-                                "type": "integer"
+                                "type": ["null", "integer"],
                             },
                             "col_float32": {
-                                "type": "number"
+                                "type": ["null", "number"],
                             },
                             "col_float64": {
-                                "type": "number"
+                                "type": ["null", "number"],
                             },
                             "col_string": {
-                                "type": "string"
+                                "type": ["null", "string"],
                             },
                             "col_date32": {
-                                "type": "string",
+                                "type": ["null", "string"],
                                 "format": "date"
                             },
                             "col_date64": {
-                                "type": "string",
+                                "type": ["null", "string"],
                                 "format": "date"
                             },
                             "col_timestamp_without_tz": {
-                                "type": "string",
+                                "type": ["null", "string"],
                                 "format": "date-time"
                             },
                             "col_timestamp_with_tz": {
-                                "type": "string",
+                                "type": ["null", "string"],
                                 "format": "date-time"
                             },
                             "col_time32s": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col_time32ms": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col_time64us": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "col_struct": {
-                                "type": "object",
+                                "type": ["null", "object"],
                             },
                             "col_list": {
-                                "type": "array",
+                                "type": ["null", "array"],
                             },
                             "col_duration": {
-                                "type": "integer",
+                                "type": ["null", "integer"],
                             },
                             "col_binary": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
-                                "type": "string"
+                                "type": "string",
                             },
                             "_ab_source_file_url": {
-                                "type": "string"
+                                "type": "string",
                             },
                         },
                     },
@@ -443,7 +443,7 @@ parquet_file_with_decimal_no_config_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string"
+                                "type": ["null", "string"]
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -500,7 +500,7 @@ parquet_file_with_decimal_as_string_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string"
+                                "type": ["null", "string"]
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -557,7 +557,7 @@ parquet_file_with_decimal_as_float_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "number"
+                                "type": ["null", "number"]
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -611,7 +611,7 @@ parquet_file_with_decimal_legacy_config_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "number"
+                                "type": ["null", "number"]
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/user_input_schema_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/user_input_schema_scenarios.py
@@ -319,7 +319,7 @@ _base_multi_stream_user_input_schema_scenario = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -515,7 +515,7 @@ multi_stream_user_input_schema_scenario_emit_nonconforming_records = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"
@@ -654,7 +654,7 @@ multi_stream_user_input_schema_scenario_skip_nonconforming_records = (
                         "type": "object",
                         "properties": {
                             "col1": {
-                                "type": "string",
+                                "type": ["null", "string"],
                             },
                             "_ab_source_file_last_modified": {
                                 "type": "string"

--- a/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+from typing import Any, Mapping
+
+import pytest
+from airbyte_cdk.sources.file_based.stream.default_file_based_stream import DefaultFileBasedStream
+
+
+@pytest.mark.parametrize(
+    "input_schema, expected_output",
+    [
+        pytest.param({}, {}, id="empty-schema"),
+        pytest.param(
+            {"type": "string"},
+            {"type": ["null", "string"]},
+            id="simple-schema",
+        ),
+        pytest.param(
+            {"type": ["string"]},
+            {"type": ["null", "string"]},
+            id="simple-schema-list-type",
+        ),
+        pytest.param(
+            {"type": ["null", "string"]},
+            {"type": ["null", "string"]},
+            id="simple-schema-already-has-null",
+        ),
+        pytest.param(
+            {"properties": {"type": "string"}},
+            {"properties": {"type": ["null", "string"]}},
+            id="nested-schema",
+        ),
+        pytest.param(
+            {"items": {"type": "string"}},
+            {"items": {"type": ["null", "string"]}},
+            id="array-schema",
+        ),
+        pytest.param(
+            {"type": "object", "properties": {"prop": {"type": "string"}}},
+            {"type": ["null", "object"], "properties": {"prop": {"type": ["null", "string"]}}},
+            id="deeply-nested-schema",
+        ),
+    ],
+)
+def test_fill_nulls(input_schema: Mapping[str, Any], expected_output: Mapping[str, Any]) -> None:
+    assert DefaultFileBasedStream._fill_nulls(input_schema) == expected_output

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -241,7 +241,7 @@ def _verify_read_output(output: Dict[str, Any], scenario: TestScenario) -> None:
         if "record" in actual:
             for key, value in actual["record"]["data"].items():
                 if isinstance(value, float):
-                    assert math.isclose(value, expected["data"][key], abs_tol=1e-04)
+                    assert math.isclose(value, float(expected["data"][key]), abs_tol=1e-04)
                 else:
                     assert value == expected["data"][key]
             assert actual["record"]["stream"] == expected["stream"]


### PR DESCRIPTION
## What
Allows null values for all columns returned in inferred schemas.

This is consistent with the schema inference in [`source_files_abstract`](https://github.com/airbytehq/airbyte/blob/ad12b1e1b20713482ec2e6c3b6e8ae95b86e6dbd/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/stream.py#L190).
