### PR TITLE
airbyte-cdk: allow Entrypoint to extract config

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -181,6 +181,13 @@ class AirbyteEntrypoint(object):
             return parsed_args.catalog
         return None
 
+    @classmethod
+    def extract_config(cls, args: List[str]) -> Optional[Any]:
+        parsed_args = cls.parse_args(args)
+        if hasattr(parsed_args, "config"):
+            return parsed_args.config
+        return None
+
     def _emit_queued_messages(self, source: Source) -> Iterable[AirbyteMessage]:
         if hasattr(source, "message_repository") and source.message_repository:
             yield from source.message_repository.consume_queue()


### PR DESCRIPTION
Updates the AirbyteEntrypoint so that we can extract the config path. This follows a similar pattern to how we're getting the catalog path for file-based sources.

This will be needed by source-S3, to allow us to identify v4-style config. (PR coming shortly.)