### PR TITLE
✨ Source Mongodb POC: add initial state support to state iterator

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbSource.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbSource.java
@@ -36,6 +36,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.bson.BsonDocument;
@@ -179,16 +180,21 @@ public class MongoDbSource extends BaseConnector implements Source {
           // (or should this check and ignore them if all fields are selected)
           final var fields = Projections.fields(Projections.include(CatalogHelpers.getTopLevelFieldNames(airbyteStream).stream().toList()));
 
-          // The filter determines the starting point of this iterator based on the state of this collection.
-          // If a state exists, it will use that state to create a query akin to "where _id > [last saved
-          // state] order by _id ASC".
-          // If no state exists, it will create a query akin to "where 1=1 order by _id ASC"
-          final Bson filter = states.entrySet().stream()
+          // find the existing state, if there is one, for this steam
+          final Optional<MongodbStreamState> existingState = states.entrySet().stream()
               // look only for states that match this stream's name
+              // TODO add namespace support
               .filter(state -> state.getKey().equals(airbyteStream.getStream().getName()))
-              .findFirst()
+              .map(Entry::getValue)
+              .findFirst();
+
+          // The filter determines the starting point of this iterator based on the state of this collection.
+          // If a state exists, it will use that state to create a query akin to
+          // "where _id > [last saved state] order by _id ASC".
+          // If no state exists, it will create a query akin to "where 1=1 order by _id ASC"
+          final Bson filter = existingState
               // TODO add type support here when we add support for _id fields that are not ObjectId types
-              .map(entry -> Filters.gt("_id", new ObjectId(entry.getValue().id())))
+              .map(state -> Filters.gt("_id", new ObjectId(state.id())))
               // if nothing was found, return a new BsonDocument
               .orElseGet(BsonDocument::new);
 
@@ -199,7 +205,7 @@ public class MongoDbSource extends BaseConnector implements Source {
               .batchSize(fetchSize)
               .cursor();
 
-          final var stateIterator = new MongoDbStateIterator(cursor, airbyteStream, emittedAt, fetchSize);
+          final var stateIterator = new MongoDbStateIterator(cursor, airbyteStream, existingState, emittedAt, fetchSize);
           return AutoCloseableIterators.fromIterator(stateIterator, cursor::close, null);
         })
         .toList();

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java
@@ -20,10 +20,16 @@ import io.airbyte.protocol.models.v0.StreamDescriptor;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A state-emitting iterator that emits a state message every batchSize messages when iterating over a MongoCursor.
+ *
+ * Will also output a state message as the last message after the wrapper iterator has completed.
+ */
 class MongoDbStateIterator implements Iterator<AirbyteMessage> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbStateIterator.class);
@@ -40,22 +46,31 @@ class MongoDbStateIterator implements Iterator<AirbyteMessage> {
    */
   private int count = 0;
   /**
-   * Pointer to the last document seen by this iterator, necessary to track the _id field for state
-   * messages
+   * Pointer to the last document _id seen by this iterator, necessary to track for state messages.
    */
-  private Document last = null;
+  private String lastId = null;
   /**
    * This iterator outputs a final state when the wrapped `iter` has concluded. When this is true, the
    * final message will be returned.
    */
   private boolean finalStateNext = false;
 
-  MongoDbStateIterator(final MongoCursor<Document> iter, final ConfiguredAirbyteStream stream, final Instant emittedAt, final int batchSize) {
+  /**
+   * Constructor.
+   *
+   * @param iter MongoCursor that iterates over Mongo documents
+   * @param stream the stream that this iterator represents
+   * @param state the initial state of this stream
+   * @param emittedAt when this iterator was started
+   * @param batchSize how often a state message should be emitted.
+   */
+  MongoDbStateIterator(final MongoCursor<Document> iter, final ConfiguredAirbyteStream stream, Optional<MongodbStreamState> state, final Instant emittedAt, final int batchSize) {
     this.iter = iter;
     this.stream = stream;
     this.batchSize = batchSize;
     this.emittedAt = emittedAt;
     fields = CatalogHelpers.getTopLevelFieldNames(stream).stream().toList();
+    lastId = state.map(MongodbStreamState::id).orElse(null);
   }
 
   @Override
@@ -86,10 +101,9 @@ class MongoDbStateIterator implements Iterator<AirbyteMessage> {
           .withStreamDescriptor(new StreamDescriptor()
               .withName(stream.getStream().getName())
               .withNamespace(stream.getStream().getNamespace()));
-      if (last != null) {
+      if (lastId != null) {
         // TODO add type support in here once more than ObjectId fields are supported
-        streamState.withStreamState(Jsons.jsonNode(
-            new MongodbStreamState(last.getObjectId("_id").toString())));
+        streamState.withStreamState(Jsons.jsonNode(new MongodbStreamState(lastId)));
       }
 
       final var stateMessage = new AirbyteStateMessage()
@@ -103,7 +117,7 @@ class MongoDbStateIterator implements Iterator<AirbyteMessage> {
     final var document = iter.next();
     final var jsonNode = MongoUtils.toJsonNode(document, fields);
 
-    last = document;
+    lastId = document.getObjectId("_id").toString();
 
     return new AirbyteMessage()
         .withType(Type.RECORD)

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIteratorTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIteratorTest.java
@@ -20,6 +20,7 @@ import io.airbyte.protocol.models.v0.DestinationSyncMode;
 import io.airbyte.protocol.models.v0.SyncMode;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.AfterEach;
@@ -79,7 +80,7 @@ class MongoDbStateIteratorTest {
 
     final var stream = catalog().getStreams().stream().findFirst().orElseThrow();
 
-    final var iter = new MongoDbStateIterator(mongoCursor, stream, Instant.now(), BATCH_SIZE);
+    final var iter = new MongoDbStateIterator(mongoCursor, stream, Optional.empty() , Instant.now(), BATCH_SIZE);
 
     // with a batch size of 2, the MongoDbStateIterator should return the following after each
     // `hasNext`/`next` call:
@@ -137,7 +138,7 @@ class MongoDbStateIteratorTest {
 
     final var stream = catalog().getStreams().stream().findFirst().orElseThrow();
 
-    final var iter = new MongoDbStateIterator(mongoCursor, stream, Instant.now(), BATCH_SIZE);
+    final var iter = new MongoDbStateIterator(mongoCursor, stream, Optional.empty() , Instant.now(), BATCH_SIZE);
 
     // with a batch size of 2, the MongoDbStateIterator should return the following after each
     // `hasNext`/`next` call:


### PR DESCRIPTION
## What
- add initial state support to state iterator
    - if no new documents exist in the existing iterator, then the initial state will be returned instead of null