### PR TITLE
[skip ci]: alpha connectors should be community

### DIFF
--- a/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 9f32dab3-77cb-45a1-9d33-347aa5fbe363
   dockerImageTag: 0.1.0
   dockerRepository: airbyte/source-activecampaign
+  documentationUrl: https://docs.airbyte.com/integrations/sources/activecampaign
   githubIssueLabel: source-activecampaign
   icon: activecampaign.svg
   license: MIT
@@ -14,12 +18,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/activecampaign
+  supportLevel: community
   tags:
     - language:low-code
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-adjust/metadata.yaml
+++ b/airbyte-integrations/connectors/source-adjust/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: d3b7fa46-111b-419a-998a-d7f046f6d66d
   dockerImageTag: 0.1.0
   dockerRepository: airbyte/source-adjust
+  documentationUrl: https://docs.airbyte.com/integrations/sources/adjust
   githubIssueLabel: source-adjust
   icon: adjust.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/adjust
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-aha/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aha/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 81ca39dc-4534-4dd2-b848-b0cfd2c11fce
   dockerImageTag: 0.3.1
   dockerRepository: airbyte/source-aha
+  documentationUrl: https://docs.airbyte.com/integrations/sources/aha
   githubIssueLabel: source-aha
   icon: aha.svg
   license: MIT
@@ -14,12 +18,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/aha
+  supportLevel: community
   tags:
     - language:low-code
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
   dockerImageTag: 1.5.0
   dockerRepository: airbyte/source-amazon-seller-partner
+  documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
   githubIssueLabel: source-amazon-seller-partner
   icon: amazonsellerpartner.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-sqs/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 983fd355-6bf3-4709-91b5-37afa391eeb6
   dockerImageTag: 0.1.0
   dockerRepository: airbyte/source-amazon-sqs
+  documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-sqs
   githubIssueLabel: source-amazon-sqs
   icon: awssqs.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-sqs
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-aws-cloudtrail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aws-cloudtrail/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 6ff047c0-f5d5-4ce5-8c81-204a830fa7e1
   dockerImageTag: 0.1.5
   dockerRepository: airbyte/source-aws-cloudtrail
+  documentationUrl: https://docs.airbyte.com/integrations/sources/aws-cloudtrail
   githubIssueLabel: source-aws-cloudtrail
   icon: awscloudtrail.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/aws-cloudtrail
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bamboo-hr/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bamboo-hr/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 90916976-a132-4ce9-8bce-82a03dd58788
   dockerImageTag: 0.2.2
   dockerRepository: airbyte/source-bamboo-hr
+  documentationUrl: https://docs.airbyte.com/integrations/sources/bamboo-hr
   githubIssueLabel: source-bamboo-hr
   icon: bamboohr.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/bamboo-hr
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bigcommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigcommerce/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 59c5501b-9f95-411e-9269-7143c939adbd
   dockerImageTag: 0.1.10
   dockerRepository: airbyte/source-bigcommerce
+  documentationUrl: https://docs.airbyte.com/integrations/sources/bigcommerce
   githubIssueLabel: source-bigcommerce
   icon: bigcommerce.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/bigcommerce
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigquery/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: database
   connectorType: source
   definitionId: bfd1ddf8-ae8a-4620-b1d7-55597d2ba08c
   dockerImageTag: 0.3.0
   dockerRepository: airbyte/source-bigquery
+  documentationUrl: https://docs.airbyte.com/integrations/sources/bigquery
   githubIssueLabel: source-bigquery
   icon: bigquery.svg
   license: ELv2
@@ -14,12 +18,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/bigquery
+  supportLevel: community
   tags:
     - language:java
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-braintree/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braintree/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 63cea06f-1c75-458d-88fe-ad48c7cb27fd
   dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-braintree
+  documentationUrl: https://docs.airbyte.com/integrations/sources/braintree
   githubIssueLabel: source-braintree
   icon: braintree.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/braintree
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-braze/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braze/metadata.yaml
@@ -1,11 +1,15 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 68b9c98e-0747-4c84-b05b-d30b47686725
   dockerImageTag: 0.1.3
-  icon: braze.svg
   dockerRepository: airbyte/source-braze
+  documentationUrl: https://docs.airbyte.com/integrations/sources/braze
   githubIssueLabel: source-braze
+  icon: braze.svg
   license: MIT
   name: Braze
   registries:
@@ -14,12 +18,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/braze
+  supportLevel: community
   tags:
     - language:low-code
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -1,4 +1,7 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   allowedHosts:
     hosts:
       - ${host}
@@ -8,6 +11,7 @@ data:
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
   dockerImageTag: 0.1.17
   dockerRepository: airbyte/source-clickhouse
+  documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   githubIssueLabel: source-clickhouse
   icon: clickhouse.svg
   license: MIT
