### PR TITLE
Docs: Update LinkedIn Ads Setup steps

### DIFF
--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -4,7 +4,7 @@ This page contains the setup guide and reference information for the LinkedIn Ad
 
 ## Prerequisites
 
-- The LinkedIn Ads account with permission to access data from accounts you want to sync.
+- A LinkedIn Ads account with permission to access data from accounts you want to sync.
 
 ## Setup guide
 

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -12,80 +12,60 @@ This page contains the setup guide and reference information for the LinkedIn Ad
 
 We recommend using **Oauth2.0** authentication for Airbyte Cloud, as this significantly simplifies the setup process, and allows you to authenticate your account directly from the Airbyte UI.
 
+<!-- /env:cloud -->
+
 <!-- env:oss -->
 
 ### Set up LinkedIn Ads authentication (Airbyte Open Source)
 
-You can authenticate the Linkedin Ads connector using one of the following options and credentials:
+To authenticate the Linkedin Ads connector, you will need to create a Linkedin developer application and use one of the following credentials:
 
-- OAuth2.0
-  - `Client ID` from your `Developer Application`
-  - `Client Secret` from your `Developer Application`
-  - `Refresh Token` obtained from successful authorization with `Client ID` + `Client Secret`
-- Access Token
-  - `Access Token` obtained from successful authorization with `Client ID` + `Client Secret`
+1. OAuth2.0 credentials, consisting of:
+
+   - Client ID
+   - Client Secret
+   - Refresh Token (expires after 12 months)
+
+2. Access Token (expires after 60 days)
+
+You can follow the steps laid out below to create the application and obtain the necessary credentials. For an overview of the LinkedIn authentication process, see the [official documentation](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authentication?context=linkedin%2Fcontext).
+
+#### Create a LinkedIn developer application
 
 1. [Log in to LinkedIn](https://developer.linkedin.com/) with a developer account.
-2. Click the **Create App** icon in the center of the page or [use here](https://www.linkedin.com/developers/apps). Fill in the required fields:  
+2. Navigate to the [Apps page](https://www.linkedin.com/developers/apps) and click the **Create App** icon. Fill in the fields below:
     1. For **App Name**, enter a name.
     2. For **LinkedIn Page**, enter your company's name or LinkedIn Company Page URL.
     3. For **Privacy policy URL**, enter the link to your company's privacy policy.
     4. For **App logo**, upload your company's logo.
-    5. For **Legal Agreement**, select **I have read and agree to these terms**.
-    6. Click **Create App**, on the bottom right of the screen. LinkedIn redirects you to a page showing the details of your application.
+    5. Check **I have read and agree to these terms**, then click **Create App**. LinkedIn redirects you to a page showing the details of your application.
 
 3. You can verify your app using the following steps:
-    1. To display the settings page, click the **Settings** tab. On the **App Settings** section, click **Verify** under **Company**. A popup window will be displayed. To generate the verification URL, click on **Generate URL**, then copy and send the URL to the Page Admin (this may be you). Click on **I'm done**.
-    If you are the administrator of your Page, simply run the URL in a new tab (if not, an administrator will have to do the next step). Click on **Verify**. Finally, Refresh the tab of app creation, the app should now be associated with your Page.
+    1. Click the **Settings** tab. On the **App Settings** section, click **Verify** under **Company**. A popup window will be displayed. To generate the verification URL, click on **Generate URL**, then copy and send the URL to the Page Admin (this may be you). Click on **I'm done**. If you are the administrator of your Page, simply run the URL in a new tab (if not, an administrator will have to do the next step). Click on **Verify**.
 
-    2. To display the Products page, click the **Product** tab. For **Marketing Developer Platform** click on the **Request access**. A popup window will be displayed. Review and Select **I have read and agree to these terms**. Finally, click **Request access**.
+    2. To display the Products page, click the **Product** tab. For **Marketing Developer Platform**, click **Request access**. A popup window will be displayed. Review and Select **I have read and agree to these terms**. Finally, click **Request access**.
 
-    3. To authorize your application, click the **Auth** tab. The authentication page is displayed. Copy the **client_id** and **client_secret** (for later steps). For **Oauth 2.0 settings**, Provide a **redirect_uri** (for later steps).
+#### Authorize your app
 
-    4. Click and review the **Analytics** tab. This page shows the daily application and user/member limits with the percent used for each resource endpoint.
+1. To authorize your application, click the **Auth** tab. Copy the **Client ID** and **Client Secret** (click the open eye icon to reveal the client secret). In the **Oauth 2.0 settings**, click the pencil icon and provide a redirect URL for your app.
 
-4. (Optional for Airbyte Cloud) Authorize your app. In case your authorization expires:
+2. Click the **OAuth 2.0 tools** link in the **Understanding authentication and OAuth 2.0** section on the right side of the page.
+3. Click **Create token**.
+4. Select the scopes you want to use for your app. We recommend using the following scopes:
+    - `r_emailaddress`
+    - `r_liteprofile`
+    - `r_ads`
+    - `r_ads_reporting`
+    - `r_organization_social`
+5. Click **Request access token**. You will be redirected to an authorization page. Use your LinkedIn credentials to log in and authorize your app and obtain your **Access Token** and **Refresh Token**.
 
-   The authorization token `lasts 60-days before expiring`. The connector app will need to be reauthorized when the authorization token expires.
-   Create an Authorization URL with the following steps:
+:::caution
+These tokens will not be displayed again, so make sure to copy them and store them securely.
+:::
 
-   1. Replace the highlighted parameters `YOUR_CLIENT_ID` and `YOUR_REDIRECT_URI` in the URL (`https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=YOUR_CLIENT_ID&redirect_uri=YOUR_REDIRECT_URI&scope=r_emailaddress,r_liteprofile,r_ads,r_ads_reporting,r_organization_social`) from the scope obtain below.
+#### Set the necessary user roles
 
-   2. Set up permissions for the following scopes `r_emailaddress,r_liteprofile,r_ads,r_ads_reporting,r_organization_social`. For **OAuth2.0**, copy the `Client ID`, and `Client Secret` from your `Developer Application`. And copy the `Refresh Token` obtained from successful authorization with `Client ID` + `Client Secret`
-
-   3. Enter the modified `URL` in the browser. You will be redirected.
-
-   4. To authorize the app, click **Allow**.
-
-   5. Copy the `code` parameter listed in the redirect URL in the Browser header URL.
-
-5. (Optional for Airbyte Cloud) Run the following curl command using `Terminal` or `Command line` with the parameters replaced to return your `access_token`. The `access_token` expires in 2-months.
-
-   ```text
-    curl -0 -v -X POST https://www.linkedin.com/oauth/v2/accessToken\
-    -H "Accept: application/json"\
-    -H "application/x-www-form-urlencoded"\
-    -d "grant_type=authorization_code"\
-    -d "code=YOUR_CODE"\
-    -d "client_id=YOUR_CLIENT_ID"\
-    -d "client_secret=YOUR_CLIENT_SECRET"\
-    -d "redirect_uri=YOUR_REDIRECT_URI"
-   ```
-
-6. (Optional for Airbyte Cloud) Use the `access_token`. Same as the approach in  `Step 5` to authorize LinkedIn Ads connector.
-
-:::note
-
-The API user account should be assigned the following permissions for the API endpoints:
-Endpoints such as: `Accounts`, `Account Users`, `Ad Direct Sponsored Contents`, `Campaign Groups`, `Campaigns`, and `Creatives` requires the following permissions set:
-
-- `r_ads`: read ads \(Recommended\), `rw_ads`: read-write ads
-  Endpoints such as: `Ad Analytics by Campaign`, and `Ad Analytics by Creatives` requires the following permissions set:
-- `r_ads_reporting`: read ads reporting
-  The complete set of permissions is as follows:
-- `r_emailaddress,r_liteprofile,r_ads,r_ads_reporting,r_organization_social`
-
-The API user account should be assigned one of the following roles:
+Before proceeding, ensure that the Linkedin Ads user is assigned one of the following roles:
 
 - ACCOUNT_BILLING_ADMIN
 - ACCOUNT_MANAGER
@@ -93,35 +73,45 @@ The API user account should be assigned one of the following roles:
 - CREATIVE_MANAGER
 - VIEWER \(Recommended\)
 
-To edit these roles, sign in to Campaign Manager and follow [these instructions](https://www.linkedin.com/help/lms/answer/a496075).
-
-:::
+To edit these roles, sign in to Campaign Manager and follow [these instructions](https://www.linkedin.com/help/lms/answer/a496075). More information on the access levels granted to each role can be found [here](https://www.linkedin.com/help/lms/answer/a425731/user-roles-and-permissions-in-campaign-manager?lang=en-us&intendedLocale=en).
 
 <!-- /env:oss -->
 
 ### Set up the LinkedIn Ads connector in Airbyte
 
-<!-- env:cloud -->
-#### For Airbyte Cloud:
+1. [Log in to your Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
+2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
+3. Find and select **LinkedIn Ads** from the list of available sources.
+4. For **Source name**, enter a name for the LinkedIn Ads connector.
+5. To authenticate:
 
-1. [Login to your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
-2. Click **Sources** and then click **+ New source**.
-3. On the Set up the source page, select **LinkedIn Ads** from the **Source type** dropdown.
-4. Enter a name for the LinkedIn Ads connector.
-5. Click **Authenticate your account**.
-6. Login and Authorize the LinkedIn Ads account
-7. Add `Start Date` - the starting point for your data replication.
-8. (Optional) Add your `Account IDs` if required.
-9. (Optional) Add `Custom Ad Analytics reports` by:
-   * click on **Add**
-   * complete the Name for the Report
-   * select **Pivot By** property for the report from the list
-   * select **Time Granularity** property for the report from the list
-10. Click **Set up source** and wait for the tests to complete.
+<!-- env:cloud -->
+#### For Airbyte Cloud
+
+- Click **Authenticate your account**.
+- Login and Authorize the LinkedIn Ads account
 <!-- /env:cloud -->
 
 <!-- env:oss -->
-#### For Airbyte Open Source:
+#### For Airbyte Open Source
+
+- Choose between Authentication Options:
+    1. For **OAuth2.0:** Copy and paste info (**Client ID**, **Client Secret**) from your **LinkedIn Ads developer application**, and obtain the **Refresh Token** using **Set up LinkedIn Ads**  guide steps and paste it into the corresponding field.
+    2. For **Access Token:** Obtain the **Access Token** using **Set up LinkedIn Ads**  guide steps and paste it into the corresponding field.
+<!-- /env:oss -->
+
+6. For **Start Date**, use the provided datepicker or enter a date programmatically in the format YYYY-MM-DD. Any data before this date will not be replicated.
+7. (Optional) For **Account IDs**, you may optionally provide a space separated list of Account IDs . If you do not specify any account IDs, the connector will replicate data from all accounts.
+8. (Optional) For **Custom Ad Analytics Reports**, you may optionally provide one or more custom reports to query the LinkedIn Ads API for. To add a custom report:
+   1. Click on **Add**.
+   2. Enter a **Name** for your report. This name will be used as the stream name in Airbyte.
+   3. For **Pivot By** property for the report from the list
+   * select **Time Granularity** property for the report from the list
+9. Click **Set up source** and wait for the tests to complete.
+<!-- /env:cloud -->
+
+<!-- env:oss -->
+#### For Airbyte Open Source
 
 1. Go to the local Airbyte page.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -4,30 +4,28 @@ This page contains the setup guide and reference information for the LinkedIn Ad
 
 ## Prerequisites
 
-<!-- env:cloud -->
-### For Airbyte Cloud
-
-* The LinkedIn Ads account with permission to access data from accounts you want to sync.
-<!-- /env:cloud -->
-
-<!-- env:oss -->
-### For Airbyte Open Source
-
-* The LinkedIn Ads account with permission to access data from accounts you want to sync.
-* Authentication Options:
-   * OAuth2.0:
-      * `Client ID` from your `Developer Application`
-      * `Client Secret` from your `Developer Application`
-      * `Refresh Token` obtained from successful authorization with `Client ID` + `Client Secret`
-   * Access Token:
-      * `Access Token` obtained from successful authorization with `Client ID` + `Client Secret`
-<!-- /env:oss -->
+- The LinkedIn Ads account with permission to access data from accounts you want to sync.
 
 ## Setup guide
 
-### Step 1: Set up LinkedIn Ads
+<!-- env:cloud -->
 
-1. [Login to LinkedIn](https://developer.linkedin.com/) with a developer account.
+We recommend using **Oauth2.0** authentication for Airbyte Cloud, as this significantly simplifies the setup process, and allows you to authenticate your account directly from the Airbyte UI.
+
+<!-- env:oss -->
+
+### Set up LinkedIn Ads authentication (Airbyte Open Source)
+
+You can authenticate the Linkedin Ads connector using one of the following options and credentials:
+
+- OAuth2.0
+  - `Client ID` from your `Developer Application`
+  - `Client Secret` from your `Developer Application`
+  - `Refresh Token` obtained from successful authorization with `Client ID` + `Client Secret`
+- Access Token
+  - `Access Token` obtained from successful authorization with `Client ID` + `Client Secret`
+
+1. [Log in to LinkedIn](https://developer.linkedin.com/) with a developer account.
 2. Click the **Create App** icon in the center of the page or [use here](https://www.linkedin.com/developers/apps). Fill in the required fields:  
     1. For **App Name**, enter a name.
     2. For **LinkedIn Page**, enter your company's name or LinkedIn Company Page URL.
@@ -36,16 +34,15 @@ This page contains the setup guide and reference information for the LinkedIn Ad
     5. For **Legal Agreement**, select **I have read and agree to these terms**.
     6. Click **Create App**, on the bottom right of the screen. LinkedIn redirects you to a page showing the details of your application.
 
-3. Verify your app. You can verify your app using the following steps:
+3. You can verify your app using the following steps:
     1. To display the settings page, click the **Settings** tab. On the **App Settings** section, click **Verify** under **Company**. A popup window will be displayed. To generate the verification URL, click on **Generate URL**, then copy and send the URL to the Page Admin (this may be you). Click on **I'm done**.
     If you are the administrator of your Page, simply run the URL in a new tab (if not, an administrator will have to do the next step). Click on **Verify**. Finally, Refresh the tab of app creation, the app should now be associated with your Page.
 
-    2.  To display the Products page, click the **Product** tab. For **Marketing Developer Platform** click on the **Request access**. A popup window will be displayed. Review and Select **I have read and agree to these terms**. Finally, click **Request access**. 
-    
-    3. To authorize your application, click the **Auth** tab. The authentication page is displayed. Copy the **client_id** and **client_secret** (for later steps). For **Oauth 2.0 settings**, Provide a **redirect_uri** (for later steps).
-    
-    4. Click and review the **Analytics** tab. This page shows the daily application and user/member limits with the percent used for each resource endpoint.
+    2. To display the Products page, click the **Product** tab. For **Marketing Developer Platform** click on the **Request access**. A popup window will be displayed. Review and Select **I have read and agree to these terms**. Finally, click **Request access**.
 
+    3. To authorize your application, click the **Auth** tab. The authentication page is displayed. Copy the **client_id** and **client_secret** (for later steps). For **Oauth 2.0 settings**, Provide a **redirect_uri** (for later steps).
+
+    4. Click and review the **Analytics** tab. This page shows the daily application and user/member limits with the percent used for each resource endpoint.
 
 4. (Optional for Airbyte Cloud) Authorize your app. In case your authorization expires:
 
@@ -61,7 +58,7 @@ This page contains the setup guide and reference information for the LinkedIn Ad
    4. To authorize the app, click **Allow**.
 
    5. Copy the `code` parameter listed in the redirect URL in the Browser header URL.
-   
+
 5. (Optional for Airbyte Cloud) Run the following curl command using `Terminal` or `Command line` with the parameters replaced to return your `access_token`. The `access_token` expires in 2-months.
 
    ```text
@@ -100,7 +97,9 @@ To edit these roles, sign in to Campaign Manager and follow [these instructions]
 
 :::
 
-### Step 2: Set up the LinkedIn Ads connector in Airbyte
+<!-- /env:oss -->
+
+### Set up the LinkedIn Ads connector in Airbyte
 
 <!-- env:cloud -->
 #### For Airbyte Cloud:
@@ -118,7 +117,7 @@ To edit these roles, sign in to Campaign Manager and follow [these instructions]
    * complete the Name for the Report
    * select **Pivot By** property for the report from the list
    * select **Time Granularity** property for the report from the list
-10. Click **Set up source**.
+10. Click **Set up source** and wait for the tests to complete.
 <!-- /env:cloud -->
 
 <!-- env:oss -->
@@ -144,7 +143,7 @@ To edit these roles, sign in to Campaign Manager and follow [these instructions]
 
 ## Supported sync modes
 
-The LinkedIn Ads source connector supports the following[ sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
+The LinkedIn Ads source connector supports the following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
 
 - [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-overwrite/)
 - [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append)

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -18,7 +18,7 @@ We recommend using **Oauth2.0** authentication for Airbyte Cloud, as this signif
 
 ### Set up LinkedIn Ads authentication (Airbyte Open Source)
 
-To authenticate the Linkedin Ads connector, you will need to create a Linkedin developer application and obtain one of the following credentials:
+To authenticate the connector in Airbyte Open Source, you will need to create a Linkedin developer application and obtain one of the following credentials:
 
 1. OAuth2.0 credentials, consisting of:
 
@@ -63,6 +63,10 @@ You can follow the steps laid out below to create the application and obtain the
 These tokens will not be displayed again, so make sure to copy them and store them securely.
 :::
 
+:::tip
+If either of your tokens expire, you can generate new ones by returning to LinkedIn's [Token Generator](https://www.linkedin.com/developers/tools/oauth/token-generator). You can also check on the status of your tokens using the [Token Inspector](https://www.linkedin.com/developers/tools/oauth/token-inspector).
+:::
+
 <!-- /env:oss -->
 
 ### Set up the LinkedIn Ads connector in Airbyte
@@ -83,21 +87,21 @@ These tokens will not be displayed again, so make sure to copy them and store th
 #### For Airbyte Open Source
 
 - Select an option from the Authentication dropdown:
-    1. For **OAuth2.0:** Enter your **Client ID**, **Client Secret** and **Refresh Token**. Please note that the refresh token expires after 12 months.
-    2. For **Access Token:** Enter your **Access Token**. Please note that the access token expires after 60 days. You can refresh the token
+  1. **OAuth2.0:** Enter your **Client ID**, **Client Secret** and **Refresh Token**. Please note that the refresh token expires after 12 months.
+  2. **Access Token:** Enter your **Access Token**. Please note that the access token expires after 60 days.
 <!-- /env:oss -->
 
 6. For **Start Date**, use the provided datepicker or enter a date programmatically in the format YYYY-MM-DD. Any data before this date will not be replicated.
 7. (Optional) For **Account IDs**, you may optionally provide a space separated list of Account IDs to pull data from. If you do not specify any account IDs, the connector will replicate data from all associated accounts.
-8. (Optional) For **Custom Ad Analytics Reports**, you may optionally provide one or more custom reports to query the LinkedIn Ads API for. To add a custom report:
+8. (Optional) For **Custom Ad Analytics Reports**, you may optionally provide one or more custom reports to query the LinkedIn Ads API for. By defining custom reports, you can better align the data pulled form LinkedIn Ads with your particular needs. To add a custom report:
    1. Click on **Add**.
-   2. Enter a **Report Name**.
-   3. Select a **Pivot Category** from the dropdown. This will be used to pivot the data in the report.
+   2. Enter a **Report Name**. This will be used as the stream name during replication.
+   3. Select a **Pivot Category** from the dropdown. This defines the main dimension by which the report data will be grouped or segmented.
    4. Select a **Time Granularity** to group the data in your report by time. The options are:
-      - `ALL`: Data is not grouped by time, and returns summarized in a single result.
-      - `DAILY`: Returns data grouped by day.
-      - `MONTHLY`: Returns data grouped by month.
-      - `YEARLY`: Returns data grouped by year.
+      - `ALL`: Data is not grouped by time, providing a cumulative view.
+      - `DAILY`: Returns data grouped by day. Useful for closely monitoring short-term changes and effects.
+      - `MONTHLY`: Returns data grouped by month. Ideal for evaluating monthly goals or observing seasonal patterns.
+      - `YEARLY`: Returns data grouped by year. Ideal for high-level analysis of long-term trends and year-over-year comparisons.
 9. Click **Set up source** and wait for the tests to complete.
 <!-- /env:cloud -->
 

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -18,7 +18,7 @@ We recommend using **Oauth2.0** authentication for Airbyte Cloud, as this signif
 
 ### Set up LinkedIn Ads authentication (Airbyte Open Source)
 
-To authenticate the Linkedin Ads connector, you will need to create a Linkedin developer application and use one of the following credentials:
+To authenticate the Linkedin Ads connector, you will need to create a Linkedin developer application and obtain one of the following credentials:
 
 1. OAuth2.0 credentials, consisting of:
 
@@ -63,18 +63,6 @@ You can follow the steps laid out below to create the application and obtain the
 These tokens will not be displayed again, so make sure to copy them and store them securely.
 :::
 
-#### Set the necessary user roles
-
-Before proceeding, ensure that the Linkedin Ads user is assigned one of the following roles:
-
-- ACCOUNT_BILLING_ADMIN
-- ACCOUNT_MANAGER
-- CAMPAIGN_MANAGER
-- CREATIVE_MANAGER
-- VIEWER \(Recommended\)
-
-To edit these roles, sign in to Campaign Manager and follow [these instructions](https://www.linkedin.com/help/lms/answer/a496075). More information on the access levels granted to each role can be found [here](https://www.linkedin.com/help/lms/answer/a425731/user-roles-and-permissions-in-campaign-manager?lang=en-us&intendedLocale=en).
-
 <!-- /env:oss -->
 
 ### Set up the LinkedIn Ads connector in Airbyte
@@ -88,48 +76,30 @@ To edit these roles, sign in to Campaign Manager and follow [these instructions]
 <!-- env:cloud -->
 #### For Airbyte Cloud
 
-- Click **Authenticate your account**.
-- Login and Authorize the LinkedIn Ads account
+- Select **OAuth2.0** from the Authentication dropdown, then click **Authenticate your LinkedIn Ads account**. Sign in to your account and click **Allow**.
 <!-- /env:cloud -->
 
 <!-- env:oss -->
 #### For Airbyte Open Source
 
-- Choose between Authentication Options:
-    1. For **OAuth2.0:** Copy and paste info (**Client ID**, **Client Secret**) from your **LinkedIn Ads developer application**, and obtain the **Refresh Token** using **Set up LinkedIn Ads**  guide steps and paste it into the corresponding field.
-    2. For **Access Token:** Obtain the **Access Token** using **Set up LinkedIn Ads**  guide steps and paste it into the corresponding field.
+- Select an option from the Authentication dropdown:
+    1. For **OAuth2.0:** Enter your **Client ID**, **Client Secret** and **Refresh Token**. Please note that the refresh token expires after 12 months.
+    2. For **Access Token:** Enter your **Access Token**. Please note that the access token expires after 60 days. You can refresh the token
 <!-- /env:oss -->
 
 6. For **Start Date**, use the provided datepicker or enter a date programmatically in the format YYYY-MM-DD. Any data before this date will not be replicated.
-7. (Optional) For **Account IDs**, you may optionally provide a space separated list of Account IDs . If you do not specify any account IDs, the connector will replicate data from all accounts.
+7. (Optional) For **Account IDs**, you may optionally provide a space separated list of Account IDs to pull data from. If you do not specify any account IDs, the connector will replicate data from all associated accounts.
 8. (Optional) For **Custom Ad Analytics Reports**, you may optionally provide one or more custom reports to query the LinkedIn Ads API for. To add a custom report:
    1. Click on **Add**.
-   2. Enter a **Name** for your report. This name will be used as the stream name in Airbyte.
-   3. For **Pivot By** property for the report from the list
-   * select **Time Granularity** property for the report from the list
+   2. Enter a **Report Name**.
+   3. Select a **Pivot Category** from the dropdown. This will be used to pivot the data in the report.
+   4. Select a **Time Granularity** to group the data in your report by time. The options are:
+      - `ALL`: Data is not grouped by time, and returns summarized in a single result.
+      - `DAILY`: Returns data grouped by day.
+      - `MONTHLY`: Returns data grouped by month.
+      - `YEARLY`: Returns data grouped by year.
 9. Click **Set up source** and wait for the tests to complete.
 <!-- /env:cloud -->
-
-<!-- env:oss -->
-#### For Airbyte Open Source
-
-1. Go to the local Airbyte page.
-2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
-3. On the Set up the source page, enter the name for the connector and select **LinkedIn Ads** from the Source type dropdown.
-4. Add `Start Date` - the starting point for your data replication.
-5. Add your `Account IDs (Optional)` if required.
-6. Choose between Authentication Options:
-    1. For **OAuth2.0:** Copy and paste info (**Client ID**, **Client Secret**) from your **LinkedIn Ads developer application**, and obtain the **Refresh Token** using **Set up LinkedIn Ads**  guide steps and paste it into the corresponding field.
-    2. For **Access Token:** Obtain the **Access Token** using **Set up LinkedIn Ads**  guide steps and paste it into the corresponding field.
-7. Add `Start Date` - the starting point for your data replication.
-8. (Optional) Add your `Account IDs` if required.
-9. (Optional) Add `Custom Ad Analytics reports` by:
-   * click on **Add**
-   * complete the Name for the Report
-   * select **Pivot By** property for the report from the list
-   * select **Time Granularity** property for the report from the list
-10. Click **Set up source**.
-<!-- /env:oss -->
 
 ## Supported sync modes
 
@@ -140,7 +110,7 @@ The LinkedIn Ads source connector supports the following [sync modes](https://do
 - [Incremental Sync - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append)
 - [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped)
 
-## Supported Streams
+## Supported streams
 
 - [Accounts](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts?tabs=http&view=li-lms-2023-05#search-for-accounts)
 - [Account Users](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-account-users?tabs=http&view=li-lms-2023-05#find-ad-account-users-by-accounts)

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -92,7 +92,7 @@ If either of your tokens expire, you can generate new ones by returning to Linke
 <!-- /env:oss -->
 
 6. For **Start Date**, use the provided datepicker or enter a date programmatically in the format YYYY-MM-DD. Any data before this date will not be replicated.
-7. (Optional) For **Account IDs**, you may optionally provide a space separated list of Account IDs to pull data from. If you do not specify any account IDs, the connector will replicate data from all associated accounts.
+7. (Optional) For **Account IDs**, you may optionally provide a space separated list of Account IDs to pull data from. If you do not specify any account IDs, the connector will replicate data from all accounts accessible using your credentials.
 8. (Optional) For **Custom Ad Analytics Reports**, you may optionally provide one or more custom reports to query the LinkedIn Ads API for. By defining custom reports, you can better align the data pulled form LinkedIn Ads with your particular needs. To add a custom report:
    1. Click on **Add**.
    2. Enter a **Report Name**. This will be used as the stream name during replication.


### PR DESCRIPTION
## What
Updated the setup instructions for Linkedin Ads

## How
- Updated pre-connector authentication steps. LinkedIn has added a built-in tool for generating and refreshing auth tokens that is extremely quick and easy to use, so I've listed it as the way to go for OSS users.
- Merged cloud/oss instructions where possible.
- Added a little more context to various fields.
