### PR TITLE
connectors-ci: skipped status  when metadata upload exits with 5

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -378,6 +378,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 
 | Version | PR                                                        | Description                                                                                  |
 |---------|-----------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| 0.3.1   | [#28938](https://github.com/airbytehq/airbyte/pull/28938) | Handle 5 status code on MetadataUpload as skipped                                |
 | 0.3.0   | [#28869](https://github.com/airbytehq/airbyte/pull/28869) | Enable the Dagger terminal UI on local `airbyte-ci` execution                                |
 | 0.2.3   | [#28907](https://github.com/airbytehq/airbyte/pull/28907) | Make dagger-in-dagger work for `airbyte-ci tests` command                                    |
 | 0.2.2   | [#28897](https://github.com/airbytehq/airbyte/pull/28897) | Sentry: Ignore error logs without exceptions from reporting                                  |

--- a/airbyte-ci/connectors/pipelines/pipelines/pipelines/metadata.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/pipelines/metadata.py
@@ -63,6 +63,10 @@ class MetadataValidation(PoetryRun):
 
 
 class MetadataUpload(PoetryRun):
+
+    # When the metadata service exits with this code, it means the metadata is valid but the upload was skipped because the metadata is already uploaded
+    skipped_exit_code = 5
+
     def __init__(
         self,
         context: PipelineContext,

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "0.3.0"
+version = "0.3.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/pull/28767 changed how we identify steps as skipped.
The exit code that leads to the "skipped" step status is now defined at the `Step` subclass level and is not global.
It introduced a regression for the MetadataUpload step - when its container exits with 5 it means the upload was skipped because the metadata yaml already exists on the bucket. 

## How
Declare in `MetadataUpload` that the skipped exit code is 5
