### PR TITLE
📚  Update the docs to be more clear about how and when you run CAT

### DIFF
--- a/airbyte-ci/connectors/ci_credentials/README.md
+++ b/airbyte-ci/connectors/ci_credentials/README.md
@@ -83,3 +83,6 @@ To upload to GSM newly updated configurations from `airbyte-integrations/connect
 VERSION=dev ci_credentials source-bing-ads update-secrets
 ```
 
+## FAQ
+### What is `VERSION=dev`?
+This is a way to tell the tool to write secrets using your local current working directory and not the Github Action runner one.

--- a/airbyte-ci/connectors/pipelines/pipelines/slack.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/slack.py
@@ -3,8 +3,8 @@
 #
 
 import json
-import requests
 
+import requests
 from pipelines import main_logger
 
 

--- a/airbyte-integrations/bases/connector-acceptance-test/README.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/README.md
@@ -3,13 +3,22 @@ This package gathers multiple test suites to assess the sanity of any Airbyte co
 It is shipped as a [pytest](https://docs.pytest.org/en/7.1.x/) plugin and relies on pytest to discover, configure and execute tests.
 Test-specific documentation can be found [here](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/)).
 
-## Running the acceptance tests on a source connector:
-1. `cd` into your connector project (e.g. `airbyte-integrations/connectors/source-pokeapi`)
-2. Edit `acceptance-test-config.yml` according to your need. Please refer to our [Connector Acceptance Test Reference](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/) if you need details about the available options.
-3. Build the connector docker image ( e.g.: `docker build . -t airbyte/source-pokeapi:dev`)
-4. Use one of the following ways to run tests (**from your connector project directory**)
+## Configuration
+The acceptance tests are configured via the `acceptance-test-config.yml` YAML file, which is passed to the plugin via the `--acceptance-test-config` option.
 
