### PR TITLE
Langchain destination: Check pincone index dimensions as part of check

### DIFF
--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -42,5 +42,5 @@ COPY destination_langchain ./destination_langchain
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.5
+LABEL io.airbyte.version=0.0.6
 LABEL io.airbyte.name=airbyte/destination-langchain

--- a/airbyte-integrations/connectors/destination-langchain/destination_langchain/indexer.py
+++ b/airbyte-integrations/connectors/destination-langchain/destination_langchain/indexer.py
@@ -96,8 +96,9 @@ class PineconeIndexer(Indexer):
     def check(self) -> Optional[str]:
         try:
             description = pinecone.describe_index(self.config.index)
-            if description.dimension != self.embedder.embedding_dimensions:
-                return f"Your embedding configuration will produce vectors with dimension {self.embedder.embedding_dimensions}, but your index is configured with dimension {description.dimension}. Make sure embedding and indexing configurations match."
+            actual_dimension = int(description.dimension)
+            if actual_dimension != self.embedder.embedding_dimensions:
+                return f"Your embedding configuration will produce vectors with dimension {self.embedder.embedding_dimensions:d}, but your index is configured with dimension {actual_dimension:d}. Make sure embedding and indexing configurations match."
         except Exception as e:
             return format_exception(e)
         return None

--- a/airbyte-integrations/connectors/destination-langchain/destination_langchain/indexer.py
+++ b/airbyte-integrations/connectors/destination-langchain/destination_langchain/indexer.py
@@ -95,7 +95,9 @@ class PineconeIndexer(Indexer):
 
     def check(self) -> Optional[str]:
         try:
-            pinecone.describe_index(self.config.index)
+            description = pinecone.describe_index(self.config.index)
+            if description.dimension != self.embedder.embedding_dimensions:
+                return f"Your embedding configuration will produce vectors with dimension {self.embedder.embedding_dimensions}, but your index is configured with dimension {description.dimension}. Make sure embedding and indexing configurations match."
         except Exception as e:
             return format_exception(e)
         return None

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: cf98d52c-ba5a-4dfd-8ada-c1baebfa6e73
-  dockerImageTag: 0.0.5
+  dockerImageTag: 0.0.6
   dockerRepository: airbyte/destination-langchain
   githubIssueLabel: destination-langchain
   icon: langchain.svg

--- a/airbyte-integrations/connectors/destination-langchain/unit_tests/pinecone_indexer_test.py
+++ b/airbyte-integrations/connectors/destination-langchain/unit_tests/pinecone_indexer_test.py
@@ -2,12 +2,14 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from unittest.mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock, patch
 
+import pytest
 from airbyte_cdk.models import ConfiguredAirbyteCatalog
 from destination_langchain.config import PineconeIndexingModel
 from destination_langchain.indexer import PineconeIndexer
 from langchain.document_loaders.base import Document
+from pinecone import IndexDescription
 
 
 def create_pinecone_indexer():
@@ -37,15 +39,14 @@ def test_pinecone_index_upsert_and_delete():
             (ANY, [4, 5, 6], {"_airbyte_stream": "abc", "text": "test2"}),
         ),
         async_req=True,
-        show_progress=False
+        show_progress=False,
     )
 
 
 def test_pinecone_index_empty_batch():
     indexer = create_pinecone_indexer()
     indexer.index(
-        [
-        ],
+        [],
         [],
     )
     indexer.pinecone_index.delete.assert_not_called()
@@ -61,41 +62,85 @@ def test_pinecone_index_upsert_batching():
     )
     assert indexer.pinecone_index.upsert.call_count == 2
     for i in range(40):
-        assert indexer.pinecone_index.upsert.call_args_list[0].kwargs["vectors"][i] == (ANY, [i, i, i], {"_airbyte_stream": "abc", "text": f"test {i}"})
+        assert indexer.pinecone_index.upsert.call_args_list[0].kwargs["vectors"][i] == (
+            ANY,
+            [i, i, i],
+            {"_airbyte_stream": "abc", "text": f"test {i}"},
+        )
     for i in range(40, 50):
-        assert indexer.pinecone_index.upsert.call_args_list[1].kwargs["vectors"][i-40] == (ANY, [i, i, i], {"_airbyte_stream": "abc", "text": f"test {i}"})
+        assert indexer.pinecone_index.upsert.call_args_list[1].kwargs["vectors"][i - 40] == (
+            ANY,
+            [i, i, i],
+            {"_airbyte_stream": "abc", "text": f"test {i}"},
+        )
 
 
 def test_pinecone_pre_sync():
     indexer = create_pinecone_indexer()
