### PR TITLE
Parquet parser return Decimal fields as strings

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
@@ -58,7 +58,10 @@ class ParquetParser(FileTypeParser):
                 batch = reader.read_row_group(row_group)
                 for i in range(batch.num_rows):
                     row_dict = {
-                        column: ParquetParser._to_output_value(batch.column(column)[i], parquet_format) for column in batch.column_names
+                        **{
+                            column: ParquetParser._to_output_value(batch.column(column)[i], parquet_format) for column in batch.column_names
+                        },
+                        **partition_columns,
                     }
                     yield row_dict
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
@@ -56,14 +56,14 @@ class ParquetParser(FileTypeParser):
             partition_columns = {x.split("=")[0]: x.split("=")[1] for x in self._extract_partitions(file.uri)}
             for row_group in range(reader.num_row_groups):
                 batch = reader.read_row_group(row_group)
-                for i in range(batch.num_rows):
-                    row_dict = {
+                for row in range(batch.num_rows):
+                    yield {
                         **{
-                            column: ParquetParser._to_output_value(batch.column(column)[i], parquet_format) for column in batch.column_names
+                            column: ParquetParser._to_output_value(batch.column(column)[row], parquet_format)
+                            for column in batch.column_names
                         },
                         **partition_columns,
                     }
-                    yield row_dict
 
     @staticmethod
     def _extract_partitions(filepath: str) -> List[str]:

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py
@@ -405,8 +405,6 @@ avro_all_types_scenario = (
                     "col_time_micros": "12:00:00.456789",
                     "col_timestamp_millis": "2022-05-29T00:00:00.456000+00:00",
                     "col_timestamp_micros": "2022-05-30T00:00:00.456789+00:00",
-                    "col_local_timestamp_millis": "2022-05-29T00:00:00.456000",
-                    "col_local_timestamp_micros": "2022-05-30T00:00:00.456789",
                     "_ab_source_file_last_modified": "2023-06-05T03:54:07.000000Z",
                     "_ab_source_file_url": "a.avro",
                 },

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -271,7 +271,7 @@ def _verify_read_output(output: Dict[str, Any], scenario: TestScenario) -> None:
         if "record" in actual:
             for key, value in actual["record"]["data"].items():
                 if isinstance(value, float):
-                    assert math.isclose(value, float(expected["data"][key]), abs_tol=1e-04)
+                    assert math.isclose(value, expected["data"][key], abs_tol=1e-04)
                 else:
                     assert value == expected["data"][key]
             assert actual["record"]["stream"] == expected["stream"]

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -100,6 +100,7 @@ from unit_tests.sources.file_based.scenarios.parquet_scenarios import (
     parquet_file_with_decimal_no_config_scenario,
     parquet_various_types_scenario,
     single_parquet_scenario,
+    single_partitioned_parquet_scenario,
 )
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenario
 from unit_tests.sources.file_based.scenarios.user_input_schema_scenarios import (
@@ -197,6 +198,7 @@ discover_scenarios = [
     avro_file_with_decimal_as_float_scenario,
     csv_newline_in_values_not_quoted_scenario,
     csv_autogenerate_column_names_scenario,
+    single_partitioned_parquet_scenario
 ]
 
 
@@ -269,6 +271,7 @@ def _verify_read_output(output: Dict[str, Any], scenario: TestScenario) -> None:
     assert len(records) == len(expected_records)
     for actual, expected in zip(records, expected_records):
         if "record" in actual:
+            assert len(actual["record"]["data"]) == len(expected["data"])
             for key, value in actual["record"]["data"].items():
                 if isinstance(value, float):
                     assert math.isclose(value, expected["data"][key], abs_tol=1e-04)


### PR DESCRIPTION
## What
* Update the parquet parser so it returns Decimal values as strings by default 

## How
* Call ParquetParser._to_output_value on each field before yielding the record

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py`
2. `airbyte-cdk/python/unit_tests/sources/file_based/scenarios/parquet_scenarios.py`
3. `airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py`
4. `airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py`