### PR TITLE
Langchain destination: Make starter pods work

### DIFF
--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -42,5 +42,5 @@ COPY destination_langchain ./destination_langchain
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.6
+LABEL io.airbyte.version=0.0.7
 LABEL io.airbyte.name=airbyte/destination-langchain

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: cf98d52c-ba5a-4dfd-8ada-c1baebfa6e73
-  dockerImageTag: 0.0.6
+  dockerImageTag: 0.0.7
   dockerRepository: airbyte/destination-langchain
   githubIssueLabel: destination-langchain
   icon: langchain.svg

--- a/airbyte-integrations/connectors/destination-langchain/unit_tests/pinecone_indexer_test.py
+++ b/airbyte-integrations/connectors/destination-langchain/unit_tests/pinecone_indexer_test.py
@@ -15,16 +15,41 @@ from pinecone import IndexDescription
 def create_pinecone_indexer():
     config = PineconeIndexingModel(mode="pinecone", pinecone_environment="myenv", pinecone_key="mykey", index="myindex")
     embedder = MagicMock()
+    embedder.embedding_dimensions = 3
     indexer = PineconeIndexer(config, embedder)
 
     indexer.pinecone_index.delete = MagicMock()
     indexer.embed_fn = MagicMock(return_value=[[1, 2, 3], [4, 5, 6]])
     indexer.pinecone_index.upsert = MagicMock()
+    indexer.pinecone_index.query = MagicMock()
     return indexer
 
 
