### PR TITLE
Destination snowflake: test tweaks

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/README.md
+++ b/airbyte-integrations/connectors/destination-snowflake/README.md
@@ -102,3 +102,5 @@ create schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA;
 grant ownership on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role INTEGRATION_TESTER_DESTINATION revoke current grants;
 grant all privileges on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role NO_ACTIVE_WAREHOUSE_ROLE;
 ```
+
+These tests are currently disabled (`testCheckWithNoProperStagingPermissionConnection`, `testCheckWithNoActiveWarehouseConnection`). Their test users keep breaking (i.e. becoming the schema owner) because our tests are tearing down `TEXT_SCHEMA` after every test.

--- a/airbyte-integrations/connectors/destination-snowflake/README.md
+++ b/airbyte-integrations/connectors/destination-snowflake/README.md
@@ -101,4 +101,5 @@ drop schema if exists INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA;
 create schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA;
 grant ownership on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role accountadmin revoke current grants;
 grant all privileges on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role NO_ACTIVE_WAREHOUSE_ROLE;
+grant all privileges on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role INTEGRATION_TESTER_DESTINATION;
 ```

--- a/airbyte-integrations/connectors/destination-snowflake/README.md
+++ b/airbyte-integrations/connectors/destination-snowflake/README.md
@@ -99,7 +99,6 @@ Log in as the `airbytetester` user, and run this:
 ```sql
 drop schema if exists INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA;
 create schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA;
-grant ownership on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role accountadmin revoke current grants;
+grant ownership on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role INTEGRATION_TESTER_DESTINATION revoke current grants;
 grant all privileges on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role NO_ACTIVE_WAREHOUSE_ROLE;
-grant all privileges on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role INTEGRATION_TESTER_DESTINATION;
 ```

--- a/airbyte-integrations/connectors/destination-snowflake/README.md
+++ b/airbyte-integrations/connectors/destination-snowflake/README.md
@@ -95,7 +95,7 @@ DROP WAREHOUSE IF EXISTS INTEGRATION_TEST_WAREHOUSE_DESTINATION;
 ```
 
 ### Setup for various error-case users:
-Log in as the `airbytetester` user, and run this:
+Log in as the `INTEGRATION_TEST_USER_DESTINATION` user, and run this:
 ```sql
 drop schema if exists INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA;
 create schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA;

--- a/airbyte-integrations/connectors/destination-snowflake/README.md
+++ b/airbyte-integrations/connectors/destination-snowflake/README.md
@@ -93,3 +93,12 @@ DROP USER IF EXISTS INTEGRATION_TEST_USER_DESTINATION;
 DROP ROLE IF EXISTS INTEGRATION_TESTER_DESTINATION;
 DROP WAREHOUSE IF EXISTS INTEGRATION_TEST_WAREHOUSE_DESTINATION;
 ```
+
+### Setup for various error-case users:
+Log in as the `airbytetester` user, and run this:
+```sql
+drop schema if exists INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA;
+create schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA;
+grant ownership on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role accountadmin revoke current grants;
+grant all privileges on schema INTEGRATION_TEST_DESTINATION.TEXT_SCHEMA to role NO_ACTIVE_WAREHOUSE_ROLE;
+```

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
@@ -199,6 +199,7 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
     DataSourceFactory.close(dataSource);
   }
 
+  @Disabled("See README for why this test is disabled")
   @Test
   public void testCheckWithNoTextSchemaPermissionConnection() throws Exception {
     // Config to user (creds) that has no permission to schema

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
@@ -173,7 +173,7 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
 
   // for each test we create a new schema in the database. run the test in there and then remove it.
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     final String schemaName = Strings.addRandomSuffix("integration_test", "_", 5);
     final String createSchemaQuery = String.format("CREATE SCHEMA %s", schemaName);
     TEST_SCHEMAS.add(schemaName);
@@ -187,28 +187,16 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     String dropSchemaQuery = String.format("DROP SCHEMA IF EXISTS %s", config.get("schema").asText());
     database.execute(dropSchemaQuery);
 
-    for (String schema : TEST_SCHEMAS) {
+    for (final String schema : TEST_SCHEMAS) {
       dropSchemaQuery = String.format("DROP SCHEMA IF EXISTS %s", schema);
       database.execute(dropSchemaQuery);
     }
 
     DataSourceFactory.close(dataSource);
-  }
-
-  @Test
-  public void testCheckWithNoActiveWarehouseConnection() throws Exception {
-    // Config to user(creds) that has no warehouse assigned
-    final JsonNode config = Jsons.deserialize(IOs.readFile(
-        Path.of("secrets/internal_staging_config_no_active_warehouse.json")));
-
-    final StandardCheckConnectionOutput standardCheckConnectionOutput = runCheck(config);
-
-    assertEquals(Status.FAILED, standardCheckConnectionOutput.getStatus());
-    assertThat(standardCheckConnectionOutput.getMessage()).contains(NO_ACTIVE_WAREHOUSE_ERR_MSG);
   }
 
   @Test

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestinationAcceptanceTest.java
@@ -23,6 +23,7 @@ import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -36,6 +37,7 @@ public class SnowflakeInternalStagingDestinationAcceptanceTest extends Snowflake
     return internalStagingConfig;
   }
 
+  @Disabled("See README for why this test is disabled")
   @Test
   public void testCheckWithNoProperStagingPermissionConnection() throws Exception {
     // Config to user (creds) that has no permission to write
@@ -48,6 +50,7 @@ public class SnowflakeInternalStagingDestinationAcceptanceTest extends Snowflake
     assertThat(standardCheckConnectionOutput.getMessage()).contains(NO_USER_PRIVILEGES_ERR_MSG);
   }
 
+  @Disabled("See README for why this test is disabled")
   @Test
   public void testCheckWithNoActiveWarehouseConnection() throws Exception {
     // Config to user(creds) that has no warehouse assigned

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestinationAcceptanceTest.java
@@ -48,6 +48,18 @@ public class SnowflakeInternalStagingDestinationAcceptanceTest extends Snowflake
     assertThat(standardCheckConnectionOutput.getMessage()).contains(NO_USER_PRIVILEGES_ERR_MSG);
   }
 
+  @Test
+  public void testCheckWithNoActiveWarehouseConnection() throws Exception {
+    // Config to user(creds) that has no warehouse assigned
+    final JsonNode config = Jsons.deserialize(IOs.readFile(
+        Path.of("secrets/internal_staging_config_no_active_warehouse.json")));
+
+    final StandardCheckConnectionOutput standardCheckConnectionOutput = runCheck(config);
+
+    assertEquals(Status.FAILED, standardCheckConnectionOutput.getStatus());
+    assertThat(standardCheckConnectionOutput.getMessage()).contains(NO_ACTIVE_WAREHOUSE_ERR_MSG);
+  }
+
   @ParameterizedTest
   @ArgumentsSource(DataArgumentsProvider.class)
   public void testSyncWithNormalizationWithKeyPairAuth(final String messagesFilename, final String catalogFilename) throws Exception {


### PR DESCRIPTION
move a test with a hardcoded config out of the base class and into the subclass. It only needs to run once rather than once per subclass.

add some readme notes + disable tests that look annoying to fix.