### PR TITLE
update docs to point at the ab-connector-integration-test

### DIFF
--- a/airbyte-ci/connectors/ci_credentials/README.md
+++ b/airbyte-ci/connectors/ci_credentials/README.md
@@ -30,12 +30,12 @@ This command installs ci_credentials and makes it globally available in your ter
 Download a Service account json key that has access to Google Secrets Manager.
 
 ### Create Service Account
-* Go to https://console.cloud.google.com/iam-admin/serviceaccounts/create?project=dataline-integration-testing
+* Go to https://console.cloud.google.com/iam-admin/serviceaccounts/create?project=ab-connector-integration-test
 * In step #1 `Service account details`, set a name and a relevant description
 * In step #2 `Grant this service account access to project`, select role `Owner` (there is a role that is more scope but I based this decision on others `<user>-testing` service account)
 
 ### Create Service Account Token
-* Go to https://console.cloud.google.com/iam-admin/serviceaccounts?project=dataline-integration-testing
+* Go to https://console.cloud.google.com/iam-admin/serviceaccounts?project=ab-connector-integration-test
 * Find your service account and click on it
 * Go in the tab "KEYS"
 * Click on "ADD KEY -> Create new key" and select JSON. This will download a file on your computer

--- a/docs/connector-development/README.md
+++ b/docs/connector-development/README.md
@@ -165,7 +165,7 @@ Connector documentation and changelogs are markdown files living either [here fo
 ## Using credentials in CI
 
 In order to run integration tests in CI, you'll often need to inject credentials into CI. There are a few steps for doing this:
-1. **Place the credentials into Google Secret Manager(GSM)**: Airbyte uses a project 'Google Secret Manager' service as the source of truth for all CI secrets. Place the credentials **exactly as they should be used by the connector** into a GSM secret [here](https://console.cloud.google.com/security/secret-manager?referrer=search&orgonly=true&project=dataline-integration-testing&supportedpurview=organizationId) i.e.: it should basically be a copy paste of the `config.json` passed into a connector via the `--config` flag. We use the following naming pattern: `SECRET_<capital source OR destination name>_CREDS` e.g: `SECRET_SOURCE-S3_CREDS` or `SECRET_DESTINATION-SNOWFLAKE_CREDS`.
+1. **Place the credentials into Google Secret Manager(GSM)**: Airbyte uses a project 'Google Secret Manager' service as the source of truth for all CI secrets. Place the credentials **exactly as they should be used by the connector** into a GSM secret [here](https://console.cloud.google.com/security/secret-manager?referrer=search&orgonly=true&project=ab-connector-integration-test&supportedpurview=organizationId) i.e.: it should basically be a copy paste of the `config.json` passed into a connector via the `--config` flag. We use the following naming pattern: `SECRET_<capital source OR destination name>_CREDS` e.g: `SECRET_SOURCE-S3_CREDS` or `SECRET_DESTINATION-SNOWFLAKE_CREDS`.
 2. **Add the GSM secret's labels**:
     * `connector` (required) -- unique connector's name or set of connectors' names with '_' as delimiter i.e.: `connector=source-s3`, `connector=destination-snowflake`
     * `filename` (optional) -- custom target secret file. Unfortunately Google doesn't use '.' into labels' values and so Airbyte CI scripts will add '.json' to the end automatically. By default secrets will be saved to `./secrets/config.json` i.e: `filename=config_auth` => `secrets/config_auth.json`
@@ -174,8 +174,8 @@ In order to run integration tests in CI, you'll often need to inject credentials
 
 #### Access CI secrets on GSM
 Access to GSM storage is limited to Airbyte employees. To give an employee permissions to the project:
-1. Go to the permissions' [page](https://console.cloud.google.com/iam-admin/iam?project=dataline-integration-testing)
-2. Add a new principal to `dataline-integration-testing`:
+1. Go to the permissions' [page](https://console.cloud.google.com/iam-admin/iam?project=ab-connector-integration-test)
+2. Add a new principal to `ab-connector-integration-test`:
 - input their login email
 - select the role `Development_CI_Secrets`
 3. Save

--- a/tools/bin/cloud_storage_logging_test.sh
+++ b/tools/bin/cloud_storage_logging_test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# GCS resources for the following tests are located in the dataline-integration-testing GCP project.
+# GCS resources for the following tests are located in the ab-connector-integration-test GCP project.
 # GCS testing creds can be found in the "google cloud storage ( gcs ) test creds" secret in the `Shared-integration-tests`
 # folder in Lastpass.
 


### PR DESCRIPTION
## What
* We are deprecating the `dataline-integration-testing` project in GCP
* Connector testing will now happen in `ab-connector-integration-test`
* Will merge once last resources are moved over.