### PR TITLE
Change docs from Airbyte Pro to Airbyte Enterprise

### DIFF
--- a/docs/airbyte-enterprise.md
+++ b/docs/airbyte-enterprise.md
@@ -1,16 +1,16 @@
-# Airbyte Pro
+# Airbyte Enterprise
 
-Airbyte Pro is a self-hosted version of Airbyte with additional features for enterprise customers. Airbyte Pro is currently in early development. Interested in Airbyte Pro for your organization? [Talk to sales](https://airbyte.com/company/talk-to-sales).
+Airbyte Enterprise is a self-hosted version of Airbyte with additional features for enterprise customers. Airbyte Enterprise is currently in early development. Interested in Airbyte Enterprise for your organization? [Learn more](https://airbyte.com/solutions/airbyte-enterprise).
 
-## Airbyte Pro License Key
+## Airbyte Enterprise License Key
 
-A valid license key is required for Airbyte Pro. Talk to your Sales Representative to receive your license key before installing Airbyte Pro.
+A valid license key is required for Airbyte Enterprise. Talk to your Sales Representative to receive your license key before installing Airbyte Enterprise.
 
 ## Single Sign-On (SSO)
 
-Airbyte Pro supports Single Sign-On, allowing an organization to manage user acces to their Airbyte Pro instance through the configuration of an Identity Provider (IdP).
+Airbyte Enterprise supports Single Sign-On, allowing an organization to manage user acces to their Airbyte Enterprise instance through the configuration of an Identity Provider (IdP).
 
-Airbyte Pro currently supports SSO via OIDC with [Okta](https://www.okta.com/) as an IdP.
+Airbyte Enterprise currently supports SSO via OIDC with [Okta](https://www.okta.com/) as an IdP.
 
 ### Setting up Okta for SSO
 
@@ -50,7 +50,7 @@ _Example values_
 
 `<your-airbyte-domain>` should point to where your Airbyte instance will be available, including the http/https protocol.
 
-#### Deploying Airbyte Pro with Okta
+#### Deploying Airbyte Enterprise with Okta
 
 Your Okta app is now set up and you're ready to deploy Airbyte with SSO! Take note of the following configuration values, as you will need them to configure Airbyte to use your new Okta SSO app integration:
 
@@ -59,4 +59,4 @@ Your Okta app is now set up and you're ready to deploy Airbyte with SSO! Take no
 - Client ID
 - Client Secret
 
-Visit [Airbyte Pro deployment](/deploying-airbyte/on-kubernetes-via-helm#alpha-airbyte-pro-deployment) for instructions on how to deploy Airbyte Pro using `kubernetes`, `kubectl` and `helm`.
+Visit [Airbyte Enterprise deployment](/deploying-airbyte/on-kubernetes-via-helm#alpha-airbyte-pro-deployment) for instructions on how to deploy Airbyte Enterprise using `kubernetes`, `kubectl` and `helm`.

--- a/docs/deploying-airbyte/on-kubernetes-via-helm.md
+++ b/docs/deploying-airbyte/on-kubernetes-via-helm.md
@@ -116,13 +116,13 @@ After specifying your own configuration, run the following command:
 helm install --values path/to/values.yaml %release_name% airbyte/airbyte
 ```
 
-### (Alpha) Airbyte Pro deployment
+### (Alpha) Airbyte Enterprise deployment
 
-[Airbyte Pro](/airbyte-pro) is in early alpha stages, so this section will likely evolve. That said, if you have an Airbyte Pro license key and wish to install Airbyte Pro via helm, follow these steps:
+[Airbyte Enterprise](/airbyte-enterprise) is in early alpha stages, so this section will likely evolve. That said, if you have an Airbyte Enterprise license key and wish to install Airbyte Enterprise via helm, follow these steps:
 
 1. Checkout the latest revision of the [airbyte-platform repository](https://github.com/airbytehq/airbyte-platform)
 
-2. Add your Airbyte Pro license key and [auth configuration details](/airbyte-pro#single-sign-on-sso) to a file called `airbyte.yml` in the root directory of `airbyte-platform`. You can copy `airbyte.sample.yml` to use as a template:
+2. Add your Airbyte Enterprise license key and [auth configuration details](/airbyte-enterprise#single-sign-on-sso) to a file called `airbyte.yml` in the root directory of `airbyte-platform`. You can copy `airbyte.sample.yml` to use as a template:
 
 ```text
 cp airbyte.sample.yml airbyte.yml
@@ -142,7 +142,7 @@ For now, auth configurations aren't easy to modify once initially installed, so 
 helm repo update
 ```
 
-4. Install Airbyte Pro on helm using the following command:
+4. Install Airbyte Enterprise on helm using the following command:
 
 ```text
 RELEASE_NAME=<your release name>./tools/bin/install_airbyte_pro_on_helm.sh

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -461,7 +461,7 @@ module.exports = {
     },
     {
       type: 'doc',
-      id: 'airbyte-pro',
+      id: 'airbyte-enterprise',
     },
     sectionHeader("Developer Guides"),
     {


### PR DESCRIPTION
## What
Changes public docs to refer to `Airbyte Enterprise` instead of `Airbyte Pro`
