### PR TITLE
Metadata: Write registry entry to docker repo override location

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -19,7 +19,7 @@ from orchestrator.utils.object_helpers import deep_copy_params
 from orchestrator.utils.dagster_helpers import OutputDataFrame
 from orchestrator.models.metadata import MetadataDefinition, LatestMetadataEntry
 from orchestrator.config import get_public_url_for_gcs_file, VALID_REGISTRIES, MAX_METADATA_PARTITION_RUN_REQUEST
-
+import orchestrator.hacks as HACKS
 from typing import List, Optional, Tuple, Union
 
 PolymorphicRegistryEntry = Union[ConnectorRegistrySourceDefinition, ConnectorRegistryDestinationDefinition]
@@ -189,7 +189,6 @@ def get_registry_entry_write_path(metadata_entry: LatestMetadataEntry, registry_
         raise Exception(f"Metadata entry {metadata_entry} does not have a file path")
 
     metadata_folder = os.path.dirname(metadata_path)
-    print(f"metadata_folder: {metadata_folder}")
     return os.path.join(metadata_folder, registry_name)
 
 
@@ -213,6 +212,7 @@ def persist_registry_entry_to_json(
     registry_entry_write_path = get_registry_entry_write_path(metadata_entry, registry_name)
     registry_entry_json = registry_entry.json(exclude_none=True)
     file_handle = registry_directory_manager.write_data(registry_entry_json.encode("utf-8"), ext="json", key=registry_entry_write_path)
+    HACKS.write_registry_to_overrode_file_paths(registry_entry, registry_name, metadata_entry, registry_directory_manager)
     return file_handle
 
 
@@ -240,6 +240,7 @@ def generate_and_persist_registry_entry(
     registry_model = ConnectorModel.parse_obj(registry_entry_with_spec)
 
     file_handle = persist_registry_entry_to_json(registry_model, registry_name, metadata_entry, metadata_directory_manager)
+
     return file_handle.public_url
 
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/hacks.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/hacks.py
@@ -53,7 +53,7 @@ def write_registry_to_overrode_file_paths(
         by the platform when looking for a specific registry entry. In this case, for cloud, it would be
         gs://my-bucket/metadata/source-postgres-strict-encrypt/dev.123/cloud.json
 
-        Ideally we would not have to do this, but the combonation of prereleases and common overrides
+        Ideally we would not have to do this, but the combination of prereleases and common overrides
         make this nessesary.
 
     Args:

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/hacks.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/hacks.py
@@ -1,0 +1,78 @@
+from dagster import get_dagster_logger
+from dagster_gcp.gcs.file_manager import GCSFileManager, GCSFileHandle
+
+from orchestrator.models.metadata import LatestMetadataEntry
+from metadata_service.constants import METADATA_FILE_NAME
+from metadata_service.gcs_upload import get_metadata_remote_file_path
+from metadata_service.models.generated.ConnectorRegistrySourceDefinition import ConnectorRegistrySourceDefinition
+from metadata_service.models.generated.ConnectorRegistryDestinationDefinition import ConnectorRegistryDestinationDefinition
+
+from typing import Union
+
+PolymorphicRegistryEntry = Union[ConnectorRegistrySourceDefinition, ConnectorRegistryDestinationDefinition]
+
+def _is_docker_repository_overridden(metadata_entry: LatestMetadataEntry, registry_entry: PolymorphicRegistryEntry,) -> bool:
+    """Check if the docker repository is overridden in the registry entry."""
+    registry_entry_docker_repository = registry_entry.dockerRepository
+    metadata_docker_repository = metadata_entry.metadata_definition.data.dockerRepository
+    return registry_entry_docker_repository != metadata_docker_repository
+
+def _get_version_specific_registry_entry_file_path(registry_entry, registry_name):
+    """Get the file path for the version specific registry entry file."""
+    docker_reposiory = registry_entry.dockerRepository
+    docker_version = registry_entry.dockerImageTag
+
+    assumed_metadata_file_path = get_metadata_remote_file_path(docker_reposiory, docker_version)
+    registry_entry_file_path = assumed_metadata_file_path.replace(METADATA_FILE_NAME, registry_name)
+    return registry_entry_file_path
+
+def _check_for_invalid_write_path(write_path: str):
+    """Check if the write path is valid."""
+
+    if "latest" in write_path:
+        raise ValueError("Cannot write to a path that contains 'latest'. That is reserved for the latest metadata file and its direct transformations")
+
+def write_registry_to_overrode_file_paths(
+    registry_entry: PolymorphicRegistryEntry,
+    registry_name: str,
+    metadata_entry: LatestMetadataEntry,
+    registry_directory_manager: GCSFileManager,
+) -> GCSFileHandle:
+    """
+    Write the registry entry to the docker repository and version specific file paths
+    in the event that the docker repository is overridden.
+
+    Underlying issue:
+        The registry entry files (oss.json and cloud.json) are traditionally written to
+        the same path as the metadata.yaml file that created them. This is fine for the
+        most cases, but when the docker repository is overridden, the registry entry
+        files need to be written to a different path.
+
+        For example if source-postgres:dev.123 is overridden to source-postgres-strict-encrypt:dev.123
+        then the oss.json file needs to be written to the path that would be assumed
+        by the platform when looking for a specific registry entry. In this case, for cloud, it would be
+        gs://my-bucket/metadata/source-postgres-strict-encrypt/dev.123/cloud.json
+
+        Ideally we would not have to do this, but the combonation of prereleases and common overrides
+        make this nessesary.
+
+    Args:
+        registry_entry (PolymorphicRegistryEntry): The registry entry to write
+        registry_name (str): The name of the registry entry (oss or cloud)
+        metadata_entry (LatestMetadataEntry): The metadata entry that created the registry entry
+        registry_directory_manager (GCSFileManager): The file manager to use to write the registry entry
+
+    Returns:
+        GCSFileHandle: The file handle of the written registry entry
+    """
+    if not _is_docker_repository_overridden(metadata_entry, registry_entry):
+        return None
+    logger = get_dagster_logger()
+    registry_entry_json = registry_entry.json(exclude_none=True)
+    overrode_registry_entry_version_write_path = _get_version_specific_registry_entry_file_path(registry_entry, registry_name)
+    _check_for_invalid_write_path(overrode_registry_entry_version_write_path)
+    logger.info(f"Writing registry entry to {overrode_registry_entry_version_write_path}")
+    file_handle = registry_directory_manager.write_data(registry_entry_json.encode("utf-8"), ext="json", key=overrode_registry_entry_version_write_path)
+    logger.info(f"Successfully wrote registry entry to {file_handle.public_url}")
+    return file_handle
+

--- a/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
@@ -2251,6 +2251,7 @@ files = [
 
 [package.dependencies]
 numpy = [
+    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
 ]
@@ -2432,6 +2433,7 @@ crashtest = ">=0.4.1,<0.5.0"
 dulwich = ">=0.21.2,<0.22.0"
 filelock = ">=3.8.0,<4.0.0"
 html5lib = ">=1.0,<2.0"
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 installer = ">=0.7.0,<0.8.0"
 jsonschema = ">=4.10.0,<5.0.0"
 keyring = ">=23.9.0,<24.0.0"
@@ -3274,6 +3276,17 @@ cryptography = ">=2.0"
 jeepney = ">=0.6"
 
 [[package]]
+name = "semver"
+version = "3.0.1"
+description = "Python helper for Semantic Versioning (https://semver.org)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "semver-3.0.1-py3-none-any.whl", hash = "sha256:2a23844ba1647362c7490fe3995a86e097bb590d16f0f32dfc383008f19e4cdf"},
+    {file = "semver-3.0.1.tar.gz", hash = "sha256:9ec78c5447883c67b97f98c3b6212796708191d22e4ad30f4570f840171cbce1"},
+]
+
+[[package]]
 name = "setuptools"
 version = "67.7.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -3435,6 +3448,7 @@ files = [
 
 [package.dependencies]
 anyio = ">=3.4.0,<5"
+typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
@@ -4140,5 +4154,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "27208e5381cda9b22c2619e13fb960fa5f042c7424dd8eb0b94ea2548babd5cc"
+python-versions = "^3.9"
+content-hash = "9bfa30fbc3ea5f1ad4d0813d4364b7be23f44223773cb4d7f37b9ae29b22ee9b"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -26,6 +26,7 @@ poetry2setup = "^1.1.0"
 slack-sdk = "^3.21.3"
 poetry = "^1.5.1"
 pydantic = "^1.10.6"
+semver = "^3.0.1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Overview
closes #28884

This writes any docker repo overrides to their cannonical version path.

## Nots for reviewer
I put this in a hacks file as the idea of having docker image overrides as a matter of process seems like a piece of legacy that we should be moving away from.