### PR TITLE
✨ Source Debezium CDC: add new `_ab_cdc_op` metadata column

### DIFF
--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumEventUtils.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumEventUtils.java
@@ -28,7 +28,6 @@ public class DebeziumEventUtils {
     final JsonNode after = debeziumRecord.get("after");
     final JsonNode source = debeziumRecord.get("source");
     final JsonNode op = debeziumRecord.get("op");
-    System.out.println("Debezium record " + debeziumRecord);
 
     final JsonNode data = formatDebeziumData(before, after, source, op, cdcMetadataInjector);
     final String schemaName = cdcMetadataInjector.namespace(source);
@@ -59,7 +58,7 @@ public class DebeziumEventUtils {
     base.put(CDC_UPDATED_AT, transactionTimestamp);
     base.put(CDC_OP, getDebeziumOpReadable(op.asText()));
     cdcMetadataInjector.addMetaData(base, source);
-  
+
     if (after.isNull()) {
       base.put(CDC_DELETED_AT, transactionTimestamp);
     } else {
@@ -77,7 +76,7 @@ public class DebeziumEventUtils {
       case DELETE -> "DELETE";
       case READ -> "READ";
       default -> throw new RuntimeException("Encountered unhandled change event operation " + op);
-      //This should never happen as truncate and message events should be skipped by connectors. 
+      // This should never happen as truncate and message events should be skipped by connectors.
     };
   }
 

--- a/airbyte-integrations/bases/debezium/src/test/java/io/airbyte/integrations/debezium/DebeziumEventUtilsTest.java
+++ b/airbyte-integrations/bases/debezium/src/test/java/io/airbyte/integrations/debezium/DebeziumEventUtilsTest.java
@@ -31,18 +31,22 @@ class DebeziumEventUtilsTest {
     final ChangeEventWithMetadata insertChangeEvent = mockChangeEvent("insert_change_event.json");
     final ChangeEventWithMetadata updateChangeEvent = mockChangeEvent("update_change_event.json");
     final ChangeEventWithMetadata deleteChangeEvent = mockChangeEvent("delete_change_event.json");
+    final ChangeEventWithMetadata snapShotChangeEvent = mockChangeEvent("snapshot_change_event.json");
 
     final AirbyteMessage actualInsert = DebeziumEventUtils.toAirbyteMessage(insertChangeEvent, cdcMetadataInjector, emittedAt);
     final AirbyteMessage actualUpdate = DebeziumEventUtils.toAirbyteMessage(updateChangeEvent, cdcMetadataInjector, emittedAt);
     final AirbyteMessage actualDelete = DebeziumEventUtils.toAirbyteMessage(deleteChangeEvent, cdcMetadataInjector, emittedAt);
+    final AirbyteMessage actualSnapshot = DebeziumEventUtils.toAirbyteMessage(snapShotChangeEvent, cdcMetadataInjector, emittedAt);
 
     final AirbyteMessage expectedInsert = createAirbyteMessage(stream, emittedAt, "insert_message.json");
     final AirbyteMessage expectedUpdate = createAirbyteMessage(stream, emittedAt, "update_message.json");
     final AirbyteMessage expectedDelete = createAirbyteMessage(stream, emittedAt, "delete_message.json");
+    final AirbyteMessage expectedSnapshot = createAirbyteMessage(stream, emittedAt, "snapshot_message.json");
 
     deepCompare(expectedInsert, actualInsert);
     deepCompare(expectedUpdate, actualUpdate);
     deepCompare(expectedDelete, actualDelete);
+    deepCompare(expectedSnapshot, actualSnapshot);
   }
 
   private static ChangeEventWithMetadata mockChangeEvent(final String resourceName) throws IOException {

--- a/airbyte-integrations/bases/debezium/src/test/resources/delete_message.json
+++ b/airbyte-integrations/bases/debezium/src/test/resources/delete_message.json
@@ -4,5 +4,6 @@
   "power": null,
   "_ab_cdc_updated_at": "2021-03-26T16:20:46.886Z",
   "_ab_cdc_lsn": 23012360,
-  "_ab_cdc_deleted_at": "2021-03-26T16:20:46.886Z"
+  "_ab_cdc_deleted_at": "2021-03-26T16:20:46.886Z",
+  "_ab_cdc_op": "DELETE"
 }

--- a/airbyte-integrations/bases/debezium/src/test/resources/insert_change_event.json
+++ b/airbyte-integrations/bases/debezium/src/test/resources/insert_change_event.json
@@ -18,7 +18,7 @@
     "lsn": 23011544,
     "xmin": null
   },
-  "op": "r",
+  "op": "c",
   "ts_ms": 1616775642624,
   "transaction": null,
   "destination": "orders.public.names"

--- a/airbyte-integrations/bases/debezium/src/test/resources/insert_message.json
+++ b/airbyte-integrations/bases/debezium/src/test/resources/insert_message.json
@@ -4,5 +4,6 @@
   "power": "Infinity",
   "_ab_cdc_updated_at": "2021-03-26T16:20:42.623Z",
   "_ab_cdc_lsn": 23011544,
-  "_ab_cdc_deleted_at": null
+  "_ab_cdc_deleted_at": null,
+  "_ab_cdc_op": "INSERT"
 }

