### PR TITLE
🤖 Cloud Availability updater: new connectors to deploy [20230814]

### DIFF
--- a/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Pulsar
   registries:
     cloud:
-      enabled: false # hide Pulsar Destination https://github.com/airbytehq/airbyte-cloud/issues/2614
+      enabled: true  # hide Pulsar Destination https://github.com/airbytehq/airbyte-cloud/issues/2614
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-chargify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargify/metadata.yaml
@@ -6,7 +6,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   connectorSubtype: api
   connectorType: source
   definitionId: 9b2d3607-7222-4709-9fa2-c2abdebbdd88


### PR DESCRIPTION
The Cloud Availability Updater decided that it's the right time to make the following 2 connectors available on Cloud!

# Promoted connectors
|connector_technical_name|connector_version|      connector_definition_id       |
|------------------------|-----------------|------------------------------------|
|source-chargify         |0.3.0            |9b2d3607-7222-4709-9fa2-c2abdebbdd88|
|destination-pulsar      |0.1.3            |2340cbba-358e-11ec-8d3d-0242ac130203|

# Excluded but eligible connectors
|connector_technical_name|connector_version|connector_definition_id|
|------------------------|-----------------|-----------------------|

 ☝️ These eligible connectors are already in the definitions masks. They might have been explicitly pinned or excluded. We're not adding these for safety.