### PR TITLE
add migrator

### DIFF
--- a/airbyte-integrations/bases/base-typing-deduping-test/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
+++ b/airbyte-integrations/bases/base-typing-deduping-test/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseTypingDedupingTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseTypingDedupingTest.class);
-  private static final JsonNode SCHEMA;
+  protected static final JsonNode SCHEMA;
   static {
     try {
       SCHEMA = Jsons.deserialize(MoreResources.readResource("dat/schema.json"));
@@ -76,8 +76,8 @@ public abstract class BaseTypingDedupingTest {
 
   private String randomSuffix;
   private JsonNode config;
-  private String streamNamespace;
-  private String streamName;
+  protected String streamNamespace;
+  protected String streamName;
   private List<AirbyteStreamNameNamespacePair> streamsToTearDown;
 
   /**
@@ -569,7 +569,7 @@ public abstract class BaseTypingDedupingTest {
     // this test probably needs some configuration per destination to specify what values are supported?
   }
 
-  private void verifySyncResult(final List<JsonNode> expectedRawRecords, final List<JsonNode> expectedFinalRecords) throws Exception {
+  protected void verifySyncResult(final List<JsonNode> expectedRawRecords, final List<JsonNode> expectedFinalRecords) throws Exception {
     verifySyncResult(expectedRawRecords, expectedFinalRecords, streamNamespace, streamName);
   }
 
@@ -592,7 +592,7 @@ public abstract class BaseTypingDedupingTest {
         .toList();
   }
 
-  private List<AirbyteMessage> readMessages(final String filename) throws IOException {
+  protected List<AirbyteMessage> readMessages(final String filename) throws IOException {
     return readMessages(filename, streamNamespace, streamName);
   }
 
@@ -629,7 +629,11 @@ public abstract class BaseTypingDedupingTest {
         Collections.emptyMap());
   }
 
-  private void runSync(final ConfiguredAirbyteCatalog catalog, final List<AirbyteMessage> messages) throws Exception {
+  protected void runSync(final ConfiguredAirbyteCatalog catalog, final List<AirbyteMessage> messages) throws Exception {
+    runSync(catalog, messages, getImageName());
+  }
+
+  protected void runSync(final ConfiguredAirbyteCatalog catalog, final List<AirbyteMessage> messages, final String imageName) throws Exception {
     catalog.getStreams().forEach(s -> streamsToTearDown.add(AirbyteStreamNameNamespacePair.fromAirbyteStream(s.getStream())));
 
     final WorkerDestinationConfig destinationConfig = new WorkerDestinationConfig()
@@ -640,7 +644,7 @@ public abstract class BaseTypingDedupingTest {
     final AirbyteDestination destination = new DefaultAirbyteDestination(new AirbyteIntegrationLauncher(
         "0",
         0,
-        getImageName(),
+        imageName,
         processFactory,
         null,
         null,

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/DefaultTyperDeduper.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/DefaultTyperDeduper.java
@@ -54,11 +54,10 @@ public class DefaultTyperDeduper<DialectTableDefinition> implements TyperDeduper
   }
 
   public DefaultTyperDeduper(
-      final SqlGenerator<DialectTableDefinition> sqlGenerator,
-      final DestinationHandler<DialectTableDefinition> destinationHandler,
-      final ParsedCatalog parsedCatalog,
-      final DestinationV1V2Migrator<DialectTableDefinition> v1V2Migrator
-  ) {
+                             final SqlGenerator<DialectTableDefinition> sqlGenerator,
+                             final DestinationHandler<DialectTableDefinition> destinationHandler,
+                             final ParsedCatalog parsedCatalog,
+                             final DestinationV1V2Migrator<DialectTableDefinition> v1V2Migrator) {
     this(sqlGenerator, destinationHandler, parsedCatalog, v1V2Migrator, new NoopV2RawTableMigrator<>());
   }
 

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/NoopV2RawTableMigrator.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/NoopV2RawTableMigrator.java
@@ -1,0 +1,8 @@
+package io.airbyte.integrations.base.destination.typing_deduping;
+
+public class NoopV2RawTableMigrator<DialectTableDefinition> implements V2RawTableMigrator<DialectTableDefinition> {
+  @Override
+  public void migrateIfNecessary(final StreamConfig streamConfig) {
+    // do nothing
+  }
+}

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/NoopV2RawTableMigrator.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/NoopV2RawTableMigrator.java
@@ -1,8 +1,14 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.base.destination.typing_deduping;
 
 public class NoopV2RawTableMigrator<DialectTableDefinition> implements V2RawTableMigrator<DialectTableDefinition> {
+
   @Override
   public void migrateIfNecessary(final StreamConfig streamConfig) {
     // do nothing
   }
+
 }

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/V2RawTableMigrator.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/V2RawTableMigrator.java
@@ -1,0 +1,5 @@
+package io.airbyte.integrations.base.destination.typing_deduping;
+
+public interface V2RawTableMigrator<DialectTableDefinition> {
+  void migrateIfNecessary(final StreamConfig streamConfig) throws InterruptedException;
+}

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/V2RawTableMigrator.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/V2RawTableMigrator.java
@@ -1,5 +1,11 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.base.destination.typing_deduping;
 
 public interface V2RawTableMigrator<DialectTableDefinition> {
+
   void migrateIfNecessary(final StreamConfig streamConfig) throws InterruptedException;
+
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -37,6 +37,7 @@ import io.airbyte.integrations.destination.bigquery.formatter.GcsCsvBigQueryReco
 import io.airbyte.integrations.destination.bigquery.typing_deduping.BigQueryDestinationHandler;
 import io.airbyte.integrations.destination.bigquery.typing_deduping.BigQuerySqlGenerator;
 import io.airbyte.integrations.destination.bigquery.typing_deduping.BigQueryV1V2Migrator;
+import io.airbyte.integrations.destination.bigquery.typing_deduping.BigQueryV2RawTableMigrator;
 import io.airbyte.integrations.destination.bigquery.uploader.AbstractBigQueryUploader;
 import io.airbyte.integrations.destination.bigquery.uploader.BigQueryUploaderFactory;
 import io.airbyte.integrations.destination.bigquery.uploader.UploaderType;
@@ -228,7 +229,7 @@ public class BigQueryDestination extends BaseConnector implements Destination {
       }
     }
 
-    String datasetLocation = BigQueryUtils.getDatasetLocation(config);
+    final String datasetLocation = BigQueryUtils.getDatasetLocation(config);
     final BigQuerySqlGenerator sqlGenerator = new BigQuerySqlGenerator(datasetLocation);
     final CatalogParser catalogParser;
     if (TypingAndDedupingFlag.getRawNamespaceOverride(RAW_DATA_DATASET).isPresent()) {
@@ -239,15 +240,17 @@ public class BigQueryDestination extends BaseConnector implements Destination {
     final ParsedCatalog parsedCatalog;
 
     final BigQuery bigquery = getBigQuery(config);
-    TyperDeduper typerDeduper;
+    final TyperDeduper typerDeduper;
     if (TypingAndDedupingFlag.isDestinationV2()) {
       parsedCatalog = catalogParser.parseCatalog(catalog);
-      BigQueryV1V2Migrator migrator = new BigQueryV1V2Migrator(bigquery, namingResolver);
+      final BigQueryV1V2Migrator migrator = new BigQueryV1V2Migrator(bigquery, namingResolver);
+      final BigQueryV2RawTableMigrator v2RawTableMigrator = new BigQueryV2RawTableMigrator(bigquery);
       typerDeduper = new DefaultTyperDeduper<>(
           sqlGenerator,
           new BigQueryDestinationHandler(bigquery, datasetLocation),
           parsedCatalog,
-          migrator);
+          migrator,
+          v2RawTableMigrator);
     } else {
       parsedCatalog = null;
       typerDeduper = new NoopTyperDeduper();
@@ -276,7 +279,7 @@ public class BigQueryDestination extends BaseConnector implements Destination {
       final StreamConfig parsedStream;
 
       final String streamName = stream.getName();
-      String targetTableName;
+      final String targetTableName;
       if (use1s1t) {
         parsedStream = parsedCatalog.getStream(stream.getNamespace(), stream.getName());
         targetTableName = parsedStream.id().rawName();
@@ -357,7 +360,7 @@ public class BigQueryDestination extends BaseConnector implements Destination {
     );
   }
 
-  public AirbyteMessageConsumer getGcsRecordConsumer(BigQuery bigQuery,
+  public AirbyteMessageConsumer getGcsRecordConsumer(final BigQuery bigQuery,
                                                      final JsonNode config,
                                                      final ConfiguredAirbyteCatalog catalog,
                                                      final ParsedCatalog parsedCatalog,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -342,7 +342,8 @@ public class BigQueryDestination extends BaseConnector implements Destination {
                                                            final ParsedCatalog parsedCatalog,
                                                            final Consumer<AirbyteMessage> outputRecordCollector,
                                                            final TyperDeduper typerDeduper)
-      throws IOException {
+      throws Exception {
+    typerDeduper.prepareTables();
     final Map<AirbyteStreamNameNamespacePair, AbstractBigQueryUploader<?>> writeConfigs = getUploaderMap(
         bigquery,
         config,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryRecordConsumer.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryRecordConsumer.java
@@ -48,11 +48,11 @@ public class BigQueryRecordConsumer extends FailureTrackingAirbyteMessageConsume
 
 
   public BigQueryRecordConsumer(final BigQuery bigquery,
-      final Map<AirbyteStreamNameNamespacePair, AbstractBigQueryUploader<?>> uploaderMap,
-      final Consumer<AirbyteMessage> outputRecordCollector,
-      final String defaultDatasetId,
-      TyperDeduper typerDeduper,
-      final ParsedCatalog catalog) {
+                                final Map<AirbyteStreamNameNamespacePair, AbstractBigQueryUploader<?>> uploaderMap,
+                                final Consumer<AirbyteMessage> outputRecordCollector,
+                                final String defaultDatasetId,
+                                final TyperDeduper typerDeduper,
+                                final ParsedCatalog catalog) {
     this.bigquery = bigquery;
     this.uploaderMap = uploaderMap;
     this.outputRecordCollector = outputRecordCollector;
@@ -66,13 +66,12 @@ public class BigQueryRecordConsumer extends FailureTrackingAirbyteMessageConsume
   }
 
   @Override
-  protected void startTracked() throws Exception {
+  protected void startTracked() {
     // todo (cgardens) - move contents of #write into this method.
-    typerDeduper.prepareTables();
     if (use1s1t) {
       // Set up our raw tables
       uploaderMap.forEach((streamId, uploader) -> {
-        StreamConfig stream = catalog.getStream(streamId);
+        final StreamConfig stream = catalog.getStream(streamId);
         if (stream.destinationSyncMode() == DestinationSyncMode.OVERWRITE) {
           // For streams in overwrite mode, truncate the raw table.
           // non-1s1t syncs actually overwrite the raw table at the end of the sync, so we only do this in

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryV2RawTableMigrator.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryV2RawTableMigrator.java
@@ -1,0 +1,64 @@
+package io.airbyte.integrations.destination.bigquery.typing_deduping;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
+import io.airbyte.integrations.base.JavaBaseConstants;
+import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig;
+import io.airbyte.integrations.base.destination.typing_deduping.V2RawTableMigrator;
+import java.util.Map;
+import org.apache.commons.text.StringSubstitutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BigQueryV2RawTableMigrator implements V2RawTableMigrator<TableDefinition> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryV2RawTableMigrator.class);
+
+  private final BigQuery bq;
+
+  public BigQueryV2RawTableMigrator(final BigQuery bq) {
+    this.bq = bq;
+  }
+
+
+  @Override
+  public void migrateIfNecessary(final StreamConfig streamConfig) throws InterruptedException {
+    final Table rawTable = bq.getTable(TableId.of(streamConfig.id().rawNamespace(), streamConfig.id().rawName()));
+    if (rawTable != null && rawTable.exists()) {
+      final Schema existingRawSchema = rawTable.getDefinition().getSchema();
+      final FieldList fields = existingRawSchema.getFields();
+      if (fields.stream().noneMatch(f -> JavaBaseConstants.COLUMN_NAME_DATA.equals(f.getName()))) {
+        throw new IllegalStateException("Table does not have a column named _airbyte_data. We are likely colliding with a completely different table.");
+      }
+      final Field dataColumn = fields.get(JavaBaseConstants.COLUMN_NAME_DATA);
+      if (dataColumn.getType() == LegacySQLTypeName.JSON) {
+        LOGGER.info("Raw table has _airbyte_data of type JSON. Migrating to STRING.");
+        bq.query(QueryJobConfiguration.of(
+            new StringSubstitutor(Map.of(
+                "raw_table", streamConfig.id().rawTableId(BigQuerySqlGenerator.QUOTE)
+            )).replace(
+                """
+                    CREATE OR REPLACE TABLE ${raw_table}
+                    PARTITION BY DATE(_airbyte_extracted_at)
+                    CLUSTER BY _airbyte_extracted_at
+                    AS (
+                      SELECT
+                        _airbyte_raw_id,
+                        to_json_string(_airbyte_data) as _airbyte_data,
+                        _airbyte_extracted_at,
+                        _airbyte_loaded_at
+                      FROM ${raw_table}
+                    );
+                    """
+            )
+        ));
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryV2RawTableMigrator.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryV2RawTableMigrator.java
@@ -50,9 +50,9 @@ public class BigQueryV2RawTableMigrator implements V2RawTableMigrator<TableDefin
                     AS (
                       SELECT
                         _airbyte_raw_id,
-                        to_json_string(_airbyte_data) as _airbyte_data,
                         _airbyte_extracted_at,
-                        _airbyte_loaded_at
+                        _airbyte_loaded_at,
+                        to_json_string(_airbyte_data) as _airbyte_data
                       FROM ${raw_table}
                     );
                     """


### PR DESCRIPTION
based on https://github.com/airbytehq/airbyte/pull/29590. Adds a migrator for existing v2 raw tables. Also modifies standard inserts mode, where we now call `prepareTables` earlier in the sync, because otherwise we throw an error trying to construct a WriteChannel into the old-style raw table.

Ran a manual sync using 1.9.0 and verified that upgrading to `dev` + running a sync works correctly. Also added a test case that runs a sync on 1.9.0 (current latest version) and then a sync on `dev`.