### PR TITLE
Reuse existing open PR if it exists when bumping platform CDK dependency

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -308,7 +308,7 @@ jobs:
           commit-message: Updating CDK version following release
           title: Updating CDK version following release
           body: This is an automatically generated PR triggered by a CDK release
-          branch: automatic-cdk-release-${{needs.bump-version.outputs.new_cdk_version}}
+          branch: automatic-cdk-release
           base: master
           delete-branch: true
       - name: Post success to Slack channel dev-connectors-extensibility


### PR DESCRIPTION
We end up with many stale PRs on the platform because of how frequently we release the CDK. This PR changes this workflow to use the same branch. This has the effect of updating an open version bump PR on the platform if it already exists, or creating a new PR if it doesn't exist