--- a/airbyte-integrations/bases/debezium/src/test/resources/snapshot_change_event.json
+++ b/airbyte-integrations/bases/debezium/src/test/resources/snapshot_change_event.json
@@ -1,0 +1,25 @@
+{
+  "before": null,
+  "after": {
+    "first_name": "san",
+    "last_name": "goku",
+    "power": "Infinity"
+  },
+  "source": {
+    "version": "1.4.2.Final",
+    "connector": "postgresql",
+    "name": "orders",
+    "ts_ms": 1616775642623,
+    "snapshot": true,
+    "db": "db_lwfoyffqvx",
+    "schema": "public",
+    "table": "names",
+    "txId": 495,
+    "lsn": 23011544,
+    "xmin": null
+  },
+  "op": "r",
+  "ts_ms": 1616775642624,
+  "transaction": null,
+  "destination": "orders.public.names"
+}

--- a/airbyte-integrations/bases/debezium/src/test/resources/snapshot_message.json
+++ b/airbyte-integrations/bases/debezium/src/test/resources/snapshot_message.json
@@ -1,0 +1,9 @@
+{
+  "first_name": "san",
+  "last_name": "goku",
+  "power": "Infinity",
+  "_ab_cdc_updated_at": "2021-03-26T16:20:42.623Z",
+  "_ab_cdc_lsn": 23011544,
+  "_ab_cdc_deleted_at": null,
+  "_ab_cdc_op": "READ"
+}

--- a/airbyte-integrations/bases/debezium/src/test/resources/update_message.json
+++ b/airbyte-integrations/bases/debezium/src/test/resources/update_message.json
@@ -4,5 +4,6 @@
   "power": 10000.2,
   "_ab_cdc_updated_at": "2021-03-26T16:20:46.881Z",
   "_ab_cdc_lsn": 23012216,
-  "_ab_cdc_deleted_at": null
+  "_ab_cdc_deleted_at": null,
+  "_ab_cdc_op": "UPDATE"
 }

--- a/airbyte-integrations/bases/debezium/src/testFixtures/java/io/airbyte/integrations/debezium/CdcSourceTest.java
+++ b/airbyte-integrations/bases/debezium/src/testFixtures/java/io/airbyte/integrations/debezium/CdcSourceTest.java
@@ -594,6 +594,7 @@ public abstract class CdcSourceTest {
 
     final AirbyteStateMessage stateMessageEmittedAfterFirstSyncCompletion = stateAfterFirstBatch.get(stateAfterFirstBatch.size() - 1);
     assertEquals(AirbyteStateMessage.AirbyteStateType.GLOBAL, stateMessageEmittedAfterFirstSyncCompletion.getType());
+    System.out.println("here 1 " + stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getSharedState());
     assertNotNull(stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getSharedState());
     final Set<StreamDescriptor> streamsInStateAfterFirstSyncCompletion = stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getStreamStates()
         .stream()
@@ -601,6 +602,7 @@ public abstract class CdcSourceTest {
         .collect(Collectors.toSet());
     assertEquals(1, streamsInStateAfterFirstSyncCompletion.size());
     assertTrue(streamsInStateAfterFirstSyncCompletion.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA)));
