### PR TITLE
Destination bigquery: GCS staging mode: do not ack uncommitted states

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DefaultDestStateLifecycleManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DefaultDestStateLifecycleManager.java
@@ -9,6 +9,7 @@ import com.google.common.base.Preconditions;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
 import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
 import java.util.Queue;
 import java.util.function.Supplier;
 
@@ -113,6 +114,11 @@ public class DefaultDestStateLifecycleManager implements DestStateLifecycleManag
   @Override
   public void markPendingAsCommitted() {
     internalStateManagerSupplier.get().markPendingAsCommitted();
+  }
+
+  @Override
+  public void markPendingAsCommitted(final AirbyteStreamNameNamespacePair stream) {
+    internalStateManagerSupplier.get().markPendingAsCommitted(stream);
   }
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestSingleStateLifecycleManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestSingleStateLifecycleManager.java
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.dest_state_lifecycle_manager;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -69,6 +70,12 @@ public class DestSingleStateLifecycleManager implements DestStateLifecycleManage
       lastCommittedState = lastPendingState;
       lastPendingState = null;
     }
+  }
+
+  @Override
+  public void markPendingAsCommitted(final AirbyteStreamNameNamespacePair stream) {
+    // We declare supportsPerStreamFlush as false, so this method should never be called.
+    throw new IllegalStateException("Committing a single stream state is not supported for this state type.");
   }
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStateLifecycleManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStateLifecycleManager.java
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.destination.dest_state_lifecycle_manager;
 
 import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
 import java.util.Queue;
 
 /**
@@ -69,6 +70,11 @@ public interface DestStateLifecycleManager {
    * Buffer -(flush)-> Staging (Blob Storage) -(commit to airbyte_raw)-> Destination table
    */
   void markPendingAsCommitted();
