### PR TITLE
🎉 Source Amazon Ads: Update docs

### DIFF
--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -80,6 +80,10 @@ This source is capable of syncing the following streams:
 
 All the reports are generated relative to the target profile' timezone.
 
+Campaign reports may sometimes have no data or not presenting in records. This can occur when there are no clicks or views associated with the campaigns on the requested day - [details](https://advertising.amazon.com/API/docs/en-us/guides/reporting/v2/faq#why-is-my-report-empty).
+
+Report data synchronization only cover the last 60 days - [details](https://advertising.amazon.com/API/docs/en-us/reference/1/reports#parameters).
+
 ## Performance considerations
 
 Information about expected report generation waiting time you may find [here](https://advertising.amazon.com/API/docs/en-us/get-started/developer-notes).
@@ -96,7 +100,6 @@ Information about expected report generation waiting time you may find [here](ht
 | `object`                 | `object`     |
 
 ## CHANGELOG
-
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## What
The stream `sponsored_display_campaigns` retrieves all campaigns, while `sponsored_display_report_stream` may return empty reports if there were 0 clicks for the requested day. However, there is a potential issue when using `sponsored_display_report_stream` as it may not show campaigns with 0 clicks within the last 60 days. This discrepancy between the two streams can lead to confusion for users.

https://github.com/airbytehq/oncall/issues/2488

## How
Updated docs

## 🚨 User Impact 🚨
No

## Pre-merge Actions
<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
