### PR TITLE
📝 Docs: update Stripe docs page

### DIFF
--- a/docs/integrations/sources/stripe.inapp.md
+++ b/docs/integrations/sources/stripe.inapp.md
@@ -1,16 +1,16 @@
 ## Prerequisites
 
-- Access to the Stripe account containing the data you wish to replicate
+- Access to the Stripe account containing the data to replicate
 
 ## Setup Guide
 
 :::note
-To authenticate the Stripe connector, you need a Stripe Secret Key with **Read** privileges for the data to replicate. For steps on obtaining and setting permissions for this key, refer to our [full Stripe documentation](https://docs.airbyte.com/integrations/sources/stripe#setup-guide).
+To authenticate the Stripe connector, you need an API key with **Read** privileges for the data to replicate. For steps on obtaining and setting permissions for this key, refer to our [full Stripe documentation](https://docs.airbyte.com/integrations/sources/stripe#setup-guide).
 :::
 
 1. For **Source name**, enter a name to help you identify this source.
 2. For **Account ID**, enter your Stripe Account ID. This ID begins with `acct_`, and can be found in the top-right corner of your Stripe [account settings page](https://dashboard.stripe.com/settings/account).
-3. For **Secret Key**, enter your Stripe API Key, which can be found at your Stripe [API keys page](https://dashboard.stripe.com/apikeys).
+3. For **Secret Key**, enter your Stripe API key, which can be found at your Stripe [API keys page](https://dashboard.stripe.com/apikeys).
 4. For **Replication Start Date**, use the provided datepicker or enter a UTC date and time programmatically in the format `YYYY-MM-DDTHH:mm:ssZ`. The data added on and after this date will be replicated.
 5. (Optional) For **Lookback Window**, you may specify a number of days from the present day to reread data. This allows the connector to retrieve data that might have been updated after its initial creation, and is useful for handling any post-transaction adjustments (such as tips, refunds, chargebacks, etc).
 
@@ -18,11 +18,11 @@ To authenticate the Stripe connector, you need a Stripe Secret Key with **Read**
     - Setting the **Lookback Window** to 1 means Airbyte will re-export and capture any data changes within the last day.
     - Setting the **Lookback Window** to 7 means Airbyte will re-export and capture any data changes within the last week.
 
-6. (Optional) For **Data Request Window**, you may specify the time window in days for data retrieval from the Stripe API. This window defines how much data is gathered in each request, with larger values retrieving more data but making fewer requests.
+6. (Optional) For **Data Request Window**, you may specify the time window in days used by the connector when requesting data from the Stripe API. This window defines the span of time covered in each request, with larger values encompassing more days in a single request. Generally speaking, the lack of overhead from making fewer requests means a larger window is faster to sync. However, this also means the state of the sync will persist less frequently. If an issue occurs or the sync is interrupted, a larger window means more data will need to be resynced, potentially causing a delay in the overall process.
 
     For example, if you are replicating three years worth of data:
 
-    - A **Data Request Window** of 365 days means Airbyte makes 3 requests, each for a year. This is generally faster but risks needing to resync up to a year's data if something goes wrong.
+    - A **Data Request Window** of 365 days means Airbyte makes 3 requests, each for a year. This is generally faster but risks needing to resync up to a year's data if the sync is interrupted.
     - A **Data Request Window** of 30 days means 36 requests, each for a month. This may be slower but minimizes the amount of data that needs to be resynced if an issue occurs.
 
     If you are unsure of which value to use, we recommend leaving this setting at its default value of 365 days.

--- a/docs/integrations/sources/stripe.inapp.md
+++ b/docs/integrations/sources/stripe.inapp.md
@@ -15,7 +15,7 @@ To authenticate the Stripe connector, you need a Stripe Secret Key with **Read**
 5. (Optional) For **Lookback Window**, you may specify a number of days from the present day to reread data. This allows the connector to retrieve data that might have been updated after its initial creation, and is useful for handling any post-transaction adjustments (such as tips, refunds, chargebacks, etc).
 
     - Leaving the **Lookback Window** at its default value of 0 means Airbyte will not re-export data after it has been synced.
-    - Setting the **Lookback Window** to 1 means Airbyte will re-export data from the past day, capturing any changes made in the last 24 hours.
+    - Setting the **Lookback Window** to 1 means Airbyte will re-export and capture any data changes within the last day.
     - Setting the **Lookback Window** to 7 means Airbyte will re-export and capture any data changes within the last week.
 
 6. (Optional) For **Data Request Window**, you may specify the time window in days for data retrieval from the Stripe API. This window defines how much data is gathered in each request, with larger values retrieving more data but making fewer requests.

--- a/docs/integrations/sources/stripe.inapp.md
+++ b/docs/integrations/sources/stripe.inapp.md
@@ -1,24 +1,35 @@
 ## Prerequisites
 
-- Your [Stripe `Account ID`](https://dashboard.stripe.com/settings/account)
-- Your [Stripe `Secret Key`](https://dashboard.stripe.com/apikeys)
+- Access to the Stripe account containing the data you wish to replicate
 
 ## Setup Guide
 
-1. Enter a name for your source.
-2. For **Account ID**, enter your [Stripe `Account ID`](https://dashboard.stripe.com/settings/account).
-3. For **Secret Key**, enter your [Stripe `Secret Key`](https://dashboard.stripe.com/apikeys)
+:::note
+To authenticate the Stripe connector, you need a Stripe Secret Key with **Read** privileges for the data to replicate. For steps on obtaining and setting permissions for this key, refer to our [full Stripe documentation](https://docs.airbyte.com/integrations/sources/stripe#setup-guide).
+:::
 
-   We recommend creating a secret key specifically for Airbyte to control which resources Airbyte can access. For ease of use, we recommend granting read permission to all resources and configuring which resource to replicate in the Airbyte UI. You can also use the API keys for the [test mode](https://stripe.com/docs/keys#obtain-api-keys) to try out the Stripe integration with Airbyte.
+1. For **Source name**, enter a name to help you identify this source.
+2. For **Account ID**, enter your Stripe Account ID. This ID begins with `acct_`, and can be found in the top-right corner of your Stripe [account settings page](https://dashboard.stripe.com/settings/account).
+3. For **Secret Key**, enter your Stripe API Key, which can be found at your Stripe [API keys page](https://dashboard.stripe.com/apikeys).
+4. For **Replication Start Date**, use the provided datepicker or enter a UTC date and time programmatically in the format `YYYY-MM-DDTHH:mm:ssZ`. The data added on and after this date will be replicated.
+5. (Optional) For **Lookback Window**, you may specify a number of days from the present day to reread data. This allows the connector to retrieve data that might have been updated after its initial creation, and is useful for handling any post-transaction adjustments (such as tips, refunds, chargebacks, etc).
 
-4. For **Replication start date**, enter the date in `YYYY-MM-DDTHH:mm:ssZ` format. Data created on and after this date will be replicated.
-5. (Optional) For **Lookback Window in days**, select the number of days the value in days prior to the start date that you to sync your data with. If your data is updated after setting up this connector, you can use the this option to reload data from the past N days. Example: If the Replication start date is set to `2021-01-01T00:00:00Z`, then:
-   - If you leave the Lookback Window in days parameter to its the default value of 0, Airbyte will sync data from the Replication start date `2021-01-01T00:00:00Z`
-   - If the Lookback Window in days value is set to 1, Airbyte will consider the Replication start date to be `2020-12-31T00:00:00Z`
-   - If the Lookback Window in days value is set to 7, Airbyte will sync data from `2020-12-25T00:00:00Z`
-6. Click **Set up source**.
+    - Leaving the **Lookback Window** at its default value of 0 means Airbyte will not re-export data after it has been synced.
+    - Setting the **Lookback Window** to 1 means Airbyte will re-export data from the past day, capturing any changes made in the last 24 hours.
+    - Setting the **Lookback Window** to 7 means Airbyte will re-export and capture any data changes within the last week.
+
+6. (Optional) For **Data Request Window**, you may specify the time window in days for data retrieval from the Stripe API. This window defines how much data is gathered in each request, with larger values retrieving more data but making fewer requests.
+
+    For example, if you are replicating three years worth of data:
+
+    - A **Data Request Window** of 365 days means Airbyte makes 3 requests, each for a year. This is generally faster but risks needing to resync up to a year's data if something goes wrong.
+    - A **Data Request Window** of 30 days means 36 requests, each for a month. This may be slower but minimizes the amount of data that needs to be resynced if an issue occurs.
+
+    If you are unsure of which value to use, we recommend leaving this setting at its default value of 365 days.
+7. Click **Set up source** and wait for the tests to complete.
 
 ### Stripe API limitations
-- When syncing `events` data from Stripe, data is only [returned for the last 30 days](https://stripe.com/docs/api/events). Using the full-refresh-overwrite sync from Airbyte will delete the events data older than 30 days from your target destination. Use an append sync mode to ensure historical data is retained.
+
+- When syncing `events` data from Stripe, data is only [returned for the last 30 days](https://stripe.com/docs/api/events). Using the Full Refresh (Overwrite) sync from Airbyte will delete the events data older than 30 days from your target destination. Use an Append sync mode to ensure historical data is retained.
 
 For detailed information on supported sync modes, supported streams, performance considerations, refer to the full documentation for [Stripe](https://docs.airbyte.com/integrations/sources/stripe).

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -8,7 +8,7 @@ This page contains the setup guide and reference information for the Stripe sour
 
 ## Setup Guide
 
-To authenticate the Stripe connector, you need to use a Stripe Secret Key. Although you may use an existing key, we recommend that you create a new restricted key specifically for Airbyte and grant it **Read** privileges only. We also recommend granting **Read** privileges to all available permissions, and configuring the specific data you would like to replicate within Airbyte.
+To authenticate the Stripe connector, you need to use a Stripe API key. Although you may use an existing key, we recommend that you create a new restricted key specifically for Airbyte and grant it **Read** privileges only. We also recommend granting **Read** privileges to all available permissions, and configuring the specific data you would like to replicate within Airbyte.
 
 ### Create a Stripe Secret Key
 
@@ -36,11 +36,11 @@ For more information on Stripe API Keys, see the [Stripe documentation](https://
     - Setting the **Lookback Window** to 1 means Airbyte will re-export data from the past day, capturing any changes made in the last 24 hours.
     - Setting the **Lookback Window** to 7 means Airbyte will re-export and capture any data changes within the last week.
 
-9. (Optional) For **Data Request Window**, you may specify the time window in days for data retrieval from the Stripe API. This window defines how much data is gathered in each request, with larger values retrieving more data but making fewer requests.
+9. (Optional) For **Data Request Window**, you may specify the time window in days used by the connector when requesting data from the Stripe API. This window defines the span of time covered in each request, with larger values encompassing more days in a single request. Generally speaking, the lack of overhead from making fewer requests means a larger window is faster to sync. However, this also means the state of the sync will persist less frequently. If an issue occurs or the sync is interrupted, a larger window means more data will need to be resynced, potentially causing a delay in the overall process.
 
     For example, if you are replicating three years worth of data:
 
-    - A **Data Request Window** of 365 days means Airbyte makes 3 requests, each for a year. This is generally faster but risks needing to resync up to a year's data if something goes wrong.
+    - A **Data Request Window** of 365 days means Airbyte makes 3 requests, each for a year. This is generally faster but risks needing to resync up to a year's data if the sync is interrupted.
     - A **Data Request Window** of 30 days means 36 requests, each for a month. This may be slower but minimizes the amount of data that needs to be resynced if an issue occurs.
 
     If you are unsure of which value to use, we recommend leaving this setting at its default value of 365 days.
@@ -85,9 +85,6 @@ The Stripe source connector supports the following streams:
 - [Disputes](https://stripe.com/docs/api/disputes/list) \(Incremental\)
 - [Early Fraud Warnings](https://stripe.com/docs/api/radar/early_fraud_warnings/list) \(Incremental\)
 - [Events](https://stripe.com/docs/api/events/list) \(Incremental\)
-  :::warning
-  **Stripe API Restriction on Events Data**: Access to the events endpoint is [guaranteed only for the last 30 days](https://stripe.com/docs/api/events) by Stripe. If you use the Full Refresh Overwrite sync, be aware that any events data older than 30 days will be **deleted** from your target destination and replaced with the data from the last 30 days only. Use an Append sync mode to ensure historical data is retained.
-  :::
 - [File Links](https://stripe.com/docs/api/file_links/list) \(Incremental\)
 - [Files](https://stripe.com/docs/api/files/list) \(Incremental\)
 - [Invoice Items](https://stripe.com/docs/api/invoiceitems/list) \(Incremental\)
@@ -114,6 +111,10 @@ The Stripe source connector supports the following streams:
 - [Transfers](https://stripe.com/docs/api/transfers/list) \(Incremental\)
 - [Transfer Reversals](https://stripe.com/docs/api/transfer_reversals/list)
 - [Usage Records](https://stripe.com/docs/api/usage_records/subscription_item_summary_list)
+
+:::warning
+**Stripe API Restriction on Events Data**: Access to the events endpoint is [guaranteed only for the last 30 days](https://stripe.com/docs/api/events) by Stripe. If you use the Full Refresh Overwrite sync, be aware that any events data older than 30 days will be **deleted** from your target destination and replaced with the data from the last 30 days only. Use an Append sync mode to ensure historical data is retained.
+:::
 
 ### Data type mapping
 

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -1,33 +1,46 @@
 # Stripe
 
-:::warning
-Stripe API Restriction: Access to the events endpoint is [guaranteed only for the last 30 days](https://stripe.com/docs/api/events). Using the full-refresh-overwrite sync from Airbyte will delete the events data older than 30 days from your target destination.
-:::
+This page contains the setup guide and reference information for the Stripe source connector.
 
-This page guides you through the process of setting up the Stripe source connector.
+:::warning
+**Stripe API Restriction on Events Data**: Access to the events endpoint is [guaranteed only for the last 30 days](https://stripe.com/docs/api/events). If you use the Full Refresh sync, any events data older than 30 days will be **deleted** from your target destination.
+:::
 
 ## Prerequisites
 
 - Your [Stripe `Account ID`](https://dashboard.stripe.com/settings/account)
 - Your [Stripe `Secret Key`](https://dashboard.stripe.com/apikeys)
 
-## Set up the Stripe source connector
+## Setup Guide
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
-2. Click **Sources** and then click **+ New source**.
-3. On the Set up the source page, select **Stripe** from the Source type dropdown.
-4. Enter a name for your source.
-5. For **Account ID**, enter your [Stripe `Account ID`](https://dashboard.stripe.com/settings/account).
-6. For **Secret Key**, enter your [Stripe `Secret Key`](https://dashboard.stripe.com/apikeys)
+To authenticate the Stripe connector, you must provide a Stripe Secret Key. Although you may use an existing key, we recommend that you create a new key specifically for Airbyte and grant it **Read** priviliges. We recommend granting **Read** priviliges to all permissions, and configuring the data you would like to replicate in the connector itself. You can also use the API keys for the [test mode](https://stripe.com/docs/keys#obtain-api-keys) to try out the Stripe integration with Airbyte.
 
-   We recommend creating a secret key specifically for Airbyte to control which resources Airbyte can access. For ease of use, we recommend granting read permission to all resources and configuring which resource to replicate in the Airbyte UI. You can also use the API keys for the [test mode](https://stripe.com/docs/keys#obtain-api-keys) to try out the Stripe integration with Airbyte.
+### Create a Stripe Secret Key
 
-7. For **Replication start date**, enter the date in `YYYY-MM-DDTHH:mm:ssZ` format. The data added on and after this date will be replicated.
-8. For **Lookback Window in days (Optional)**, select the number of days the value in days prior to the start date that you to sync your data with. If your data is updated after setting up this connector, you can use the this option to reload data from the past N days. Example: If the Replication start date is set to `2021-01-01T00:00:00Z`, then:
-   - If you leave the Lookback Window in days parameter to its the default value of 0, Airbyte will sync data from the Replication start date `2021-01-01T00:00:00Z`
-   - If the Lookback Window in days value is set to 1, Airbyte will consider the Replication start date to be `2020-12-31T00:00:00Z`
-   - If the Lookback Window in days value is set to 7, Airbyte will sync data from `2020-12-25T00:00:00Z`
-9. Click **Set up source**.
+1. Log in to your [Stripe account](https://dashboard.stripe.com/login).
+2. In the top navigation bar, click **Developers**.
+3. In the top-left corner, click **API keys**.
+4. Click **+ Create restricted key**.
+5. Choose a **Key name**, and select **Read** for all permissions.
+6. Click **Create key**.
+
+### Set up the Stripe source connector in Airbyte
+
+1. Log in to your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
+2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
+3. Find and select **Stripe** from the list of available sources.
+4. For **Source name**, enter a name to help you identify this source.
+5. For **Account ID**, enter your Stripe Account ID. This ID begins with `acct_`, and can be found in the top-right corner of your Stripe [account settings page](https://dashboard.stripe.com/settings/account).
+6. For **Secret Key**, enter your Stripe API Key.
+7. For **Replication Start Date**, use the provided datepicker or enter the UTC date and time programmatically in the format `YYYY-MM-DDTHH:mm:ssZ`. The data added on and after this date will be replicated.
+8. (Optional) For **Lookback Window in days**, select the number of days prior to the start date for which you want to sync your data. This value allows the connector to retrieve data that might have been updated after its initial creation. For example, if the start date is set to `2021-01-01T00:00:00Z`, then:
+
+- Leaving the Lookback Window in days parameter at its default value of 0 means Airbyte will sync data starting from 2021-01-01T00:00:00Z.
+- Setting the Lookback Window in days value to 1 means Airbyte will consider the Replication start date to be one day earlier, or 2020-12-31T00:00:00Z.
+- Setting the Lookback Window in days value to 7 means Airbyte will sync data starting from seven days earlier, or 2020-12-25T00:00:00Z.
+
+9. (Optional) For **Data Sync Frequency**, select the time increment in days for the connector to use when requesting data from the Stripe API. Setting this value higher will reduce the number of requests, speeding up the sync process. However, this will result in data being updated less frequently. The default value is 365 days.
+10. Click **Set up source** and wait for the tests to complete.
 
 ## Supported sync modes
 

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -13,7 +13,7 @@ This page contains the setup guide and reference information for the Stripe sour
 
 ## Setup Guide
 
-To authenticate the Stripe connector, you must provide a Stripe Secret Key. Although you may use an existing key, we recommend that you create a new key specifically for Airbyte and grant it **Read** priviliges. We recommend granting **Read** priviliges to all permissions, and configuring the data you would like to replicate in the connector itself. You can also use the API keys for the [test mode](https://stripe.com/docs/keys#obtain-api-keys) to try out the Stripe integration with Airbyte.
+To authenticate the Stripe connector, you need a Stripe Secret Key. Although you may use an existing key, we recommend that you create a new key specifically for Airbyte and grant it **Read** priviliges. We recommend granting **Read** priviliges to all permissions, and configuring the data you would like to replicate in the connector itself.
 
 ### Create a Stripe Secret Key
 
@@ -24,6 +24,8 @@ To authenticate the Stripe connector, you must provide a Stripe Secret Key. Alth
 5. Choose a **Key name**, and select **Read** for all permissions.
 6. Click **Create key**.
 
+For more information on Stripe API Keys, see the [Stripe documentation](https://stripe.com/docs/keys).
+
 ### Set up the Stripe source connector in Airbyte
 
 1. Log in to your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
@@ -32,14 +34,14 @@ To authenticate the Stripe connector, you must provide a Stripe Secret Key. Alth
 4. For **Source name**, enter a name to help you identify this source.
 5. For **Account ID**, enter your Stripe Account ID. This ID begins with `acct_`, and can be found in the top-right corner of your Stripe [account settings page](https://dashboard.stripe.com/settings/account).
 6. For **Secret Key**, enter your Stripe API Key.
-7. For **Replication Start Date**, use the provided datepicker or enter the UTC date and time programmatically in the format `YYYY-MM-DDTHH:mm:ssZ`. The data added on and after this date will be replicated.
+7. For **Replication Start Date**, use the provided datepicker or enter a UTC date and time programmatically in the format `YYYY-MM-DDTHH:mm:ssZ`. The data added on and after this date will be replicated.
 8. (Optional) For **Lookback Window in days**, select the number of days prior to the start date for which you want to sync your data. This value allows the connector to retrieve data that might have been updated after its initial creation. For example, if the start date is set to `2021-01-01T00:00:00Z`, then:
 
 - Leaving the Lookback Window in days parameter at its default value of 0 means Airbyte will sync data starting from 2021-01-01T00:00:00Z.
 - Setting the Lookback Window in days value to 1 means Airbyte will consider the Replication start date to be one day earlier, or 2020-12-31T00:00:00Z.
 - Setting the Lookback Window in days value to 7 means Airbyte will sync data starting from seven days earlier, or 2020-12-25T00:00:00Z.
 
-9. (Optional) For **Data Sync Frequency**, select the time increment in days for the connector to use when requesting data from the Stripe API. Setting this value higher will reduce the number of requests, speeding up the sync process. However, this will result in data being updated less frequently. The default value is 365 days.
+9. (Optional) For **Data Request Window**, select the time increment in days for the connector to use when requesting data from the Stripe API. Setting this value higher will reduce the number of requests, speeding up the sync process. However, this will result in data being updated less frequently. The default value is 365 days.
 10. Click **Set up source** and wait for the tests to complete.
 
 ## Supported sync modes


### PR DESCRIPTION
## What
Updated the main and in-app docs pages for the Stripe source connector.

## How
- Updated API Key setup steps in main docs, and added link to them in in-app page.
- The current description of the Lookback Window seems to imply the window is tied to the replication start date, but my understanding is the window is meant to capture data changes from the most recent N days, rather than syncing data from N days before the Start Date. I've changed the explanation and example to reflect this, let me know if this is a misunderstanding on my part!
- Added an example for the data request window
- Alphabetized streams
- Moved `events` stream warning from top of page to "supported streams" section