### PR TITLE
Destination bigquery v2: verify error on reserved column name prefixes

### DIFF
--- a/airbyte-integrations/bases/base-typing-deduping-test/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/BaseSqlGeneratorIntegrationTest.java
+++ b/airbyte-integrations/bases/base-typing-deduping-test/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/BaseSqlGeneratorIntegrationTest.java
@@ -105,7 +105,7 @@ public abstract class BaseSqlGeneratorIntegrationTest<DialectTableDefinition> {
   protected DestinationHandler<DialectTableDefinition> destinationHandler;
   protected String namespace;
 
-  private StreamId streamId;
+  protected StreamId streamId;
   private List<ColumnId> primaryKey;
   private ColumnId cursor;
 

--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -47,7 +47,7 @@ ENV AIRBYTE_NORMALIZATION_INTEGRATION bigquery
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=1.8.1
+LABEL io.airbyte.version=1.9.0
 LABEL io.airbyte.name=airbyte/destination-bigquery
 
 ENV AIRBYTE_ENTRYPOINT "/airbyte/run_with_normalization.sh"

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 1.8.1
+  dockerImageTag: 1.9.0
   dockerRepository: airbyte/destination-bigquery
   githubIssueLabel: destination-bigquery
   icon: bigquery.svg

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQuerySqlGenerator.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQuerySqlGenerator.java
@@ -63,7 +63,6 @@ public class BigQuerySqlGenerator implements SqlGenerator<TableDefinition> {
   @Override
   public StreamId buildStreamId(final String namespace, final String name, final String rawNamespaceOverride) {
     return new StreamId(
-        // TODO is this correct?
         nameTransformer.getNamespace(namespace),
         nameTransformer.convertStreamName(name),
         nameTransformer.getNamespace(rawNamespaceOverride),
@@ -74,26 +73,9 @@ public class BigQuerySqlGenerator implements SqlGenerator<TableDefinition> {
 
   @Override
   public ColumnId buildColumnId(final String name) {
-    String quotedName = name;
-
-    // Column names aren't allowed to start with certain strings. Prepend an underscore if this happens.
-    final List<String> invalidColumnPrefixes = List.of(
-        "_table_",
-        "_file_",
-        "_partition_",
-        "_row_timestamp_",
-        "__root__",
-        "_colidentifier_"
-    );
-    String canonicalized = name.toLowerCase();
     // Bigquery columns are case-insensitive, so do all our validation on the lowercased name
-    if (invalidColumnPrefixes.stream().anyMatch(prefix -> name.toLowerCase().startsWith(prefix))) {
-      quotedName = "_" + quotedName;
-      canonicalized = "_" + canonicalized;
-    }
-
-    // TODO this is probably wrong
-    return new ColumnId(nameTransformer.getIdentifier(quotedName), name, canonicalized);
+    final String canonicalized = name.toLowerCase();
+    return new ColumnId(nameTransformer.getIdentifier(name), name, canonicalized);
   }
 
   public StandardSQLTypeName toDialectType(final AirbyteType type) {

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQuerySqlGeneratorTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQuerySqlGeneratorTest.java
@@ -15,20 +15,17 @@ import io.airbyte.integrations.base.destination.typing_deduping.AirbyteProtocolT
 import io.airbyte.integrations.base.destination.typing_deduping.AirbyteType;
 import io.airbyte.integrations.base.destination.typing_deduping.Array;
 import io.airbyte.integrations.base.destination.typing_deduping.ColumnId;
+import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig;
 import io.airbyte.integrations.base.destination.typing_deduping.Struct;
 import io.airbyte.integrations.base.destination.typing_deduping.Union;
 import io.airbyte.integrations.base.destination.typing_deduping.UnsupportedOneOf;
+import io.airbyte.protocol.models.v0.DestinationSyncMode;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig;
-import io.airbyte.protocol.models.v0.DestinationSyncMode;
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -61,11 +58,6 @@ public class BigQuerySqlGeneratorTest {
     assertEquals(
         new ColumnId("foo", "foo", "foo"),
         generator.buildColumnId("foo"));
-    // Certain strings can't be the start of a column name, so we prepend an underscore
-    // Also, downcase the canonical name
-    assertEquals(
-        new ColumnId("__TABLE_foo_bar", "_TABLE_foo_bar", "__table_foo_bar"),
-        generator.buildColumnId("_TABLE_foo_bar"));
   }
 
   @Test
@@ -78,7 +70,7 @@ public class BigQuerySqlGeneratorTest {
             null);
 
     // Clustering is null
-    StandardTableDefinition existingTable = Mockito.mock(StandardTableDefinition.class);
+    final StandardTableDefinition existingTable = Mockito.mock(StandardTableDefinition.class);
     Mockito.when(existingTable.getClustering()).thenReturn(null);
     Assertions.assertFalse(generator.clusteringMatches(stream, existingTable));
 
@@ -116,7 +108,7 @@ public class BigQuerySqlGeneratorTest {
 
   @Test
   public void testPartitioningMatches() {
-    StandardTableDefinition existingTable = Mockito.mock(StandardTableDefinition.class);
+    final StandardTableDefinition existingTable = Mockito.mock(StandardTableDefinition.class);
     // Partitioning is null
     Mockito.when(existingTable.getTimePartitioning()).thenReturn(null);
     Assertions.assertFalse(generator.partitioningMatches(existingTable));

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -135,6 +135,7 @@ Now that you have set up the BigQuery destination connector, check out the follo
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                  |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------|
+| 1.9.0   | 2023-08-17 | [\#29560](https://github.com/airbytehq/airbyte/pull/29560) | Destinations v2: throw an error on disallowed column name prefixes                                                       |
 | 1.8.1   | 2023-08-17 | [\#29522](https://github.com/airbytehq/airbyte/pull/29522) | Migration BugFix - ensure raw dataset created                                                                            |
 | 1.8.0   | 2023-08-17 | [\#29498](https://github.com/airbytehq/airbyte/pull/29498) | Fix checkpointing logic in GCS staging mode                                                                              |
 | 1.7.8   | 2023-08-15 | [\#29461](https://github.com/airbytehq/airbyte/pull/29461) | Migration BugFix - ensure migration happens before table creation for GCS staging.                                       |


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/28418

as noted in https://github.com/airbytehq/airbyte/issues/28418#issuecomment-1682991494, this case is never actually happening. remove support for it + add a test to verify that we throw an error.

minor bump since this is technically behavior change, but impact is nonexistent.