### PR TITLE
cat: use airbyte-protocol-model~=0.4.0

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -19,7 +19,7 @@ jobs:
         id: scd
         uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           permission: write
           commands: |
             test

--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+Pin airbyte-protocol-model to <1.0.0.
+
 ## 1.0.0
 Bump to Python 3.10, use dagger instead of docker-py in the ConnectorRunner.
 

--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -24,7 +24,7 @@ RUN poetry install --no-root --only main --no-interaction --no-ansi
 COPY . /app
 RUN poetry install --only main --no-cache --no-interaction --no-ansi
 
-LABEL io.airbyte.version=1.0.0
+LABEL io.airbyte.version=1.0.1
 LABEL io.airbyte.name=airbyte/connector-acceptance-test
 WORKDIR /test_input
 ENTRYPOINT ["python", "-m", "pytest", "-p", "connector_acceptance_test.plugin", "-r", "fEsx", "--show-capture=log"]

--- a/airbyte-integrations/bases/connector-acceptance-test/poetry.lock
+++ b/airbyte-integrations/bases/connector-acceptance-test/poetry.lock
@@ -2,17 +2,17 @@
 
 [[package]]
 name = "airbyte-protocol-models"
-version = "1.0.1"
+version = "0.4.1"
 description = "Declares the Airbyte Protocol."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.8"
 files = [
-    {file = "airbyte_protocol_models-1.0.1-py3-none-any.whl", hash = "sha256:2c214fb8cb42b74aa6408beeea2cd52f094bc8a3ba0e78af20bb358e5404f4a8"},
-    {file = "airbyte_protocol_models-1.0.1.tar.gz", hash = "sha256:caa860d15c9c9073df4b221f58280b9855d36de07519e010d1e610546458d0a7"},
+    {file = "airbyte_protocol_models-0.4.1-py3-none-any.whl", hash = "sha256:95f1197c800d7867ba067f75770b83aeff4c2cec9b3d1def2dbf70261fee89ee"},
+    {file = "airbyte_protocol_models-0.4.1.tar.gz", hash = "sha256:92602134eab4c921d1328fa4f24e9a810a679c117ccb352cf6b1521f95f0ed53"},
 ]
 
 [package.dependencies]
-pydantic = ">=1.9.2,<1.10.0"
+pydantic = ">=1.9.2,<2.0.0"
 
 [[package]]
 name = "anyio"
@@ -1489,4 +1489,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "dc94f212796e27c07d193ff182b26dc08ecccbbc836788a50dbf84e537b0f00b"
+content-hash = "d0bfe69918b1133a0ea31368570203e0413bccf22aabfca6b5339cca59e2df2d"

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/airbytehq/airbyte"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-airbyte-protocol-models = "*"
+airbyte-protocol-models = "<1.0.0"
 dagger-io = "==0.6.4"
 PyYAML = "~=6.0"
 icdiff = "~=1.9"

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
@@ -35,7 +35,9 @@ from connector_acceptance_test.tests.test_incremental import (
     future_state_fixture,
 )
 
-pytestmark = (pytest.mark.anyio,)
+pytestmark = [
+    pytest.mark.anyio,
+]
 
 
 def build_messages_from_record_data(stream: str, records: list[dict]) -> list[AirbyteMessage]:


### PR DESCRIPTION
CAT was not pinning its dependecy to airbyte-protocols-models. It led to the installation of an old version which is semantically higher than the most recent one. 