-### Using `airbyte-ci`
+## Running the acceptance tests locally
+Note there are MANY ways to do this at this time, but we are working on consolidating them.
+
+Which method you choose to use depends on the context you are in.
+
+Pre-requisites:
+- Setting up a Service Account for Google Secrets Manager (GSM) access. See [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/ci_credentials/README.md)
+- Ensuring that you have the `GCP_GSM_CREDENTIALS` environment variable set to the contents of your GSM service account key file.
+- [Poetry](https://python-poetry.org/docs/#installation) installed
+- [Pipx](https://pypa.github.io/pipx/installation/) installed
+
+### Running CAT in the same environment as our CI/CD pipeline (`airbyte-ci`)
+
 _Note: Install instructions for airbyte-ci are [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) _
 
 **This runs connector acceptance and other tests that run in our CI**
@@ -17,40 +26,63 @@ _Note: Install instructions for airbyte-ci are [here](https://github.com/airbyte
 airbyte-ci connectors --name=<connector-name> test
 ```
 
-### Using Bash
+### Running CAT locally for Debugging/Development Purposes
 ```bash
-./acceptance-test-docker.sh
+# Hook up your GSM service account
+export GCP_GSM_CREDENTIALS=`cat <path-to-gsm-service-account-key-file>`
+
+# Install the credentials tool
+pipx install airbyte-ci/connectors/ci_credentials/
+
+# Writes the secrets to airbyte-integrations/connectors/source-faker/secrets
+VERSION=dev ci_credentials connectors/source-faker write-to-storage
+
+# Navigate to our CAT test directory
+cd airbyte-integrations/bases/connector-acceptance-test/
+
+# Install dependencies
+poetry install
+
+# Run tests against your connector
+poetry run pytest -p connector_acceptance_test.plugin --acceptance-test-config=../../connectors/source-faker --pdb
 ```
-_Note: this will use the latest docker image for connector-acceptance-test and will also build docker image for the connector_
 
-You can also use the following environment variables with the Gradle and Bash commands:
-- `LOCAL_CDK=1`: Run tests against the local python CDK, if relevant. If not set, tests against the latest package published to pypi, or the version specified in the connector's setup.py.
-- `FETCH_SECRETS=1`: Fetch secrets required by CATs. This requires you to have a Google Service Account, and the GCP_GSM_CREDENTIALS environment variable to be set, per the instructions [here](https://github.com/airbytehq/airbyte/tree/b03653a24ef16be641333380f3a4d178271df0ee/tools/ci_credentials).
+### Running CAT via the production docker image (deprecated)
+This is the old method and is not useful outside of helping third party connector developers run their tests.
 
-## Running the acceptance tests on multiple connectors:
-If you are contributing to the python CDK, you may want to validate your changes by running acceptance tests against multiple connectors.
+```
+# Hook up your GSM service account
+export GCP_GSM_CREDENTIALS=`cat<path-to-gsm-service-account-key-file>`
 
-To do so, from the root of the `airbyte` repo, run `./airbyte-cdk/python/bin/run-cats-with-local-cdk.sh -c <connector1>,<connector2>,...`
+# Navigate to the connectors folder
+cd airbyte-integrations/connectors/source-faker
 
-## When does acceptance test run?
-* When running local acceptance tests on connector:
-  * When running `connectorAcceptanceTest` `gradle` task
-  * When running or `./acceptance-test-docker.sh` in a connector project
-* In the CI on each push to a connector PR.
+# Run the tests
+FETCH_SECRETS=1 ./acceptance-test-docker.sh
+```
+
+Note you can also use `LOCAL_CDK=1` to run tests against the local python CDK, if relevant. If not set, tests against the latest package published to pypi, or the version specified in the connector's setup.py.
+
+### Manually
+1. `cd` into your connector project (e.g. `airbyte-integrations/connectors/source-pokeapi`)
+2. Edit `acceptance-test-config.yml` according to your need. Please refer to our [Connector Acceptance Test Reference](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/) if you need details about the available options.
+3. Build the connector docker image ( e.g.: `docker build . -t airbyte/source-pokeapi:dev`)
+4. Use one of the following ways to run tests (**from your connector project directory**)
+
 
 ## Developing on the acceptance tests
 You may want to iterate on the acceptance test project itself: adding new tests, fixing a bug etc.
 These iterations are more conveniently achieved by remaining in the current directory.
 
-1. `poetry install`
+1. Install dependencies via `poetry install`
 3. Run the unit tests on the acceptance tests themselves: `poetry run python -m pytest unit_tests` (add the `--pdb` option if you want to enable the debugger on test failure)
 4. Make the changes you want:
     * Global pytest fixtures are defined in `./connector_acceptance_test/conftest.py`
     * Existing test modules are defined in `./connector_acceptance_test/tests`
     * `acceptance-test-config.yaml` structure is defined in `./connector_acceptance_test/config.py`
 5. Unit test your changes by adding tests to `./unit_tests`
-6. Run the unit tests on the acceptance tests again: `python -m pytest unit_tests`, make sure the coverage did not decrease. You can bypass slow tests by using the `slow` marker: `python -m pytest unit_tests -m "not slow"`.
-7. Manually test the changes you made by running acceptance tests on a specific connector. e.g. `python -m pytest -p connector_acceptance_test.plugin --acceptance-test-config=../../connectors/source-pokeapi`
+6. Run the unit tests on the acceptance tests again: `poetry run pytest unit_tests`, make sure the coverage did not decrease. You can bypass slow tests by using the `slow` marker: `poetry run pytest unit_tests -m "not slow"`.
+7. Manually test the changes you made by running acceptance tests on a specific connector. e.g. `poetry run pytest -p connector_acceptance_test.plugin --acceptance-test-config=../../connectors/source-pokeapi`
 8. Make sure you updated `docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md` according to your changes
 9. Bump the acceptance test docker image version in `airbyte-integrations/bases/connector-acceptance-test/Dockerfile`
 10. Update the project changelog `airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md`

--- a/airbyte-integrations/bases/connector-acceptance-test/README.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/README.md
@@ -1,4 +1,4 @@
-# Connector Acceptance Tests
+# Connector Acceptance Tests (CAT)
 This package gathers multiple test suites to assess the sanity of any Airbyte connector.
 It is shipped as a [pytest](https://docs.pytest.org/en/7.1.x/) plugin and relies on pytest to discover, configure and execute tests.
 Test-specific documentation can be found [here](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/)).
@@ -27,22 +27,41 @@ airbyte-ci connectors --name=<connector-name> test
 ```
 
 ### Running CAT locally for Debugging/Development Purposes
+
+**Pre-requisites:**
+
+To learn how to set up `ci_credentials` and your GSM Service account see [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/ci_credentials/README.md)
+
 ```bash
 # Hook up your GSM service account
 export GCP_GSM_CREDENTIALS=`cat <path-to-gsm-service-account-key-file>`
 
 # Install the credentials tool
 pipx install airbyte-ci/connectors/ci_credentials/
+```
+
+**Retrieve a connectors sandbox secrets**
+
+```bash
+# From the root of the airbyte repo
 
 # Writes the secrets to airbyte-integrations/connectors/source-faker/secrets
 VERSION=dev ci_credentials connectors/source-faker write-to-storage
+```
 
+**Run install dependencies**
+
+```bash
 # Navigate to our CAT test directory
 cd airbyte-integrations/bases/connector-acceptance-test/
 
 # Install dependencies
 poetry install
+```
 
+**Run the tests**
+
+```bash
 # Run tests against your connector
 poetry run pytest -p connector_acceptance_test.plugin --acceptance-test-config=../../connectors/source-faker --pdb
 ```
@@ -50,10 +69,12 @@ poetry run pytest -p connector_acceptance_test.plugin --acceptance-test-config=.
 ### Running CAT via the production docker image (deprecated)
 This is the old method and is not useful outside of helping third party connector developers run their tests.
 
-```
-# Hook up your GSM service account
-export GCP_GSM_CREDENTIALS=`cat<path-to-gsm-service-account-key-file>`
+Ideally you should use `airbyte-ci` as described above.
 
+_Note: To use `FETCH_SECRETS=1` you must have `ci_credentials` and your GSM Service account setup see [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/ci_credentials/README.md)_
+
+
+```bash
 # Navigate to the connectors folder
 cd airbyte-integrations/connectors/source-faker
 

--- a/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md
+++ b/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md
@@ -36,27 +36,32 @@ Build your connector image if needed.
 docker build .
 ```
 
-Run one of the two scripts in the root of the connector:
+and test via one of the two following options
 
-- `python -m pytest -p integration_tests.acceptance` - to run tests inside virtual environment
+### (Prefered) Option 1: Run against the production acceptance test image
 
-  - On test completion, a log will be outputted to the terminal verifying:
+From the root of your connector run:
+```bash
+./acceptance-test-docker.sh
+```
 
-    - The connector the tests were ran for
-    - The git hash of the code used
-    - Whether the tests passed or failed
+This will run you local connector image against the same test suite that Airbyte uses in production
 
-    This is useful to provide in your PR as evidence of the acceptance tests passing locally.
+### (Debugging) Option 2: Run against the acceptance tests on your branch
 
-- `./acceptance-test-docker.sh` - to run tests from a docker container
+This will run the acceptance test suite directly with pytest. Allowing you to set breakpoints and debug your connector locally.
 
-If the test fails you will see detail about the test and where to find its inputs and outputs to reproduce it. You can also debug failed tests by adding `—pdb —last-failed`:
+The only pre-requisite is that you have [Poetry](https://python-poetry.org/docs/#installation) installed.
 
-```text
-python -m pytest -p integration_tests.acceptance --pdb --last-failed
+Afterwards you do the following from the root of the `airbyte` repo:
+```bash
+cd airbyte-integrations/bases/connector-acceptance-test/
+poetry install
+poetry run pytest -p connector_acceptance_test.plugin --acceptance-test-config=../../connectors/<your-connector> --pdb
 ```
 
 See other useful pytest options [here](https://docs.pytest.org/en/stable/usage.html)
+See a more comprehensive guide in our README [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/connector-acceptance-test/README.md)
 
 ## Dynamically managing inputs & resources used in standard tests
 

--- a/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md
+++ b/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md
@@ -36,7 +36,7 @@ Build your connector image if needed.
 docker build .
 ```
 
-and test via one of the two following options
+And test via one of the two following Options
 
 ### (Prefered) Option 1: Run against the production acceptance test image
 
@@ -47,7 +47,13 @@ From the root of your connector run:
 
 This will run you local connector image against the same test suite that Airbyte uses in production
 
-### (Debugging) Option 2: Run against the acceptance tests on your branch
+### Option 2: Run against the Airbyte CI test suite
+```bash
+pipx install airbyte-ci/connectors/pipelines/
+airbyte-ci connectors --name=<name-of-your-connector></name-of-your-connector> --use-remote-secrets=false test
+```
+
+### (Debugging) Option 3: Run against the acceptance tests on your branch
 
 This will run the acceptance test suite directly with pytest. Allowing you to set breakpoints and debug your connector locally.
 


### PR DESCRIPTION
## Overview
@postamar Was our test subject here and noticed that our CAT test docs were unweildly and confusing.

This is a first effort to attempt to better direct Airbyte devs to which method they should use when debugging CAT tests.

In addition to providing more clarity for how third party developers can run the CAT test suite against their connector