### PR TITLE
[Source-MySQL] Rollback to 2.1.2 in case 3.0.0 fails [DO NOT MERGE]

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 2.1.2
+  dockerImageTag: 3.0.0
   dockerRepository: airbyte/source-mysql
   githubIssueLabel: source-mysql
   icon: mysql.svg
@@ -15,8 +15,10 @@ data:
   registries:
     cloud:
       dockerRepository: airbyte/source-mysql-strict-encrypt
+      dockerImageTag: 2.1.2
       enabled: true
     oss:
+      dockerImageTag: 2.1.2
       enabled: true
   releaseStage: beta
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql


### PR DESCRIPTION
## What
In the case that we need to rollback this [PR](https://github.com/airbytehq/airbyte/pull/28756/files). This PR redirects version 3.0.0 to point at 2.1.2. In the case that we need to rollback, this PR will be merged, and another PR will be submitted with version 3.0.1 that removes the previous changes. Also, `mysql.md` changelog will be updated with version 3.0.1 stating the rollback.