### PR TITLE
🐛 fix: correct language tag for low-code based connector

### DIFF
--- a/airbyte-integrations/connector-templates/source-configuration-based/metadata.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-configuration-based/metadata.yaml.hbs
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/{{dashCase name}}
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*

The current low-code connector template uses the "lowcode" string for the language tag instead of "low-code" which causes QA checks to fail

## How
*Describe the solution*
Change lowcode to low-code in the metadata.yaml template file

## Recommended reading order
1. metadata.yaml.hbs