### PR TITLE
File-based CDK: allow FileBasedSource to take a Cursor object

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_source.py
@@ -24,8 +24,6 @@ from airbyte_cdk.sources.file_based.stream.cursor.default_file_based_cursor impo
 from airbyte_cdk.sources.streams import Stream
 from pydantic.error_wrappers import ValidationError
 
-DEFAULT_MAX_HISTORY_SIZE = 10_000
-
 
 class FileBasedSource(AbstractSource, ABC):
     def __init__(
@@ -37,8 +35,7 @@ class FileBasedSource(AbstractSource, ABC):
         discovery_policy: AbstractDiscoveryPolicy = DefaultDiscoveryPolicy(),
         parsers: Mapping[str, FileTypeParser] = default_parsers,
         validation_policies: Mapping[str, AbstractSchemaValidationPolicy] = DEFAULT_SCHEMA_VALIDATION_POLICIES,
-        max_history_size: int = DEFAULT_MAX_HISTORY_SIZE,
-        cursor: Optional[AbstractFileBasedCursor] = None,
+        cursor_cls: Type[AbstractFileBasedCursor] = DefaultFileBasedCursor,
     ):
         self.stream_reader = stream_reader
         self.spec_class = spec_class
@@ -48,8 +45,7 @@ class FileBasedSource(AbstractSource, ABC):
         self.validation_policies = validation_policies
         catalog = self.read_catalog(catalog_path) if catalog_path else None
         self.stream_schemas = {s.stream.name: s.stream.json_schema for s in catalog.streams} if catalog else {}
-        self.cursor = cursor or None
-        self.max_history_size = max_history_size
+        self.cursor_cls = cursor_cls
         self.logger = logging.getLogger(f"airbyte.{self.name}")
 
     def check_connection(self, logger: logging.Logger, config: Mapping[str, Any]) -> Tuple[bool, Optional[Any]]:
@@ -107,7 +103,7 @@ class FileBasedSource(AbstractSource, ABC):
                         discovery_policy=self.discovery_policy,
                         parsers=self.parsers,
                         validation_policy=self._validate_and_get_validation_policy(stream_config),
-                        cursor=self.cursor or DefaultFileBasedCursor(self.max_history_size, stream_config.days_to_sync_if_history_is_full),
+                        cursor=self.cursor_cls(stream_config),
                     )
                 )
             return streams

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/__init__.py
@@ -1,4 +1,4 @@
+from .abstract_file_based_cursor import AbstractFileBasedCursor
 from .default_file_based_cursor import DefaultFileBasedCursor
-from .file_based_cursor import FileBasedCursor
 
-__all__ = ["FileBasedCursor", "DefaultFileBasedCursor"]
+__all__ = ["AbstractFileBasedCursor", "DefaultFileBasedCursor"]

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/abstract_file_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/abstract_file_based_cursor.py
@@ -19,6 +19,9 @@ class AbstractFileBasedCursor(ABC):
 
     @abstractmethod
     def __init__(self, stream_config: FileBasedStreamConfig, **kwargs: Any):
+        """
+        Common interface for all cursors.
+        """
         ...
 
     @abstractmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/abstract_file_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/abstract_file_based_cursor.py
@@ -11,7 +11,7 @@ from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.types import StreamState
 
 
-class FileBasedCursor(ABC):
+class AbstractFileBasedCursor(ABC):
     """
     Abstract base class for cursors used by file-based streams.
     """

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/abstract_file_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/abstract_file_based_cursor.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Iterable, MutableMapping
 
+from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.types import StreamState
 
@@ -15,6 +16,10 @@ class AbstractFileBasedCursor(ABC):
     """
     Abstract base class for cursors used by file-based streams.
     """
+
+    @abstractmethod
+    def __init__(self, stream_config: FileBasedStreamConfig, **kwargs: Any):
+        ...
 
     @abstractmethod
     def add_file(self, file: RemoteFile) -> None:

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/default_file_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/default_file_based_cursor.py
@@ -7,11 +7,11 @@ from datetime import datetime, timedelta
 from typing import Iterable, MutableMapping, Optional
 
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
-from airbyte_cdk.sources.file_based.stream.cursor.file_based_cursor import FileBasedCursor
+from airbyte_cdk.sources.file_based.stream.cursor.abstract_file_based_cursor import AbstractFileBasedCursor
 from airbyte_cdk.sources.file_based.types import StreamState
 
 
