### PR TITLE
connectors-ci: increase connectors package install max duration

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -367,9 +367,10 @@ This command runs tests for the metadata service orchestrator.
 `airbyte-ci metadata test orchestrator`
 
 ## Changelog
-| Version | PR  | Description                                                                                |
-| ------- | --- | ------------------------------------------------------------------------------------------ |
-| 0.1.0   |     | Alpha version not in production yet. All the commands described in this doc are available. |
+| Version | PR                                                        | Description                                                                                |
+| ------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| 0.1.1   | [#28858](https://github.com/airbytehq/airbyte/pull/28858) | Increase the max duration of Connector Package install to 20mn.                            |
+| 0.1.0   |                                                           | Alpha version not in production yet. All the commands described in this doc are available. |
 
 ## More info
 This project is owned by the Connectors Operations team.

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/python_connectors.py
@@ -59,7 +59,7 @@ class ConnectorPackageInstall(Step):
     """A step to install the Python connector package in a container."""
 
     title = "Connector package install"
-    max_duration = timedelta(minutes=10)
+    max_duration = timedelta(minutes=20)
     max_retries = 3
 
     async def _run(self) -> StepResult:

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "0.1.0"
+version = "0.1.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
During nightly build concurrent execution context some connectors take more than 10mn to complete their Connector Package Install step. Increasing the timeout to 20mn.
CF: https://airbytehq-team.slack.com/archives/C02TYE9QL9M/p1690797994052729?thread_ts=1690783339.381649&cid=C02TYE9QL9M