### PR TITLE
Destinations v2: Add docs for manually migrating raw tables

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/StandardNameTransformer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/StandardNameTransformer.java
@@ -83,4 +83,7 @@ public class StandardNameTransformer implements NamingConventionTransformer {
     }
   }
 
+  public static void main(final String[] args) {
+    System.out.println(new StandardNameTransformer().convertStreamName("\u0041\u006d\u00e9\u006c\u0069\u0065"));
+  }
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/StandardNameTransformer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/StandardNameTransformer.java
@@ -83,8 +83,4 @@ public class StandardNameTransformer implements NamingConventionTransformer {
     }
   }
 
-  public static void main(final String[] args) {
-    System.out.println(new StandardNameTransformer().convertStreamName("\u0041\u006d\u00e9\u006c\u0069\u0065"));
-  }
-
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/StandardNameTransformer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/StandardNameTransformer.java
@@ -86,4 +86,5 @@ public class StandardNameTransformer implements NamingConventionTransformer {
   public static void main(final String[] args) {
     System.out.println(new StandardNameTransformer().convertStreamName("\u0041\u006d\u00e9\u006c\u0069\u0065"));
   }
+
 }

--- a/docs/release_notes/destinations_v2.js
+++ b/docs/release_notes/destinations_v2.js
@@ -1,4 +1,6 @@
-export function concatenateRawTableName(namespace, name) {
+import React from 'react';
+
+function concatenateRawTableName(namespace, name) {
   let plainConcat = namespace + name;
   // Pretend we always have at least one underscore, so that we never generate `_raw_stream_`
   let longestUnderscoreRun = 1;
@@ -14,7 +16,7 @@ export function concatenateRawTableName(namespace, name) {
   return namespace + "_raw" + "_".repeat(longestUnderscoreRun + 1) + "stream_" + name;
 }
 
-export function setSql(namespace, name, destination, sql) {
+function setSql(namespace, name, destination, sql, defaultMessage) {
   var output;
   if (namespace != "" && name != "") {
     output = sql;
@@ -24,4 +26,88 @@ export function setSql(namespace, name, destination, sql) {
   document.getElementById("sql_output_block_" + destination).innerHTML = output;
 }
 
-export const defaultMessage = "Enter your stream's name and namespace to see the SQL output.\nIf your stream has no namespace, take the default value from the destination connector's settings.";
+const SqlOutput = ({ destination, defaultMessage }) => {
+  return (
+    <pre id={ "sql_output_block_" + destination }>
+      { defaultMessage }
+    </pre>
+  );
+};
+
+export const BigQueryMigrationGenerator = () => {
+  const defaultMessage =
+`Enter your stream's name and namespace to generate a SQL statement.
+If your stream has no namespace, take the default value from the destination connector's settings.
+You may need to tweak the sql statement if your stream name/namespace contain unusual characters.`;
+  function updateSql(event) {
+    let namespace = document.getElementById("stream_namespace_bigquery").value;
+    let name = document.getElementById("stream_name_bigquery").value;
+    let v2RawTableName = '`' + concatenateRawTableName(namespace, name) + '`';
+    let v1RawTableName = '`' + namespace + '`.`_airbyte_raw_' + name + '`';
+    let sql =
+`CREATE OR REPLACE TABLE \`airbyte_internal\`.${v2RawTableName} (
+  _airbyte_raw_id STRING NOT NULL,
+  _airbyte_data JSON NOT NULL,
+  _airbyte_extracted_at TIMESTAMP NOT NULL,
+  _airbyte_loaded_at TIMESTAMP)
+PARTITION BY DATE(_airbyte_extracted_at)
+CLUSTER BY _airbyte_extracted_at
+AS (
+    SELECT
+        _airbyte_ab_id AS _airbyte_raw_id,
+        PARSE_JSON(_airbyte_data) AS _airbyte_data,
+        _airbyte_emitted_at AS _airbyte_extracted_at,
+        CAST(NULL AS TIMESTAMP) AS _airbyte_loaded_at
+    FROM ${v1RawTableName}
+)`;
+    setSql(namespace, name, "bigquery", sql, defaultMessage);
+  }
+  return (
+    <div>
+      <label>Stream namespace </label>
+      <input type="text" id="stream_namespace_bigquery" name="stream_namespace" onChange={ updateSql }/><br/>
+      <label>Stream name </label>
+      <input type="text" id="stream_name_bigquery" name="stream_name" onChange={ updateSql }/><br/>
+      <SqlOutput destination="bigquery" defaultMessage={ defaultMessage }/>
+    </div>
+  )
+}
+
+export const SnowflakeMigrationGenerator = () => {
+  const defaultMessage =
+`Enter your stream's name and namespace to see the SQL output.
+If your stream has no namespace, take the default value from the destination connector's settings.
+You may need to tweak the sql statement if your stream name/namespace contain unusual characters.`;
+  function updateSql(event) {
+    let namespace = document.getElementById("stream_namespace_snowflake").value;
+    let name = document.getElementById("stream_name_snowflake").value;
+    let v2RawTableName = '"' + concatenateRawTableName(namespace, name) + '"';
+    let v1RawTableName = namespace + '._airbyte_raw_' + name;
+    let sql =
+`CREATE OR REPLACE TABLE "airbyte_internal".${v2RawTableName} (
+  "_airbyte_raw_id" STRING NOT NULL,
+  "_airbyte_data" JSON NOT NULL,
+  "_airbyte_extracted_at" TIMESTAMP NOT NULL,
+  "_airbyte_loaded_at" TIMESTAMP)
+PARTITION BY DATE("_airbyte_extracted_at")
+CLUSTER BY "_airbyte_extracted_at"
+AS (
+    SELECT
+        _airbyte_ab_id AS "_airbyte_raw_id",
+        PARSE_JSON(_airbyte_data) AS "_airbyte_data",
+        _airbyte_emitted_at AS "_airbyte_extracted_at",
+        CAST(NULL AS TIMESTAMP) AS "_airbyte_loaded_at"
+    FROM ${v1RawTableName}
+)`
+    setSql(namespace, name, "snowflake", sql, defaultMessage)
+  }
+  return (
+    <div>
+      <label>Stream namespace </label>
+      <input type="text" id="stream_namespace_snowflake" name="stream_namespace" onChange={ updateSql }/><br/>
+      <label>Stream name </label>
+      <input type="text" id="stream_name_snowflake" name="stream_name" onChange={ updateSql }/><br/>
+      <SqlOutput destination="snowflake" defaultMessage={ defaultMessage }/>
+    </div>
+  )
+}

--- a/docs/release_notes/destinations_v2.js
+++ b/docs/release_notes/destinations_v2.js
@@ -116,11 +116,11 @@ If your stream has no namespace, take the default value from the destination con
     let namespace = document.getElementById("stream_namespace_" + destination).value;
     let name = document.getElementById("stream_name_" + destination).value;
     var raw_dataset = document.getElementById("raw_dataset_" + destination).value;
-    if (raw_dataset == '') {
+    if (raw_dataset === '') {
       raw_dataset = 'airbyte_internal';
     }
     let sql = generateSql(namespace, name, raw_dataset);
-    if (namespace != "" && name != "") {
+    if (namespace !== "" && name !== "") {
       updateMessage({
         'message': sql,
         'language': 'sql'

--- a/docs/release_notes/destinations_v2.js
+++ b/docs/release_notes/destinations_v2.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import CodeBlock from '@theme/CodeBlock';
 
 function concatenateRawTableName(namespace, name) {
   let plainConcat = namespace + name;
@@ -23,14 +24,6 @@ function convertStreamName(str) {
     .replaceAll(/\s+/g, "_")
     .replaceAll(/[^A-Za-z0-9_]/g, "_");
 }
-
-const SqlOutput = ({ destination, defaultMessage }) => {
-  return (
-    <pre id={ "sql_output_block_" + destination }>
-      { defaultMessage }
-    </pre>
-  );
-};
 
 export const BigQueryMigrationGenerator = () => {
   // See BigQuerySQLNameTransformer
@@ -115,6 +108,10 @@ export const MigrationGenerator = ({destination, generateSql}) => {
   const defaultMessage =
 `Enter your stream's name and namespace to see the SQL output.
 If your stream has no namespace, take the default value from the destination connector's settings.`;
+  const [message, updateMessage] = useState({
+    'message': defaultMessage,
+    'language': 'text'
+  });
   function updateSql(event) {
     let namespace = document.getElementById("stream_namespace_" + destination).value;
     let name = document.getElementById("stream_name_" + destination).value;
@@ -123,14 +120,19 @@ If your stream has no namespace, take the default value from the destination con
       raw_dataset = 'airbyte_internal';
     }
     let sql = generateSql(namespace, name, raw_dataset);
-    var output;
     if (namespace != "" && name != "") {
-      output = sql;
+      updateMessage({
+        'message': sql,
+        'language': 'sql'
+      });
     } else {
-      output = defaultMessage;
+      updateMessage({
+        'message': defaultMessage,
+        'language': 'text'
+      });
     }
-    document.getElementById("sql_output_block_" + destination).innerHTML = output;
   }
+
   return (
     <div>
       <label>Stream namespace </label>
@@ -139,7 +141,9 @@ If your stream has no namespace, take the default value from the destination con
       <input type="text" id={"stream_name_" + destination} onChange={ updateSql }/><br/>
       <label>Raw table dataset/schema (defaults to <code>airbyte_internal</code>) </label>
       <input type="text" id={"raw_dataset_" + destination} onChange={ updateSql }/><br/>
-      <SqlOutput destination={destination} defaultMessage={ defaultMessage }/>
+      <CodeBlock id={ "sql_output_block_" + destination } language={ message['language'] }>
+        { message['message'] }
+      </CodeBlock>
     </div>
   );
 }

--- a/docs/release_notes/destinations_v2.js
+++ b/docs/release_notes/destinations_v2.js
@@ -1,0 +1,27 @@
+export function concatenateRawTableName(namespace, name) {
+  let plainConcat = namespace + name;
+  // Pretend we always have at least one underscore, so that we never generate `_raw_stream_`
+  let longestUnderscoreRun = 1;
+  for (let i = 0; i < plainConcat.length; i++) {
+    // If we've found an underscore, count the number of consecutive underscores
+    let underscoreRun = 0;
+    while (i < plainConcat.length && plainConcat.charAt(i) === '_') {
+        underscoreRun++;
+        i++;
+    }
+    longestUnderscoreRun = Math.max(longestUnderscoreRun, underscoreRun);
+  }
+  return namespace + "_raw" + "_".repeat(longestUnderscoreRun + 1) + "stream_" + name;
+}
+
+export function setSql(namespace, name, destination, sql) {
+  var output;
+  if (namespace != "" && name != "") {
+    output = sql;
+  } else {
+    output = defaultMessage;
+  }
+  document.getElementById("sql_output_block_" + destination).innerHTML = output;
+}
+
+export const defaultMessage = "Enter your stream's name and namespace to see the SQL output.\nIf your stream has no namespace, take the default value from the destination connector's settings.";

--- a/docs/release_notes/destinations_v2.js
+++ b/docs/release_notes/destinations_v2.js
@@ -16,16 +16,6 @@ function concatenateRawTableName(namespace, name) {
   return namespace + "_raw" + "_".repeat(longestUnderscoreRun + 1) + "stream_" + name;
 }
 
-function setSql(namespace, name, destination, sql, defaultMessage) {
-  var output;
-  if (namespace != "" && name != "") {
-    output = sql;
-  } else {
-    output = defaultMessage;
-  }
-  document.getElementById("sql_output_block_" + destination).innerHTML = output;
-}
-
 const SqlOutput = ({ destination, defaultMessage }) => {
   return (
     <pre id={ "sql_output_block_" + destination }>
@@ -35,17 +25,10 @@ const SqlOutput = ({ destination, defaultMessage }) => {
 };
 
 export const BigQueryMigrationGenerator = () => {
-  const defaultMessage =
-`Enter your stream's name and namespace to generate a SQL statement.
-If your stream has no namespace, take the default value from the destination connector's settings.
-You may need to tweak the sql statement if your stream name/namespace contain unusual characters.`;
-  function updateSql(event) {
-    let namespace = document.getElementById("stream_namespace_bigquery").value;
-    let name = document.getElementById("stream_name_bigquery").value;
+  function generateSql(namespace, name) {
     let v2RawTableName = '`' + concatenateRawTableName(namespace, name) + '`';
     let v1RawTableName = '`' + namespace + '`.`_airbyte_raw_' + name + '`';
-    let sql =
-`CREATE OR REPLACE TABLE \`airbyte_internal\`.${v2RawTableName} (
+    return `CREATE OR REPLACE TABLE \`airbyte_internal\`.${v2RawTableName} (
   _airbyte_raw_id STRING NOT NULL,
   _airbyte_data JSON NOT NULL,
   _airbyte_extracted_at TIMESTAMP NOT NULL,
@@ -60,31 +43,17 @@ AS (
         CAST(NULL AS TIMESTAMP) AS _airbyte_loaded_at
     FROM ${v1RawTableName}
 )`;
-    setSql(namespace, name, "bigquery", sql, defaultMessage);
   }
   return (
-    <div>
-      <label>Stream namespace </label>
-      <input type="text" id="stream_namespace_bigquery" name="stream_namespace" onChange={ updateSql }/><br/>
-      <label>Stream name </label>
-      <input type="text" id="stream_name_bigquery" name="stream_name" onChange={ updateSql }/><br/>
-      <SqlOutput destination="bigquery" defaultMessage={ defaultMessage }/>
-    </div>
-  )
+    <MigrationGenerator destination="bigquery" generateSql={generateSql}/>
+  );
 }
 
 export const SnowflakeMigrationGenerator = () => {
-  const defaultMessage =
-`Enter your stream's name and namespace to see the SQL output.
-If your stream has no namespace, take the default value from the destination connector's settings.
-You may need to tweak the sql statement if your stream name/namespace contain unusual characters.`;
-  function updateSql(event) {
-    let namespace = document.getElementById("stream_namespace_snowflake").value;
-    let name = document.getElementById("stream_name_snowflake").value;
+  function generateSql(namespace, name) {
     let v2RawTableName = '"' + concatenateRawTableName(namespace, name) + '"';
     let v1RawTableName = namespace + '._airbyte_raw_' + name;
-    let sql =
-`CREATE OR REPLACE TABLE "airbyte_internal".${v2RawTableName} (
+    return `CREATE OR REPLACE TABLE "airbyte_internal".${v2RawTableName} (
   "_airbyte_raw_id" STRING NOT NULL,
   "_airbyte_data" JSON NOT NULL,
   "_airbyte_extracted_at" TIMESTAMP NOT NULL,
@@ -94,20 +63,40 @@ CLUSTER BY "_airbyte_extracted_at"
 AS (
     SELECT
         _airbyte_ab_id AS "_airbyte_raw_id",
-        PARSE_JSON(_airbyte_data) AS "_airbyte_data",
+        _airbyte_data AS "_airbyte_data",
         _airbyte_emitted_at AS "_airbyte_extracted_at",
         CAST(NULL AS TIMESTAMP) AS "_airbyte_loaded_at"
     FROM ${v1RawTableName}
-)`
-    setSql(namespace, name, "snowflake", sql, defaultMessage)
+)`;
+  }
+  return (
+    <MigrationGenerator destination="snowflake" generateSql={generateSql}/>
+  );
+}
+
+export const MigrationGenerator = ({destination, generateSql}) => {
+  const defaultMessage =
+`Enter your stream's name and namespace to see the SQL output.
+If your stream has no namespace, take the default value from the destination connector's settings.`;
+  function updateSql(event) {
+    let namespace = document.getElementById("stream_namespace_" + destination).value;
+    let name = document.getElementById("stream_name_" + destination).value;
+    let sql = generateSql(namespace, name);
+    var output;
+    if (namespace != "" && name != "") {
+      output = sql;
+    } else {
+      output = defaultMessage;
+    }
+    document.getElementById("sql_output_block_" + destination).innerHTML = output;
   }
   return (
     <div>
       <label>Stream namespace </label>
-      <input type="text" id="stream_namespace_snowflake" name="stream_namespace" onChange={ updateSql }/><br/>
+      <input type="text" id={"stream_namespace_" + destination} onChange={ updateSql }/><br/>
       <label>Stream name </label>
-      <input type="text" id="stream_name_snowflake" name="stream_name" onChange={ updateSql }/><br/>
-      <SqlOutput destination="snowflake" defaultMessage={ defaultMessage }/>
+      <input type="text" id={"stream_name_" + destination} onChange={ updateSql }/><br/>
+      <SqlOutput destination={destination} defaultMessage={ defaultMessage }/>
     </div>
-  )
+  );
 }

--- a/docs/release_notes/upgrading_to_destinations_v2.md
+++ b/docs/release_notes/upgrading_to_destinations_v2.md
@@ -1,4 +1,97 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import {concatenateRawTableName, setSql, defaultMessage} from './destinations_v2.js'
+
 # Upgrading to Destinations V2
+
+export const SqlOutput = ({ destination }) => {
+  return (
+    <code>
+      <div id={ "sql_output_block_" + destination }>
+        { defaultMessage }
+      </div>
+    </code>
+  );
+};
+
+export const BigQueryMigrationGenerator = () => {
+  function updateSql(event) {
+    let namespace = document.getElementById("stream_namespace_bigquery").value;
+    let name = document.getElementById("stream_name_bigquery").value;
+    let v2RawTableName = '`' + concatenateRawTableName(namespace, name) + '`';
+    let v1RawTableName = '`' + namespace + '`.`_airbyte_raw_' + name + '`';
+    let sql =
+`CREATE OR REPLACE TABLE \`airbyte_internal\`.${v2RawTableName} (
+  _airbyte_raw_id STRING NOT NULL,
+  _airbyte_data JSON NOT NULL,
+  _airbyte_extracted_at TIMESTAMP NOT NULL,
+  _airbyte_loaded_at TIMESTAMP)
+PARTITION BY DATE(_airbyte_extracted_at)
+CLUSTER BY _airbyte_extracted_at
+AS (
+    SELECT
+        _airbyte_ab_id AS _airbyte_raw_id,
+        PARSE_JSON(_airbyte_data) AS _airbyte_data,
+        _airbyte_emitted_at AS _airbyte_extracted_at,
+        CAST(NULL AS TIMESTAMP) AS _airbyte_loaded_at
+    FROM ${v1RawTableName}
+)`
+    setSql(namespace, name, "bigquery", sql)
+  }
+  return (
+    <div>
+      <label>Stream namespace </label>
+      <input type="text" id="stream_namespace_bigquery" name="stream_namespace" onChange={ updateSql }/><br/>
+      <label>Stream name </label>
+      <input type="text" id="stream_name_bigquery" name="stream_name" onChange={ updateSql }/><br/>
+      <SqlOutput destination="bigquery"/>
+    </div>
+  )
+}
+
+export const SnowflakeMigrationGenerator = () => {
+  function updateSql(event) {
+    let namespace = document.getElementById("stream_namespace_snowflake").value;
+    let name = document.getElementById("stream_name_snowflake").value;
+    let v2RawTableName = '"' + concatenateRawTableName(namespace, name) + '"';
+    let v1RawTableName = namespace + '._airbyte_raw_' + name;
+    let sql =
+`CREATE OR REPLACE TABLE "airbyte_internal".${v2RawTableName} (
+  "_airbyte_raw_id" STRING NOT NULL,
+  "_airbyte_data" JSON NOT NULL,
+  "_airbyte_extracted_at" TIMESTAMP NOT NULL,
+  "_airbyte_loaded_at" TIMESTAMP)
+PARTITION BY DATE("_airbyte_extracted_at")
+CLUSTER BY "_airbyte_extracted_at"
+AS (
+    SELECT
+        _airbyte_ab_id AS "_airbyte_raw_id",
+        PARSE_JSON(_airbyte_data) AS "_airbyte_data",
+        _airbyte_emitted_at AS "_airbyte_extracted_at",
+        CAST(NULL AS TIMESTAMP) AS "_airbyte_loaded_at"
+    FROM ${v1RawTableName}
+)`
+    setSql(namespace, name, "snowflake", sql)
+  }
+  return (
+    <div>
+      <label>Stream namespace </label>
+      <input type="text" id="stream_namespace_snowflake" name="stream_namespace" onChange={ updateSql }/><br/>
+      <label>Stream name </label>
+      <input type="text" id="stream_name_snowflake" name="stream_name" onChange={ updateSql }/><br/>
+      <SqlOutput destination="snowflake"/>
+    </div>
+  )
+}
+
+<Tabs>
+  <TabItem value="bigquery" label="BigQuery" default>
+    <BigQueryMigrationGenerator />
+  </TabItem>
+  <TabItem value="snowflake" label="Snowflake">
+    <SnowflakeMigrationGenerator />
+  </TabItem>
+</Tabs>
 
 ## What is Destinations V2?
 

--- a/docs/release_notes/upgrading_to_destinations_v2.md
+++ b/docs/release_notes/upgrading_to_destinations_v2.md
@@ -53,20 +53,12 @@ Pre-existing raw tables, SCD tables and "unnested" tables will always be left un
 Each destination version is managed separately, so if you have multiple destinations, they all need to be upgraded one by one.
 
 Versions are tied to the destination. When you update the destination, **all connections tied to that destination will be sending data in the Destinations V2 format**. For upgrade paths that will minimize disruption to existing dashboards, see:
-* [Upgrading to Destinations V2](#upgrading-to-destinations-v2)
-  * [What is Destinations V2?](#what-is-destinations-v2)
-  * [Deprecating Legacy Normalization](#deprecating-legacy-normalization)
-    * [Breakdown of Breaking Changes](#breakdown-of-breaking-changes)
-  * [Quick Start to Upgrading](#quick-start-to-upgrading)
-  * [Advanced Upgrade Paths](#advanced-upgrade-paths)
-    * [Upgrading Connections One by One with Dual-Writing](#upgrading-connections-one-by-one-with-dual-writing)
-      * [Steps to Follow for All Sync Modes](#steps-to-follow-for-all-sync-modes)
-      * [Additional Steps for Incremental Sync Modes](#additional-steps-for-incremental-sync-modes)
-    * [Testing Destinations V2 for a Single Connection](#testing-destinations-v2-for-a-single-connection)
-    * [Upgrading as a User of Raw Tables](#upgrading-as-a-user-of-raw-tables)
-    * [Upgrade Paths for Connections using CDC](#upgrade-paths-for-connections-using-cdc)
-  * [Destinations V2 Compatible Versions](#destinations-v2-compatible-versions)
-
+* [Upgrading Connections One by One with Dual-Writing](#upgrading-connections-one-by-one-with-dual-writing)
+* [Testing Destinations V2 on a Single Connection](#testing-destinations-v2-for-a-single-connection)
+* [Upgrading Connections One by One Using CDC](#upgrade-paths-for-connections-using-cdc)
+* [Upgrading as a User of Raw Tables](#upgrading-as-a-user-of-raw-tables)
+* [Rolling back to Legacy Normalization](#oss-only-rolling-back-to-legacy-normalization)
+ 
 ## Advanced Upgrade Paths
 
 ### Upgrading Connections One by One with Dual-Writing

--- a/docs/release_notes/upgrading_to_destinations_v2.md
+++ b/docs/release_notes/upgrading_to_destinations_v2.md
@@ -39,7 +39,7 @@ The quickest path to upgrading is to click upgrade on any out-of-date connection
 ![Upgrade Path](./assets/airbyte_destinations_v2_upgrade_prompt.png)
 
 After upgrading the out-of-date destination to a [Destinations V2 compatible version](#destinations-v2-effective-versions), the following will occur at the next sync **for each connection** sending data to the updated destination:
-1. Existing raw tables replicated to this destination will be copied to a new `airbyte` schema. 
+1. Existing raw tables replicated to this destination will be copied to a new `airbyte` schema.
 2. The new raw tables will be updated to the new Destinations V2 format.
 3. The new raw tables will be updated with any new data since the last sync, like normal.
 4. The new raw tables will be typed and de-duplicated according to the Destinations V2 format.
@@ -92,7 +92,7 @@ DECLARE new_table STRING;
 
 SET gcp_project = '';
 SET target_dataset = 'airbyte_internal';
-SET target_table = ''; 
+SET target_table = '';
 SET source_dataset = '';
 SET source_table = '';
 SET old_table = CONCAT(gcp_project, '.', source_dataset, '.', source_table);
@@ -109,7 +109,7 @@ AS (
         _airbyte_emitted_at AS _airbyte_extracted_at,
         CAST(NULL AS TIMESTAMP) AS _airbyte_loaded_at
     FROM `%s`
-) 
+)
 ''', new_table, old_table);
 
 END;
@@ -120,7 +120,7 @@ END;
 ![img.png](assets/airbyte_connection_update_state.png)
 
 3. Go to your newly created connection, replace the state with the copied contents in the previous step, then click `Update State`. This will ensure historical data is not replicated again.
-4. Enabling the connection will now provide a parallel copy of all streams in the updated format. 
+4. Enabling the connection will now provide a parallel copy of all streams in the updated format.
 5. You can move your dashboards to rely on the new tables, then pause the out-of-date connection.
 
 ### Testing Destinations V2 for a Single Connection
@@ -135,7 +135,7 @@ When you are done testing, you can disable or delete this testing connection, an
 
 If you have written downstream transformations directly from the output of raw tables, or use the "Raw JSON" normalization setting, you should know that:
 * Multiple column names are being updated (from `airbyte_ab_id` to `airbyte_raw_id`, and `airbyte_emitted_at` to `airbyte_extracted_at`).
-* The location of raw tables will from now on default to an `airbyte` schema in your destination. 
+* The location of raw tables will from now on default to an `airbyte` schema in your destination.
 * When you upgrade to a [Destinations V2 compatible version](#destinations-v2-effective-versions) of your destination, we will never alter your existing raw data. Although existing downstream dashboards will go stale, they will never be broken.
 * You can dual write by following the [steps above](#upgrading-connections-one-by-one-with-dual-writing) and copying your raw data to the schema of your newly created connection.
 


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/29196

I basically haven't written any javascript in a decade, feel free to roast me :) 
* couldn't figure out how to import prefab components, so I'm using raw html input fields :shrug:
* didn't spend any effort on making this look pretty
* probably there's some way to define the sql contents as a functional thing instead of using onChange callbacks? I didn't google very hard

demo https://www.loom.com/share/b5c6c1e68a604aa9bc3fd1be93512a16

This does require users to generate sql for one table at a time. Plausibly someone better at frontend could make a thing to accept a list of streams and generate all of their sql statements as a single batch. I think this is good enough for the usecase of "user wants to try out v2 on a small subset of their streams".