-class DefaultFileBasedCursor(FileBasedCursor):
+class DefaultFileBasedCursor(AbstractFileBasedCursor):
     DEFAULT_DAYS_TO_SYNC_IF_HISTORY_IS_FULL = 3
     DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/default_file_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/cursor/default_file_based_cursor.py
@@ -4,8 +4,9 @@
 
 import logging
 from datetime import datetime, timedelta
-from typing import Iterable, MutableMapping, Optional
+from typing import Any, Iterable, MutableMapping, Optional
 
+from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.stream.cursor.abstract_file_based_cursor import AbstractFileBasedCursor
 from airbyte_cdk.sources.file_based.types import StreamState
@@ -13,17 +14,16 @@ from airbyte_cdk.sources.file_based.types import StreamState
 
 class DefaultFileBasedCursor(AbstractFileBasedCursor):
     DEFAULT_DAYS_TO_SYNC_IF_HISTORY_IS_FULL = 3
+    DEFAULT_MAX_HISTORY_SIZE = 10_000
     DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
-    def __init__(self, max_history_size: int, days_to_sync_if_history_is_full: Optional[int]):
+    def __init__(self, stream_config: FileBasedStreamConfig, **_: Any):
+        super().__init__(stream_config)
         self._file_to_datetime_history: MutableMapping[str, str] = {}
-        self._max_history_size = max_history_size
         self._time_window_if_history_is_full = timedelta(
-            days=days_to_sync_if_history_is_full or self.DEFAULT_DAYS_TO_SYNC_IF_HISTORY_IS_FULL
+            days=stream_config.days_to_sync_if_history_is_full or self.DEFAULT_DAYS_TO_SYNC_IF_HISTORY_IS_FULL
         )
 
-        if self._max_history_size <= 0:
-            raise ValueError(f"max_history_size must be a positive integer, got {self._max_history_size}")
         if self._time_window_if_history_is_full <= timedelta():
             raise ValueError(f"days_to_sync_if_history_is_full must be a positive timedelta, got {self._time_window_if_history_is_full}")
 
@@ -37,7 +37,7 @@ class DefaultFileBasedCursor(AbstractFileBasedCursor):
 
     def add_file(self, file: RemoteFile) -> None:
         self._file_to_datetime_history[file.uri] = file.last_modified.strftime(self.DATE_TIME_FORMAT)
-        if len(self._file_to_datetime_history) > self._max_history_size:
+        if len(self._file_to_datetime_history) > self.DEFAULT_MAX_HISTORY_SIZE:
             # Get the earliest file based on its last modified date and its uri
             oldest_file = self._compute_earliest_file_in_history()
             if oldest_file:
@@ -67,7 +67,7 @@ class DefaultFileBasedCursor(AbstractFileBasedCursor):
         """
         Returns true if the state's history is full, meaning new entries will start to replace old entries.
         """
