### PR TITLE
🐛 Source Mongo Internal POC: Remove fetch size configuration

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/integration_tests/expected_spec.json
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/integration_tests/expected_spec.json
@@ -47,13 +47,6 @@
         "type": "string",
         "description": "The name of the replica set to be replicated.",
         "order": 6
-      },
-      "fetch_size": {
-        "title": "Fetch Size",
-        "type": "number",
-        "description": "The maximum number of documents that should be read in one go from each collection for the initial snapshot.",
-        "default": 1000,
-        "order": 7
       }
     }
   },

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoConstants.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoConstants.java
@@ -7,9 +7,9 @@ package io.airbyte.integrations.source.mongodb.internal;
 public class MongoConstants {
 
   public static final String AUTH_SOURCE_CONFIGURATION_KEY = "auth_source";
+  public static final Integer CHECKPOINT_INTERVAL = 1000;
   public static final String CONNECTION_STRING_CONFIGURATION_KEY = "connection_string";
   public static final String DATABASE_CONFIGURATION_KEY = "database";
-  public static final String FETCH_SIZE_CONFIGURATION_KEY = "fetch_size";
   public static final String PASSWORD_CONFIGURATION_KEY = "password";
   public static final String REPLICA_SET_CONFIGURATION_KEY = "replica_set";
   public static final String USER_CONFIGURATION_KEY = "user";

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoConstants.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoConstants.java
@@ -10,6 +10,7 @@ public class MongoConstants {
   public static final Integer CHECKPOINT_INTERVAL = 1000;
   public static final String CONNECTION_STRING_CONFIGURATION_KEY = "connection_string";
   public static final String DATABASE_CONFIGURATION_KEY = "database";
+  public static final String ID_FIELD = "_id";
   public static final String PASSWORD_CONFIGURATION_KEY = "password";
   public static final String REPLICA_SET_CONFIGURATION_KEY = "replica_set";
   public static final String USER_CONFIGURATION_KEY = "user";

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java
@@ -51,7 +51,10 @@ class MongoDbStateIterator implements Iterator<AirbyteMessage> {
    */
   private boolean finalStateNext = false;
 
-  MongoDbStateIterator(final MongoCursor<Document> iter, final ConfiguredAirbyteStream stream, final Instant emittedAt, final Integer checkpointInterval) {
+  MongoDbStateIterator(final MongoCursor<Document> iter,
+                       final ConfiguredAirbyteStream stream,
+                       final Instant emittedAt,
+                       final Integer checkpointInterval) {
     this.iter = iter;
     this.stream = stream;
     this.checkpointInterval = checkpointInterval;

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java
@@ -27,33 +27,34 @@ import org.slf4j.LoggerFactory;
 class MongoDbStateIterator implements Iterator<AirbyteMessage> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbStateIterator.class);
+
   private final MongoCursor<Document> iter;
-
   private final ConfiguredAirbyteStream stream;
-
   private final List<String> fields;
-
   private final Instant emittedAt;
-  private final int batchSize;
+  private final Integer checkpointInterval;
+
   /**
    * Counts the number of records seen in this batch, resets when a state-message has been generated.
    */
   private int count = 0;
+
   /**
    * Pointer to the last document seen by this iterator, necessary to track the _id field for state
    * messages
    */
   private Document last = null;
+
   /**
    * This iterator outputs a final state when the wrapped `iter` has concluded. When this is true, the
    * final message will be returned.
    */
   private boolean finalStateNext = false;
 
-  MongoDbStateIterator(final MongoCursor<Document> iter, final ConfiguredAirbyteStream stream, final Instant emittedAt, final int batchSize) {
+  MongoDbStateIterator(final MongoCursor<Document> iter, final ConfiguredAirbyteStream stream, final Instant emittedAt, final Integer checkpointInterval) {
     this.iter = iter;
     this.stream = stream;
-    this.batchSize = batchSize;
+    this.checkpointInterval = checkpointInterval;
     this.emittedAt = emittedAt;
     fields = CatalogHelpers.getTopLevelFieldNames(stream).stream().toList();
   }
@@ -79,7 +80,7 @@ class MongoDbStateIterator implements Iterator<AirbyteMessage> {
 
   @Override
   public AirbyteMessage next() {
-    if ((count > 0 && count % batchSize == 0) || finalStateNext) {
+    if ((count > 0 && count % checkpointInterval == 0) || finalStateNext) {
       count = 0;
 
       final var streamState = new AirbyteStreamState()

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/resources/spec.json
@@ -47,13 +47,6 @@
         "type": "string",
         "description": "The name of the replica set to be replicated.",
         "order": 6
-      },
-      "fetch_size": {
-        "title": "Fetch Size",
-        "type": "number",
-        "description": "The maximum number of documents that should be read in one go from each collection for the initial snapshot.",
-        "default": 1000,
-        "order": 7
       }
     }
   }

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIteratorTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIteratorTest.java
@@ -32,7 +32,7 @@ import org.mockito.stubbing.Answer;
 
 class MongoDbStateIteratorTest {
 
-  private static final int BATCH_SIZE = 2;
+  private static final int CHECKPOINT_INTERVAL = 2;
   @Mock
   private MongoCursor<Document> mongoCursor;
   private AutoCloseable closeable;
@@ -59,7 +59,7 @@ class MongoDbStateIteratorTest {
       public Boolean answer(InvocationOnMock invocation) throws Throwable {
         count++;
         // hasNext will be called for each doc plus for each state message
-        return count <= (docs.size() + (docs.size() % BATCH_SIZE));
+        return count <= (docs.size() + (docs.size() % CHECKPOINT_INTERVAL));
       }
 
     });
@@ -79,7 +79,7 @@ class MongoDbStateIteratorTest {
 
     final var stream = catalog().getStreams().stream().findFirst().orElseThrow();
 
-    final var iter = new MongoDbStateIterator(mongoCursor, stream, Instant.now(), BATCH_SIZE);
+    final var iter = new MongoDbStateIterator(mongoCursor, stream, Instant.now(), CHECKPOINT_INTERVAL);
 
     // with a batch size of 2, the MongoDbStateIterator should return the following after each
     // `hasNext`/`next` call:
@@ -137,7 +137,7 @@ class MongoDbStateIteratorTest {
 
     final var stream = catalog().getStreams().stream().findFirst().orElseThrow();
 
-    final var iter = new MongoDbStateIterator(mongoCursor, stream, Instant.now(), BATCH_SIZE);
+    final var iter = new MongoDbStateIterator(mongoCursor, stream, Instant.now(), CHECKPOINT_INTERVAL);
 
     // with a batch size of 2, the MongoDbStateIterator should return the following after each
     // `hasNext`/`next` call:


### PR DESCRIPTION
## What
* Remove unnecessary/confusing configuration added for testing

## How
* Remove `fetch_size` from spec
* Remove explicit setting of find batch size to instead use default 16 MB size
* Rename state iterator batch size to checkpoint interval for clarity

## Recommended reading order
1. `spec.json`
2. `MongoDbSource.java`
3. `MongoDbStateIterator.java`