### PR TITLE
hack for intellij: make integrationTestJavaClasses depend on airbyteDocker

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 1.7.6
+  dockerImageTag: 1.7.7
   dockerRepository: airbyte/destination-bigquery
   githubIssueLabel: destination-bigquery
   icon: bigquery.svg

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -43,6 +43,17 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
 
             if(project.hasProperty('airbyteDocker')) {
                 dependsOn project.airbyteDocker
+
+                // This is a hack to make intellij work better with our test setup.
+                // Many of our tests are defined as abstract classes in a shared base module,
+                // which means that you run the test methods from the abstract class in intellij.
+                // Intellij only runs `destination-xyz:integrationTestJavaClass` in this case,
+                // i.e. it does not run `destination-xyz:integrationTestJava`.
+                // So adding this dependency forces intellij to rebuild the docker image
+                // no matter how you run the test.
+                project.tasks.named('integrationTestJavaClasses') {
+                    dependsOn project.airbyteDocker
+                }
             }
 
             //This allows to set up a `gradle.properties` file inside the connector folder to reduce number of threads and reduce parallelization.


### PR DESCRIPTION
see comment for explanation. This will (hopefully) improve the intellij dev experience... probably need to get https://github.com/airbytehq/airbyte/pull/28817 figured out first so that it builds the docker image correctly?

(will revert the metadata version bump before merging)