### PR TITLE
postgres-cdc:only include incremental streams for ctid sync

### DIFF
--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mysql/MySqlDebeziumStateUtil.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mysql/MySqlDebeziumStateUtil.java
@@ -129,7 +129,7 @@ public class MySqlDebeziumStateUtil {
       } else if (gtidSets.size() == 1) {
         return Optional.of(gtidSets.get(0));
       } else {
-        throw new RuntimeException("Not expecting gtid set size to br greater than 1");
+        throw new RuntimeException("Not expecting gtid set size to be greater than 1");
       }
     } catch (final SQLException e) {
       throw new RuntimeException(e);

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcCtidUtils.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcCtidUtils.java
@@ -26,7 +26,12 @@ public class PostgresCdcCtidUtils {
   public static CtidStreams streamsToSyncViaCtid(final CdcStateManager stateManager, final ConfiguredAirbyteCatalog fullCatalog,
       final boolean savedOffsetAfterReplicationSlotLSN) {
     if (!savedOffsetAfterReplicationSlotLSN) {
-      return new CtidStreams(fullCatalog.getStreams(), new HashMap<>());
+      return new CtidStreams(
+          fullCatalog.getStreams()
+              .stream()
+              .filter(c -> c.getSyncMode() == SyncMode.INCREMENTAL)
+              .collect(Collectors.toList()),
+          new HashMap<>());
     }
 
     final AirbyteStateMessage airbyteStateMessage = stateManager.getRawStateMessage();


### PR DESCRIPTION
There is no issue for this. This is just a minor change. We already filter out only for INCREMENTAL streams for ctid and cdc syncs, just adding that check here as well.