-        return len(self._file_to_datetime_history) >= self._max_history_size
+        return len(self._file_to_datetime_history) >= self.DEFAULT_MAX_HISTORY_SIZE
 
     def _should_sync_file(self, file: RemoteFile, logger: logging.Logger) -> bool:
         if file.uri in self._file_to_datetime_history:

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -21,7 +21,7 @@ from airbyte_cdk.sources.file_based.exceptions import (
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.schema_helpers import merge_schemas, schemaless_schema
 from airbyte_cdk.sources.file_based.stream import AbstractFileBasedStream
-from airbyte_cdk.sources.file_based.stream.cursor import FileBasedCursor
+from airbyte_cdk.sources.file_based.stream.cursor import AbstractFileBasedCursor
 from airbyte_cdk.sources.file_based.types import StreamSlice
 from airbyte_cdk.sources.streams import IncrementalMixin
 from airbyte_cdk.sources.streams.core import JsonSchema
@@ -39,7 +39,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
     ab_file_name_col = "_ab_source_file_url"
     airbyte_columns = [ab_last_mod_col, ab_file_name_col]
 
-    def __init__(self, cursor: FileBasedCursor, **kwargs: Any):
+    def __init__(self, cursor: AbstractFileBasedCursor, **kwargs: Any):
         super().__init__(**kwargs)
         self._cursor = cursor
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/helpers.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/helpers.py
@@ -14,6 +14,7 @@ from airbyte_cdk.sources.file_based.file_types.csv_parser import CsvParser
 from airbyte_cdk.sources.file_based.file_types.jsonl_parser import JsonlParser
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.schema_validation_policies import AbstractSchemaValidationPolicy
+from airbyte_cdk.sources.file_based.stream.cursor import DefaultFileBasedCursor
 from unit_tests.sources.file_based.in_memory_files_source import InMemoryFilesStreamReader
 
 
@@ -52,6 +53,10 @@ class FailingSchemaValidationPolicy(AbstractSchemaValidationPolicy):
 
     def record_passes_validation_policy(self, record: Mapping[str, Any], schema: Optional[Mapping[str, Any]]) -> bool:
         return False
+
+
+class LowHistoryLimitCursor(DefaultFileBasedCursor):
+    DEFAULT_MAX_HISTORY_SIZE = 3
 
 
 def make_remote_files(files: List[str]) -> List[RemoteFile]:

--- a/airbyte-cdk/python/unit_tests/sources/file_based/in_memory_files_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/in_memory_files_source.py
@@ -20,11 +20,12 @@ from airbyte_cdk.models import ConfiguredAirbyteCatalog
 from airbyte_cdk.sources.file_based.availability_strategy import AbstractFileBasedAvailabilityStrategy, DefaultFileBasedAvailabilityStrategy
 from airbyte_cdk.sources.file_based.config.abstract_file_based_spec import AbstractFileBasedSpec
 from airbyte_cdk.sources.file_based.discovery_policy import AbstractDiscoveryPolicy, DefaultDiscoveryPolicy
-from airbyte_cdk.sources.file_based.file_based_source import DEFAULT_MAX_HISTORY_SIZE, FileBasedSource
+from airbyte_cdk.sources.file_based.file_based_source import FileBasedSource
 from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader, FileReadMode
 from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.schema_validation_policies import DEFAULT_SCHEMA_VALIDATION_POLICIES, AbstractSchemaValidationPolicy
+from airbyte_cdk.sources.file_based.stream.cursor import AbstractFileBasedCursor, DefaultFileBasedCursor
 from avro import datafile
 from pydantic import AnyUrl, Field
 
@@ -41,7 +42,7 @@ class InMemoryFilesSource(FileBasedSource):
         stream_reader: Optional[AbstractFileBasedStreamReader],
         catalog: Optional[Mapping[str, Any]],
         file_write_options: Mapping[str, Any],
-        max_history_size: int,
+        cursor_cls: Optional[AbstractFileBasedCursor],
     ):
         # Attributes required for test purposes
         self.files = files
@@ -59,7 +60,7 @@ class InMemoryFilesSource(FileBasedSource):
             discovery_policy=discovery_policy or DefaultDiscoveryPolicy(),
             parsers=parsers,
             validation_policies=validation_policies or DEFAULT_SCHEMA_VALIDATION_POLICIES,
-            max_history_size=max_history_size or DEFAULT_MAX_HISTORY_SIZE,
+            cursor_cls=cursor_cls or DefaultFileBasedCursor,
         )
 
     def read_catalog(self, catalog_path: str) -> ConfiguredAirbyteCatalog:

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/incremental_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/incremental_scenarios.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+from unit_tests.sources.file_based.helpers import LowHistoryLimitCursor
 from unit_tests.sources.file_based.scenarios.scenario_builder import IncrementalScenarioConfig, TestScenarioBuilder
 
 single_csv_input_state_is_earlier_scenario = (
@@ -1004,7 +1005,7 @@ multi_csv_remove_old_files_if_history_is_full_scenario = (
         }
     )
     .set_file_type("csv")
