### PR TITLE
Source Stripe: Add properties to customer_shipping field in invoices stream

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -13,5 +13,5 @@ ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
 
-LABEL io.airbyte.version=3.17.0
+LABEL io.airbyte.version=3.17.1
 LABEL io.airbyte.name=airbyte/source-stripe

--- a/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
@@ -14,7 +14,7 @@ acceptance_tests:
     tests:
       - config_path: "secrets/config.json"
         backward_compatibility_tests_config:
-          disable_for_version: "3.8.0" # new streams added; no actual breaking changes; schemas refactoring
+          disable_for_version: "3.17.0" # invoices schema fix
   basic_read:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e094cb9a-26de-4645-8761-65c0c425d1de
-  dockerImageTag: 3.17.0
+  dockerImageTag: 3.17.1
   dockerRepository: airbyte/source-stripe
   githubIssueLabel: source-stripe
   icon: stripe.svg
@@ -14,7 +14,6 @@ data:
   registries:
     cloud:
       enabled: true
-      dockerImageTag: 3.15.0  # p0-stripe-schema-broken
     oss:
       enabled: true
   releaseStage: generally_available

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoices.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoices.json
@@ -332,35 +332,65 @@
     },
     "customer_shipping": {
       "type": ["null", "object"],
-      "address": {
-        "type": ["null", "object"],
-        "properties": {
-          "city": {
-            "type": ["null", "string"]
+      "additionalProperties": true,
+      "properties": {
+          "address" : {
+            "type" : [
+              "null",
+              "object"
+            ],
+            "properties" : {
+              "city" : {
+                "type" : [
+                  "null",
+                  "string"
+                ]
+              },
+              "country" : {
+                "type" : [
+                  "null",
+                  "string"
+                ]
+              },
+              "line1" : {
+                "type" : [
+                  "null",
+                  "string"
+                ]
+              },
+              "line2" : {
+                "type" : [
+                  "null",
+                  "string"
+                ]
+              },
+              "postal_code" : {
+                "type" : [
+                  "null",
+                  "string"
+                ]
+              },
+              "state" : {
+                "type" : [
+                  "null",
+                  "string"
+                ]
+              }
+            }
           },
-          "country": {
-            "type": ["null", "string"]
+          "name" : {
+            "type" : [
+              "null",
+              "string"
+            ]
           },
-          "line1": {
-            "type": ["null", "string"]
-          },
-          "line2": {
-            "type": ["null", "string"]
-          },
-          "postal_code": {
-            "type": ["null", "string"]
-          },
-          "state": {
-            "type": ["null", "string"]
+          "phone" : {
+            "type" : [
+              "null",
+              "string"
+            ]
           }
         }
-      },
-      "name": {
-        "type": ["null", "string"]
-      },
-      "phone": {
-        "type": ["null", "string"]
-      }
     },
     "application": {
       "type": ["null", "string"]

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -103,7 +103,8 @@ The Stripe connector should not run into Stripe API limitations under normal usa
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                              |
-| :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:--------|:-----------| :------------------------------------------------------- |:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.17.1  | 2023-08-01 | [28887](https://github.com/airbytehq/airbyte/pull/28887) | Fix `Invoices` schema                                                                                                                                |
 | 3.17.0  | 2023-07-28 | [26127](https://github.com/airbytehq/airbyte/pull/26127) | Add `Prices` stream                                                                                                                                  |
 | 3.16.0  | 2023-07-27 | [28776](https://github.com/airbytehq/airbyte/pull/28776) | Add new fields to stream schemas                                                                                                                     |
 | 3.15.0  | 2023-07-09 | [28709](https://github.com/airbytehq/airbyte/pull/28709) | Remove duplicate streams                                                                                                                             |


### PR DESCRIPTION
## What
Broken schema for invoices stream
Fixed: https://github.com/airbytehq/oncall/issues/2609

## How
Moved all the properties of customer shipping filed in invoices stream under a properties field. 

## 🚨 User Impact 🚨
No

## Pre-merge Actions
<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>