### PR TITLE
Source Sentry: fix None value in stream state

### DIFF
--- a/airbyte-integrations/connectors/source-sentry/Dockerfile
+++ b/airbyte-integrations/connectors/source-sentry/Dockerfile
@@ -34,5 +34,5 @@ COPY source_sentry ./source_sentry
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.3
+LABEL io.airbyte.version=0.2.4
 LABEL io.airbyte.name=airbyte/source-sentry

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: cdaf146a-9b75-49fd-9dd2-9d64a0bb4781
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   maxSecondsBetweenMessages: 64800
   dockerRepository: airbyte/source-sentry
   githubIssueLabel: source-sentry

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/streams.py
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/streams.py
@@ -183,7 +183,7 @@ class Issues(SentryIncremental):
 
     def _get_filter_date(self, stream_state: Optional[Mapping[str, Any]]) -> str:
         """Retrieve the filter date from the stream state or use the start_date."""
-        return stream_state.get(self.cursor_field) if stream_state else self.start_date
+        return stream_state.get(self.cursor_field) or self.start_date if stream_state else self.start_date
 
     def _build_query_params(self, filter_date: str) -> Dict[str, str]:
         """Generate query parameters for the request."""

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -47,6 +47,7 @@ The Sentry source connector supports the following [sync modes](https://docs.air
 
 | Version | Date       | Pull Request                                             | Subject                                                                 |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------|
+| 0.2.4   | 2023-08-14 | [29401](https://github.com/airbytehq/airbyte/pull/29401) | Fix `null` value in stream state                                        |
 | 0.2.3   | 2023-08-03 | [29023](https://github.com/airbytehq/airbyte/pull/29023) | Add incremental for `issues` stream                                     |
 | 0.2.2   | 2023-05-02 | [25759](https://github.com/airbytehq/airbyte/pull/25759) | Change stream that used in check_connection                             |
 | 0.2.1   | 2023-04-27 | [25602](https://github.com/airbytehq/airbyte/pull/25602) | Add validation of project and organization names during connector setup |


### PR DESCRIPTION
## What

Resolve

- https://github.com/airbytehq/oncall/issues/2691
- https://github.com/airbytehq/oncall/issues/2692

## How

set filtered date to start date if stream state is null: `"issues": {"lastSeen": null}`

## Recommended reading order
1. `streams.py`

## 🚨 User Impact 🚨

no breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
