### PR TITLE
qa-checks: Ignore jar files for HTTPS checks

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py
@@ -168,7 +168,7 @@ IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS = {
     ".hypothesis",
 }
 
-IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS = {"*Test.java", "*.pyc", "*.gz", "*.svg"}
+IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS = {"*Test.java", "*.jar", "*.pyc", "*.gz", "*.svg"}
 IGNORED_URLS_PREFIX = {
     "http://json-schema.org",
     "http://localhost",


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

When running QA Checks for java connectors, we see this line:

```
airbyte-integrations/connectors/destination-snowflake/lib/snowflake-jdbc.jar could not be decoded as it is not UTF8.
```

Which comes from https://github.com/airbytehq/airbyte/blob/96e862f8f4c9d195c494efb2e8a321eb2281dc10/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py#L155

We should ignore jar files when checking for HTTPS urls.

## How

Add it to the exclusions list
