### PR TITLE
use GITHUB TOKEN in slash commands

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -19,7 +19,7 @@ jobs:
         id: scd
         uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           permission: write
           commands: |
             test


### PR DESCRIPTION
The original token is rate limited. Switching temporarily to GITHUB TOKEN.