### PR TITLE
HOTFIX: Ensure we use the alias when exporting

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/utils.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/utils.py
@@ -13,4 +13,10 @@ def to_json_sanitized_dict(pydantic_model_obj: BaseModel, **kwargs) -> dict:
     Returns:
         dict: a sanitized dictionary
     """
+    defalut_kwargs = {
+        "by_alias": True, # Ensure that the original field name from the jsonschema is used in the event it begins with an underscore (e.g. _ab_internal)
+    }
+
+    kwargs = {**defalut_kwargs, **kwargs}
+
     return json.loads(pydantic_model_obj.json(**kwargs))

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
@@ -1791,13 +1791,13 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jsonschema"
-version = "4.18.4"
+version = "4.18.6"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jsonschema-4.18.4-py3-none-any.whl", hash = "sha256:971be834317c22daaa9132340a51c01b50910724082c2c1a2ac87eeec153a3fe"},
-    {file = "jsonschema-4.18.4.tar.gz", hash = "sha256:fb3642735399fa958c0d2aad7057901554596c63349f4f6b283c493cf692a25d"},
+    {file = "jsonschema-4.18.6-py3-none-any.whl", hash = "sha256:dc274409c36175aad949c68e5ead0853aaffbe8e88c830ae66bb3c7a1728ad2d"},
+    {file = "jsonschema-4.18.6.tar.gz", hash = "sha256:ce71d2f8c7983ef75a756e568317bf54bc531dc3ad7e66a128eae0d51623d8a3"},
 ]
 
 [package.dependencies]
@@ -1984,7 +1984,7 @@ files = [
 
 [[package]]
 name = "metadata-service"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 optional = false
 python-versions = "^3.9"


### PR DESCRIPTION
## Overview
Pydantic doesnt handle fields that start with a _ well and instead chooses to
1. Prepend `field` 
2. Use the `_abc` field name as an alias

This is a problem when converted back to json or a dict as it prefers to use the `field_` definition and not the alias

## Note for reviewer
Im quickly merging in this fix to unblock a P0 and introducing a much more thorough PR right after 