@@ -20,12 +24,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
+  supportLevel: community
   tags:
     - language:java
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dynamodb/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 50401137-8871-4c5a-abb7-1f5fda35545a
   dockerImageTag: 0.1.2
   dockerRepository: airbyte/source-dynamodb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/dynamodb
   githubIssueLabel: source-dynamodb
   icon: dynamodb.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/dynamodb
+  supportLevel: community
   tags:
     - language:java
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gcs/metadata.yaml
@@ -1,24 +1,24 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: file
   connectorType: source
   definitionId: 2a8c41ae-8c23-4be0-a73f-2ab10ca1a820
   dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-gcs
+  documentationUrl: https://docs.airbyte.com/integrations/sources/gcs
   githubIssueLabel: source-gcs
   icon: gcs.svg
   license: ELv2
   name: GCS
-  releaseStage: alpha
   registries:
     cloud:
       enabled: true
     oss:
       enabled: true
-  documentationUrl: https://docs.airbyte.com/integrations/sources/gcs
+  releaseStage: alpha
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-linkedin-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-pages/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: af54297c-e8f8-4d63-a00d-a94695acc9d3
   dockerImageTag: 1.0.2
   dockerRepository: airbyte/source-linkedin-pages
+  documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-pages
   githubIssueLabel: source-linkedin-pages
   icon: linkedin.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-pages
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: database
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
   dockerImageTag: 0.2.5
   dockerRepository: airbyte/source-mongodb-v2
+  documentationUrl: https://docs.airbyte.com/integrations/sources/mongodb-v2
   githubIssueLabel: source-mongodb-v2
   icon: mongodb.svg
   license: ELv2
@@ -16,12 +20,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/mongodb-v2
+  supportLevel: community
   tags:
     - language:java
     - language:python
-  ab_internal:
-    sl: 300
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -1,4 +1,7 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   allowedHosts:
     hosts:
       - ${host}
@@ -8,6 +11,7 @@ data:
   definitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
   dockerImageTag: 1.1.1
   dockerRepository: airbyte/source-mssql
+  documentationUrl: https://docs.airbyte.com/integrations/sources/mssql
   githubIssueLabel: source-mssql
   icon: mssql.svg
   license: ELv2
@@ -19,12 +23,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/mssql
+  supportLevel: community
   tags:
     - language:java
     - language:python
-  ab_internal:
-    sl: 300
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-netsuite/metadata.yaml
+++ b/airbyte-integrations/connectors/source-netsuite/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 4f2f093d-ce44-4121-8118-9d13b7bfccd0
   dockerImageTag: 0.1.3
   dockerRepository: airbyte/source-netsuite
+  documentationUrl: https://docs.airbyte.com/integrations/sources/netsuite
   githubIssueLabel: source-netsuite
   icon: netsuite.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/netsuite
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 300
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-okta/metadata.yaml
+++ b/airbyte-integrations/connectors/source-okta/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 1d4fdb25-64fc-4569-92da-fcdca79a8372
   dockerImageTag: 0.1.16
   dockerRepository: airbyte/source-okta
+  documentationUrl: https://docs.airbyte.com/integrations/sources/okta
   githubIssueLabel: source-okta
   icon: okta.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/okta
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-onesignal/metadata.yaml
+++ b/airbyte-integrations/connectors/source-onesignal/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: bb6afd81-87d5-47e3-97c4-e2c2901b1cf8
   dockerImageTag: 1.0.1
   dockerRepository: airbyte/source-onesignal
+  documentationUrl: https://docs.airbyte.com/integrations/sources/onesignal
   githubIssueLabel: source-onesignal
   icon: onesignal.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/onesignal
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle/metadata.yaml
@@ -1,4 +1,7 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   allowedHosts:
     hosts:
       - ${host}
@@ -8,6 +11,7 @@ data:
   definitionId: b39a7370-74c3-45a6-ac3a-380d48520a83
   dockerImageTag: 0.4.0
   dockerRepository: airbyte/source-oracle
+  documentationUrl: https://docs.airbyte.com/integrations/sources/oracle
   githubIssueLabel: source-oracle
   icon: oracle.svg
   license: ELv2
@@ -20,12 +24,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/oracle
+  supportLevel: community
   tags:
     - language:java
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-outreach/metadata.yaml
+++ b/airbyte-integrations/connectors/source-outreach/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 3490c201-5d95-4783-b600-eaf07a4c7787
   dockerImageTag: 0.4.0
   dockerRepository: airbyte/source-outreach
+  documentationUrl: https://docs.airbyte.com/integrations/sources/outreach
   githubIssueLabel: source-outreach
   icon: outreach.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/outreach
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-public-apis/metadata.yaml
+++ b/airbyte-integrations/connectors/source-public-apis/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: a4617b39-3c14-44cd-a2eb-6e720f269235
   dockerImageTag: 0.1.0
   dockerRepository: airbyte/source-public-apis