-    .set_max_history_size(3)
+    .set_cursor_cls(LowHistoryLimitCursor)
     .set_expected_catalog(
         {
             "streams": [
@@ -1151,7 +1152,7 @@ multi_csv_same_timestamp_more_files_than_history_size_scenario = (
         }
     )
     .set_file_type("csv")
-    .set_max_history_size(3)
+    .set_cursor_cls(LowHistoryLimitCursor)
     .set_expected_catalog(
         {
             "streams": [
@@ -1268,7 +1269,7 @@ multi_csv_sync_recent_files_if_history_is_incomplete_scenario = (
             },
         }
     )
-    .set_max_history_size(3)
+    .set_cursor_cls(LowHistoryLimitCursor)
     .set_file_type("csv")
     .set_expected_catalog(
         {
@@ -1386,7 +1387,7 @@ multi_csv_sync_files_within_time_window_if_history_is_incomplete__different_time
         }
     )
     .set_file_type("csv")
-    .set_max_history_size(3)
+    .set_cursor_cls(LowHistoryLimitCursor)
     .set_expected_catalog(
         {
             "streams": [
@@ -1509,7 +1510,7 @@ multi_csv_sync_files_within_history_time_window_if_history_is_incomplete_differe
         }
     )
     .set_file_type("csv")
-    .set_max_history_size(3)
+    .set_cursor_cls(LowHistoryLimitCursor)
     .set_expected_catalog(
         {
             "streams": [

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/scenario_builder.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/scenario_builder.py
@@ -11,10 +11,11 @@ from airbyte_cdk.sources.file_based.availability_strategy.abstract_file_based_av
     AbstractFileBasedAvailabilityStrategy,
 )
 from airbyte_cdk.sources.file_based.discovery_policy import AbstractDiscoveryPolicy, DefaultDiscoveryPolicy
-from airbyte_cdk.sources.file_based.file_based_source import DEFAULT_MAX_HISTORY_SIZE, default_parsers
+from airbyte_cdk.sources.file_based.file_based_source import default_parsers
 from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader
 from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 from airbyte_cdk.sources.file_based.schema_validation_policies import AbstractSchemaValidationPolicy
+from airbyte_cdk.sources.file_based.stream.cursor import AbstractFileBasedCursor
 from unit_tests.sources.file_based.in_memory_files_source import InMemoryFilesSource
 
 
@@ -46,7 +47,7 @@ class TestScenario:
             expected_read_error: Tuple[Optional[Type[Exception]], Optional[str]],
             incremental_scenario_config: Optional[IncrementalScenarioConfig],
             file_write_options: Mapping[str, Any],
-            max_history_size: int,
+            cursor_cls: Optional[Type[AbstractFileBasedCursor]],
     ):
         self.name = name
         self.config = config
@@ -68,7 +69,7 @@ class TestScenario:
             stream_reader,
             self.configured_catalog(SyncMode.incremental if incremental_scenario_config else SyncMode.full_refresh),
             file_write_options,
-            max_history_size,
+            cursor_cls,
         )
         self.incremental_scenario_config = incremental_scenario_config
         self.validate()
@@ -124,7 +125,7 @@ class TestScenarioBuilder:
         self._expected_read_error: Tuple[Optional[Type[Exception]], Optional[str]] = None, None
         self._incremental_scenario_config: Optional[IncrementalScenarioConfig] = None
         self._file_write_options: Mapping[str, Any] = {}
-        self._max_history_size = DEFAULT_MAX_HISTORY_SIZE
+        self._cursor_cls: Optional[Type[AbstractFileBasedCursor]] = None
 
     def set_name(self, name: str) -> "TestScenarioBuilder":
         self._name = name
@@ -182,8 +183,8 @@ class TestScenarioBuilder:
         self._stream_reader = stream_reader
         return self
 
-    def set_max_history_size(self, max_history_size: int) -> "TestScenarioBuilder":
-        self._max_history_size = max_history_size
+    def set_cursor_cls(self, cursor_cls: AbstractFileBasedCursor) -> "TestScenarioBuilder":
+        self._cursor_cls = cursor_cls
         return self
 
     def set_incremental_scenario_config(self, incremental_scenario_config: IncrementalScenarioConfig) -> "TestScenarioBuilder":
@@ -232,5 +233,5 @@ class TestScenarioBuilder:
             self._expected_read_error,
             self._incremental_scenario_config,
             self._file_write_options,
-            self._max_history_size,
+            self._cursor_cls,
         )

--- a/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_cursor.py
@@ -7,6 +7,7 @@ from typing import Any, List, Mapping
 from unittest.mock import MagicMock
 
 import pytest
+from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.stream.cursor.default_file_based_cursor import DefaultFileBasedCursor
 from freezegun import freeze_time
@@ -103,7 +104,7 @@ from freezegun import freeze_time
     ],
 )
 def test_add_file(files_to_add: List[RemoteFile], expected_start_time: List[datetime], expected_state_dict: Mapping[str, Any]) -> None:
-    cursor = DefaultFileBasedCursor(3, 3)
+    cursor = get_cursor(max_history_size=3, days_to_sync_if_history_is_full=3)
     assert cursor._compute_start_time() == datetime.min
 
     for index, f in enumerate(files_to_add):
@@ -160,7 +161,7 @@ def test_add_file(files_to_add: List[RemoteFile], expected_start_time: List[date
 ])
 def test_get_files_to_sync(files: List[RemoteFile], expected_files_to_sync: List[RemoteFile], max_history_size: int, history_is_partial: bool) -> None:
     logger = MagicMock()
-    cursor = DefaultFileBasedCursor(max_history_size, 3)
+    cursor = get_cursor(max_history_size, 3)
 
     files_to_sync = list(cursor.get_files_to_sync(files, logger))
     for f in files_to_sync:
@@ -173,7 +174,7 @@ def test_get_files_to_sync(files: List[RemoteFile], expected_files_to_sync: List
 @freeze_time("2023-06-16T00:00:00Z")
 def test_only_recent_files_are_synced_if_history_is_full() -> None:
     logger = MagicMock()
-    cursor = DefaultFileBasedCursor(2, 3)
+    cursor = get_cursor(2, 3)
 
     files_in_history = [
         RemoteFile(uri="b1.csv", last_modified=datetime(2021, 1, 2), file_type="csv"),
@@ -210,7 +211,7 @@ def test_only_recent_files_are_synced_if_history_is_full() -> None:
 ])
 def test_sync_file_already_present_in_history(modified_at_delta: timedelta, should_sync_file: bool) -> None:
     logger = MagicMock()
-    cursor = DefaultFileBasedCursor(2, 3)
+    cursor = get_cursor(2, 3)
     original_modified_at = datetime(2021, 1, 2)
     filename = "a.csv"
     files_in_history = [
@@ -245,7 +246,7 @@ def test_sync_file_already_present_in_history(modified_at_delta: timedelta, shou
 )
 def test_should_sync_file(file_name: str, last_modified: datetime, earliest_dt_in_history: datetime, should_sync_file: bool) -> None:
     logger = MagicMock()
-    cursor = DefaultFileBasedCursor(1, 3)
+    cursor = get_cursor(1, 3)
 
     cursor.add_file(RemoteFile(uri="b.csv", last_modified=earliest_dt_in_history, file_type="csv"))
     cursor._start_time = cursor._compute_start_time()
@@ -255,13 +256,13 @@ def test_should_sync_file(file_name: str, last_modified: datetime, earliest_dt_i
 
 
 def test_set_initial_state_no_history() -> None:
-    cursor = DefaultFileBasedCursor(1, 3)
+    cursor = get_cursor(1, 3)
     cursor.set_initial_state({})
 
 
-def test_instantiate_with_negative_values() -> None:
-    with pytest.raises(ValueError):
-        DefaultFileBasedCursor(-1, 3)
-
-    with pytest.raises(ValueError):
-        DefaultFileBasedCursor(1, -3)
+def get_cursor(max_history_size: int, days_to_sync_if_history_is_full: int) -> DefaultFileBasedCursor:
+    cursor_cls = DefaultFileBasedCursor
+    cursor_cls.DEFAULT_MAX_HISTORY_SIZE = max_history_size
+    config = FileBasedStreamConfig(
+        file_type="csv", name="test", validation_policy="emit_records", days_to_sync_if_history_is_full=days_to_sync_if_history_is_full)
+    return cursor_cls(config)


### PR DESCRIPTION
Updates the FileBasedSource so that it take an optional Cursor argument.

This will be used by source-s3 to provide an adapter, so that we can convert history from the old format to the new.