### PR TITLE
Source Intercom: migrate to latest cdk (0.50.2)

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/Dockerfile
+++ b/airbyte-integrations/connectors/source-intercom/Dockerfile
@@ -34,5 +34,5 @@ COPY source_intercom ./source_intercom
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.3.0
 LABEL io.airbyte.name=airbyte/source-intercom

--- a/airbyte-integrations/connectors/source-intercom/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-intercom/acceptance-test-config.yml
@@ -6,7 +6,7 @@ acceptance_tests:
   spec:
     tests:
     - spec_path: "source_intercom/spec.json"
-      # Small fix: advanced auth configuration contain `client_id` and `client_secret` fields but they were missing in spec. 
+      # Spec fix: advanced auth configuration contain `client_id` and `client_secret` fields but they were missing in spec. 
       backward_compatibility_tests_config:
         disable_for_version: "0.2.1"
   connection:
@@ -18,12 +18,14 @@ acceptance_tests:
   discovery:
     tests:
     - config_path: "secrets/config.json"
+      # Schema fix: update schemas with undeclared fields which is not breaking change
+      backward_compatibility_tests_config:
+        disable_for_version: "0.2.1"
   basic_read:
     tests:
     - config_path: "secrets/config.json"
       expect_records:
         path: "integration_tests/expected_records.jsonl"
-      fail_on_extra_columns: false
   incremental:
     tests:
     - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-intercom/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-intercom/acceptance-test-config.yml
@@ -6,6 +6,9 @@ acceptance_tests:
   spec:
     tests:
     - spec_path: "source_intercom/spec.json"
+      # Small fix: advanced auth configuration contain `client_id` and `client_secret` fields but they were missing in spec. 
+      backward_compatibility_tests_config:
+        disable_for_version: "0.2.1"
   connection:
     tests:
     - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.3.0
   dockerRepository: airbyte/source-intercom
   githubIssueLabel: source-intercom
   icon: intercom.svg

--- a/airbyte-integrations/connectors/source-intercom/setup.py
+++ b/airbyte-integrations/connectors/source-intercom/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk==0.29.0",
+    "airbyte-cdk",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/components.py
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/components.py
@@ -2,41 +2,36 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-import os
 from dataclasses import InitVar, dataclass, field
-from functools import lru_cache, wraps
+from functools import wraps
 from time import sleep
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 
-import dpath.util
 import requests
-from airbyte_cdk.models import AirbyteMessage, SyncMode, Type
-from airbyte_cdk.sources.declarative.auth.declarative_authenticator import DeclarativeAuthenticator, NoAuth
+from airbyte_cdk.models import SyncMode
+from airbyte_cdk.sources.declarative.incremental.cursor import Cursor
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.partition_routers.substream_partition_router import ParentStreamConfig
-from airbyte_cdk.sources.declarative.requesters.error_handlers.default_error_handler import DefaultErrorHandler
-from airbyte_cdk.sources.declarative.requesters.error_handlers.error_handler import ErrorHandler
 from airbyte_cdk.sources.declarative.requesters.error_handlers.response_status import ResponseStatus
+from airbyte_cdk.sources.declarative.requesters.http_requester import HttpRequester
 from airbyte_cdk.sources.declarative.requesters.request_option import RequestOptionType
 from airbyte_cdk.sources.declarative.requesters.request_options.interpolated_request_input_provider import InterpolatedRequestInputProvider
-from airbyte_cdk.sources.declarative.requesters.requester import HttpMethod, Requester
-from airbyte_cdk.sources.declarative.stream_slicers.stream_slicer import StreamSlicer
+from airbyte_cdk.sources.declarative.requesters.request_options.interpolated_nested_request_input_provider import InterpolatedNestedRequestInputProvider
 from airbyte_cdk.sources.declarative.types import Config, Record, StreamSlice, StreamState
 from airbyte_cdk.sources.streams.core import Stream
+
 
 RequestInput = Union[str, Mapping[str, str]]
 
 
 @dataclass
-class IncrementalSingleSlice(StreamSlicer):
-
+class IncrementalSingleSliceCursor(Cursor):
     cursor_field: Union[InterpolatedString, str]
     config: Config
     parameters: InitVar[Mapping[str, Any]]
-    _cursor: dict = field(default_factory=dict)
-    initial_state: dict = field(default_factory=dict)
 
     def __post_init__(self, parameters: Mapping[str, Any]):