+    System.out.println("Here 2 " + stateMessageEmittedAfterFirstSyncCompletion.getData());
     assertNotNull(stateMessageEmittedAfterFirstSyncCompletion.getData());
 
     assertEquals((MODEL_RECORDS.size()), recordsFromFirstBatch.size());

--- a/airbyte-integrations/bases/debezium/src/testFixtures/java/io/airbyte/integrations/debezium/CdcSourceTest.java
+++ b/airbyte-integrations/bases/debezium/src/testFixtures/java/io/airbyte/integrations/debezium/CdcSourceTest.java
@@ -594,7 +594,6 @@ public abstract class CdcSourceTest {
 
     final AirbyteStateMessage stateMessageEmittedAfterFirstSyncCompletion = stateAfterFirstBatch.get(stateAfterFirstBatch.size() - 1);
     assertEquals(AirbyteStateMessage.AirbyteStateType.GLOBAL, stateMessageEmittedAfterFirstSyncCompletion.getType());
-    System.out.println("here 1 " + stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getSharedState());
     assertNotNull(stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getSharedState());
     final Set<StreamDescriptor> streamsInStateAfterFirstSyncCompletion = stateMessageEmittedAfterFirstSyncCompletion.getGlobal().getStreamStates()
         .stream()
@@ -602,7 +601,6 @@ public abstract class CdcSourceTest {
         .collect(Collectors.toSet());
     assertEquals(1, streamsInStateAfterFirstSyncCompletion.size());
     assertTrue(streamsInStateAfterFirstSyncCompletion.contains(new StreamDescriptor().withName(MODELS_STREAM_NAME).withNamespace(MODELS_SCHEMA)));
-    System.out.println("Here 2 " + stateMessageEmittedAfterFirstSyncCompletion.getData());
     assertNotNull(stateMessageEmittedAfterFirstSyncCompletion.getData());
 
     assertEquals((MODEL_RECORDS.size()), recordsFromFirstBatch.size());

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
@@ -41,6 +41,7 @@ public abstract class SourceAcceptanceTest extends AbstractSourceConnectorTest {
   public static final String CDC_LSN = "_ab_cdc_lsn";
   public static final String CDC_UPDATED_AT = "_ab_cdc_updated_at";
   public static final String CDC_DELETED_AT = "_ab_cdc_deleted_at";
+  public static final String CDC_OP = "_ab_cdc_op";
   public static final String CDC_LOG_FILE = "_ab_cdc_log_file";
   public static final String CDC_LOG_POS = "_ab_cdc_log_pos";
   public static final String CDC_EVENT_SERIAL_NO = "_ab_cdc_event_serial_no";
@@ -358,6 +359,7 @@ public abstract class SourceAcceptanceTest extends AbstractSourceConnectorTest {
     ((ObjectNode) clone.getData()).remove(CDC_LOG_POS);
     ((ObjectNode) clone.getData()).remove(CDC_UPDATED_AT);
     ((ObjectNode) clone.getData()).remove(CDC_DELETED_AT);
+    ((ObjectNode) clone.getData()).remove(CDC_OP);
     ((ObjectNode) clone.getData()).remove(CDC_EVENT_SERIAL_NO);
     return clone;
   }

--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/Dockerfile
@@ -24,5 +24,5 @@ ENV APPLICATION source-mssql-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=1.1.0
+LABEL io.airbyte.version=1.2.0
 LABEL io.airbyte.name=airbyte/source-mssql-strict-encrypt

--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
-  dockerImageTag: 1.1.0
+  dockerImageTag: 1.2.0
   dockerRepository: airbyte/source-mssql-strict-encrypt
   githubIssueLabel: source-mssql
   icon: mssql.svg

--- a/airbyte-integrations/connectors/source-mssql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mssql/Dockerfile
@@ -24,5 +24,5 @@ ENV APPLICATION source-mssql
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=1.1.0
+LABEL io.airbyte.version=1.2.0
 LABEL io.airbyte.name=airbyte/source-mssql

--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
-  dockerImageTag: 1.1.0
+  dockerImageTag: 1.2.0
   dockerRepository: airbyte/source-mssql
   githubIssueLabel: source-mssql
   icon: mssql.svg

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlCdcConnectorMetadataInjector.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.source.mssql;
 
+import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_OP;
 import static io.airbyte.integrations.source.mssql.MssqlSource.CDC_EVENT_SERIAL_NO;
 import static io.airbyte.integrations.source.mssql.MssqlSource.CDC_LSN;
 
@@ -19,6 +20,7 @@ public class MssqlCdcConnectorMetadataInjector implements CdcMetadataInjector {
     final String eventSerialNo = source.get("event_serial_no").asText();
     event.put(CDC_LSN, commitLsn);
     event.put(CDC_EVENT_SERIAL_NO, eventSerialNo);
+    event.put(CDC_OP, event.get(CDC_OP).asText());
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -6,6 +6,7 @@ package io.airbyte.integrations.source.mssql;
 
 import static io.airbyte.integrations.debezium.AirbyteDebeziumHandler.shouldUseCDC;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_DELETED_AT;
+import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_OP;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_UPDATED_AT;
 import static io.airbyte.integrations.source.relationaldb.RelationalDbQueryUtils.enquoteIdentifier;
 import static io.airbyte.integrations.source.relationaldb.RelationalDbQueryUtils.enquoteIdentifierList;
@@ -505,6 +506,7 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
     properties.set(CDC_EVENT_SERIAL_NO, stringType);
+    properties.set(CDC_OP, stringType);
 
     return stream;
   }

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.source.mssql;
 
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_DELETED_AT;
+import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_OP;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_UPDATED_AT;
 import static io.airbyte.integrations.source.mssql.MssqlSource.CDC_EVENT_SERIAL_NO;
 import static io.airbyte.integrations.source.mssql.MssqlSource.CDC_LSN;
@@ -374,6 +375,7 @@ public class CdcMssqlSourceTest extends CdcSourceTest {
     data.remove(CDC_UPDATED_AT);
     data.remove(CDC_DELETED_AT);
     data.remove(CDC_EVENT_SERIAL_NO);
+    data.remove(CDC_OP);
   }
 
   @Override
@@ -409,6 +411,7 @@ public class CdcMssqlSourceTest extends CdcSourceTest {
     assertNull(data.get(CDC_UPDATED_AT));
     assertNull(data.get(CDC_DELETED_AT));
     assertNull(data.get(CDC_EVENT_SERIAL_NO));
+    assertNull(data.get(CDC_OP));
   }
 
   @Override
@@ -416,6 +419,7 @@ public class CdcMssqlSourceTest extends CdcSourceTest {
     assertNotNull(data.get(CDC_LSN));
     assertNotNull(data.get(CDC_EVENT_SERIAL_NO));
     assertNotNull(data.get(CDC_UPDATED_AT));
+    assertNotNull(data.get(CDC_OP));
     if (deletedAtNull) {
       assertTrue(data.get(CDC_DELETED_AT).isNull());
     } else {
@@ -433,6 +437,7 @@ public class CdcMssqlSourceTest extends CdcSourceTest {
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
     properties.set(CDC_EVENT_SERIAL_NO, stringType);
+    properties.set(CDC_OP, stringType);
 
   }
 

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/Dockerfile
@@ -24,6 +24,6 @@ ENV APPLICATION source-mysql-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=2.1.0
+LABEL io.airbyte.version=2.2.0
 
 LABEL io.airbyte.name=airbyte/source-mysql-strict-encrypt

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 2.1.0
+  dockerImageTag: 2.2.0
   dockerRepository: airbyte/source-mysql-strict-encrypt
   githubIssueLabel: source-mysql
   icon: mysql.svg

--- a/airbyte-integrations/connectors/source-mysql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql/Dockerfile
@@ -24,6 +24,6 @@ ENV APPLICATION source-mysql
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=2.1.0
+LABEL io.airbyte.version=2.2.0
 
 LABEL io.airbyte.name=airbyte/source-mysql

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 2.1.0
+  dockerImageTag: 2.2.0
   dockerRepository: airbyte/source-mysql
   githubIssueLabel: source-mysql
   icon: mysql.svg

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcConnectorMetadataInjector.java
@@ -4,8 +4,10 @@
 
 package io.airbyte.integrations.source.mysql;
 
+import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_OP;
 import static io.airbyte.integrations.source.mysql.MySqlSource.CDC_LOG_FILE;
 import static io.airbyte.integrations.source.mysql.MySqlSource.CDC_LOG_POS;
+
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -17,6 +19,7 @@ public class MySqlCdcConnectorMetadataInjector implements CdcMetadataInjector {
   public void addMetaData(final ObjectNode event, final JsonNode source) {
     event.put(CDC_LOG_FILE, source.get("file").asText());
     event.put(CDC_LOG_POS, source.get("pos").asLong());
+    event.put(CDC_OP, event.get(CDC_OP).asText());
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.source.mysql;
 import static io.airbyte.db.jdbc.JdbcUtils.EQUALS;
 import static io.airbyte.integrations.debezium.AirbyteDebeziumHandler.shouldUseCDC;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_DELETED_AT;
+import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_OP;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_UPDATED_AT;
 import static io.airbyte.integrations.source.jdbc.JdbcDataSourceUtils.DEFAULT_JDBC_PARAMETERS_DELIMITER;
 import static io.airbyte.integrations.source.jdbc.JdbcDataSourceUtils.assertCustomParametersDontOverwriteDefaultParameters;
@@ -147,6 +148,7 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
     properties.set(CDC_LOG_POS, numberType);
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
+    properties.set(CDC_OP, stringType);
 
     return stream;
   }

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.source.mysql;
 
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_DELETED_AT;
+import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_OP;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_UPDATED_AT;
 import static io.airbyte.integrations.debezium.internals.mysql.MySqlDebeziumStateUtil.MYSQL_CDC_OFFSET;
 import static io.airbyte.integrations.debezium.internals.mysql.MySqlDebeziumStateUtil.MYSQL_DB_HISTORY;
@@ -155,6 +156,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     assertNull(data.get(CDC_LOG_POS));
     assertNull(data.get(CDC_UPDATED_AT));
     assertNull(data.get(CDC_DELETED_AT));
+    assertNull(data.get(CDC_OP));
   }
 
   @Override
@@ -162,6 +164,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     assertNotNull(data.get(CDC_LOG_FILE));
     assertNotNull(data.get(CDC_LOG_POS));
     assertNotNull(data.get(CDC_UPDATED_AT));
+    assertNotNull(data.get(CDC_OP));
     if (deletedAtNull) {
       assertTrue(data.get(CDC_DELETED_AT).isNull());
     } else {
@@ -175,6 +178,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     data.remove(CDC_LOG_POS);
     data.remove(CDC_UPDATED_AT);
     data.remove(CDC_DELETED_AT);
+    data.remove(CDC_OP);
   }
 
   @Override
@@ -189,6 +193,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     properties.set(CDC_LOG_POS, numberType);
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
+    properties.set(CDC_OP, stringType);
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
@@ -24,5 +24,5 @@ ENV APPLICATION source-postgres-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=3.1.1
+LABEL io.airbyte.version=3.2.0
 LABEL io.airbyte.name=airbyte/source-postgres-strict-encrypt

--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
   maxSecondsBetweenMessages: 7200
-  dockerImageTag: 3.1.1
+  dockerImageTag: 3.2.0
   dockerRepository: airbyte/source-postgres-strict-encrypt
   githubIssueLabel: source-postgres
   icon: postgresql.svg

--- a/airbyte-integrations/connectors/source-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres/Dockerfile
@@ -24,5 +24,5 @@ ENV APPLICATION source-postgres
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=3.1.1
+LABEL io.airbyte.version=3.2.0
 LABEL io.airbyte.name=airbyte/source-postgres

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -56,4 +56,3 @@ jsonSchema2Pojo {
     includeConstructors = false
     includeSetters = true
 }
-

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -57,6 +57,3 @@ jsonSchema2Pojo {
     includeSetters = true
 }
 
-test {
-    testLogging.showStandardStreams = true
-}

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -56,3 +56,7 @@ jsonSchema2Pojo {
     includeConstructors = false
     includeSetters = true
 }
+
+test {
+    testLogging.showStandardStreams = true
+}

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.1.1
+  dockerImageTag: 3.2.0
   maxSecondsBetweenMessages: 7200
   dockerRepository: airbyte/source-postgres
   githubIssueLabel: source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresCatalogHelper.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresCatalogHelper.java
@@ -85,6 +85,7 @@ public final class PostgresCatalogHelper {
     properties.set(DebeziumEventUtils.CDC_LSN, numberType);
     properties.set(DebeziumEventUtils.CDC_UPDATED_AT, stringType);
     properties.set(DebeziumEventUtils.CDC_DELETED_AT, stringType);
+    properties.set(DebeziumEventUtils.CDC_OP, stringType);
 
     return stream;
   }

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcConnectorMetadataInjector.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.source.postgres.cdc;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_DELETED_AT;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_LSN;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_UPDATED_AT;
+import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_OP;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -18,6 +19,7 @@ public class PostgresCdcConnectorMetadataInjector implements CdcMetadataInjector
   public void addMetaData(final ObjectNode event, final JsonNode source) {
     final long lsn = source.get("lsn").asLong();
     event.put(CDC_LSN, lsn);
+    event.put(CDC_OP, event.get(CDC_OP).asText());
   }
 
   @Override
@@ -25,6 +27,7 @@ public class PostgresCdcConnectorMetadataInjector implements CdcMetadataInjector
     record.put(CDC_UPDATED_AT, transactionTimestamp);
     record.put(CDC_LSN, lsn);
     record.put(CDC_DELETED_AT, (String) null);
+    record.put(CDC_OP, (String) null);
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
@@ -266,7 +266,6 @@ public class CdcPostgresSourceTest extends CdcSourceTest {
 
   @Override
   protected void assertCdcMetaData(final JsonNode data, final boolean deletedAtNull) {
-    System.out.println("THis is the data " + data);
     assertNotNull(data.get(CDC_LSN));
     assertNotNull(data.get(CDC_UPDATED_AT));
     assertNotNull(data.get(CDC_OP));

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.source.postgres;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_DELETED_AT;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_LSN;
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_UPDATED_AT;
+import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_OP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -260,12 +261,15 @@ public class CdcPostgresSourceTest extends CdcSourceTest {
     assertNull(data.get(CDC_LSN));
     assertNull(data.get(CDC_UPDATED_AT));
     assertNull(data.get(CDC_DELETED_AT));
+    assertNull(data.get(CDC_OP));
   }
 
   @Override
   protected void assertCdcMetaData(final JsonNode data, final boolean deletedAtNull) {
+    System.out.println("THis is the data " + data);
     assertNotNull(data.get(CDC_LSN));
     assertNotNull(data.get(CDC_UPDATED_AT));
+    assertNotNull(data.get(CDC_OP));
     if (deletedAtNull) {
       assertTrue(data.get(CDC_DELETED_AT).isNull());
     } else {
@@ -278,6 +282,7 @@ public class CdcPostgresSourceTest extends CdcSourceTest {
     data.remove(CDC_LSN);
     data.remove(CDC_UPDATED_AT);
     data.remove(CDC_DELETED_AT);
+    data.remove(CDC_OP);
   }
 
   @Override
@@ -290,6 +295,7 @@ public class CdcPostgresSourceTest extends CdcSourceTest {
     properties.set(CDC_LSN, numberType);
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
+    properties.set(CDC_OP, stringType);
 
   }
 

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresCatalogHelperTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresCatalogHelperTest.java
@@ -85,7 +85,8 @@ class PostgresCatalogHelperTest {
     final JsonNode properties = Jsons.jsonNode(Map.of(
         "_ab_cdc_lsn", Jsons.jsonNode(Map.of("type", "number")),
         "_ab_cdc_updated_at", Jsons.jsonNode(Map.of("type", "string")),
-        "_ab_cdc_deleted_at", Jsons.jsonNode(Map.of("type", "string"))));
+        "_ab_cdc_deleted_at", Jsons.jsonNode(Map.of("type", "string")),
+        "_ab_cdc_op", Jsons.jsonNode(Map.of("type", "string"))));
     final AirbyteStream after = new AirbyteStream()
         .withJsonSchema(Jsons.jsonNode(Map.of("properties", properties)));
 

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/DbSourceDiscoverUtil.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/DbSourceDiscoverUtil.java
@@ -37,7 +37,8 @@ public class DbSourceDiscoverUtil {
   private static final Logger LOGGER = LoggerFactory.getLogger(DbSourceDiscoverUtil.class);
   private static final List<String> AIRBYTE_METADATA = Arrays.asList("_ab_cdc_lsn",
       "_ab_cdc_updated_at",
-      "_ab_cdc_deleted_at");
+      "_ab_cdc_deleted_at",
+      "_ab_cdc_op");
 
   /*
    * This method logs schema drift between source table and the catalog. This can happen if (i)

--- a/docs/understanding-airbyte/cdc.md
+++ b/docs/understanding-airbyte/cdc.md
@@ -15,6 +15,7 @@ The Airbyte Protocol outputs records from sources. Records from `UPDATE` stateme
 We add some metadata columns for CDC sources:
 
 * `_ab_cdc_lsn` \(postgres and sql server sources\) is the point in the log where the record was retrieved
+* `_ab_cdc_op` \(postgres, mysql, and sql server sources\) is a string representation of the operation which produced the record `DELETE`/`INSERT`/`READ` (obtained via a snapshot) /`UPDATE`
 * `_ab_cdc_log_file` & `_ab_cdc_log_pos` \(specific to mysql source\) is the file name and position in the file where the record was retrieved
 * `_ab_cdc_updated_at` is the timestamp for the database transaction that resulted in this record change and is present for records from `DELETE`/`INSERT`/`UPDATE` statements 
 * `_ab_cdc_deleted_at` is the timestamp for the database transaction that resulted in this record change and is only present for records from `DELETE` statements


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*

Closes #24438. As described in the issue, there is no easy way of distinguishing between a record that is new, and a record that has been updated. In the same vein, there is no way to determine if a record was received via a snapshot of the database. 


## How
*Describe the solution*
Adds a new `_ab_cdc_op` column  providing an easy mapping to the operation that took place. Ie whether it was an `INSERT`, `UPDATE`, `DELETE`, or `READ` operation.

## Recommended reading order
1 . `DebeziumEventUtils.java`
2. `DbSourceDiscoverUtil.java`
3. `PostgresCdcConnectorMetadataInjector.java`
4. `PostgresCatalogHelper.java`
5. `MySqlSource.java`
6. `MySqlCdcConnectorMetadataInjector.java`
7. `MssqlSource.java`
8. `MssqlCdcConnectorMetadataInjector.java`
9. `snapshot_change_event.json`
10. `snapshot_message.json`
11. `insert_change_event.json`
12. `insert_message.json`
13. `update_message.json`
14. `delete_message.json`
15. `*Test.java`
16. `cdc.md`


## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
