### PR TITLE
🐛 Source Close.com: fix replication start date field type

### DIFF
--- a/airbyte-integrations/connectors/source-close-com/Dockerfile
+++ b/airbyte-integrations/connectors/source-close-com/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.4.1
+LABEL io.airbyte.version=0.4.2
 LABEL io.airbyte.name=airbyte/source-close-com

--- a/airbyte-integrations/connectors/source-close-com/metadata.yaml
+++ b/airbyte-integrations/connectors/source-close-com/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfffecb7-9a13-43e9-acdc-b92af7997ca9
-  dockerImageTag: 0.4.1
+  dockerImageTag: 0.4.2
   dockerRepository: airbyte/source-close-com
   githubIssueLabel: source-close-com
   icon: close.svg

--- a/airbyte-integrations/connectors/source-close-com/source_close_com/spec.json
+++ b/airbyte-integrations/connectors/source-close-com/source_close_com/spec.json
@@ -20,7 +20,7 @@
         "examples": ["2021-01-01"],
         "default": "2021-01-01",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-        "format": "date-time"
+        "format": "date"
       }
     }
   }

--- a/docs/integrations/sources/close-com.md
+++ b/docs/integrations/sources/close-com.md
@@ -105,6 +105,7 @@ The Close.com connector is subject to rate limits. For more information on this 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------|
+| 0.4.2   | 2023-08-07 | [29148](https://github.com/airbytehq/airbyte/pull/29148) | Change Start Date format from date-time to date                                                        | 
 | 0.4.1   | 2023-07-04 | [27950](https://github.com/airbytehq/airbyte/pull/27950) | Add human readable titles to API Key and Start Date fields                                             |
 | 0.4.0   | 2023-06-27 | [27776](https://github.com/airbytehq/airbyte/pull/27776) | Update the `Email Followup Tasks` stream schema                                                        |
 | 0.3.0   | 2023-05-12 | [26024](https://github.com/airbytehq/airbyte/pull/26024) | Update the `Email sequences` stream schema                                                             |


### PR DESCRIPTION
## What
This source has a field incorrectly marked as `date-time` (`YYYY-MM-DDTHH:mm:ssZ`) which should be a `date` (`YYYY-MM-DD`). This results in the datepicker component outputting the wrong format:

![image](https://github.com/airbytehq/airbyte/assets/7550957/95f788b3-d9ef-4189-bd9e-d495f6205c7b)

## How
Changes the spec to use the `date` format instead.

I marked this as a `patch` update, because it's essentially a UI bug fix, but I'm not sure if it technically qualifies as "backwards compatible".