### PR TITLE
🐛 Source Shopify: handle the `HTTP-500` `Internal Server Error`

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify/Dockerfile
@@ -28,5 +28,5 @@ COPY source_shopify ./source_shopify
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.6.1
+LABEL io.airbyte.version=0.6.2
 LABEL io.airbyte.name=airbyte/source-shopify

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9da77001-af33-4bcd-be46-6252bf9342b9
-  dockerImageTag: 0.6.1
+  dockerImageTag: 0.6.2
   dockerRepository: airbyte/source-shopify
   githubIssueLabel: source-shopify
   icon: shopify.svg

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/utils.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/utils.py
@@ -58,6 +58,7 @@ class ShopifyNonRetryableErrors:
             402: f"Stream `{stream}`. The shop's plan does not have access to this feature. Please upgrade your plan to be  able to access this stream.",
             403: f"Stream `{stream}`. Unable to access Shopify endpoint for {stream}. Check that you have the appropriate access scopes to read data from this endpoint.",
             404: f"Stream `{stream}`. Not available or missing.",
+            500: f"Stream `{stream}`. Entity might not be available or missing."
             # extend the mapping with more handable errors, if needed.
         }
 

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/unit_test.py
@@ -5,7 +5,7 @@
 
 import pytest
 import requests
-from source_shopify.source import BalanceTransactions, DiscountCodes, PriceRules, FulfillmentOrders, ShopifyStream, SourceShopify
+from source_shopify.source import BalanceTransactions, DiscountCodes, FulfillmentOrders, PriceRules, ShopifyStream, SourceShopify
 
 
 def test_get_next_page_token(requests_mock):

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/unit_test.py
@@ -5,7 +5,7 @@
 
 import pytest
 import requests
-from source_shopify.source import BalanceTransactions, DiscountCodes, PriceRules, ShopifyStream, SourceShopify
+from source_shopify.source import BalanceTransactions, DiscountCodes, PriceRules, FulfillmentOrders, ShopifyStream, SourceShopify
 
 
 def test_get_next_page_token(requests_mock):
@@ -54,21 +54,23 @@ def test_privileges_validation(requests_mock, basic_config):
 
 
 @pytest.mark.parametrize(
-    "stream, status, json_response, expected_output",
+    "stream, slice, status, json_response, expected_output",
     [
-        (BalanceTransactions, 404, {"errors": "Not Found"}, False),
-        (PriceRules, 403, {"errors": "Forbidden"}, False)
+        (BalanceTransactions, None, 404, {"errors": "Not Found"}, False),
+        (PriceRules, None, 403, {"errors": "Forbidden"}, False),
+        (FulfillmentOrders, {"order_id": 123}, 500, {"errors": "Internal Server Error"}, False),
     ],
     ids=[
         "Stream not found (404)",
         "No permissions (403)",
+        "Internal Server Error for slice (500)",
     ],
 )
-def test_unavailable_stream(requests_mock, basic_config, stream, status, json_response, expected_output):
+def test_unavailable_stream(requests_mock, basic_config, stream, slice, status, json_response, expected_output):
     config = basic_config
     config["authenticator"] = None
     stream = stream(config)
-    url = stream.url_base + stream.path()
+    url = stream.url_base + stream.path(stream_slice=slice)
     requests_mock.get(url=url, json=json_response, status_code=status)
     response = requests.get(url)
     assert stream.should_retry(response) is expected_output

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -150,6 +150,7 @@ This is expected when the connector hits the 429 - Rate Limit Exceeded HTTP Erro
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| 0.6.2   | 2023-08-09 | [29302](https://github.com/airbytehq/airbyte/pull/29302) | Handle the `Internal Server Error` when entity could be fetched                 |
 | 0.6.1   | 2023-08-08 | [28291](https://github.com/airbytehq/airbyte/pull/28291) | Allow `shop` field to accept `*.myshopify.com` shop names, updated `OAuth Spec`                  |
 | 0.6.0   | 2023-08-02 | [28770](https://github.com/airbytehq/airbyte/pull/28770) | Added `Disputes` stream  |
 | 0.5.1   | 2023-07-13 | [28700](https://github.com/airbytehq/airbyte/pull/28700) | Improved `error messages` with more user-friendly description, refactored code  |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/airbyte/issues/29297

## How
- added the `500` code to the `utils.ShopifyNonRetryableErrors` to bypass the slice or stream when the error is hit
- covered with `unit_test` 

## 🚨 User Impact 🚨
No impact is expected. Patch changes.