### PR TITLE
🐛 Create a connection in the acceptance test setup and close is in the tear down

### DIFF
--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/Database.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/Database.java
@@ -27,7 +27,9 @@ public class Database {
     return dslContext.transactionResult(configuration -> transform.query(DSL.using(configuration)));
   }
 
-  public void close() {
-    dslContext.close();
+  public void close() throws SQLException {
+    System.out.println("CLOSING DATABASE");
+    dslContext.parsingConnection().close();
+    dslContext.diagnosticsConnection().close();
   }
 }

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/Database.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/Database.java
@@ -27,4 +27,7 @@ public class Database {
     return dslContext.transactionResult(configuration -> transform.query(DSL.using(configuration)));
   }
 
+  public void close() {
+    dslContext.close();
+  }
 }

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/Database.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/Database.java
@@ -30,4 +30,5 @@ public class Database {
   public void close() {
     dslContext.close();
   }
+
 }

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/Database.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/Database.java
@@ -27,10 +27,4 @@ public class Database {
     return dslContext.transactionResult(configuration -> transform.query(DSL.using(configuration)));
   }
 
-  public void close() throws SQLException {
-    System.out.println("CLOSING DATABASE");
-    dslContext.parsingConnection().close();
-    dslContext.diagnosticsConnection().close();
-  }
-
 }

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
@@ -1,0 +1,27 @@
+package io.airbyte.db.factory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+
+public class ConnectionFactory {
+    public static Connection create(final String username,
+                                    final String password,
+                                    final Map<String, String> connectionProperties,
+                                    final String jdbcConnectionString) {
+        try {
+            Properties properties = new Properties();
+            properties.put("user", username);
+            properties.put("password", password);
+            connectionProperties.forEach((k, v) -> properties.put(k, v));
+
+           return DriverManager.getConnection(jdbcConnectionString,
+                    properties);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
@@ -28,7 +28,7 @@ public class ConnectionFactory {
 
            return DriverManager.getConnection(jdbcConnectionString,
                     properties);
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             throw new RuntimeException(e);
         }
     }

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
@@ -7,6 +7,15 @@ import java.util.Map;
 import java.util.Properties;
 
 public class ConnectionFactory {
+
+    /**
+     * Construct a new {@link Connection} instance using the provided configuration.
+     * @param username The username of the database user.
+     * @param password The password of the database user.
+     * @param connectionProperties The extra properties to add to the connection.
+     * @param jdbcConnectionString The JDBC connection string.
+     * @return The configured {@link Connection}
+     */
     public static Connection create(final String username,
                                     final String password,
                                     final Map<String, String> connectionProperties,

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.db.factory;
 
 import java.sql.Connection;
@@ -8,29 +12,30 @@ import java.util.Properties;
 
 public class ConnectionFactory {
 
-    /**
-     * Construct a new {@link Connection} instance using the provided configuration.
-     * @param username The username of the database user.
-     * @param password The password of the database user.
-     * @param connectionProperties The extra properties to add to the connection.
-     * @param jdbcConnectionString The JDBC connection string.
-     * @return The configured {@link Connection}
-     */
-    public static Connection create(final String username,
-                                    final String password,
-                                    final Map<String, String> connectionProperties,
-                                    final String jdbcConnectionString) {
-        try {
-            Properties properties = new Properties();
-            properties.put("user", username);
-            properties.put("password", password);
-            connectionProperties.forEach((k, v) -> properties.put(k, v));
+  /**
+   * Construct a new {@link Connection} instance using the provided configuration.
+   *
+   * @param username The username of the database user.
+   * @param password The password of the database user.
+   * @param connectionProperties The extra properties to add to the connection.
+   * @param jdbcConnectionString The JDBC connection string.
+   * @return The configured {@link Connection}
+   */
+  public static Connection create(final String username,
+                                  final String password,
+                                  final Map<String, String> connectionProperties,
+                                  final String jdbcConnectionString) {
+    try {
+      Properties properties = new Properties();
+      properties.put("user", username);
+      properties.put("password", password);
+      connectionProperties.forEach((k, v) -> properties.put(k, v));
 
-           return DriverManager.getConnection(jdbcConnectionString,
-                    properties);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+      return DriverManager.getConnection(jdbcConnectionString,
+          properties);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
     }
+  }
 
 }

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
@@ -11,9 +11,9 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * This class as been added in order to be able to save the connection in a test.
- * It was found that the {@link javax.sql.DataSource} close method wasn't propagating the connection properly.
- * It shouldn't be needed in our application code.
+ * This class as been added in order to be able to save the connection in a test. It was found that
+ * the {@link javax.sql.DataSource} close method wasn't propagating the connection properly. It
+ * shouldn't be needed in our application code.
  */
 public class ConnectionFactory {
 

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/ConnectionFactory.java
@@ -10,6 +10,11 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * This class as been added in order to be able to save the connection in a test.
+ * It was found that the {@link javax.sql.DataSource} close method wasn't propagating the connection properly.
+ * It shouldn't be needed in our application code.
+ */
 public class ConnectionFactory {
 
   /**

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftConnectionHandler.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftConnectionHandler.java
@@ -1,0 +1,22 @@
+package io.airbyte.integrations.destination.redshift;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class RedshiftConnectionHandler {
+
+    /**
+     * For to close a connection. Aimed to be use in test only.
+     *
+     * @param connection The connection to close
+     */
+    public static void close(Connection connection) {
+        try {
+            connection.setAutoCommit(false);
+            connection.commit();
+            connection.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftStagingS3DestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftStagingS3DestinationAcceptanceTest.java
@@ -48,6 +48,7 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
   private final RedshiftSQLNameTransformer namingResolver = new RedshiftSQLNameTransformer();
   private final String USER_WITHOUT_CREDS = Strings.addRandomSuffix("test_user", "_", 5);
 
+  private Database database;
   protected TestDestinationEnv testDestinationEnv;
 
   private final ObjectMapper mapper = new ObjectMapper();
@@ -120,7 +121,7 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
   public void testGetFileBufferDefault() {
     final RedshiftStagingS3Destination destination = new RedshiftStagingS3Destination();
     assertEquals(destination.getNumberOfFileBuffers(config),
-        FileBuffer.DEFAULT_MAX_CONCURRENT_STREAM_IN_BUFFER);
+            FileBuffer.DEFAULT_MAX_CONCURRENT_STREAM_IN_BUFFER);
   }
 
   @Test
@@ -171,11 +172,11 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
                                            final String streamName,
                                            final String namespace,
                                            final JsonNode streamSchema)
-      throws Exception {
+          throws Exception {
     return retrieveRecordsFromTable(namingResolver.getRawTableName(streamName), namespace)
-        .stream()
-        .map(j -> j.get(JavaBaseConstants.COLUMN_NAME_DATA))
-        .collect(Collectors.toList());
+            .stream()
+            .map(j -> j.get(JavaBaseConstants.COLUMN_NAME_DATA))
+            .collect(Collectors.toList());
   }
 
   @Override
@@ -185,7 +186,7 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
 
   @Override
   protected List<JsonNode> retrieveNormalizedRecords(final TestDestinationEnv testEnv, final String streamName, final String namespace)
-      throws Exception {
+          throws Exception {
     String tableName = namingResolver.getIdentifier(streamName);
     if (!tableName.startsWith("\"")) {
       // Currently, Normalization always quote tables identifiers
@@ -196,11 +197,11 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
 
   private List<JsonNode> retrieveRecordsFromTable(final String tableName, final String schemaName) throws SQLException {
     return getDatabase().query(
-        ctx -> ctx
-            .fetch(String.format("SELECT * FROM %s.%s ORDER BY %s ASC;", schemaName, tableName, JavaBaseConstants.COLUMN_NAME_EMITTED_AT))
-            .stream()
-            .map(this::getJsonFromRecord)
-            .collect(Collectors.toList()));
+            ctx -> ctx
+                    .fetch(String.format("SELECT * FROM %s.%s ORDER BY %s ASC;", schemaName, tableName, JavaBaseConstants.COLUMN_NAME_EMITTED_AT))
+                    .stream()
+                    .map(this::getJsonFromRecord)
+                    .collect(Collectors.toList()));
   }
 
   // for each test we create a new schema in the database. run the test in there and then remove it.
@@ -209,9 +210,10 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
     final String schemaName = Strings.addRandomSuffix("integration_test", "_", 5);
     final String createSchemaQuery = String.format("CREATE SCHEMA %s", schemaName);
     baseConfig = getStaticConfig();
+    database = createDatabase();
     getDatabase().query(ctx -> ctx.execute(createSchemaQuery));
     final String createUser = String.format("create user %s with password '%s' SESSION TIMEOUT 60;",
-        USER_WITHOUT_CREDS, baseConfig.get("password").asText());
+            USER_WITHOUT_CREDS, baseConfig.get("password").asText());
     getDatabase().query(ctx -> ctx.execute(createUser));
     final JsonNode configForSchema = Jsons.clone(baseConfig);
     ((ObjectNode) configForSchema).put("schema", schemaName);
@@ -228,20 +230,25 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
       getDatabase().query(ctx -> ctx.execute(String.format("DROP SCHEMA IF EXISTS %s CASCADE", schema)));
     }
     getDatabase().query(ctx -> ctx.execute(String.format("drop user if exists %s;", USER_WITHOUT_CREDS)));
+    database.close();
+  }
+
+  protected Database createDatabase() {
+    return new Database(
+            DSLContextFactory.create(
+                    baseConfig.get(JdbcUtils.USERNAME_KEY).asText(),
+                    baseConfig.get(JdbcUtils.PASSWORD_KEY).asText(),
+                    DatabaseDriver.REDSHIFT.getDriverClassName(),
+                    String.format(DatabaseDriver.REDSHIFT.getUrlFormatString(),
+                            baseConfig.get(JdbcUtils.HOST_KEY).asText(),
+                            baseConfig.get(JdbcUtils.PORT_KEY).asInt(),
+                            baseConfig.get(JdbcUtils.DATABASE_KEY).asText()),
+                    null,
+                    RedshiftInsertDestination.SSL_JDBC_PARAMETERS));
   }
 
   protected Database getDatabase() {
-    return new Database(
-        DSLContextFactory.create(
-            baseConfig.get(JdbcUtils.USERNAME_KEY).asText(),
-            baseConfig.get(JdbcUtils.PASSWORD_KEY).asText(),
-            DatabaseDriver.REDSHIFT.getDriverClassName(),
-            String.format(DatabaseDriver.REDSHIFT.getUrlFormatString(),
-                baseConfig.get(JdbcUtils.HOST_KEY).asText(),
-                baseConfig.get(JdbcUtils.PORT_KEY).asInt(),
-                baseConfig.get(JdbcUtils.DATABASE_KEY).asText()),
-            null,
-            RedshiftInsertDestination.SSL_JDBC_PARAMETERS));
+    return database;
   }
 
   public RedshiftSQLNameTransformer getNamingResolver() {

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftStagingS3DestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftStagingS3DestinationAcceptanceTest.java
@@ -126,8 +126,7 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
   @Test
   public void testGetFileBufferDefault() {
     final RedshiftStagingS3Destination destination = new RedshiftStagingS3Destination();
-    assertEquals(destination.getNumberOfFileBuffers(config),
-            FileBuffer.DEFAULT_MAX_CONCURRENT_STREAM_IN_BUFFER);
+    assertEquals(destination.getNumberOfFileBuffers(config), FileBuffer.DEFAULT_MAX_CONCURRENT_STREAM_IN_BUFFER);
   }
 
   @Test
@@ -236,9 +235,7 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
       getDatabase().query(ctx -> ctx.execute(String.format("DROP SCHEMA IF EXISTS %s CASCADE", schema)));
     }
     getDatabase().query(ctx -> ctx.execute(String.format("drop user if exists %s;", USER_WITHOUT_CREDS)));
-    connection.setAutoCommit(false);
-    connection.commit();
-    connection.close();
+    RedshiftConnectionHandler.close(connection);
   }
 
   protected Database createDatabase() {

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/SshRedshiftDestinationBaseAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/SshRedshiftDestinationBaseAcceptanceTest.java
@@ -219,9 +219,7 @@ public abstract class SshRedshiftDestinationBaseAcceptanceTest extends JdbcDesti
         config -> {
           getDatabase().query(ctx -> ctx.fetch(String.format("DROP USER IF EXISTS %s;", USER_WITHOUT_CREDS)));
         });
-    connection.setAutoCommit(false);
-    connection.commit();
-    connection.close();
+    RedshiftConnectionHandler.close(connection);
   }
 
 }


### PR DESCRIPTION
## What
Update the Redshift acceptance test in order to limit the number of connections opened by the redshift acceptance tests.
We are now directly creating a connection without using a datasource. It is needed because it has been observed that:
- `datasource.close()` doesn't close the opened connection
- According to the javadoc, `datasource.getConnection()` may return a new connection.
This means that we can not ensure that a connection is being closed by using the datasource. Which explains why we switch to using a Connection directly.

## Recommended reading order
1. `ConnectionFactory.java`
2. The test files.