-def test_pinecone_index_upsert_and_delete():
+def create_index_description(dimensions=3, pod_type="p1"):
+    return IndexDescription(
+        name="",
+        metric="",
+        replicas=1,
+        dimension=dimensions,
+        shards=1,
+        pods=1,
+        pod_type=pod_type,
+        status=None,
+        metadata_config=None,
+        source_collection=None,
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_describe_index():
+    with patch('pinecone.describe_index') as mock:
+        mock.return_value = create_index_description()
+        yield mock
+
+
+def test_pinecone_index_upsert_and_delete(mock_describe_index):
     indexer = create_pinecone_indexer()
+    indexer._pod_type = "p1"
     indexer.index(
         [
             Document(page_content="test", metadata={"_airbyte_stream": "abc"}),
@@ -33,6 +58,29 @@ def test_pinecone_index_upsert_and_delete():
         ["delete_id1", "delete_id2"],
     )
     indexer.pinecone_index.delete.assert_called_with(filter={"_record_id": {"$in": ["delete_id1", "delete_id2"]}})
+    indexer.pinecone_index.upsert.assert_called_with(
+        vectors=(
+            (ANY, [1, 2, 3], {"_airbyte_stream": "abc", "text": "test"}),
+            (ANY, [4, 5, 6], {"_airbyte_stream": "abc", "text": "test2"}),
+        ),
+        async_req=True,
+        show_progress=False,
+    )
+
+
+def test_pinecone_index_upsert_and_delete_starter(mock_describe_index):
+    indexer = create_pinecone_indexer()
+    indexer._pod_type = "starter"
+    indexer.pinecone_index.query.return_value = MagicMock(matches=[MagicMock(id="doc_id1"), MagicMock(id="doc_id2")])
+    indexer.index(
+        [
+            Document(page_content="test", metadata={"_airbyte_stream": "abc"}),
+            Document(page_content="test2", metadata={"_airbyte_stream": "abc"}),
+        ],
+        ["delete_id1", "delete_id2"],
+    )
+    indexer.pinecone_index.query.assert_called_with(vector=[0,0,0],filter={"_record_id": {"$in": ["delete_id1", "delete_id2"]}}, top_k=10_000)
+    indexer.pinecone_index.delete.assert_called_with(ids=["doc_id1", "doc_id2"])
     indexer.pinecone_index.upsert.assert_called_with(
         vectors=(
             (ANY, [1, 2, 3], {"_airbyte_stream": "abc", "text": "test"}),
@@ -75,41 +123,52 @@ def test_pinecone_index_upsert_batching():
         )
 
 
-def test_pinecone_pre_sync():
-    indexer = create_pinecone_indexer()
-    indexer.pre_sync(
-        ConfiguredAirbyteCatalog.parse_obj(
-            {
-                "streams": [
-                    {
-                        "stream": {
-                            "name": "example_stream",
-                            "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
-                            "supported_sync_modes": ["full_refresh", "incremental"],
-                            "source_defined_cursor": False,
-                            "default_cursor_field": ["column_name"],
-                        },
-                        "primary_key": [["id"]],
-                        "sync_mode": "incremental",
-                        "destination_sync_mode": "append_dedup",
+def generate_catalog():
+    return ConfiguredAirbyteCatalog.parse_obj(
+        {
+            "streams": [
+                {
+                    "stream": {
+                        "name": "example_stream",
+                        "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
+                        "supported_sync_modes": ["full_refresh", "incremental"],
+                        "source_defined_cursor": False,
+                        "default_cursor_field": ["column_name"],
                     },
-                    {
-                        "stream": {
-                            "name": "example_stream2",
-                            "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
-                            "supported_sync_modes": ["full_refresh", "incremental"],
-                            "source_defined_cursor": False,
-                            "default_cursor_field": ["column_name"],
-                        },
-                        "primary_key": [["id"]],
-                        "sync_mode": "full_refresh",
-                        "destination_sync_mode": "overwrite",
+                    "primary_key": [["id"]],
+                    "sync_mode": "incremental",
+                    "destination_sync_mode": "append_dedup",
+                },
+                {
+                    "stream": {
+                        "name": "example_stream2",
+                        "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
+                        "supported_sync_modes": ["full_refresh", "incremental"],
+                        "source_defined_cursor": False,
+                        "default_cursor_field": ["column_name"],
                     },
-                ]
-            }
-        )
+                    "primary_key": [["id"]],
+                    "sync_mode": "full_refresh",
+                    "destination_sync_mode": "overwrite",
+                },
+            ]
+        }
     )
+
+
+def test_pinecone_pre_sync(mock_describe_index):
+    indexer = create_pinecone_indexer()
+    indexer.pre_sync(generate_catalog())
     indexer.pinecone_index.delete.assert_called_with(filter={"_airbyte_stream": "example_stream2"})
+
+
+def test_pinecone_pre_sync_starter(mock_describe_index):
+    mock_describe_index.return_value = create_index_description(pod_type="starter")
+    indexer = create_pinecone_indexer()
+    indexer.pinecone_index.query.return_value = MagicMock(matches=[MagicMock(id="doc_id1"), MagicMock(id="doc_id2")])
+    indexer.pre_sync(generate_catalog())
+    indexer.pinecone_index.query.assert_called_with(vector=[0,0,0],filter={"_airbyte_stream": "example_stream2"}, top_k=10_000)
+    indexer.pinecone_index.delete.assert_called_with(ids=["doc_id1", "doc_id2"])
 
 
 @pytest.mark.parametrize(
@@ -127,18 +186,7 @@ def test_pinecone_check(describe_mock, describe_throws, reported_dimensions, che
     indexer.embedder.embedding_dimensions = 3
     if describe_throws:
         describe_mock.side_effect = Exception("describe failed")
-    describe_mock.return_value = IndexDescription(
-        name="",
-        metric="",
-        replicas=1,
-        dimension=reported_dimensions,
-        shards=1,
-        pods=1,
-        pod_type="p1",
-        status=None,
-        metadata_config=None,
-        source_collection=None,
-    )
+    describe_mock.return_value = create_index_description(dimensions=reported_dimensions)
     result = indexer.check()
     if check_succeeds:
         assert result is None

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -139,7 +139,7 @@ Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a M
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.0.7   | 2023-08-18 | [#28977](https://github.com/airbytehq/airbyte/pull/28977)     | Fix for starter pods  |
+| 0.0.7   | 2023-08-18 | [#29513](https://github.com/airbytehq/airbyte/pull/29513)     | Fix for starter pods  |
 | 0.0.6   | 2023-08-02 | [#28977](https://github.com/airbytehq/airbyte/pull/28977)     | Validate pinecone index dimensions during check  |
 | 0.0.5   | 2023-07-25 | [#28605](https://github.com/airbytehq/airbyte/pull/28605)     | Add Chroma support  |
 | 0.0.4   | 2023-07-21 | [#28556](https://github.com/airbytehq/airbyte/pull/28556)     | Correctly dedupe records with composite and nested primary keys  |

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -53,6 +53,12 @@ vector_store = Pinecone(index, embeddings.embed_query, "text")
 qa = RetrievalQA.from_chain_type(llm=OpenAI(temperature=0), chain_type="stuff", retriever=vector_store.as_retriever())
 ```
 
+:::caution
+
+For Pinecone pods of type starter, only up to 10,000 chunks can be indexed. For production use, please use a higher tier.
+
+:::
+
 #### Chroma vector store
 
 The [Chroma vector store](https://trychroma.com) is running the Chroma embedding database as persistent client and stores the vectors in a local file.
@@ -133,6 +139,7 @@ Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a M
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.0.7   | 2023-08-18 | [#28977](https://github.com/airbytehq/airbyte/pull/28977)     | Fix for starter pods  |
 | 0.0.6   | 2023-08-02 | [#28977](https://github.com/airbytehq/airbyte/pull/28977)     | Validate pinecone index dimensions during check  |
 | 0.0.5   | 2023-07-25 | [#28605](https://github.com/airbytehq/airbyte/pull/28605)     | Add Chroma support  |
 | 0.0.4   | 2023-07-21 | [#28556](https://github.com/airbytehq/airbyte/pull/28556)     | Correctly dedupe records with composite and nested primary keys  |


### PR DESCRIPTION
Fixes https://github.com/airbytehq/airbyte/issues/29356

On starter pods, it's not possible to delete by filter. This PR adds logic to the connector to check the pod type and delete by searching with the filter, then deleting by ids. This limits the number of vectors that can be deleted this way to 10k, but that's OK for testing purposes.

This is also adjusting the tests - for starter pods, it adds some sleeps because starter pods have a pretty relevant lag until vectors show up.