+  documentationUrl: https://docs.airbyte.com/integrations/sources/public-apis
   githubIssueLabel: source-public-apis
   icon: publicapi.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/public-apis
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-qualaroo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-qualaroo/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: b08e4776-d1de-4e80-ab5c-1e51dad934a2
   dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-qualaroo
+  documentationUrl: https://docs.airbyte.com/integrations/sources/qualaroo
   githubIssueLabel: source-qualaroo
   icon: qualaroo.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/qualaroo
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-recurly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recurly/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: cd42861b-01fc-4658-a8ab-5d11d0510f01
   dockerImageTag: 0.4.1
   dockerRepository: airbyte/source-recurly
+  documentationUrl: https://docs.airbyte.com/integrations/sources/recurly
   githubIssueLabel: source-recurly
   icon: recurly.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/recurly
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/source-redshift/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: database
   connectorType: source
   definitionId: e87ffa8e-a3b5-f69c-9076-6011339de1f6
   dockerImageTag: 0.4.0
   dockerRepository: airbyte/source-redshift
+  documentationUrl: https://docs.airbyte.com/integrations/sources/redshift
   githubIssueLabel: source-redshift
   icon: redshift.svg
   license: ELv2
@@ -14,12 +18,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/redshift
+  supportLevel: community
   tags:
     - language:java
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sendinblue/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendinblue/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 2e88fa20-a2f6-43cc-bba6-98a0a3f244fb
   dockerImageTag: 0.1.0
   dockerRepository: airbyte/source-sendinblue
+  documentationUrl: https://docs.airbyte.com/integrations/sources/sendinblue
   githubIssueLabel: source-sendinblue
   icon: sendinblue.svg
   license: MIT
@@ -14,12 +18,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/sendinblue
+  supportLevel: community
   tags:
     - language:low-code
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: file
   connectorType: source
   definitionId: 31e3242f-dee7-4cdc-a4b8-8e06c5458517
   dockerImageTag: 0.1.2
   dockerRepository: airbyte/source-sftp-bulk
+  documentationUrl: https://docs.airbyte.com/integrations/sources/sftp-bulk
   githubIssueLabel: source-sftp-bulk
   icon: sftp.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/sftp-bulk
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sftp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: file
   connectorType: source
   definitionId: a827c52e-791c-4135-a245-e233c5255199
   dockerImageTag: 0.1.2
   dockerRepository: airbyte/source-sftp
+  documentationUrl: https://docs.airbyte.com/integrations/sources/sftp
   githubIssueLabel: source-sftp
   icon: sftp.svg
   license: MIT
@@ -14,12 +18,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/sftp
+  supportLevel: community
   tags:
     - language:java
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 9da77001-af33-4bcd-be46-6252bf9342b9
   dockerImageTag: 0.6.2
   dockerRepository: airbyte/source-shopify
+  documentationUrl: https://docs.airbyte.com/integrations/sources/shopify
   githubIssueLabel: source-shopify
   icon: shopify.svg
   license: ELv2
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/shopify
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 300
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -1,4 +1,7 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   allowedHosts:
     hosts:
       - ${host}
@@ -7,6 +10,7 @@ data:
   definitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
   dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-snowflake
+  documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
   githubIssueLabel: source-snowflake
   icon: snowflake.svg
   license: ELv2
@@ -17,12 +21,8 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
+  supportLevel: community
   tags:
     - language:java
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 4942d392-c7b5-4271-91f9-3b4f4e51eb3e
   dockerImageTag: 0.1.2
   dockerRepository: airbyte/source-zoho-crm
+  documentationUrl: https://docs.airbyte.com/integrations/sources/zoho-crm
   githubIssueLabel: source-zoho-crm
   icon: zohocrm.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/zoho-crm
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zoom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoom/metadata.yaml
@@ -19,7 +19,7 @@ data:
     - language:low-code
     - language:python
   ab_internal:
-    sl: 200
+    sl: 100
     ql: 200
-  supportLevel: certified
+  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zuora/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zuora/metadata.yaml
@@ -1,9 +1,13 @@
 data:
+  ab_internal:
+    ql: 200
+    sl: 100
   connectorSubtype: api
   connectorType: source
   definitionId: 3dc3037c-5ce8-4661-adc2-f7a9e3c5ece5
   dockerImageTag: 0.1.3
   dockerRepository: airbyte/source-zuora
+  documentationUrl: https://docs.airbyte.com/integrations/sources/zuora
   githubIssueLabel: source-zuora
   icon: zuora.svg
   license: MIT
@@ -14,11 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/zuora
+  supportLevel: community
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 200
-  supportLevel: certified
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
We mistakenly labelled a bunch of alpha connectors as certified. We should roll them back to community.