### PR TITLE
🐛 Source Close-Com: fix `DatePicker` format issue with `Start Date`

### DIFF
--- a/airbyte-integrations/connectors/source-close-com/Dockerfile
+++ b/airbyte-integrations/connectors/source-close-com/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.4.1
+LABEL io.airbyte.version=0.4.2
 LABEL io.airbyte.name=airbyte/source-close-com

--- a/airbyte-integrations/connectors/source-close-com/metadata.yaml
+++ b/airbyte-integrations/connectors/source-close-com/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfffecb7-9a13-43e9-acdc-b92af7997ca9
-  dockerImageTag: 0.4.1
+  dockerImageTag: 0.4.2
   dockerRepository: airbyte/source-close-com
   githubIssueLabel: source-close-com
   icon: close.svg

--- a/airbyte-integrations/connectors/source-close-com/source_close_com/spec.json
+++ b/airbyte-integrations/connectors/source-close-com/source_close_com/spec.json
@@ -20,7 +20,7 @@
         "examples": ["2021-01-01"],
         "default": "2021-01-01",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-        "format": "date-time"
+        "format": "date"
       }
     }
   }

--- a/docs/integrations/sources/close-com.md
+++ b/docs/integrations/sources/close-com.md
@@ -105,6 +105,7 @@ The Close.com connector is subject to rate limits. For more information on this 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------|
+| 0.4.2   | 2023-08-08 | [29206](https://github.com/airbytehq/airbyte/pull/29206) | Fixed the issue with `DatePicker` format for `start date`                                            |
 | 0.4.1   | 2023-07-04 | [27950](https://github.com/airbytehq/airbyte/pull/27950) | Add human readable titles to API Key and Start Date fields                                             |
 | 0.4.0   | 2023-06-27 | [27776](https://github.com/airbytehq/airbyte/pull/27776) | Update the `Email Followup Tasks` stream schema                                                        |
 | 0.3.0   | 2023-05-12 | [26024](https://github.com/airbytehq/airbyte/pull/26024) | Update the `Email sequences` stream schema                                                             |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/oncall/issues/2496

## How
- changed the format for `start_date` from `date-time` to  `date` in `spec.json`

## 🚨 User Impact 🚨
No impact is expected.