+
+  /**
+   * Mark all pending states for the given stream as committed.
+   */
+  void markPendingAsCommitted(AirbyteStreamNameNamespacePair stream);
 
   /**
    * List all tracked state messages that are committed.

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStreamStateLifecycleManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStreamStateLifecycleManager.java
@@ -16,7 +16,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.stream.Collectors;
 
@@ -94,11 +93,14 @@ public class DestStreamStateLifecycleManager implements DestStateLifecycleManage
   @Override
   public void markPendingAsCommitted(final AirbyteStreamNameNamespacePair stream) {
     // extremely hacky solution for specific connection:
-    // Handle the case where the connection is configured to use a custom namespace. In this case, the records' namespace
-    // will be set to that override, but the streams' namespace will still be the source's original namespace.
+    // Handle the case where the connection is configured to use a custom namespace. In this case, the
+    // records' namespace
+    // will be set to that override, but the streams' namespace will still be the source's original
+    // namespace.
     // We need to match purely on the stream name.
     // This is a hack to work around https://github.com/airbytehq/airbyte-platform-internal/pull/8365.
-    // There are many cases that this code does not handle. edgao to submit other issues for those cases.
+    // There are many cases that this code does not handle. edgao to submit other issues for those
+    // cases.
     final List<Entry<StreamDescriptor, AirbyteMessage>> matchingStates = streamToLastPendingState.entrySet().stream()
         .filter(entry -> entry.getKey().getName().equals(stream.getName()))
         .toList();

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStreamStateLifecycleManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStreamStateLifecycleManager.java
@@ -13,8 +13,10 @@ import io.airbyte.protocol.models.v0.StreamDescriptor;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.stream.Collectors;
 
@@ -91,10 +93,39 @@ public class DestStreamStateLifecycleManager implements DestStateLifecycleManage
 
   @Override
   public void markPendingAsCommitted(final AirbyteStreamNameNamespacePair stream) {
-    final StreamDescriptor sd = new StreamDescriptor().withName(stream.getName()).withNamespace(stream.getNamespace());
-    final AirbyteMessage lastPendingState = streamToLastPendingState.remove(sd);
-    if (lastPendingState != null) {
-      streamToLastCommittedState.put(sd, lastPendingState);
+    // Handle the case where the connection is configured to use a custom namespace. In this case, the records' namespace
+    // will be set to that override, but the streams' namespace will still be the source's original namespace.
+    // We need to match purely on the stream name.
+    // TODO handle stream name prefixes (i.e. use endsWith instead of equals)
+    // This is a hack to work around https://github.com/airbytehq/airbyte-platform-internal/pull/8365.
+    final List<Entry<StreamDescriptor, AirbyteMessage>> matchingStates = streamToLastPendingState.entrySet().stream()
+        .filter(entry -> entry.getKey().getName().equals(stream.getName()))
+        .toList();
+    final StreamDescriptor streamToCommit;
+    if (matchingStates.size() > 1) {
+      // Multiple streams have this name. Check if any of them have the right namespace.
+      final Optional<Entry<StreamDescriptor, AirbyteMessage>> matchingState = matchingStates.stream()
+          .filter(entry -> entry.getKey().getNamespace().equals(stream.getNamespace()))
+          .findFirst();
+      streamToCommit = matchingState.map(Entry::getKey).orElse(null);
+    } else if (matchingStates.isEmpty()) {
+      // None of the states match this stream. We can't commit anything.
+      streamToCommit = null;
+    } else {
+      // Exactly one stream has this name. Assume that we can commit it.
+      // This is technically wrong: it's possible for a source to emit these messages:
+      // 1. record(name=foo, namespace=bar)
+      // 2. state(name=foo, namespace=baz)
+      // But in practice, sources will emit records and states belonging to the same stream. And having multiple streams
+      // with the same but different namespace is relatively uncommon...
+      streamToCommit = matchingStates.get(0).getKey();
+    }
+
+    if (streamToCommit != null) {
+      final AirbyteMessage lastPendingState = streamToLastPendingState.remove(streamToCommit);
+      if (lastPendingState != null) {
+        streamToLastCommittedState.put(streamToCommit, lastPendingState);
+      }
     }
   }
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStreamStateLifecycleManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStreamStateLifecycleManager.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -86,6 +87,15 @@ public class DestStreamStateLifecycleManager implements DestStateLifecycleManage
   @Override
   public void markPendingAsCommitted() {
     moveToNextPhase(streamToLastPendingState, streamToLastCommittedState);
+  }
+
+  @Override
+  public void markPendingAsCommitted(final AirbyteStreamNameNamespacePair stream) {
+    final StreamDescriptor sd = new StreamDescriptor().withName(stream.getName()).withNamespace(stream.getNamespace());
+    final AirbyteMessage lastPendingState = streamToLastPendingState.remove(sd);
+    if (lastPendingState != null) {
+      streamToLastCommittedState.put(sd, lastPendingState);
+    }
   }
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumerTest.java
@@ -418,8 +418,8 @@ public class BufferedStreamConsumerTest {
   }
 
   /**
-   * Same idea as {@link #testStreamTail()} but with global state. We shouldn't emit any state messages
-   * until we close the consumer.
+   * Same idea as {@link #testStreamTail()} but with global state. We shouldn't emit any state
+   * messages until we close the consumer.
    */
   @Test
   void testStreamTailGlobalSTate() throws Exception {

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumerTest.java
@@ -357,8 +357,8 @@ public class BufferedStreamConsumerTest {
   }
 
   /**
-   * Verify that if we ack a state message for stream2 while stream1 has unflushed records+state,
-   * that we do _not_ ack stream1's state message.
+   * Verify that if we ack a state message for stream2 while stream1 has unflushed records+state, that
+   * we do _not_ ack stream1's state message.
    */
   @Test
   void testStreamTail() throws Exception {

--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -47,7 +47,7 @@ ENV AIRBYTE_NORMALIZATION_INTEGRATION bigquery
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=1.7.6
+LABEL io.airbyte.version=1.7.7
 LABEL io.airbyte.name=airbyte/destination-bigquery
 
 ENV AIRBYTE_ENTRYPOINT "/airbyte/run_with_normalization.sh"

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 1.7.6
+  dockerImageTag: 1.7.7
   dockerRepository: airbyte/destination-bigquery
   githubIssueLabel: destination-bigquery
   icon: bigquery.svg

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -135,6 +135,7 @@ Now that you have set up the BigQuery destination connector, check out the follo
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                  |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------|
+| 1.7.7   | 2023-08-14 | [\#29420](https://github.com/airbytehq/airbyte/pull/29420) | Fix checkpointing logic in GCS staging mode                                                                              |
 | 1.7.6   | 2023-08-04 | [\#28894](https://github.com/airbytehq/airbyte/pull/28894) | Destinations v2: Add v1 -> v2 migration Logic                                                                            |
 | 1.7.5   | 2023-08-04 | [\#29106](https://github.com/airbytehq/airbyte/pull/29106) | Destinations v2: handle unusual CDC deletion edge case                                                                   |
 | 1.7.4   | 2023-08-04 | [\#29089](https://github.com/airbytehq/airbyte/pull/29089) | Destinations v2: improve special character handling in column names                                                      |


### PR DESCRIPTION
hack PR for a specific workspace. Will not be merged, will prerelease publish + pin a single workspace. see https://github.com/airbytehq/oncall/issues/2734

example problematic sequence:
1. stream1 emits a few records + a state. We hold this in memory.
2. stream2 emits many records + state. We commit this to bigquery. 
3. We now ack stream2's state (correctly) _and_ stream1's state (incorrectly)

This PR fixes our logic, so that we only ack stream2's state. This PR also includes a workaround for platform sending us state messages with the wrong namespace. Specifically:
* The connection sets a custom namespace in the replication settings
* Platform sets that namespace on the catalog and all record messages
* Platform does _not_ set that namespace on state messages
* Therefore we need to match record messages to state messages using only the stream name
* Fortunately, all streams in the workspace's connections have different names, and it's not setting a stream name prefix, so this is safe.