### PR TITLE
change to use the Exchange Rate Data API access token instead of the …

### DIFF
--- a/docs/connector-development/config-based/tutorial/0-getting-started.md
+++ b/docs/connector-development/config-based/tutorial/0-getting-started.md
@@ -31,12 +31,12 @@ The output schema of our stream will look like the following:
 ## Exchange Rates API Setup
 
 Before we get started, you'll need to generate an API access key for the Exchange Rates API.
-This can be done by signing up for the Free tier plan on [Exchange Rates API](https://exchangeratesapi.io/):
+This can be done by signing up for the Free tier plan on [Exchange Rates Data API](https://apilayer.com/marketplace/exchangerates_data-api), not [Exchange Rates API](https://exchangeratesapi.io/):
 
-1. Visit https://exchangeratesapi.io and click "Get free API key" on the top right
-2. You'll be taken to https://apilayer.com -- finish the sign up process, signing up for the free tier
-3. Once you're signed in, visit https://apilayer.com/marketplace/exchangerates_data-api#documentation-tab and click "Live Demo"
-4. Inside that editor, you'll see an API key. This is your API key.
+1. Visit https://apilayer.com/ and click "Sign In" on the top
+2. Finish the sign up process, signing up for the free tier
+3. Once you're signed in, visit https://apilayer.com/marketplace/exchangerates_data-api and click "Subscribe" for free
+4. On the top right, you'll see an API key. This is your API key.
 
 ## Requirements
 

--- a/docs/connector-development/tutorials/cdk-tutorial-python-http/getting-started.md
+++ b/docs/connector-development/tutorials/cdk-tutorial-python-http/getting-started.md
@@ -14,7 +14,7 @@ All the commands below assume that `python` points to a version of python &gt;=3
 
 ## Exchange Rates API Setup
 
-For this guide we will be making API calls to the Exchange Rates API. In order to generate the API access key that will be used by the new connector, you will have to follow steps on the [Exchange Rates API](https://exchangeratesapi.io/) by signing up for the Free tier plan. Once you have an API access key, you can continue with the guide.
+For this guide we will be making API calls to the Exchange Rates API. In order to generate the API access key that will be used by the new connector, you will have to follow steps on the [Exchange Rates Data API](https://apilayer.com/marketplace/exchangerates_data-api/) by signing up for the Free tier plan. Once you have an API access key, you can continue with the guide.
 
 ## Checklist
 

--- a/docs/integrations/sources/exchange-rates.md
+++ b/docs/integrations/sources/exchange-rates.md
@@ -4,7 +4,7 @@
 
 The exchange rates integration is a toy integration to demonstrate how Airbyte works with a very simple source.
 
-It pulls all its data from [https://exchangeratesapi.io](https://exchangeratesapi.io)
+It pulls all its data from [https://apilayer.com/marketplace/exchangerates_data-api](https://apilayer.com/marketplace/exchangerates_data-api)
 
 #### Output schema
 


### PR DESCRIPTION
## What
- Configuration check failed because of Invalid authentication credentials when choose Exchange Rates API as source

## How
- To change to get API access key from [Exchange Rates Data API](https://apilayer.com/marketplace/exchangerates_data-api) instead of [Exchange Rates API](https://exchangeratesapi.io/)

## Recommended reading order
1. docs/connector-development/tutorials/cdk-tutorial-python-http/getting-started.md
2. docs/connector-development/config-based/tutorial/0-getting-started.md
3. docs/integrations/sources/exchange-rates.md

## 🚨 User Impact 🚨
Users will have a smooth tutorial experience.