+        self._state = {}
         self.cursor_field = InterpolatedString.create(self.cursor_field, parameters=parameters)
 
     def get_request_params(
@@ -45,7 +40,8 @@ class IncrementalSingleSlice(StreamSlicer):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
-        # Pass the stream_slice from the argument, not the cursor because the cursor is updated after processing the response
+        # Current implementation does not provide any options to update request params.
+        # Returns empty dict
         return self._get_request_option(RequestOptionType.request_parameter, stream_slice)
 
     def get_request_headers(
@@ -54,7 +50,8 @@ class IncrementalSingleSlice(StreamSlicer):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
-        # Pass the stream_slice from the argument, not the cursor because the cursor is updated after processing the response
+        # Current implementation does not provide any options to update request headers.
+        # Returns empty dict
         return self._get_request_option(RequestOptionType.header, stream_slice)
 
     def get_request_body_data(
@@ -63,7 +60,8 @@ class IncrementalSingleSlice(StreamSlicer):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
-        # Pass the stream_slice from the argument, not the cursor because the cursor is updated after processing the response
+        # Current implementation does not provide any options to update body data.
+        # Returns empty dict
         return self._get_request_option(RequestOptionType.body_data, stream_slice)
 
     def get_request_body_json(
@@ -72,100 +70,65 @@ class IncrementalSingleSlice(StreamSlicer):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Optional[Mapping]:
-        # Pass the stream_slice from the argument, not the cursor because the cursor is updated after processing the response
+        # Current implementation does not provide any options to update body json.
+        # Returns empty dict
         return self._get_request_option(RequestOptionType.body_json, stream_slice)
 
     def _get_request_option(self, option_type: RequestOptionType, stream_slice: StreamSlice):
         return {}
 
     def get_stream_state(self) -> StreamState:
-        return self._cursor if self._cursor else {}
+        return self._state
 
-    def _get_max_state_value(
-        self,
-        current_state_value: Optional[Union[int, str]],
-        last_record_value: Optional[Union[int, str]],
-    ) -> Optional[Union[int, str]]:
-        if current_state_value and last_record_value:
-            cursor = max(current_state_value, last_record_value)
-        elif current_state_value:
-            cursor = current_state_value
-        else:
-            cursor = last_record_value
-        return cursor
+    def set_initial_state(self, stream_state: StreamState):
+        cursor_field = self.cursor_field.eval(self.config)
+        cursor_value = stream_state.get(cursor_field)
+        if cursor_value:
+            self._state[cursor_field] = cursor_value
+            self._state["prior_state"] = self._state.copy()
 
-    def _set_initial_state(self, stream_slice: StreamSlice):
-        self.initial_state = stream_slice if not self.initial_state else self.initial_state
+    def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
+        latest_record = self._state if self.is_greater_than_or_equal(self._state, most_recent_record) else most_recent_record
+        if latest_record:
+            cursor_field = self.cursor_field.eval(self.config)
+            self._state[cursor_field] = latest_record[cursor_field]
 
-    def _update_cursor_with_prior_state(self):
-        self._cursor["prior_state"] = {self.cursor_field.eval(self.config): self.initial_state.get(self.cursor_field.eval(self.config))}
-
-    def _get_current_state(self, stream_slice: StreamSlice) -> Union[str, float, int]:
-        return stream_slice.get(self.cursor_field.eval(self.config))
-
-    def _get_last_record_value(self, last_record: Optional[Record] = None) -> Union[str, float, int]:
-        return last_record.get(self.cursor_field.eval(self.config)) if last_record else None
-
-    def _get_current_cursor_value(self) -> Union[str, float, int]:
-        return self._cursor.get(self.cursor_field.eval(self.config)) if self._cursor else None
-
-    def _update_current_cursor(
-        self,
-        current_cursor_value: Optional[Union[str, float, int]] = None,
-        updated_cursor_value: Optional[Union[str, float, int]] = None,
-    ):
-        if current_cursor_value and updated_cursor_value:
-            self._cursor.update(**{self.cursor_field.eval(self.config): max(updated_cursor_value, current_cursor_value)})
-        elif updated_cursor_value:
-            self._cursor.update(**{self.cursor_field.eval(self.config): updated_cursor_value})
-
-    def _update_stream_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
-        self._update_current_cursor(
-            self._get_current_cursor_value(),
-            self._get_max_state_value(
-                self._get_current_state(stream_slice),
-                self._get_last_record_value(last_record),
-            ),
-        )
-
-    def update_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
-        # freeze initial state
-        self._set_initial_state(stream_slice)
-        # update the state of the child stream cursor_field value from previous sync,
-        # and freeze it to have an ability to compare the record vs state
-        self._update_cursor_with_prior_state()
-        self._update_stream_cursor(stream_slice, last_record)
-
-    def stream_slices(self, sync_mode: SyncMode, stream_state: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    def stream_slices(self) -> Iterable[Mapping[str, Any]]:
         yield {}
+
+    def should_be_synced(self, record: Record) -> bool:
+        """
+        Evaluating if a record should be synced allows for filtering and stop condition on pagination
+        """
+        record_cursor_value = record.get(self.cursor_field.eval(self.config))
+        return bool(record_cursor_value)
+
+    def is_greater_than_or_equal(self, first: Record, second: Record) -> bool:
+        """
+        Evaluating which record is greater in terms of cursor. This is used to avoid having to capture all the records to close a slice
+        """
+        cursor_field = self.cursor_field.eval(self.config)
+        first_cursor_value = first.get(cursor_field) if first else None
+        second_cursor_value = second.get(cursor_field) if second else None
+        if first_cursor_value and second_cursor_value:
+            return first_cursor_value > second_cursor_value
+        elif first_cursor_value:
+            return True
+        else:
+            return False
 
 
 @dataclass
-class IncrementalSubstreamSlicer(StreamSlicer):
-    """
-    Like SubstreamSlicer, but works incrementaly with both parent and substream.
-
-    Input Arguments:
-
-    :: cursor_field: srt - substream cursor_field value
-    :: parent_complete_fetch: bool - If `True`, all slices is fetched into a list first, then yield.
-        If `False`, substream emits records on each parernt slice yield.
-    :: parent_stream_configs: ParentStreamConfig - Describes how to create a stream slice from a parent stream.
-
-    """
-
-    config: Config
-    parameters: InitVar[Mapping[str, Any]]
-    cursor_field: Union[InterpolatedString, str]
+class IncrementalSubstreamSlicerCursor(IncrementalSingleSliceCursor):
     parent_stream_configs: List[ParentStreamConfig]
     parent_complete_fetch: bool = field(default=False)
-    _cursor: dict = field(default_factory=dict)
-    initial_state: dict = field(default_factory=dict)
 
     def __post_init__(self, parameters: Mapping[str, Any]):
+        super().__post_init__(parameters)
+
         if not self.parent_stream_configs:
             raise ValueError("IncrementalSubstreamSlicer needs at least 1 parent stream")
-        self.cursor_field = InterpolatedString.create(self.cursor_field, parameters=parameters)
+
         # parent stream parts
         self.parent_config: ParentStreamConfig = self.parent_stream_configs[0]
         self.parent_stream: Stream = self.parent_config.stream
@@ -175,186 +138,59 @@ class IncrementalSubstreamSlicer(StreamSlicer):
         self.substream_slice_field: str = self.parent_stream_configs[0].partition_field.eval(self.config)
         self.parent_field: str = self.parent_stream_configs[0].parent_key.eval(self.config)
 
-    def get_request_params(
-        self,
-        stream_state: Optional[StreamState] = None,
-        stream_slice: Optional[StreamSlice] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
-    ) -> Mapping[str, Any]:
-        # Pass the stream_slice from the argument, not the cursor because the cursor is updated after processing the response
-        return self._get_request_option(RequestOptionType.request_parameter, stream_slice)
+    def set_initial_state(self, stream_state: StreamState):
+        super().set_initial_state(stream_state=stream_state)
+        if self.parent_stream_name in stream_state and stream_state.get(self.parent_stream_name, {}).get(self.parent_cursor_field):
+            parent_stream_state = {
+                self.parent_cursor_field: stream_state[self.parent_stream_name][self.parent_cursor_field]
+            }
+            self._state[self.parent_stream_name] = parent_stream_state
+            if "prior_state" in self._state:
+                self._state["prior_state"][self.parent_stream_name] = parent_stream_state
 
-    def get_request_headers(
-        self,
-        stream_state: Optional[StreamState] = None,
-        stream_slice: Optional[StreamSlice] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
-    ) -> Mapping[str, Any]:
-        # Pass the stream_slice from the argument, not the cursor because the cursor is updated after processing the response
-        return self._get_request_option(RequestOptionType.header, stream_slice)
+    def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
+        super().close_slice(stream_slice=stream_slice, most_recent_record=most_recent_record)
+        if self.parent_stream:
+            self._state[self.parent_stream_name] = self.parent_stream.state
 
-    def get_request_body_data(
-        self,
-        stream_state: Optional[StreamState] = None,
-        stream_slice: Optional[StreamSlice] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
-    ) -> Mapping[str, Any]:
-        # Pass the stream_slice from the argument, not the cursor because the cursor is updated after processing the response
-        return self._get_request_option(RequestOptionType.body_data, stream_slice)
-
-    def get_request_body_json(
-        self,
-        stream_state: Optional[StreamState] = None,
-        stream_slice: Optional[StreamSlice] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
-    ) -> Optional[Mapping]:
-        # Pass the stream_slice from the argument, not the cursor because the cursor is updated after processing the response
-        return self._get_request_option(RequestOptionType.body_json, stream_slice)
-
-    def _get_request_option(self, option_type: RequestOptionType, stream_slice: StreamSlice):
-        return {}
-
-    def _get_max_state_value(
-        self, current_state_value: Optional[Union[int, str]], last_record_value: Optional[Union[int, str]]
-    ) -> Optional[Union[int, str]]:
-        if current_state_value and last_record_value:
-            cursor = max(current_state_value, last_record_value)
-        elif current_state_value:
-            cursor = current_state_value
-        else:
-            cursor = last_record_value
-        return cursor
-
-    def _set_initial_state(self, stream_slice: StreamSlice):
-        self.initial_state = stream_slice if not self.initial_state else self.initial_state
-
-    def _get_last_record_value(self, last_record: Optional[Record] = None, parent: Optional[bool] = False) -> Union[str, float, int]:
-        if parent:
-            return last_record.get(self.parent_cursor_field) if last_record else None
-        else:
-            return last_record.get(self.cursor_field.eval(self.config)) if last_record else None
-
-    def _get_current_cursor_value(self, parent: Optional[bool] = False) -> Union[str, float, int]:
-        if parent:
-            return self._cursor.get(self.parent_stream_name, {}).get(self.parent_cursor_field) if self._cursor else None
-        else:
-            return self._cursor.get(self.cursor_field.eval(self.config)) if self._cursor else None
-
-    def _get_current_state(self, stream_slice: StreamSlice, parent: Optional[bool] = False) -> Union[str, float, int]:
-        if parent:
-            return stream_slice.get(self.parent_stream_name, {}).get(self.parent_cursor_field)
-        else:
-            return stream_slice.get(self.cursor_field.eval(self.config))
-
-    def _update_current_cursor(
-        self,
-        current_cursor_value: Optional[Union[str, float, int]] = None,
-        updated_cursor_value: Optional[Union[str, float, int]] = None,
-        parent: Optional[bool] = False,
-    ):
-        if current_cursor_value and updated_cursor_value:
-            if parent:
-                self._cursor.update(
-                    **{self.parent_stream_name: {self.parent_cursor_field: max(updated_cursor_value, current_cursor_value)}}
-                )
-            else:
-                self._cursor.update(**{self.cursor_field.eval(self.config): max(updated_cursor_value, current_cursor_value)})
-        elif updated_cursor_value:
-            if parent:
-                self._cursor.update(**{self.parent_stream_name: {self.parent_cursor_field: updated_cursor_value}})
-            else:
-                self._cursor.update(**{self.cursor_field.eval(self.config): updated_cursor_value})
-
-    def _update_substream_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
-        self._update_current_cursor(
-            self._get_current_cursor_value(),
-            self._get_max_state_value(
-                self._get_current_state(stream_slice),
-                self._get_last_record_value(last_record),
-            ),
-        )
-
-    def _update_parent_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
-        if self.parent_cursor_field:
-            self._update_current_cursor(
-                self._get_current_cursor_value(parent=True),
-                self._get_max_state_value(
-                    self._get_current_state(stream_slice, parent=True),
-                    self._get_last_record_value(last_record, parent=True),
-                ),
-            )
-
-    def _update_cursor_with_prior_state(self):
-        self._cursor["prior_state"] = {
-            self.cursor_field.eval(self.config): self.initial_state.get(self.cursor_field.eval(self.config)),
-            self.parent_stream_name: {
-                self.parent_cursor_field: self.initial_state.get(self.parent_stream_name, {}).get(self.parent_cursor_field)
-            },
-        }
-
-    def get_stream_state(self) -> StreamState:
-        return self._cursor if self._cursor else {}
-
-    def update_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
-        # freeze initial state
-        self._set_initial_state(stream_slice)
-        # update the state of the child stream cursor_field value from previous sync,
-        # and freeze it to have an ability to compare the record vs state
-        self._update_cursor_with_prior_state()
-        # we focus on updating the substream's cursor in this method,
-        # the parent's cursor is updated while reading parent stream
-        self._update_substream_cursor(stream_slice, last_record)
+    def stream_slices(self) -> Iterable[Mapping[str, Any]]:
+        parent_state = (self._state or {}).get(self.parent_stream_name, {})
+        slices_generator = self.read_parent_stream(self.parent_sync_mode, self.parent_cursor_field, parent_state)
+        yield from [slice for slice in slices_generator] if self.parent_complete_fetch else slices_generator
 
     def read_parent_stream(
         self, sync_mode: SyncMode, cursor_field: Optional[str], stream_state: Mapping[str, Any]
     ) -> Iterable[Mapping[str, Any]]:
+        self.parent_stream.state = stream_state
 
-        for parent_slice in self.parent_stream.stream_slices(sync_mode=sync_mode, cursor_field=cursor_field, stream_state=stream_state):
-            empty_parent_slice = True
+        parent_stream_slices_gen = self.parent_stream.stream_slices(
+            sync_mode=sync_mode,
+            cursor_field=cursor_field,
+            stream_state=stream_state
+        )
 
-            # update slice with parent state, to pass the initial parent state to the parent instance
-            # stream_state is being replaced by empty object, since the parent stream is not directly initiated
-            parent_prior_state = self._cursor.get("prior_state", {}).get(self.parent_stream_name, {}).get(self.parent_cursor_field)
-            parent_slice.update({"prior_state": {self.parent_cursor_field: parent_prior_state}})
+        for parent_slice in parent_stream_slices_gen:
 
-            for parent_record in self.parent_stream.read_records(
-                sync_mode=sync_mode, cursor_field=cursor_field, stream_slice=parent_slice, stream_state=stream_state
-            ):
-                # Skip non-records (eg AirbyteLogMessage)
-                if isinstance(parent_record, AirbyteMessage):
-                    if parent_record.type == Type.RECORD:
-                        parent_record = parent_record.record.data
+            parent_records_gen = self.parent_stream.read_records(
+                sync_mode=sync_mode,
+                cursor_field=cursor_field,
+                stream_slice=parent_slice,
+                stream_state=stream_state
+            )
 
+            for parent_record in parent_records_gen:
                 try:
-                    substream_slice = dpath.util.get(parent_record, self.parent_field)
+                    substream_slice_value = parent_record[self.parent_field]
                 except KeyError:
-                    pass
-                else:
-                    empty_parent_slice = False
-                    slice = {
-                        self.substream_slice_field: substream_slice,
-                        self.cursor_field.eval(self.config): self._cursor.get(self.cursor_field.eval(self.config)),
-                        self.parent_stream_name: {
-                            self.parent_cursor_field: self._cursor.get(self.parent_stream_name, {}).get(self.parent_cursor_field)
-                        },
+                    continue
+                cursor_field = self.cursor_field.eval(self.config)
+                yield {
+                    self.substream_slice_field: substream_slice_value,
+                    cursor_field: self._state.get(cursor_field),
+                    self.parent_stream_name: {
+                        self.parent_cursor_field: self._state.get(self.parent_stream_name, {}).get(self.parent_cursor_field)
                     }
-                    # track and update the parent cursor
-                    self._update_parent_cursor(slice, parent_record)
-                    yield slice
-
-            # If the parent slice contains no records,
-            if empty_parent_slice:
-                yield from []
-
-    def stream_slices(self, sync_mode: SyncMode, stream_state: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
-        stream_state = self.initial_state or {}
-        parent_state = stream_state.get(self.parent_stream_name, {})
-        parent_state.update(**{"prior_state": self._cursor.get("prior_state", {}).get(self.parent_stream_name, {})})
-        slices_generator = self.read_parent_stream(self.parent_sync_mode, self.parent_cursor_field, parent_state)
-        if self.parent_complete_fetch:
-            yield from [slice for slice in slices_generator]
-        else:
-            yield from slices_generator
+                }
 
 
 @dataclass
@@ -479,57 +315,26 @@ class IntercomRateLimiter:
         return decorator
 
 
-@dataclass
-class HttpRequesterWithRateLimiter(Requester):
+@dataclass(eq=False)
+class HttpRequesterWithRateLimiter(HttpRequester):
     """
     The difference between the built-in `HttpRequester` and this one is the custom decorator,
     applied on top of `interpret_response_status` to preserve the api calls for a defined amount of time,
     calculated using the rate limit headers and not use the custom backoff strategy,
     since we deal with Response.status_code == 200,
     the default requester's logic doesn't allow to handle the status of 200 with `should_retry()`.
-
-    Attributes:
-        name (str): Name of the stream. Only used for request/response caching
-        url_base (Union[InterpolatedString, str]): Base url to send requests to
-        path (Union[InterpolatedString, str]): Path to send requests to
-        http_method (Union[str, HttpMethod]): HTTP method to use when sending requests
-        request_options_provider (Optional[InterpolatedRequestOptionsProvider]): request option provider defining the options to set on outgoing requests
-        authenticator (DeclarativeAuthenticator): Authenticator defining how to authenticate to the source
-        error_handler (Optional[ErrorHandler]): Error handler defining how to detect and handle errors
-        config (Config): The user-provided configuration as specified by the source's spec
     """
 
-    name: str
-    url_base: Union[InterpolatedString, str]
-    path: Union[InterpolatedString, str]
-    config: Config
-    parameters: InitVar[Mapping[str, Any]]
-    http_method: Union[str, HttpMethod] = HttpMethod.GET
+    request_headers:    Optional[RequestInput] = None
+    request_body_json:  Optional[RequestInput] = None
     request_parameters: Optional[RequestInput] = None
-    request_headers: Optional[RequestInput] = None
-    request_body_data: Optional[RequestInput] = None
-    request_body_json: Optional[RequestInput] = None
-    authenticator: DeclarativeAuthenticator = None
-    error_handler: Optional[ErrorHandler] = None
 
-    def __post_init__(self, parameters: Mapping[str, Any]):
-        self.url_base = InterpolatedString.create(self.url_base, parameters=parameters)
-        self.path = InterpolatedString.create(self.path, parameters=parameters)
-
-        self.authenticator = self.authenticator or NoAuth(parameters=parameters)
-        if type(self.http_method) == str:
-            self.http_method = HttpMethod[self.http_method]
-        self._method = self.http_method
-        self.error_handler = self.error_handler or DefaultErrorHandler(parameters=parameters, config=self.config)
-        self._parameters = parameters
+    def __post_init__(self, parameters: Mapping[str, Any]) -> None:
+        super().__post_init__(parameters)
 
         self.request_parameters = self.request_parameters if self.request_parameters else {}
         self.request_headers = self.request_headers if self.request_headers else {}
-        self.request_body_data = self.request_body_data if self.request_body_data else {}
         self.request_body_json = self.request_body_json if self.request_body_json else {}
-
-        if self.request_body_json and self.request_body_data:
-            raise ValueError("RequestOptionsProvider should only contain either 'request_body_data' or 'request_body_json' not both")
 
         self._parameter_interpolator = InterpolatedRequestInputProvider(
             config=self.config, request_inputs=self.request_parameters, parameters=parameters
@@ -537,46 +342,15 @@ class HttpRequesterWithRateLimiter(Requester):
         self._headers_interpolator = InterpolatedRequestInputProvider(
             config=self.config, request_inputs=self.request_headers, parameters=parameters
         )
-        self._body_data_interpolator = InterpolatedRequestInputProvider(
-            config=self.config, request_inputs=self.request_body_data, parameters=parameters
-        )
-        self._body_json_interpolator = InterpolatedRequestInputProvider(
+        self._body_json_interpolator = InterpolatedNestedRequestInputProvider(
             config=self.config, request_inputs=self.request_body_json, parameters=parameters
         )
 
-    @property
-    def cache_filename(self) -> str:
-        return f"{self.name}.yml"
-
-    @property
-    def use_cache(self) -> bool:
-        return False
-
-    def __hash__(self):
-        return hash(tuple(self.__dict__))
-
-    def get_authenticator(self):
-        return self.authenticator
-
-    def get_url_base(self):
-        return os.path.join(self.url_base.eval(self.config), "")
-
-    def get_path(
-        self, *, stream_state: Optional[StreamState], stream_slice: Optional[StreamSlice], next_page_token: Optional[Mapping[str, Any]]
-    ) -> str:
-        kwargs = {"stream_state": stream_state, "stream_slice": stream_slice, "next_page_token": next_page_token}
-        path = self.path.eval(self.config, **kwargs)
-        return path.strip("/")
-
-    def get_method(self):
-        return self._method
-
     # The RateLimiter is applied to balance the api requests.
-    @lru_cache(maxsize=10)
     @IntercomRateLimiter.balance_rate_limit()
     def interpret_response_status(self, response: requests.Response) -> ResponseStatus:
         # Check for response.headers to define the backoff time before the next api call
-        return self.error_handler.interpret_response(response)
+        return super().interpret_response_status(response)
 
     def get_request_params(
         self,
@@ -598,16 +372,7 @@ class HttpRequesterWithRateLimiter(Requester):
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
         return self._headers_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token)
-
-    def get_request_body_data(
-        self,
-        *,
-        stream_state: Optional[StreamState] = None,
-        stream_slice: Optional[StreamSlice] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
-    ) -> Optional[Union[Mapping, str]]:
-        return self._body_data_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token)
-
+    
     def get_request_body_json(
         self,
         *,
@@ -616,12 +381,3 @@ class HttpRequesterWithRateLimiter(Requester):
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Optional[Mapping]:
         return self._body_json_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token)
-
-    def request_kwargs(
-        self,
-        *,
-        stream_state: Optional[StreamState] = None,
-        stream_slice: Optional[StreamSlice] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
-    ) -> Mapping[str, Any]:
-        return {}

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/components.py
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/components.py
@@ -173,18 +173,16 @@ class IncrementalSubstreamSlicerCursor(IncrementalSingleSliceCursor):
             )
 
             for parent_record in parent_records_gen:
-                try:
-                    substream_slice_value = parent_record[self.parent_field]
-                except KeyError:
-                    continue
-                cursor_field = self.cursor_field.eval(self.config)
-                yield {
-                    self.substream_slice_field: substream_slice_value,
-                    cursor_field: self._state.get(cursor_field),
-                    self.parent_stream_name: {
-                        self.parent_cursor_field: self._state.get(self.parent_stream_name, {}).get(self.parent_cursor_field)
-                    },
-                }
+                substream_slice_value = parent_record.get(self.parent_field)
+                if substream_slice_value:
+                    cursor_field = self.cursor_field.eval(self.config)
+                    yield {
+                        self.substream_slice_field: substream_slice_value,
+                        cursor_field: self._state.get(cursor_field),
+                        self.parent_stream_name: {
+                            self.parent_cursor_field: self._state.get(self.parent_stream_name, {}).get(self.parent_cursor_field)
+                        },
+                    }
 
 
 @dataclass

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -1,4 +1,4 @@
-version: "0.1.0"
+version: "0.50.2"
 
 definitions:
 
@@ -41,7 +41,7 @@ definitions:
         inject_into: request_parameter
         field_name: per_page
       page_token_option:
-        type: RequestPath      
+        type: RequestPath
   requester_incremental_search:
     $ref: "#/definitions/requester"
     http_method: "POST"
@@ -98,7 +98,7 @@ definitions:
       primary_key: "name"
       path: "teams"
       data_field: "teams"
-  
+
   stream_data_attributes:
     description: "https://developers.intercom.com/intercom-api-reference/reference#list-data-attributes"
     $ref: "#/definitions/stream_full_refresh"
@@ -124,7 +124,7 @@ definitions:
       primary_key: "name"
       path: "data_attributes"
       model: "contact"
-  
+
   # semi-incremental 
   # (full-refresh and emit records >= *prior state)
   # (prior state - frozen state from previous sync, it automatically updates with next sync)
@@ -132,7 +132,7 @@ definitions:
     $ref: "#/definitions/stream_full_refresh"
     incremental_sync:
       type: CustomIncrementalSync
-      class_name: source_intercom.components.IncrementalSingleSlice
+      class_name: source_intercom.components.IncrementalSingleSliceCursor
       cursor_field: "updated_at"
     retriever:
       $ref: "#/definitions/stream_full_refresh/retriever"
@@ -193,13 +193,13 @@ definitions:
               response_filters:
                 - http_codes: [ 404 ]
                   action: IGNORE
-    
+
   # semi-incremental substreams
   substream_semi_incremental:
     $ref: "#/definitions/stream_full_refresh"
     incremental_sync:
       type: CustomIncrementalSync
-      class_name: source_intercom.components.IncrementalSubstreamSlicer
+      class_name: source_intercom.components.IncrementalSubstreamSlicerCursor
       cursor_field: "updated_at"
     retriever:
       $ref: "#/definitions/stream_full_refresh/retriever"
@@ -256,7 +256,7 @@ definitions:
     $ref: "#/definitions/stream_full_refresh"
     incremental_sync:
       type: CustomIncrementalSync
-      class_name: source_intercom.components.IncrementalSingleSlice
+      class_name: source_intercom.components.IncrementalSingleSliceCursor
       cursor_field: "updated_at"
     retriever:
       $ref: "#/definitions/stream_full_refresh/retriever"
@@ -287,7 +287,7 @@ definitions:
       path: "conversations/search"
       data_field: "conversations"
       page_size: 150
-         
+
 streams:
   - "#/definitions/admins"
   - "#/definitions/tags"
@@ -302,5 +302,5 @@ streams:
   - "#/definitions/company_segments"
 
 check:
-  stream_names: 
+  stream_names:
     - "tags"

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -23,6 +23,8 @@ definitions:
     request_headers:
       Intercom-Version: '2.5' # ATTENTION: API version change is possible here
       Accept: 'application/json'
+    error_handler:
+      type: "DefaultErrorHandler"
   retriever:
     description: "Base Retriever for Full Refresh streams"
     record_selector:
@@ -67,7 +69,7 @@ definitions:
         'page': {{ next_page_token.get('next_page_token').get('page') }},
         'starting_after': '{{ next_page_token.get('next_page_token').get('starting_after') }}'
       }"
-  
+
   ## streams
   # full-refresh
   stream_full_refresh:

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/admins.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/admins.json
@@ -58,6 +58,23 @@
     },
     "type": {
       "type": ["null", "string"]
+    },
+    "team_priority_level": {
+      "type": ["null", "object"],
+      "properties": {
+        "primary_team_ids": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["null", "integer"]
+          }
+        },
+        "secondary_team_ids": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["null", "integer"]
+          }
+        }
+      }
     }
   }
 }

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/company_attributes.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/company_attributes.json
@@ -1,6 +1,9 @@
 {
   "type": "object",
   "properties": {
+    "id": {
+      "type": ["null", "integer"]
+    },
     "admin_id": {
       "type": ["null", "string"]
     },

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contact_attributes.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contact_attributes.json
@@ -1,6 +1,9 @@
 {
   "type": ["null", "object"],
   "properties": {
+    "id": {
+      "type": ["null", "integer"]
+    },
     "type": {
       "type": ["null", "string"]
     },

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contacts.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contacts.json
@@ -304,6 +304,58 @@
           "type": ["null", "boolean"]
         }
       }
+    },
+    "opted_in_subscription_types": {
+      "type": ["null", "object"],
+      "properties": {
+        "type": {
+          "type": ["null", "string"]
+        },
+        "data": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["null", "object"],
+            "properties": {
+              "type": {
+                "type": ["null", "string"]
+              },
+              "id": {
+                "type": ["null", "string"]
+              },
+              "url": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "url": {
+          "type": ["null", "string"]
+        },
+        "total_count": {
+          "type": ["null", "integer"]
+        },
+        "has_more": {
+          "type": ["null", "boolean"]
+        }
+      }
+    },
+    "utm_content": {
+      "type": ["null", "string"]
+    },
+    "utm_campaign": {
+      "type": ["null", "string"]
+    },
+    "utm_source": {
+      "type": ["null", "string"]
+    },
+    "referrer": {
+      "type": ["null", "string"]
+    },
+    "utm_term": {
+      "type": ["null", "string"]
+    },
+    "utm_medium": {
+      "type": ["null", "string"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/conversations.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/conversations.json
@@ -428,6 +428,34 @@
     },
     "redacted": {
       "type": ["null", "boolean"]
+    },
+    "topics": {
+      "type": ["null", "object"],
+      "properties": {
+        "type": {
+          "type": ["null", "string"]
+        },
+        "topics": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["null", "object"],
+            "properties": {
+              "type": {
+                "type": ["null", "string"]
+              },
+              "id": {
+                "type": ["null", "integer"]
+              },
+              "name": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "total_count": {
+          "type": ["null", "integer"]
+        }
+      }
     }
   }
 }

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/spec.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/spec.json
@@ -20,6 +20,18 @@
         "type": "string",
         "description": "Access token for making authenticated requests. See the <a href=\"https://developers.intercom.com/building-apps/docs/authentication-types#how-to-get-your-access-token\">Intercom docs</a> for more information.",
         "airbyte_secret": true
+      },
+      "client_id": {
+        "title": "Client Id",
+        "type": "string",
+        "description": "Client Id for your Intercom application.",
+        "airbyte_secret": true
+      },
+      "client_secret": {
+        "title": "Client Secret",
+        "type": "string",
+        "description": "Client Secret for your Intercom application.",
+        "airbyte_secret": true
       }
     }
   },

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -47,42 +47,42 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                                                                                       |
-|:--------| :--------- | :------------------------------------------------------- | :-------------------------------------------------------------------------------------------- |
-| 0.3.0   | 2023-05-25 | [29598](https://github.com/airbytehq/airbyte/pull/29598) | Migrate to latest cdk==0.50.2                                                                 |
-| 0.2.1   | 2023-05-25 | [26571](https://github.com/airbytehq/airbyte/pull/26571) | Remove authSpecification from spec.json in favour of advancedAuth                             |
-| 0.2.0   | 2023-04-05 | [23013](https://github.com/airbytehq/airbyte/pull/23013) | Migrated to Low-code (YAML Frramework)                                                        |
-| 0.1.33  | 2023-03-20 | [22980](https://github.com/airbytehq/airbyte/pull/22980) | Specified date formatting in specification                                                    |
-| 0.1.32  | 2023-02-27 | [22095](https://github.com/airbytehq/airbyte/pull/22095) | Extended `Contacts` schema adding `opted_out_subscription_types` property                     |
-| 0.1.31  | 2023-02-17 | [23152](https://github.com/airbytehq/airbyte/pull/23152) | Add `TypeTransformer` to stream `companies`                                                   |
-| 0.1.30  | 2023-01-27 | [22010](https://github.com/airbytehq/airbyte/pull/22010) | Set `AvailabilityStrategy` for streams explicitly to `None`                                   |
-| 0.1.29  | 2022-10-31 | [18681](https://github.com/airbytehq/airbyte/pull/18681) | Define correct version for airbyte-cdk~=0.2                                                   |
-| 0.1.28  | 2022-10-20 | [18216](https://github.com/airbytehq/airbyte/pull/18216) | Use airbyte-cdk~=0.2.0 with SQLite caching                                                    |
-| 0.1.27  | 2022-08-28 | [17326](https://github.com/airbytehq/airbyte/pull/17326) | Migrate to per-stream states.                                                                 |
-| 0.1.26  | 2022-08-18 | [16540](https://github.com/airbytehq/airbyte/pull/16540) | Fix JSON schema                                                                               |
-| 0.1.25  | 2022-08-18 | [15681](https://github.com/airbytehq/airbyte/pull/15681) | Update Intercom API to v 2.5                                                                  |
-| 0.1.24  | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from schemas                                              |
-| 0.1.23  | 2022-07-19 | [14830](https://github.com/airbytehq/airbyte/pull/14830) | Added `checkpoint_interval` for Incremental streams                                           |
-| 0.1.22  | 2022-07-09 | [14554](https://github.com/airbytehq/airbyte/pull/14554) | Fixed `conversation_parts` stream schema definition                                           |
-| 0.1.21  | 2022-07-05 | [14403](https://github.com/airbytehq/airbyte/pull/14403) | Refactored  `Conversations`, `Conversation Parts`, `Company Segments` to increase performance |
-| 0.1.20  | 2022-06-24 | [14099](https://github.com/airbytehq/airbyte/pull/14099) | Extended `Contacts` stream schema with `sms_consent`,`unsubscribe_from_sms` properties        |
-| 0.1.19  | 2022-05-25 | [13204](https://github.com/airbytehq/airbyte/pull/13204) | Fixed `conversation_parts` stream schema definition                                           |
-| 0.1.18  | 2022-05-04 | [12482](https://github.com/airbytehq/airbyte/pull/12482) | Update input configuration copy                                                               |
-| 0.1.17  | 2022-04-29 | [12374](https://github.com/airbytehq/airbyte/pull/12374) | Fixed filtering of conversation_parts                                                         |
-| 0.1.16  | 2022-03-23 | [11206](https://github.com/airbytehq/airbyte/pull/11206) | Added conversation_id field to conversation_part records                                      |
-| 0.1.15  | 2022-03-22 | [11176](https://github.com/airbytehq/airbyte/pull/11176) | Correct `check_connection` URL                                                                |
-| 0.1.14  | 2022-03-16 | [11208](https://github.com/airbytehq/airbyte/pull/11208) | Improve 'conversations' incremental sync speed                                                |
-| 0.1.13  | 2022-01-14 | [9513](https://github.com/airbytehq/airbyte/pull/9513)   | Added handling of scroll param when it expired                                                |
-| 0.1.12  | 2021-12-14 | [8429](https://github.com/airbytehq/airbyte/pull/8429)   | Updated fields and descriptions                                                               |
-| 0.1.11  | 2021-12-13 | [8685](https://github.com/airbytehq/airbyte/pull/8685)   | Remove time.sleep for rate limit                                                              |
-| 0.1.10  | 2021-12-10 | [8637](https://github.com/airbytehq/airbyte/pull/8637)   | Fix 'conversations' order and sorting. Correction of the companies stream                     |
-| 0.1.9   | 2021-12-03 | [8395](https://github.com/airbytehq/airbyte/pull/8395)   | Fix backoff of 'companies' stream                                                             |
-| 0.1.8   | 2021-11-09 | [7060](https://github.com/airbytehq/airbyte/pull/7060)   | Added oauth support                                                                           |
-| 0.1.7   | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)   | Remove base-python dependencies                                                               |
-| 0.1.6   | 2021-10-07 | [6879](https://github.com/airbytehq/airbyte/pull/6879)   | Corrected pagination for contacts                                                             |
-| 0.1.5   | 2021-09-28 | [6082](https://github.com/airbytehq/airbyte/pull/6082)   | Corrected android\_last\_seen\_at field data type in schemas                                  |
-| 0.1.4   | 2021-09-20 | [6087](https://github.com/airbytehq/airbyte/pull/6087)   | Corrected updated\_at field data type in schemas                                              |
-| 0.1.3   | 2021-09-08 | [5908](https://github.com/airbytehq/airbyte/pull/5908)   | Corrected timestamp and arrays in schemas                                                     |
-| 0.1.2   | 2021-08-19 | [5531](https://github.com/airbytehq/airbyte/pull/5531)   | Corrected pagination                                                                          |
-| 0.1.1   | 2021-07-31 | [5123](https://github.com/airbytehq/airbyte/pull/5123)   | Corrected rate limit                                                                          |
-| 0.1.0   | 2021-07-19 | [4676](https://github.com/airbytehq/airbyte/pull/4676)   | Release Intercom CDK Connector                                                                |
+| Version | Date       | Pull Request                                             | Subject                                                                                                  |
+|:--------| :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------- |
+| 0.3.0   | 2023-05-25 | [29598](https://github.com/airbytehq/airbyte/pull/29598) | Update custom components to make them compatible with latest cdk==0.50.2, simplify logic, update schemas |
+| 0.2.1   | 2023-05-25 | [26571](https://github.com/airbytehq/airbyte/pull/26571) | Remove authSpecification from spec.json in favour of advancedAuth                                        |
+| 0.2.0   | 2023-04-05 | [23013](https://github.com/airbytehq/airbyte/pull/23013) | Migrated to Low-code (YAML Frramework)                                                                   |
+| 0.1.33  | 2023-03-20 | [22980](https://github.com/airbytehq/airbyte/pull/22980) | Specified date formatting in specification                                                               |
+| 0.1.32  | 2023-02-27 | [22095](https://github.com/airbytehq/airbyte/pull/22095) | Extended `Contacts` schema adding `opted_out_subscription_types` property                                |
+| 0.1.31  | 2023-02-17 | [23152](https://github.com/airbytehq/airbyte/pull/23152) | Add `TypeTransformer` to stream `companies`                                                              |
+| 0.1.30  | 2023-01-27 | [22010](https://github.com/airbytehq/airbyte/pull/22010) | Set `AvailabilityStrategy` for streams explicitly to `None`                                              |
+| 0.1.29  | 2022-10-31 | [18681](https://github.com/airbytehq/airbyte/pull/18681) | Define correct version for airbyte-cdk~=0.2                                                              |
+| 0.1.28  | 2022-10-20 | [18216](https://github.com/airbytehq/airbyte/pull/18216) | Use airbyte-cdk~=0.2.0 with SQLite caching                                                               |
+| 0.1.27  | 2022-08-28 | [17326](https://github.com/airbytehq/airbyte/pull/17326) | Migrate to per-stream states.                                                                            |
+| 0.1.26  | 2022-08-18 | [16540](https://github.com/airbytehq/airbyte/pull/16540) | Fix JSON schema                                                                                          |
+| 0.1.25  | 2022-08-18 | [15681](https://github.com/airbytehq/airbyte/pull/15681) | Update Intercom API to v 2.5                                                                             |
+| 0.1.24  | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from schemas                                                         |
+| 0.1.23  | 2022-07-19 | [14830](https://github.com/airbytehq/airbyte/pull/14830) | Added `checkpoint_interval` for Incremental streams                                                      |
+| 0.1.22  | 2022-07-09 | [14554](https://github.com/airbytehq/airbyte/pull/14554) | Fixed `conversation_parts` stream schema definition                                                      |
+| 0.1.21  | 2022-07-05 | [14403](https://github.com/airbytehq/airbyte/pull/14403) | Refactored  `Conversations`, `Conversation Parts`, `Company Segments` to increase performance            |
+| 0.1.20  | 2022-06-24 | [14099](https://github.com/airbytehq/airbyte/pull/14099) | Extended `Contacts` stream schema with `sms_consent`,`unsubscribe_from_sms` properties                   |
+| 0.1.19  | 2022-05-25 | [13204](https://github.com/airbytehq/airbyte/pull/13204) | Fixed `conversation_parts` stream schema definition                                                      |
+| 0.1.18  | 2022-05-04 | [12482](https://github.com/airbytehq/airbyte/pull/12482) | Update input configuration copy                                                                          |
+| 0.1.17  | 2022-04-29 | [12374](https://github.com/airbytehq/airbyte/pull/12374) | Fixed filtering of conversation_parts                                                                    |
+| 0.1.16  | 2022-03-23 | [11206](https://github.com/airbytehq/airbyte/pull/11206) | Added conversation_id field to conversation_part records                                                 |
+| 0.1.15  | 2022-03-22 | [11176](https://github.com/airbytehq/airbyte/pull/11176) | Correct `check_connection` URL                                                                           |
+| 0.1.14  | 2022-03-16 | [11208](https://github.com/airbytehq/airbyte/pull/11208) | Improve 'conversations' incremental sync speed                                                           |
+| 0.1.13  | 2022-01-14 | [9513](https://github.com/airbytehq/airbyte/pull/9513)   | Added handling of scroll param when it expired                                                           |
+| 0.1.12  | 2021-12-14 | [8429](https://github.com/airbytehq/airbyte/pull/8429)   | Updated fields and descriptions                                                                          |
+| 0.1.11  | 2021-12-13 | [8685](https://github.com/airbytehq/airbyte/pull/8685)   | Remove time.sleep for rate limit                                                                         |
+| 0.1.10  | 2021-12-10 | [8637](https://github.com/airbytehq/airbyte/pull/8637)   | Fix 'conversations' order and sorting. Correction of the companies stream                                |
+| 0.1.9   | 2021-12-03 | [8395](https://github.com/airbytehq/airbyte/pull/8395)   | Fix backoff of 'companies' stream                                                                        |
+| 0.1.8   | 2021-11-09 | [7060](https://github.com/airbytehq/airbyte/pull/7060)   | Added oauth support                                                                                      |
+| 0.1.7   | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)   | Remove base-python dependencies                                                                          |
+| 0.1.6   | 2021-10-07 | [6879](https://github.com/airbytehq/airbyte/pull/6879)   | Corrected pagination for contacts                                                                        |
+| 0.1.5   | 2021-09-28 | [6082](https://github.com/airbytehq/airbyte/pull/6082)   | Corrected android\_last\_seen\_at field data type in schemas                                             |
+| 0.1.4   | 2021-09-20 | [6087](https://github.com/airbytehq/airbyte/pull/6087)   | Corrected updated\_at field data type in schemas                                                         |
+| 0.1.3   | 2021-09-08 | [5908](https://github.com/airbytehq/airbyte/pull/5908)   | Corrected timestamp and arrays in schemas                                                                |
+| 0.1.2   | 2021-08-19 | [5531](https://github.com/airbytehq/airbyte/pull/5531)   | Corrected pagination                                                                                     |
+| 0.1.1   | 2021-07-31 | [5123](https://github.com/airbytehq/airbyte/pull/5123)   | Corrected rate limit                                                                                     |
+| 0.1.0   | 2021-07-19 | [4676](https://github.com/airbytehq/airbyte/pull/4676)   | Release Intercom CDK Connector                                                                           |

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -49,6 +49,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version | Date       | Pull Request                                             | Subject                                                                                       |
 |:--------| :--------- | :------------------------------------------------------- | :-------------------------------------------------------------------------------------------- |
+| 0.3.0   | 2023-05-25 | [29598](https://github.com/airbytehq/airbyte/pull/29598) | Migrate to latest cdk==0.50.2                                                                 |
 | 0.2.1   | 2023-05-25 | [26571](https://github.com/airbytehq/airbyte/pull/26571) | Remove authSpecification from spec.json in favour of advancedAuth                             |
 | 0.2.0   | 2023-04-05 | [23013](https://github.com/airbytehq/airbyte/pull/23013) | Migrated to Low-code (YAML Frramework)                                                        |
 | 0.1.33  | 2023-03-20 | [22980](https://github.com/airbytehq/airbyte/pull/22980) | Specified date formatting in specification                                                    |

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -49,7 +49,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                  |
 |:--------| :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------- |
-| 0.3.0   | 2023-05-25 | [29598](https://github.com/airbytehq/airbyte/pull/29598) | Update custom components to make them compatible with latest cdk==0.50.2, simplify logic, update schemas |
+| 0.3.0   | 2023-05-25 | [29598](https://github.com/airbytehq/airbyte/pull/29598) | Update custom components to make them compatible with latest cdk version, simplify logic, update schemas |
 | 0.2.1   | 2023-05-25 | [26571](https://github.com/airbytehq/airbyte/pull/26571) | Remove authSpecification from spec.json in favour of advancedAuth                                        |
 | 0.2.0   | 2023-04-05 | [23013](https://github.com/airbytehq/airbyte/pull/23013) | Migrated to Low-code (YAML Frramework)                                                                   |
 | 0.1.33  | 2023-03-20 | [22980](https://github.com/airbytehq/airbyte/pull/22980) | Specified date formatting in specification                                                               |


### PR DESCRIPTION
## What
*Migrating to latest cdk 0.29.0 -> 0.50.2*
- *`HttpRequesterWithRateLimiter` is now a subclass of `HttpRequester` and it has been simplified. It mostly uses inheritance except some parts related to `request_options_provider`. Because of limitation on custom component it is not allowed to include `request_options_provider` section to custom requester*
- *`IncrementalSingleSliceCursor` and `IncrementalSubstreamSlicer` were significantly changed because of changes in Slicer interface in cdk 0.50.2. They have also been simplified by reducing the amount of code and simplifying the logic*

https://github.com/airbytehq/airbyte/issues/28214

Fixed: #24486

## How
- *Change cdk and manifest version to 0.50.2*
- *Implement new interfaces for all custom components*
- *Make refactoring and rethinking of current slicing logic*
