### PR TITLE
Only GA destinations should be certified

### DIFF
--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -20,5 +20,5 @@ data:
   ab_internal:
     sl: 200
     ql: 200
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -18,7 +18,7 @@ data:
   tags:
     - language:python
   ab_internal:
-    sl: 200
+    sl: 100
     ql: 200
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
@@ -26,5 +26,5 @@ data:
   ab_internal:
     sl: 200
     ql: 300
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
@@ -24,7 +24,7 @@ data:
   tags:
     - language:java
   ab_internal:
-    sl: 200
+    sl: 100
     ql: 300
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -24,7 +24,7 @@ data:
   tags:
     - language:java
   ab_internal:
-    sl: 200
+    sl: 100
     ql: 200
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -26,5 +26,5 @@ data:
   ab_internal:
     sl: 200
     ql: 200
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
@@ -18,7 +18,7 @@ data:
   tags:
     - language:java
   ab_internal:
-    sl: 200
+    sl: 100
     ql: 200
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
@@ -20,5 +20,5 @@ data:
   ab_internal:
     sl: 200
     ql: 200
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs/metadata.yaml
@@ -26,5 +26,5 @@ data:
   ab_internal:
     sl: 200
     ql: 300
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs/metadata.yaml
@@ -24,7 +24,7 @@ data:
   tags:
     - language:java
   ab_internal:
-    sl: 200
+    sl: 100
     ql: 300
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
@@ -18,7 +18,7 @@ data:
   tags:
     - language:python
   ab_internal:
-    sl: 300
+    sl: 100
     ql: 200
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
@@ -20,5 +20,5 @@ data:
   ab_internal:
     sl: 300
     ql: 200
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -24,7 +24,7 @@ data:
   tags:
     - language:java
   ab_internal:
-    sl: 300
+    sl: 100
     ql: 200
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -26,5 +26,5 @@ data:
   ab_internal:
     sl: 300
     ql: 200
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql/metadata.yaml
@@ -24,7 +24,7 @@ data:
   tags:
     - language:java
   ab_internal:
-    sl: 300
+    sl: 100
     ql: 200
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql/metadata.yaml
@@ -26,5 +26,5 @@ data:
   ab_internal:
     sl: 300
     ql: 200
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -24,7 +24,7 @@ data:
   tags:
     - language:java
   ab_internal:
-    sl: 200
+    sl: 100
     ql: 200
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -26,5 +26,5 @@ data:
   ab_internal:
     sl: 200
     ql: 200
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -24,7 +24,7 @@ data:
   tags:
     - language:java
   ab_internal:
-    sl: 300
+    sl: 100
     ql: 200
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -26,5 +26,5 @@ data:
   ab_internal:
     sl: 300
     ql: 200
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -31,5 +31,5 @@ data:
   ab_internal:
     sl: 200
     ql: 300
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -29,7 +29,7 @@ data:
   tags:
     - language:java
   ab_internal:
-    sl: 200
+    sl: 100
     ql: 300
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -22,6 +22,9 @@ data:
         resourceRequirements:
           cpu_limit: "4.0"
           cpu_request: "1.0"
+        resourceRequirements:
+          cpu_limit: "4.0"
+          cpu_request: "1.0"
   suggestedStreams:
     streams:
       - users

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -22,9 +22,6 @@ data:
         resourceRequirements:
           cpu_limit: "4.0"
           cpu_request: "1.0"
-        resourceRequirements:
-          cpu_limit: "4.0"
-          cpu_request: "1.0"
   suggestedStreams:
     streams:
       - users
@@ -36,7 +33,8 @@ data:
   releases:
     breakingChanges:
       5.0.0:
-        message: "ID and products.year fields are changing to be integers instead
+        message:
+          "ID and products.year fields are changing to be integers instead
           of floats."
         upgradeDeadline: "2023-08-31"
       4.0.0:


### PR DESCRIPTION
Updates the work done in https://github.com/airbytehq/airbyte/pull/28904 for destinations - only GA destinations should be Certified.  Alpha and Beta destinations are Community.