### PR TITLE
Revert "use GITHUB TOKEN in slash commands (#29554)"

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -19,7 +19,7 @@ jobs:
         id: scd
         uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           permission: write
           commands: |
             test


### PR DESCRIPTION
This reverts commit 3f13de9d7abb26e18c50e016a0753e34aa5346f3.
