### PR TITLE
[ISSUE #26764] support brute force multiline json objects for JSONL

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/jsonl_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/jsonl_parser.py
@@ -17,7 +17,6 @@ from airbyte_cdk.sources.file_based.schema_helpers import PYTHON_TYPE_MAPPING, m
 class JsonlParser(FileTypeParser):
 
     MAX_BYTES_PER_FILE_FOR_SCHEMA_INFERENCE = 1_000_000
-    _WITH_READ_LIMIT = True
     ENCODING = "utf8"
 
     async def infer_schema(
@@ -33,7 +32,7 @@ class JsonlParser(FileTypeParser):
         """
         inferred_schema: Dict[str, Any] = {}
 
-        for entry in self._parse_jsonl_entries(file, stream_reader, logger, self._WITH_READ_LIMIT):
+        for entry in self._parse_jsonl_entries(file, stream_reader, logger, read_limit=True):
             line_schema = self._infer_schema_for_record(entry)
             inferred_schema = merge_schemas(inferred_schema, line_schema)
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_jsonl_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_jsonl_parser.py
@@ -3,8 +3,10 @@
 #
 
 from typing import Any, Dict, Mapping
+from unittest.mock import MagicMock, Mock
 
 import pytest
+from airbyte_cdk.sources.file_based.exceptions import RecordParseError
 from airbyte_cdk.sources.file_based.file_types import JsonlParser
 
 
@@ -33,3 +35,66 @@ def test_type_mapping(record: Dict[str, Any], expected_schema: Mapping[str, str]
             JsonlParser().infer_schema_for_record(record)
     else:
         assert JsonlParser.infer_schema_for_record(record) == expected_schema
+
+
+JSONL_CONTENT_WITHOUT_MULTILINE_JSON_OBJECTS = [
+    b'{"a": 1, "b": "1"}',
+    b'{"a": 2, "b": "2"}',
+]
+JSONL_CONTENT_WITH_MULTILINE_JSON_OBJECTS = [
+    b'{',
+    b'  "a": 1,',
+    b'  "b": "1"',
+    b'}',
+    b'{',
+    b'  "a": 2,',
+    b'  "b": "2"',
+    b'}',
+]
+INVALID_JSON_CONTENT = [
+    b'{',
+    b'  "a": 1,',
+    b'  "b": "1"',
+    b'{',
+    b'  "a": 2,',
+    b'  "b": "2"',
+    b'}',
+]
+
+
+def test_given_one_json_per_line_when_parse_records_then_return_records() -> None:
+    stream_reader = MagicMock()
+    stream_reader.open_file.return_value.__enter__.return_value = JSONL_CONTENT_WITHOUT_MULTILINE_JSON_OBJECTS
+
+    records = list(JsonlParser().parse_records(Mock(), Mock(), stream_reader, Mock()))
+
+    assert records == [{"a": 1, "b": "1"}, {"a": 2, "b": "2"}]
+
+
+def test_given_multiline_json_object_when_parse_records_then_return_records() -> None:
+    stream_reader = MagicMock()
+    stream_reader.open_file.return_value.__enter__.return_value = JSONL_CONTENT_WITH_MULTILINE_JSON_OBJECTS
+
+    records = list(JsonlParser().parse_records(Mock(), Mock(), stream_reader, Mock()))
+
+    assert records == [{"a": 1, "b": "1"}, {"a": 2, "b": "2"}]
+
+
+def test_given_multiline_json_object_when_parse_records_then_log_once_one_record_yielded() -> None:
+    stream_reader = MagicMock()
+    stream_reader.open_file.return_value.__enter__.return_value = JSONL_CONTENT_WITH_MULTILINE_JSON_OBJECTS
+    logger = Mock()
+
+    next(iter(JsonlParser().parse_records(Mock(), Mock(), stream_reader, logger)))
+
+    assert logger.warning.call_count == 1
+
+
+def test_given_unparsable_json_when_parse_records_then_raise_error() -> None:
+    stream_reader = MagicMock()
+    stream_reader.open_file.return_value.__enter__.return_value = INVALID_JSON_CONTENT
+    logger = Mock()
+
+    with pytest.raises(RecordParseError):
+        list(JsonlParser().parse_records(Mock(), Mock(), stream_reader, logger))
+    assert logger.warning.call_count == 0

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_jsonl_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_jsonl_parser.py
@@ -121,6 +121,15 @@ def test_given_one_json_per_line_when_parse_records_then_return_records(stream_r
     assert records == [{"a": 1, "b": "1"}, {"a": 2, "b": "2"}]
 
 
+def test_given_one_json_per_line_when_parse_records_then_do_not_send_warning(stream_reader: MagicMock) -> None:
+    stream_reader.open_file.return_value.__enter__.return_value = JSONL_CONTENT_WITHOUT_MULTILINE_JSON_OBJECTS
+    logger = Mock()
+
+    list(JsonlParser().parse_records(Mock(), Mock(), stream_reader, logger))
+
+    assert logger.warning.call_count == 0
+
+
 def test_given_multiline_json_object_when_parse_records_then_return_records(stream_reader: MagicMock) -> None:
     stream_reader.open_file.return_value.__enter__.return_value = JSONL_CONTENT_WITH_MULTILINE_JSON_OBJECTS
     records = list(JsonlParser().parse_records(Mock(), Mock(), stream_reader, Mock()))

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_jsonl_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_jsonl_parser.py
@@ -2,40 +2,16 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from typing import Any, Dict, Mapping
+import asyncio
+import io
+import json
+from typing import Any, Dict
 from unittest.mock import MagicMock, Mock
 
 import pytest
 from airbyte_cdk.sources.file_based.exceptions import RecordParseError
+from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader
 from airbyte_cdk.sources.file_based.file_types import JsonlParser
-
-
-@pytest.mark.parametrize(
-    "record, expected_schema",
-    [
-        pytest.param({}, {}, id="no_records"),
-        pytest.param(
-            {"col1": 1, "col2": 2.2, "col3": "3", "col4": ["a", "list"], "col5": {"inner": "obj"}, "col6": None, "col7": True},
-            {
-                "col1": {"type": "integer"},
-                "col2": {"type": "number"},
-                "col3": {"type": "string"},
-                "col4": {"type": "array"},
-                "col5": {"type": "object"},
-                "col6": {"type": "null"},
-                "col7": {"type": "boolean"},
-            },
-            id="all_columns_included_in_schema"
-        ),
-    ]
-)
-def test_type_mapping(record: Dict[str, Any], expected_schema: Mapping[str, str]) -> None:
-    if expected_schema is None:
-        with pytest.raises(ValueError):
-            JsonlParser().infer_schema_for_record(record)
-    else:
-        assert JsonlParser.infer_schema_for_record(record) == expected_schema
-
 
 JSONL_CONTENT_WITHOUT_MULTILINE_JSON_OBJECTS = [
     b'{"a": 1, "b": "1"}',
@@ -62,26 +38,96 @@ INVALID_JSON_CONTENT = [
 ]
 
 
-def test_given_one_json_per_line_when_parse_records_then_return_records() -> None:
-    stream_reader = MagicMock()
-    stream_reader.open_file.return_value.__enter__.return_value = JSONL_CONTENT_WITHOUT_MULTILINE_JSON_OBJECTS
-
-    records = list(JsonlParser().parse_records(Mock(), Mock(), stream_reader, Mock()))
-
-    assert records == [{"a": 1, "b": "1"}, {"a": 2, "b": "2"}]
+@pytest.fixture
+def stream_reader() -> MagicMock:
+    return MagicMock(spec=AbstractFileBasedStreamReader)
 
 
-def test_given_multiline_json_object_when_parse_records_then_return_records() -> None:
-    stream_reader = MagicMock()
+def _infer_schema(stream_reader: MagicMock) -> Dict[str, Any]:
+    loop = asyncio.new_event_loop()
+    task = loop.create_task(JsonlParser().infer_schema(Mock(), Mock(), stream_reader, Mock()))
+    loop.run_until_complete(task)
+    return task.result()  # type: ignore  # asyncio has no typing
+
+
+def test_when_infer_then_return_proper_types(stream_reader: MagicMock) -> None:
+    record = {"col1": 1, "col2": 2.2, "col3": "3", "col4": ["a", "list"], "col5": {"inner": "obj"}, "col6": None, "col7": True}
+    stream_reader.open_file.return_value.__enter__.return_value = io.BytesIO(
+        json.dumps(record).encode("utf-8")
+    )
+
+    schema = _infer_schema(stream_reader)
+
+    assert schema == {
+        "col1": {"type": "integer"},
+        "col2": {"type": "number"},
+        "col3": {"type": "string"},
+        "col4": {"type": "array"},
+        "col5": {"type": "object"},
+        "col6": {"type": "null"},
+        "col7": {"type": "boolean"},
+    }
+
+
+def test_given_empty_record_when_infer_then_return_empty_schema(stream_reader: MagicMock) -> None:
+    stream_reader.open_file.return_value.__enter__.return_value = io.BytesIO("{}".encode("utf-8"))
+    schema = _infer_schema(stream_reader)
+    assert schema == {}
+
+
+def test_given_no_records_when_infer_then_return_empty_schema(stream_reader: MagicMock) -> None:
+    stream_reader.open_file.return_value.__enter__.return_value = io.BytesIO("".encode("utf-8"))
+    schema = _infer_schema(stream_reader)
+    assert schema == {}
+
+
+def test_given_limit_hit_when_infer_then_stop_considering_records(stream_reader: MagicMock) -> None:
+    jsonl_file_content = ('{"key": 2.' + "2" * JsonlParser.MAX_BYTES_PER_FILE_FOR_SCHEMA_INFERENCE + '}\n{"key": "a string"}')
+    stream_reader.open_file.return_value.__enter__.return_value = io.BytesIO(jsonl_file_content.encode("utf-8"))
+
+    schema = _infer_schema(stream_reader)
+
+    assert schema == {"key": {"type": "number"}}
+
+
+def test_given_multiline_json_objects_and_read_limit_hit_when_infer_then_return_parse_until_at_least_one_record(
+    stream_reader: MagicMock
+) -> None:
+    jsonl_file_content = ('{\n"key": 2.' + "2" * JsonlParser.MAX_BYTES_PER_FILE_FOR_SCHEMA_INFERENCE + "\n}")
+    stream_reader.open_file.return_value.__enter__.return_value = io.BytesIO(jsonl_file_content.encode("utf-8"))
+
+    schema = _infer_schema(stream_reader)
+
+    assert schema == {"key": {"type": "number"}}
+
+
+def test_given_multiline_json_objects_and_hits_read_limit_when_infer_then_return_proper_types(
+    stream_reader: MagicMock
+) -> None:
     stream_reader.open_file.return_value.__enter__.return_value = JSONL_CONTENT_WITH_MULTILINE_JSON_OBJECTS
+    schema = _infer_schema(stream_reader)
+    assert schema == {"a": {"type": "integer"}, "b": {"type": "string"}}
 
+
+def test_given_multiple_records_then_merge_types(stream_reader: MagicMock) -> None:
+    stream_reader.open_file.return_value.__enter__.return_value = io.BytesIO('{"col1": 1}\n{"col1": 2.3}'.encode("utf-8"))
+    schema = _infer_schema(stream_reader)
+    assert schema == {"col1": {"type": "number"}}
+
+
+def test_given_one_json_per_line_when_parse_records_then_return_records(stream_reader: MagicMock) -> None:
+    stream_reader.open_file.return_value.__enter__.return_value = JSONL_CONTENT_WITHOUT_MULTILINE_JSON_OBJECTS
     records = list(JsonlParser().parse_records(Mock(), Mock(), stream_reader, Mock()))
-
     assert records == [{"a": 1, "b": "1"}, {"a": 2, "b": "2"}]
 
 
-def test_given_multiline_json_object_when_parse_records_then_log_once_one_record_yielded() -> None:
-    stream_reader = MagicMock()
+def test_given_multiline_json_object_when_parse_records_then_return_records(stream_reader: MagicMock) -> None:
+    stream_reader.open_file.return_value.__enter__.return_value = JSONL_CONTENT_WITH_MULTILINE_JSON_OBJECTS
+    records = list(JsonlParser().parse_records(Mock(), Mock(), stream_reader, Mock()))
+    assert records == [{"a": 1, "b": "1"}, {"a": 2, "b": "2"}]
+
+
+def test_given_multiline_json_object_when_parse_records_then_log_once_one_record_yielded(stream_reader: MagicMock) -> None:
     stream_reader.open_file.return_value.__enter__.return_value = JSONL_CONTENT_WITH_MULTILINE_JSON_OBJECTS
     logger = Mock()
 
@@ -90,8 +136,7 @@ def test_given_multiline_json_object_when_parse_records_then_log_once_one_record
     assert logger.warning.call_count == 1
 
 
-def test_given_unparsable_json_when_parse_records_then_raise_error() -> None:
-    stream_reader = MagicMock()
+def test_given_unparsable_json_when_parse_records_then_raise_error(stream_reader: MagicMock) -> None:
     stream_reader.open_file.return_value.__enter__.return_value = INVALID_JSON_CONTENT
     logger = Mock()
 


### PR DESCRIPTION
## What
Adresses https://github.com/airbytehq/airbyte/issues/26764

As mentioned in the ticket:
* Specifying `newlines_in_values` does not change the behavior i.e. having this True or False still allows for multiline JSON and therefore, all JSONL files synced in production could have been considered "newlines_in_values"
* The drawback `block_size` issues using pyarrow seems too annoying for now as it broke stream before
* We agreed on supporting multiline jsonl by brute force in the CDK and adding log to see if users actually have this. We will add a reminder to search for this log after the release. Unfortunately, we will only know this once V4 is installed though. I've created this reminder on August 21st. Ping me if you want to be invited to the event

## How
If a line is not parsable, accumulate the content of this line and parse using the following line. Rince and repeat until JSON parsing works
