### PR TITLE
cat: fix fixture skipping backward compatiblity testing

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.2
+Fix bug in skip_backward_compatibility_tests_fixture, the previous connector version could not be retrieved.
+
 ## 1.0.1
 Pin airbyte-protocol-model to <1.0.0.
 

--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -24,7 +24,7 @@ RUN poetry install --no-root --only main --no-interaction --no-ansi
 COPY . /app
 RUN poetry install --only main --no-cache --no-interaction --no-ansi
 
-LABEL io.airbyte.version=1.0.1
+LABEL io.airbyte.version=1.0.2
 LABEL io.airbyte.name=airbyte/connector-acceptance-test
 WORKDIR /test_input
 ENTRYPOINT ["python", "-m", "pytest", "-p", "connector_acceptance_test.plugin", "-r", "fEsx", "--show-capture=log"]

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -55,6 +55,10 @@ from connector_acceptance_test.utils.json_schema_helper import (
     get_paths_in_connector_config,
 )
 
+pytestmark = [
+    pytest.mark.anyio,
+]
+
 
 @pytest.fixture(name="connector_spec_dict")
 def connector_spec_dict_fixture(actual_connector_spec):
@@ -92,7 +96,7 @@ DATETIME_PATTERN = "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2})?$"
 @pytest.mark.default_timeout(5 * 60)
 class TestSpec(BaseTest):
     @pytest.fixture(name="skip_backward_compatibility_tests")
-    def skip_backward_compatibility_tests_fixture(
+    async def skip_backward_compatibility_tests_fixture(
         self,
         inputs: SpecTestConfig,
         previous_connector_docker_runner: ConnectorRunner,
@@ -106,7 +110,7 @@ class TestSpec(BaseTest):
             pytest.skip("The previous connector image could not be retrieved.")
 
         # Get the real connector version in case 'latest' is used in the config:
-        previous_connector_version = previous_connector_docker_runner._image.labels.get("io.airbyte.version")
+        previous_connector_version = await previous_connector_docker_runner.get_container_label("io.airbyte.version")
 
         if previous_connector_version == inputs.backward_compatibility_tests_config.disable_for_version:
             pytest.skip(f"Backward compatibility tests are disabled for version {previous_connector_version}.")
@@ -612,7 +616,7 @@ class TestDiscovery(BaseTest):
     ]
 
     @pytest.fixture(name="skip_backward_compatibility_tests")
-    def skip_backward_compatibility_tests_fixture(
+    async def skip_backward_compatibility_tests_fixture(
         self,
         inputs: DiscoveryTestConfig,
         previous_connector_docker_runner: ConnectorRunner,
@@ -626,7 +630,7 @@ class TestDiscovery(BaseTest):
             pytest.skip("The previous connector image could not be retrieved.")
 
         # Get the real connector version in case 'latest' is used in the config:
-        previous_connector_version = previous_connector_docker_runner._image.labels.get("io.airbyte.version")
+        previous_connector_version = await previous_connector_docker_runner.get_container_label("io.airbyte.version")
 
         if previous_connector_version == inputs.backward_compatibility_tests_config.disable_for_version:
             pytest.skip(f"Backward compatibility tests are disabled for version {previous_connector_version}.")


### PR DESCRIPTION
## What
The `skip_backward_compatibility_fixture` was still accessing a connector runner attribute that was removed in https://github.com/airbytehq/airbyte/pull/28000

## How
Read the previous connector version from the container labels.