-    indexer.pre_sync(ConfiguredAirbyteCatalog.parse_obj(
-        {
-            "streams": [
-                {
-                    "stream": {
-                        "name": "example_stream",
-                        "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
-                        "supported_sync_modes": ["full_refresh", "incremental"],
-                        "source_defined_cursor": False,
-                        "default_cursor_field": ["column_name"],
+    indexer.pre_sync(
+        ConfiguredAirbyteCatalog.parse_obj(
+            {
+                "streams": [
+                    {
+                        "stream": {
+                            "name": "example_stream",
+                            "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
+                            "supported_sync_modes": ["full_refresh", "incremental"],
+                            "source_defined_cursor": False,
+                            "default_cursor_field": ["column_name"],
+                        },
+                        "primary_key": [["id"]],
+                        "sync_mode": "incremental",
+                        "destination_sync_mode": "append_dedup",
                     },
-                    "primary_key": [["id"]],
-                    "sync_mode": "incremental",
-                    "destination_sync_mode": "append_dedup",
-                },
-                {
-                    "stream": {
-                        "name": "example_stream2",
-                        "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
-                        "supported_sync_modes": ["full_refresh", "incremental"],
-                        "source_defined_cursor": False,
-                        "default_cursor_field": ["column_name"],
+                    {
+                        "stream": {
+                            "name": "example_stream2",
+                            "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
+                            "supported_sync_modes": ["full_refresh", "incremental"],
+                            "source_defined_cursor": False,
+                            "default_cursor_field": ["column_name"],
+                        },
+                        "primary_key": [["id"]],
+                        "sync_mode": "full_refresh",
+                        "destination_sync_mode": "overwrite",
                     },
-                    "primary_key": [["id"]],
-                    "sync_mode": "full_refresh",
-                    "destination_sync_mode": "overwrite",
-                }
-            ]
-        }
-    ))
+                ]
+            }
+        )
+    )
     indexer.pinecone_index.delete.assert_called_with(filter={"_airbyte_stream": "example_stream2"})
+
+
+@pytest.mark.parametrize(
+    "describe_throws,reported_dimensions,check_succeeds",
+    [
+        (False, 3, True),
+        (False, 4, False),
+        (True, 3, False),
+        (True, 4, False),
+    ],
+)
+@patch("pinecone.describe_index")
+def test_pinecone_check(describe_mock, describe_throws, reported_dimensions, check_succeeds):
+    indexer = create_pinecone_indexer()
+    indexer.embedder.embedding_dimensions = 3
+    if describe_throws:
+        describe_mock.side_effect = Exception("describe failed")
+    describe_mock.return_value = IndexDescription(
+        name="",
+        metric="",
+        replicas=1,
+        dimension=reported_dimensions,
+        shards=1,
+        pods=1,
+        pod_type="p1",
+        status=None,
+        metadata_config=None,
+        source_collection=None,
+    )
+    result = indexer.check()
+    if check_succeeds:
+        assert result is None
+    else:
+        assert result is not None

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -133,7 +133,7 @@ Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a M
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.0.6   | 2023-08-02 | [#28605](https://github.com/airbytehq/airbyte/pull/28605)     | Validate pinecone index dimensions during check  |
+| 0.0.6   | 2023-08-02 | [#28977](https://github.com/airbytehq/airbyte/pull/28977)     | Validate pinecone index dimensions during check  |
 | 0.0.5   | 2023-07-25 | [#28605](https://github.com/airbytehq/airbyte/pull/28605)     | Add Chroma support  |
 | 0.0.4   | 2023-07-21 | [#28556](https://github.com/airbytehq/airbyte/pull/28556)     | Correctly dedupe records with composite and nested primary keys  |
 | 0.0.3   | 2023-07-20 | [#28509](https://github.com/airbytehq/airbyte/pull/28509)     | Change the base image to python:3.9-slim to fix build  |

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -133,6 +133,7 @@ Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a M
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.0.6   | 2023-08-02 | [#28605](https://github.com/airbytehq/airbyte/pull/28605)     | Validate pinecone index dimensions during check  |
 | 0.0.5   | 2023-07-25 | [#28605](https://github.com/airbytehq/airbyte/pull/28605)     | Add Chroma support  |
 | 0.0.4   | 2023-07-21 | [#28556](https://github.com/airbytehq/airbyte/pull/28556)     | Correctly dedupe records with composite and nested primary keys  |
 | 0.0.3   | 2023-07-20 | [#28509](https://github.com/airbytehq/airbyte/pull/28509)     | Change the base image to python:3.9-slim to fix build  |


### PR DESCRIPTION
The check of this destination only validates the configured index is reachable, but a sync might still fail if the dimensions are not configured correctly. This PR makes this part of the check to have an actionable error message:
<img width="876" alt="Screenshot 2023-08-02 at 16 52 21" src="https://github.com/airbytehq/airbyte/assets/1508364/95a1e2ee-4b9b-4cdd-a569-ff2549bf4505">
