### PR TITLE
Source Intercom: add undeclared columns to spec

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-intercom/acceptance-test-config.yml
@@ -20,7 +20,6 @@ acceptance_tests:
     - config_path: "secrets/config.json"
       expect_records:
         path: "integration_tests/expected_records.jsonl"
-      fail_on_extra_columns: false
   incremental:
     tests:
     - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/admins.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/admins.json
@@ -58,6 +58,23 @@
     },
     "type": {
       "type": ["null", "string"]
+    },
+    "team_priority_level": {
+      "type": ["null", "object"],
+      "properties": {
+        "primary_team_ids": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["null", "integer"]
+          }
+        },
+        "secondary_team_ids": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["null", "integer"]
+          }
+        }
+      }
     }
   }
 }

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/company_attributes.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/company_attributes.json
@@ -1,6 +1,9 @@
 {
   "type": "object",
   "properties": {
+    "id": {
+      "type": ["null", "integer"]
+    },
     "admin_id": {
       "type": ["null", "string"]
     },

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contact_attributes.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contact_attributes.json
@@ -1,6 +1,9 @@
 {
   "type": ["null", "object"],
   "properties": {
+    "id": {
+      "type": ["null", "integer"]
+    },
     "type": {
       "type": ["null", "string"]
     },

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contacts.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contacts.json
@@ -304,6 +304,58 @@
           "type": ["null", "boolean"]
         }
       }
+    },
+    "opted_in_subscription_types": {
+      "type": ["null", "object"],
+      "properties": {
+        "type": {
+          "type": ["null", "string"]
+        },
+        "data": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["null", "object"],
+            "properties": {
+              "type": {
+                "type": ["null", "string"]
+              },
+              "id": {
+                "type": ["null", "string"]
+              },
+              "url": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "url": {
+          "type": ["null", "string"]
+        },
+        "total_count": {
+          "type": ["null", "integer"]
+        },
+        "has_more": {
+          "type": ["null", "boolean"]
+        }
+      }
+    },
+    "utm_content": {
+      "type": ["null", "string"]
+    },
+    "utm_campaign": {
+      "type": ["null", "string"]
+    },
+    "utm_source": {
+      "type": ["null", "string"]
+    },
+    "referrer": {
+      "type": ["null", "string"]
+    },
+    "utm_term": {
+      "type": ["null", "string"]
+    },
+    "utm_medium": {
+      "type": ["null", "string"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/conversations.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/conversations.json
@@ -428,6 +428,34 @@
     },
     "redacted": {
       "type": ["null", "boolean"]
+    },
+    "topics": {
+      "type": ["null", "object"],
+      "properties": {
+        "type": {
+          "type": ["null", "string"]
+        },
+        "topics": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["null", "object"],
+            "properties": {
+              "type": {
+                "type": ["null", "string"]
+              },
+              "id": {
+                "type": ["null", "integer"]
+              },
+              "name": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "total_count": {
+          "type": ["null", "integer"]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## What
- *https://github.com/airbytehq/airbyte/issues/24486*

## How
- *Add `team_priority_level` to `admins` stream*
- *Add `id` to `company_attributes` and `contact_attrubutes` streams*
- *Add `opted_in_subscription_types`, `utm_content`, `utm_campaign`, `utm_source`, `referrer`, `utm_term`, `utm_medium` to `contacts` stream*
- *Add `topics` to `conversation` stream*
