### PR TITLE
[Source-Mysql] Add breaking changes key to mysql-strict-encrypt

### DIFF
--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/metadata.yaml
@@ -21,4 +21,9 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   tags:
     - language:java
+  releases:
+    breakingChanges:
+      3.0.0:
+        message: "Add default cursor for cdc"
+        upgradeDeadline: "2023-08-17"
 metadataSpecVersion: "1.0"

--- a/docs/integrations/sources/mysql-migrations.md
+++ b/docs/integrations/sources/mysql-migrations.md
@@ -1,0 +1,4 @@
+# Source Mysql Migration Guide
+
+## Upgrading to 3.0.0
+CDC syncs now has default cursor field called `_ab_cdc_cursor`. You will need to force normalization to rebuild your destination tables by manually dropping the SCD tables, refreshing the connection schema (skipping the reset), and running a sync. Alternatively, you can just run a reset. 


### PR DESCRIPTION
## What:
Added a releases/breakingChanges key to indicate a major version bump in metadata.yaml