### PR TITLE
DATs: Fix spurious failures

### DIFF
--- a/airbyte-integrations/bases/s3-destination-base-integration-test/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/s3-destination-base-integration-test/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationAcceptanceTest.java
@@ -126,7 +126,7 @@ public abstract class S3DestinationAcceptanceTest extends DestinationAcceptanceT
    * <li>Construct the S3 client.</li>
    */
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     final JsonNode baseConfigJson = getBaseConfigJson();
     // Set a random s3 bucket path for each integration test
     final JsonNode configJson = Jsons.clone(baseConfigJson);
@@ -150,7 +150,7 @@ public abstract class S3DestinationAcceptanceTest extends DestinationAcceptanceT
    * Remove all the S3 output from the tests.
    */
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     final List<KeyVersion> keysToDelete = new LinkedList<>();
     final List<S3ObjectSummary> objects = s3Client
         .listObjects(config.getBucketName(), config.getBucketPath())

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -1082,12 +1082,13 @@ public abstract class DestinationAcceptanceTest {
         DataArgumentsProvider.NAMESPACE_CONFIG.getMessageFileVersion(getProtocolVersion())).lines()
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class))
         .collect(Collectors.toList());
-    final List<AirbyteMessage> messagesWithNewNamespace = getRecordMessagesWithNewNamespace(
-        messages, namespace);
+    final List<AirbyteMessage> messagesWithNewNamespace = getRecordMessagesWithNewNamespace(messages, namespace);
 
     final JsonNode config = getConfig();
     try {
       runSyncAndVerifyStateOutput(config, messagesWithNewNamespace, configuredCatalog, false);
+      // Add to the list of schemas to clean up.
+      TEST_SCHEMAS.add(namespace);
     } catch (final Exception e) {
       throw new IOException(String.format(
           "[Test Case %s] Destination failed to sync data to namespace %s, see \"namespace_test_cases.json for details\"",
@@ -1805,7 +1806,8 @@ public abstract class DestinationAcceptanceTest {
           .filter(testCase -> testCase.get("enabled").asBoolean())
           .map(testCase -> Arguments.of(
               testCase.get("id").asText(),
-              testCase.get("namespace").asText(),
+              // Randomise namespace to avoid collisions between tests.
+              Strings.addRandomSuffix(testCase.get("namespace").asText(), "", 5),
               testCase.get("normalized").asText()));
     }
 

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -1082,13 +1082,12 @@ public abstract class DestinationAcceptanceTest {
         DataArgumentsProvider.NAMESPACE_CONFIG.getMessageFileVersion(getProtocolVersion())).lines()
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class))
         .collect(Collectors.toList());
-    final List<AirbyteMessage> messagesWithNewNamespace = getRecordMessagesWithNewNamespace(messages, namespace);
+    final List<AirbyteMessage> messagesWithNewNamespace = getRecordMessagesWithNewNamespace(
+        messages, namespace);
 
     final JsonNode config = getConfig();
     try {
       runSyncAndVerifyStateOutput(config, messagesWithNewNamespace, configuredCatalog, false);
-      // Add to the list of schemas to clean up.
-      TEST_SCHEMAS.add(namespace);
     } catch (final Exception e) {
       throw new IOException(String.format(
           "[Test Case %s] Destination failed to sync data to namespace %s, see \"namespace_test_cases.json for details\"",
@@ -1806,8 +1805,7 @@ public abstract class DestinationAcceptanceTest {
           .filter(testCase -> testCase.get("enabled").asBoolean())
           .map(testCase -> Arguments.of(
               testCase.get("id").asText(),
-              // Randomise namespace to avoid collisions between tests.
-              Strings.addRandomSuffix(testCase.get("namespace").asText(), "", 5),
+              testCase.get("namespace").asText(),
               testCase.get("normalized").asText()));
     }
 

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -100,7 +100,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class DestinationAcceptanceTest {
 
-  private static final HashSet<String> TEST_SCHEMAS = new HashSet<>();
+  protected static final HashSet<String> TEST_SCHEMAS = new HashSet<>();
 
   private static final Random RANDOM = new Random();
   private static final String NORMALIZATION_VERSION = "dev";

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -334,10 +334,9 @@ public abstract class DestinationAcceptanceTest {
    * destination so that there is no contamination across tests.
    *
    * @param testEnv - information about the test environment.
-   * @param TEST_SCHEMAS
    * @throws Exception - can throw any exception, test framework will handle.
    */
-  protected abstract void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception;
+  protected abstract void tearDown(TestDestinationEnv testEnv) throws Exception;
 
   /**
    * @deprecated This method is moved to the AdvancedTestDataComparator. Please move your destination
@@ -372,7 +371,7 @@ public abstract class DestinationAcceptanceTest {
 
   @AfterEach
   void tearDownInternal() throws Exception {
-    tearDown(testEnv, TEST_SCHEMAS);
+    tearDown(testEnv);
   }
 
   /**

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -1804,11 +1804,14 @@ public abstract class DestinationAcceptanceTest {
           Jsons.deserialize(MoreResources.readResource(NAMESPACE_TEST_CASES_JSON));
       return MoreIterators.toList(testCases.elements()).stream()
           .filter(testCase -> testCase.get("enabled").asBoolean())
-          .map(testCase -> Arguments.of(
-              testCase.get("id").asText(),
-              // Randomise namespace to avoid collisions between tests.
-              Strings.addRandomSuffix(testCase.get("namespace").asText(), "", 5),
-              testCase.get("normalized").asText()));
+          .map(testCase -> {
+            final String randomSuffix = Strings.addRandomSuffix("", "", 5);
+            return Arguments.of(
+                testCase.get("id").asText(),
+                // Randomise namespace to avoid collisions between tests.
+                testCase.get("namespace").asText() + randomSuffix,
+                testCase.get("normalized").asText() + randomSuffix);
+          });
     }
 
   }

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/java/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/java/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageDestinationAcceptanceTest.java
@@ -80,19 +80,19 @@ public abstract class AzureBlobStorageDestinationAcceptanceTest extends Destinat
         .buildAppendBlobClient();
 
     final BlobContainerClient containerClient = streamAppendBlobClient.getContainerClient();
-    var blobItemList = StreamSupport.stream(containerClient.listBlobs().spliterator(), false)
+    final var blobItemList = StreamSupport.stream(containerClient.listBlobs().spliterator(), false)
         .collect(Collectors.toList());
-    var filteredBlobList = blobItemList.stream()
+    final var filteredBlobList = blobItemList.stream()
         .filter(blob -> blob.getName().startsWith(streamName + "/"))
         .toList();
     if (!filteredBlobList.isEmpty()) {
-      List<AppendBlobClient> clobClientList = new ArrayList<>();
+      final List<AppendBlobClient> clobClientList = new ArrayList<>();
       filteredBlobList.forEach(blobItem -> {
         clobClientList.add(specializedBlobClientBuilder.blobName(blobItem.getName()).buildAppendBlobClient());
       });
       return clobClientList;
     } else {
-      var errorText = String.format("Can not find blob started with: %s/", streamName);
+      final var errorText = String.format("Can not find blob started with: %s/", streamName);
       LOGGER.error(errorText);
       throw new Exception(errorText);
     }
@@ -126,7 +126,7 @@ public abstract class AzureBlobStorageDestinationAcceptanceTest extends Destinat
    * <li>Construct the Azure Blob client.</li>
    */
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     final JsonNode baseConfigJson = getBaseConfigJson();
 
     configJson = Jsons.jsonNode(ImmutableMap.builder()
@@ -160,7 +160,7 @@ public abstract class AzureBlobStorageDestinationAcceptanceTest extends Destinat
    * Remove all the Container output from the tests.
    */
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     final BlobServiceClient storageClient =
         new BlobServiceClientBuilder()
             .endpoint(azureBlobStorageDestinationConfig.getEndpointUrl())

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDenormalizedDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDenormalizedDestinationAcceptanceTest.java
@@ -204,14 +204,14 @@ public class BigQueryDenormalizedDestinationAcceptanceTest extends DestinationAc
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     config = createConfig();
     bigquery = configureBigQuery(config);
     dataset = getBigQueryDataSet(config, bigquery);
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     tearDownBigQuery(dataset, bigquery);
   }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryGcsDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryGcsDestinationAcceptanceTest.java
@@ -37,7 +37,7 @@ public class BigQueryGcsDestinationAcceptanceTest extends AbstractBigQueryDestin
    * @see DestinationAcceptanceTest#setUpInternal()
    */
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     // use secrets file with GCS staging config
     secretsFile = Path.of("secrets/credentials-gcs-staging.json");
     setUpBigQuery();
@@ -53,13 +53,12 @@ public class BigQueryGcsDestinationAcceptanceTest extends AbstractBigQueryDestin
   /**
    * Removes data from bigquery and GCS This function will be called after EACH test
    *
-   * @param testEnv      - information about the test environment.
-   * @param TEST_SCHEMAS
+   * @param testEnv - information about the test environment.
    * @throws Exception - can throw any exception, test framework will handle.
    * @see DestinationAcceptanceTest#tearDownInternal()
    */
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     tearDownBigQuery();
     tearDownGcs();
   }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryStandardDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryStandardDestinationAcceptanceTest.java
@@ -27,7 +27,7 @@ public class BigQueryStandardDestinationAcceptanceTest extends AbstractBigQueryD
    * @see DestinationAcceptanceTest#setUpInternal()
    */
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     secretsFile = Path.of("secrets/credentials-standard.json");
     setUpBigQuery();
   }
@@ -35,13 +35,12 @@ public class BigQueryStandardDestinationAcceptanceTest extends AbstractBigQueryD
   /**
    * Removes data from bigquery This function will be called after EACH test
    *
-   * @param testEnv      - information about the test environment.
-   * @param TEST_SCHEMAS
+   * @param testEnv - information about the test environment.
    * @throws Exception - can throw any exception, test framework will handle.
    * @see DestinationAcceptanceTest#tearDownInternal()
    */
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     tearDownBigQuery();
   }
 

--- a/airbyte-integrations/connectors/destination-cassandra/src/test-integration/java/io/airbyte/integrations/destination/cassandra/CassandraDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-cassandra/src/test-integration/java/io/airbyte/integrations/destination/cassandra/CassandraDestinationAcceptanceTest.java
@@ -30,21 +30,21 @@ public class CassandraDestinationAcceptanceTest extends DestinationAcceptanceTes
   }
 
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     configJson = TestDataFactory.createJsonConfig(
         cassandraContainer.getUsername(),
         cassandraContainer.getPassword(),
         HostPortResolver.resolveHost(cassandraContainer),
         HostPortResolver.resolvePort(cassandraContainer));
-    var cassandraConfig = new CassandraConfig(configJson);
+    final var cassandraConfig = new CassandraConfig(configJson);
     cassandraCqlProvider = new CassandraCqlProvider(cassandraConfig);
     cassandraNameTransformer = new CassandraNameTransformer(cassandraConfig);
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     cassandraCqlProvider.retrieveMetadata().forEach(meta -> {
-      var keyspace = meta.value1();
+      final var keyspace = meta.value1();
       meta.value2().forEach(table -> cassandraCqlProvider.truncate(keyspace, table));
     });
   }
@@ -74,12 +74,12 @@ public class CassandraDestinationAcceptanceTest extends DestinationAcceptanceTes
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema) {
-    var keyspace = cassandraNameTransformer.outputKeyspace(namespace);
-    var table = cassandraNameTransformer.outputTable(streamName);
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema) {
+    final var keyspace = cassandraNameTransformer.outputKeyspace(namespace);
+    final var table = cassandraNameTransformer.outputTable(streamName);
     return cassandraCqlProvider.select(keyspace, table).stream()
         .sorted(Comparator.comparing(CassandraRecord::getTimestamp))
         .map(CassandraRecord::getData)

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationStrictEncryptAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationStrictEncryptAcceptanceTest.java
@@ -165,7 +165,7 @@ public class ClickhouseDestinationStrictEncryptAcceptanceTest extends Destinatio
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     db = new GenericContainer<>(new ImageFromDockerfile("clickhouse-test")
         .withFileFromClasspath("Dockerfile", "docker/Dockerfile")
         .withFileFromClasspath("clickhouse_certs.sh", "docker/clickhouse_certs.sh"))
@@ -185,7 +185,7 @@ public class ClickhouseDestinationStrictEncryptAcceptanceTest extends Destinatio
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     db.stop();
     db.close();
   }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationAcceptanceTest.java
@@ -138,7 +138,7 @@ public class ClickhouseDestinationAcceptanceTest extends DestinationAcceptanceTe
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     db = new ClickHouseContainer("clickhouse/clickhouse-server:22.5")
         .waitingFor(Wait.forHttp("/ping").forPort(8123)
             .forStatusCode(200).withStartupTimeout(Duration.of(60, SECONDS)));
@@ -146,7 +146,7 @@ public class ClickhouseDestinationAcceptanceTest extends DestinationAcceptanceTe
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     db.stop();
     db.close();
   }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/SshClickhouseDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/SshClickhouseDestinationAcceptanceTest.java
@@ -155,14 +155,14 @@ public abstract class SshClickhouseDestinationAcceptanceTest extends Destination
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     bastion.initAndStartBastion(network);
     db = (ClickHouseContainer) new ClickHouseContainer("clickhouse/clickhouse-server:22.5").withNetwork(network);
     db.start();
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     bastion.stopAndCloseContainers(db);
   }
 

--- a/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationAcceptanceTest.java
@@ -52,7 +52,7 @@ public class CsvDestinationAcceptanceTest extends DestinationAcceptanceTest {
     return Jsons.jsonNode(ImmutableMap.of("destination_path", Path.of("/local").resolve(RELATIVE_PATH).toString()));
   }
 
-  protected JsonNode getConfigWithDelimiter(String delimiter) {
+  protected JsonNode getConfigWithDelimiter(final String delimiter) {
     config = Jsons.jsonNode(ImmutableMap.of("destination_path", Path.of("/local").resolve(RELATIVE_PATH).toString(), "delimiter", delimiter));
     return config;
   }
@@ -76,7 +76,7 @@ public class CsvDestinationAcceptanceTest extends DestinationAcceptanceTest {
 
   @ParameterizedTest
   @ArgumentsSource(CSVDataArgumentsProvider.class)
-  public void testSyncWithDelimiter(final String messagesFilename, final String catalogFilename, String delimiter)
+  public void testSyncWithDelimiter(final String messagesFilename, final String catalogFilename, final String delimiter)
       throws Exception {
     final AirbyteCatalog catalog = Jsons.deserialize(MoreResources.readResource(catalogFilename),
         AirbyteCatalog.class);
@@ -119,12 +119,12 @@ public class CsvDestinationAcceptanceTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     // no op
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     // no op
   }
 
@@ -134,7 +134,7 @@ public class CsvDestinationAcceptanceTest extends DestinationAcceptanceTest {
 
     @Override
     public Stream<? extends Arguments> provideArguments(final ExtensionContext context) throws Exception {
-      ProtocolVersion protocolVersion = ArgumentProviderUtil.getProtocolVersion(context);
+      final ProtocolVersion protocolVersion = ArgumentProviderUtil.getProtocolVersion(context);
       return Stream.of(
           Arguments.of(EXCHANGE_RATE_CONFIG.getMessageFileVersion(protocolVersion), EXCHANGE_RATE_CONFIG.getCatalogFileVersion(protocolVersion),
               "\\u002c"),

--- a/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksAzureBlobStorageDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksAzureBlobStorageDestinationAcceptanceTest.java
@@ -46,7 +46,7 @@ public class DatabricksAzureBlobStorageDestinationAcceptanceTest extends Databri
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     final JsonNode baseConfigJson = Jsons.deserialize(IOs.readFile(Path.of(SECRETS_CONFIG_JSON)));
 
     // Set a random Azure path and database schema for each integration test
@@ -70,7 +70,7 @@ public class DatabricksAzureBlobStorageDestinationAcceptanceTest extends Databri
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws SQLException {
+  protected void tearDown(final TestDestinationEnv testEnv) throws SQLException {
     final BlobServiceClient storageClient = new BlobServiceClientBuilder()
         .endpoint(azureBlobStorageConfig.getEndpointUrl())
         .sasToken(azureBlobStorageConfig.getSasToken())
@@ -84,7 +84,7 @@ public class DatabricksAzureBlobStorageDestinationAcceptanceTest extends Databri
       blobContainerClient.delete();
     }
 
-    super.tearDown(testEnv, TEST_SCHEMAS);
+    super.tearDown(testEnv);
   }
 
 }

--- a/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationAcceptanceTest.java
@@ -18,7 +18,6 @@ import io.airbyte.integrations.destination.s3.avro.JsonFieldNameUpdater;
 import io.airbyte.integrations.destination.s3.util.AvroRecordHelper;
 import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
 import java.sql.SQLException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jooq.DSLContext;
@@ -68,7 +67,7 @@ public abstract class DatabricksDestinationAcceptanceTest extends DestinationAcc
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws SQLException {
+  protected void tearDown(final TestDestinationEnv testEnv) throws SQLException {
     DatabricksUtilTest.cleanUpData(databricksConfig);
   }
 

--- a/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksManagedTablesDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksManagedTablesDestinationAcceptanceTest.java
@@ -87,7 +87,7 @@ public class DatabricksManagedTablesDestinationAcceptanceTest extends Destinatio
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws SQLException {
+  protected void tearDown(final TestDestinationEnv testEnv) throws SQLException {
     DatabricksUtilTest.cleanUpData(databricksConfig);
   }
 

--- a/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksS3DestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksS3DestinationAcceptanceTest.java
@@ -64,7 +64,7 @@ public class DatabricksS3DestinationAcceptanceTest extends DatabricksDestination
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws SQLException {
+  protected void tearDown(final TestDestinationEnv testEnv) throws SQLException {
     // clean up s3
     final List<KeyVersion> keysToDelete = new LinkedList<>();
     final List<S3ObjectSummary> objects = s3Client
@@ -83,7 +83,7 @@ public class DatabricksS3DestinationAcceptanceTest extends DatabricksDestination
     }
     s3Client.shutdown();
 
-    super.tearDown(testEnv, TEST_SCHEMAS);
+    super.tearDown(testEnv);
   }
 
 }

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/java/io/airbyte/integrations/destination/dev_null/DevNullDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/java/io/airbyte/integrations/destination/dev_null/DevNullDestinationAcceptanceTest.java
@@ -47,7 +47,7 @@ public class DevNullDestinationAcceptanceTest extends DestinationAcceptanceTest 
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     // do nothing
   }
 

--- a/airbyte-integrations/connectors/destination-doris/src/test-integration/java/io/airbyte/integrations/destination/doris/DorisDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-doris/src/test-integration/java/io/airbyte/integrations/destination/doris/DorisDestinationAcceptanceTest.java
@@ -45,13 +45,13 @@ public class DorisDestinationAcceptanceTest extends DestinationAcceptanceTest {
 
   @BeforeAll
   public static void getConnect() {
-    JsonNode config = Jsons.deserialize(IOs.readFile(Paths.get("../../../secrets/config.json")));
-    String dbUrl = String.format(DB_URL_PATTERN, config.get("host").asText(), PORT);
+    final JsonNode config = Jsons.deserialize(IOs.readFile(Paths.get("../../../secrets/config.json")));
+    final String dbUrl = String.format(DB_URL_PATTERN, config.get("host").asText(), PORT);
     try {
       Class.forName(JDBC_DRIVER);
       conn =
           DriverManager.getConnection(dbUrl, config.get("username").asText(), config.get("password") == null ? "" : config.get("password").asText());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       e.printStackTrace();
     }
 
@@ -81,10 +81,10 @@ public class DorisDestinationAcceptanceTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema)
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema)
       throws IOException, SQLException {
     // TODO Implement this method to retrieve records which written to the destination by the connector.
     // Records returned from this method will be compared against records provided to the connector
@@ -92,15 +92,15 @@ public class DorisDestinationAcceptanceTest extends DestinationAcceptanceTest {
 
     final String tableName = namingResolver.getIdentifier(streamName);
 
-    String query = String.format(
+    final String query = String.format(
         "SELECT * FROM %s.%s ORDER BY %s ASC;", configJson.get("database").asText(), tableName,
         JavaBaseConstants.COLUMN_NAME_EMITTED_AT);
-    PreparedStatement stmt = conn.prepareStatement(query);
-    ResultSet resultSet = stmt.executeQuery();
+    final PreparedStatement stmt = conn.prepareStatement(query);
+    final ResultSet resultSet = stmt.executeQuery();
 
-    List<JsonNode> res = new ArrayList<>();
+    final List<JsonNode> res = new ArrayList<>();
     while (resultSet.next()) {
-      String sss = resultSet.getString(JavaBaseConstants.COLUMN_NAME_DATA);
+      final String sss = resultSet.getString(JavaBaseConstants.COLUMN_NAME_DATA);
       res.add(Jsons.deserialize(StringEscapeUtils.unescapeJava(sss)));
     }
     stmt.close();
@@ -108,12 +108,12 @@ public class DorisDestinationAcceptanceTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     // TODO Implement this method to run any setup actions needed before every test case
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     // TODO Implement this method to run any cleanup actions needed after every test case
   }
 

--- a/airbyte-integrations/connectors/destination-dynamodb/src/test-integration/java/io/airbyte/integrations/destination/dynamodb/DynamodbDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-dynamodb/src/test-integration/java/io/airbyte/integrations/destination/dynamodb/DynamodbDestinationAcceptanceTest.java
@@ -105,7 +105,7 @@ public class DynamodbDestinationAcceptanceTest extends DestinationAcceptanceTest
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     final JsonNode baseConfigJson = getBaseConfigJson();
     // Set a random s3 bucket path for each integration test
     final JsonNode configJson = Jsons.clone(baseConfigJson);
@@ -139,7 +139,7 @@ public class DynamodbDestinationAcceptanceTest extends DestinationAcceptanceTest
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     final var dynamodb = new DynamoDB(this.client);
     final List<String> tables = new ArrayList<String>();
     dynamodb.listTables().forEach(o -> {

--- a/airbyte-integrations/connectors/destination-e2e-test/src/test-integration/java/io/airbyte/integrations/destination/e2e_test/TestingSilentDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-e2e-test/src/test-integration/java/io/airbyte/integrations/destination/e2e_test/TestingSilentDestinationAcceptanceTest.java
@@ -43,12 +43,12 @@ public class TestingSilentDestinationAcceptanceTest extends DestinationAcceptanc
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     // do nothing
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     // do nothing
   }
 

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchStrictEncryptDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchStrictEncryptDestinationAcceptanceTest.java
@@ -138,7 +138,7 @@ public class ElasticsearchStrictEncryptDestinationAcceptanceTest extends Destina
   protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {}
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     final ElasticsearchConnection connection = new ElasticsearchConnection(mapper.convertValue(getConfig(), ConnectorConfiguration.class));
     connection.allIndices().forEach(connection::deleteIndexIfPresent);
   }

--- a/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchDestinationAcceptanceTest.java
@@ -23,7 +23,7 @@ public class ElasticsearchDestinationAcceptanceTest extends DestinationAcceptanc
   private static final String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:8.3.3";
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchDestinationAcceptanceTest.class);
 
-  private ObjectMapper mapper = new ObjectMapper();
+  private final ObjectMapper mapper = new ObjectMapper();
   private static ElasticsearchContainer container;
 
   @BeforeAll
@@ -84,7 +84,7 @@ public class ElasticsearchDestinationAcceptanceTest extends DestinationAcceptanc
 
   @Override
   protected JsonNode getConfig() throws Exception {
-    var configJson = mapper.createObjectNode();
+    final var configJson = mapper.createObjectNode();
     configJson.put("endpoint", String.format("http://%s:%s", container.getHost(), container.getMappedPort(9200)));
     return configJson;
   }
@@ -92,16 +92,16 @@ public class ElasticsearchDestinationAcceptanceTest extends DestinationAcceptanc
   @Override
   protected JsonNode getFailCheckConfig() throws Exception {
     // should result in a failed connection check
-    var configJson = mapper.createObjectNode();
+    final var configJson = mapper.createObjectNode();
     configJson.put("endpoint", String.format("htp::/%s:-%s", container.getHost(), container.getMappedPort(9200)));
     return configJson;
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema)
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema)
       throws Exception {
     // Records returned from this method will be compared against records provided to the connector
     // to verify they were written correctly
@@ -110,16 +110,16 @@ public class ElasticsearchDestinationAcceptanceTest extends DestinationAcceptanc
         .setStreamName(streamName)
         .getIndexName();
 
-    ElasticsearchConnection connection = new ElasticsearchConnection(mapper.convertValue(getConfig(), ConnectorConfiguration.class));
+    final ElasticsearchConnection connection = new ElasticsearchConnection(mapper.convertValue(getConfig(), ConnectorConfiguration.class));
     return connection.getRecords(indexName);
   }
 
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {}
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {}
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
-    ElasticsearchConnection connection = new ElasticsearchConnection(mapper.convertValue(getConfig(), ConnectorConfiguration.class));
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
+    final ElasticsearchConnection connection = new ElasticsearchConnection(mapper.convertValue(getConfig(), ConnectorConfiguration.class));
     connection.allIndices().forEach(connection::deleteIndexIfPresent);
     connection.close();
   }

--- a/airbyte-integrations/connectors/destination-exasol/src/test-integration/java/io/airbyte/integrations/destination/exasol/ExasolDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-exasol/src/test-integration/java/io/airbyte/integrations/destination/exasol/ExasolDestinationAcceptanceTest.java
@@ -44,7 +44,7 @@ public class ExasolDestinationAcceptanceTest extends JdbcDestinationAcceptanceTe
     config = createExasolConfig(EXASOL);
   }
 
-  private static JsonNode createExasolConfig(ExasolContainer<? extends ExasolContainer<?>> exasol) {
+  private static JsonNode createExasolConfig(final ExasolContainer<? extends ExasolContainer<?>> exasol) {
     return Jsons.jsonNode(ImmutableMap.builder()
         .put(JdbcUtils.HOST_KEY, exasol.getHost())
         .put(JdbcUtils.PORT_KEY, exasol.getFirstMappedDatabasePort())
@@ -98,10 +98,10 @@ public class ExasolDestinationAcceptanceTest extends JdbcDestinationAcceptanceTe
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema)
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema)
       throws SQLException {
     return retrieveRecordsFromTable(namingResolver.getRawTableName(streamName), "\"" + namespace + "\"")
         .stream()
@@ -111,7 +111,7 @@ public class ExasolDestinationAcceptanceTest extends JdbcDestinationAcceptanceTe
   }
 
   private List<JsonNode> retrieveRecordsFromTable(final String tableName, final String schemaName) throws SQLException {
-    String query = String.format("SELECT * FROM %s.%s ORDER BY %s ASC", schemaName, tableName, ExasolSqlOperations.COLUMN_NAME_EMITTED_AT);
+    final String query = String.format("SELECT * FROM %s.%s ORDER BY %s ASC", schemaName, tableName, ExasolSqlOperations.COLUMN_NAME_EMITTED_AT);
     LOGGER.info("Retrieving records using query {}", query);
     try (final DSLContext dslContext = getDSLContext(config)) {
       final List<org.jooq.Record> result = new Database(dslContext)
@@ -125,9 +125,9 @@ public class ExasolDestinationAcceptanceTest extends JdbcDestinationAcceptanceTe
   }
 
   private static DSLContext getDSLContext(final JsonNode config) {
-    String jdbcUrl =
+    final String jdbcUrl =
         String.format(DatabaseDriver.EXASOL.getUrlFormatString(), config.get(JdbcUtils.HOST_KEY).asText(), config.get(JdbcUtils.PORT_KEY).asInt());
-    Map<String, String> jdbcConnectionProperties = Map.of("fingerprint", config.get("certificateFingerprint").asText());
+    final Map<String, String> jdbcConnectionProperties = Map.of("fingerprint", config.get("certificateFingerprint").asText());
     return DSLContextFactory.create(
         config.get(JdbcUtils.USERNAME_KEY).asText(),
         config.get(JdbcUtils.PASSWORD_KEY).asText(),
@@ -138,12 +138,12 @@ public class ExasolDestinationAcceptanceTest extends JdbcDestinationAcceptanceTe
   }
 
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     // Nothing to do
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     EXASOL.purgeDatabase();
   }
 

--- a/airbyte-integrations/connectors/destination-gcs/src/test-integration/java/io/airbyte/integrations/destination/gcs/GcsDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/test-integration/java/io/airbyte/integrations/destination/gcs/GcsDestinationAcceptanceTest.java
@@ -161,7 +161,7 @@ public abstract class GcsDestinationAcceptanceTest extends DestinationAcceptance
    * <li>Construct the GCS client.</li>
    */
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     final JsonNode baseConfigJson = getBaseConfigJson();
     // Set a random GCS bucket path for each integration test
     final JsonNode configJson = Jsons.clone(baseConfigJson);
@@ -185,7 +185,7 @@ public abstract class GcsDestinationAcceptanceTest extends DestinationAcceptance
    * Remove all the S3 output from the tests.
    */
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     final List<KeyVersion> keysToDelete = new LinkedList<>();
     final List<S3ObjectSummary> objects = s3Client
         .listObjects(config.getBucketName(), config.getBucketPath())

--- a/airbyte-integrations/connectors/destination-iceberg/src/test-integration/java/io/airbyte/integrations/destination/iceberg/hadoop/BaseIcebergHadoopCatalogS3IntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-iceberg/src/test-integration/java/io/airbyte/integrations/destination/iceberg/hadoop/BaseIcebergHadoopCatalogS3IntegrationTest.java
@@ -44,13 +44,13 @@ public abstract class BaseIcebergHadoopCatalogS3IntegrationTest extends Destinat
   private MinioContainer s3Storage;
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     s3Storage = IcebergIntegrationTestUtil.createAndStartMinioContainer(null);
     IcebergIntegrationTestUtil.createS3WarehouseBucket(getConfig());
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     IcebergIntegrationTestUtil.stopAndCloseContainer(s3Storage, "Minio");
   }
 
@@ -61,7 +61,7 @@ public abstract class BaseIcebergHadoopCatalogS3IntegrationTest extends Destinat
 
   @Override
   protected JsonNode getConfig() {
-    String s3Endpoint = "http://" + s3Storage.getHostAddress();
+    final String s3Endpoint = "http://" + s3Storage.getHostAddress();
     LOGGER.info("Configurate S3 endpoint to {}", s3Endpoint);
     return Jsons.jsonNode(ofEntries(
         entry(ICEBERG_CATALOG_CONFIG_KEY,
@@ -80,7 +80,7 @@ public abstract class BaseIcebergHadoopCatalogS3IntegrationTest extends Destinat
 
   @Override
   protected JsonNode getFailCheckConfig() {
-    String s3Endpoint = "http://%s:%s".formatted(HostPortResolver.resolveHost(s3Storage),
+    final String s3Endpoint = "http://%s:%s".formatted(HostPortResolver.resolveHost(s3Storage),
         HostPortResolver.resolvePort(s3Storage));
     return Jsons.jsonNode(ofEntries(
         entry(ICEBERG_CATALOG_CONFIG_KEY,
@@ -98,10 +98,10 @@ public abstract class BaseIcebergHadoopCatalogS3IntegrationTest extends Destinat
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema)
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema)
       throws Exception {
     return IcebergIntegrationTestUtil.retrieveRecords(getConfig(), namespace, streamName);
   }

--- a/airbyte-integrations/connectors/destination-iceberg/src/test-integration/java/io/airbyte/integrations/destination/iceberg/hive/IcebergHiveCatalogS3AvroIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-iceberg/src/test-integration/java/io/airbyte/integrations/destination/iceberg/hive/IcebergHiveCatalogS3AvroIntegrationTest.java
@@ -49,10 +49,10 @@ public class IcebergHiveCatalogS3AvroIntegrationTest extends DestinationAcceptan
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {}
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {}
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {}
+  protected void tearDown(final TestDestinationEnv testEnv) {}
 
   @Override
   protected String getImageName() {
@@ -70,10 +70,10 @@ public class IcebergHiveCatalogS3AvroIntegrationTest extends DestinationAcceptan
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema)
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema)
       throws Exception {
     return IcebergIntegrationTestUtil.retrieveRecords(getConfig(), namespace, streamName);
   }

--- a/airbyte-integrations/connectors/destination-iceberg/src/test-integration/java/io/airbyte/integrations/destination/iceberg/hive/IcebergHiveCatalogS3ParquetIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-iceberg/src/test-integration/java/io/airbyte/integrations/destination/iceberg/hive/IcebergHiveCatalogS3ParquetIntegrationTest.java
@@ -49,10 +49,10 @@ public class IcebergHiveCatalogS3ParquetIntegrationTest extends DestinationAccep
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {}
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {}
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {}
+  protected void tearDown(final TestDestinationEnv testEnv) {}
 
   @Override
   protected String getImageName() {
@@ -70,10 +70,10 @@ public class IcebergHiveCatalogS3ParquetIntegrationTest extends DestinationAccep
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema)
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema)
       throws Exception {
     return IcebergIntegrationTestUtil.retrieveRecords(getConfig(), namespace, streamName);
   }

--- a/airbyte-integrations/connectors/destination-iceberg/src/test-integration/java/io/airbyte/integrations/destination/iceberg/jdbc/BaseIcebergJdbcCatalogS3IntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-iceberg/src/test-integration/java/io/airbyte/integrations/destination/iceberg/jdbc/BaseIcebergJdbcCatalogS3IntegrationTest.java
@@ -53,7 +53,7 @@ public abstract class BaseIcebergJdbcCatalogS3IntegrationTest extends Destinatio
   private MinioContainer s3Storage;
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     catalogDb = new PostgreSQLContainer<>("postgres:13-alpine");
     catalogDb.start();
     LOGGER.info("==> Started PostgreSQL docker container...");
@@ -63,7 +63,7 @@ public abstract class BaseIcebergJdbcCatalogS3IntegrationTest extends Destinatio
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     IcebergIntegrationTestUtil.stopAndCloseContainer(s3Storage, "Minio");
     IcebergIntegrationTestUtil.stopAndCloseContainer(catalogDb, "PostgreSQL");
   }
@@ -75,9 +75,9 @@ public abstract class BaseIcebergJdbcCatalogS3IntegrationTest extends Destinatio
 
   @Override
   protected JsonNode getConfig() {
-    String jdbcUrl = catalogDb.getJdbcUrl();
+    final String jdbcUrl = catalogDb.getJdbcUrl();
     LOGGER.info("Postgresql jdbc url: {}", jdbcUrl);
-    String s3Endpoint = "http://" + s3Storage.getHostAddress();
+    final String s3Endpoint = "http://" + s3Storage.getHostAddress();
     return Jsons.jsonNode(ofEntries(
         entry(ICEBERG_CATALOG_CONFIG_KEY,
             Jsons.jsonNode(ofEntries(
@@ -100,10 +100,10 @@ public abstract class BaseIcebergJdbcCatalogS3IntegrationTest extends Destinatio
 
   @Override
   protected JsonNode getFailCheckConfig() {
-    String jdbcUrl = "jdbc:postgresql://%s:%d/%s".formatted(HostPortResolver.resolveHost(catalogDb),
+    final String jdbcUrl = "jdbc:postgresql://%s:%d/%s".formatted(HostPortResolver.resolveHost(catalogDb),
         HostPortResolver.resolvePort(catalogDb),
         catalogDb.getDatabaseName());
-    String s3Endpoint = "http://%s:%s".formatted(HostPortResolver.resolveHost(s3Storage),
+    final String s3Endpoint = "http://%s:%s".formatted(HostPortResolver.resolveHost(s3Storage),
         HostPortResolver.resolvePort(s3Storage));
     return Jsons.jsonNode(ofEntries(
         entry(ICEBERG_CATALOG_CONFIG_KEY,
@@ -126,10 +126,10 @@ public abstract class BaseIcebergJdbcCatalogS3IntegrationTest extends Destinatio
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema)
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema)
       throws Exception {
     return IcebergIntegrationTestUtil.retrieveRecords(getConfig(), namespace, streamName);
   }

--- a/airbyte-integrations/connectors/destination-iceberg/src/test-integration/java/io/airbyte/integrations/destination/iceberg/rest/BaseIcebergRESTCatalogS3IntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-iceberg/src/test-integration/java/io/airbyte/integrations/destination/iceberg/rest/BaseIcebergRESTCatalogS3IntegrationTest.java
@@ -25,7 +25,7 @@ public abstract class BaseIcebergRESTCatalogS3IntegrationTest extends Destinatio
   private static RESTServerWithMinioCompose composeContainer;
   private static JsonNode config;
 
-  static void startCompose(DataFileFormat fileFormat) {
+  static void startCompose(final DataFileFormat fileFormat) {
     composeContainer = new RESTServerWithMinioCompose();
     composeContainer.start();
     config = composeContainer.getComposeConfig(fileFormat);
@@ -39,10 +39,10 @@ public abstract class BaseIcebergRESTCatalogS3IntegrationTest extends Destinatio
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {}
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {}
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {}
+  protected void tearDown(final TestDestinationEnv testEnv) {}
 
   @Override
   protected String getImageName() {
@@ -60,10 +60,10 @@ public abstract class BaseIcebergRESTCatalogS3IntegrationTest extends Destinatio
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-      String streamName,
-      String namespace,
-      JsonNode streamSchema)
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema)
       throws Exception {
     return IcebergIntegrationTestUtil.retrieveRecords(getConfig(), namespace, streamName);
   }

--- a/airbyte-integrations/connectors/destination-kafka/src/test-integration/java/io/airbyte/integrations/destination/kafka/KafkaDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-kafka/src/test-integration/java/io/airbyte/integrations/destination/kafka/KafkaDestinationAcceptanceTest.java
@@ -167,13 +167,13 @@ public class KafkaDestinationAcceptanceTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     KAFKA = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.0"));
     KAFKA.start();
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     KAFKA.close();
   }
 

--- a/airbyte-integrations/connectors/destination-keen/src/test-integration/java/io/airbyte/integrations/destination/keen/KeenDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-keen/src/test-integration/java/io/airbyte/integrations/destination/keen/KeenDestinationTest.java
@@ -96,7 +96,7 @@ public class KeenDestinationTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     if (!Files.exists(Path.of(SECRET_FILE_PATH))) {
       throw new IllegalStateException(
           "Must provide path to a file containing Keen account credentials: Project ID and Master API Key. " +
@@ -109,7 +109,7 @@ public class KeenDestinationTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
     for (final String keenCollection : collectionsToDelete) {
       keenHttpClient.eraseStream(keenCollection, projectId, apiKey);
     }

--- a/airbyte-integrations/connectors/destination-kinesis/src/test-integration/java/io/airbyte/integrations/destination/kinesis/KinesisDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-kinesis/src/test-integration/java/io/airbyte/integrations/destination/kinesis/KinesisDestinationAcceptanceTest.java
@@ -35,7 +35,7 @@ public class KinesisDestinationAcceptanceTest extends DestinationAcceptanceTest 
   }
 
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     configJson = KinesisDataFactory.jsonConfig(
         kinesisContainer.getEndpointOverride().toString(),
         kinesisContainer.getRegion(),
@@ -66,7 +66,7 @@ public class KinesisDestinationAcceptanceTest extends DestinationAcceptanceTest 
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     kinesisStream.deleteAllStreams();
   }
 
@@ -95,11 +95,11 @@ public class KinesisDestinationAcceptanceTest extends DestinationAcceptanceTest 
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema) {
-    var stream = kinesisNameTransformer.streamName(namespace, streamName);
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema) {
+    final var stream = kinesisNameTransformer.streamName(namespace, streamName);
     return kinesisStream.getRecords(stream).stream()
         .sorted(Comparator.comparing(KinesisRecord::getTimestamp))
         .map(KinesisRecord::getData)

--- a/airbyte-integrations/connectors/destination-local-json/src/test-integration/java/io/airbyte/integrations/destination/local_json/LocalJsonDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/test-integration/java/io/airbyte/integrations/destination/local_json/LocalJsonDestinationAcceptanceTest.java
@@ -92,12 +92,12 @@ public class LocalJsonDestinationAcceptanceTest extends DestinationAcceptanceTes
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     // no op
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     // no op
   }
 

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/src/test-integration/java/io/airbyte/integrations/destination/mariadb_columnstore/MariadbColumnstoreDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/src/test-integration/java/io/airbyte/integrations/destination/mariadb_columnstore/MariadbColumnstoreDestinationAcceptanceTest.java
@@ -129,7 +129,7 @@ public class MariadbColumnstoreDestinationAcceptanceTest extends DestinationAcce
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     db.stop();
     db.close();
   }

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/src/test-integration/java/io/airbyte/integrations/destination/mariadb_columnstore/SshMariadbColumnstoreDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/src/test-integration/java/io/airbyte/integrations/destination/mariadb_columnstore/SshMariadbColumnstoreDestinationAcceptanceTest.java
@@ -130,7 +130,7 @@ public abstract class SshMariadbColumnstoreDestinationAcceptanceTest extends Des
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     bastion.initAndStartBastion(network);
     startAndInitJdbcContainer();
   }
@@ -148,7 +148,7 @@ public abstract class SshMariadbColumnstoreDestinationAcceptanceTest extends Des
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     bastion.stopAndCloseContainers(db);
   }
 

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/mongodb/MongodbDestinationStrictEncryptAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/mongodb/MongodbDestinationStrictEncryptAcceptanceTest.java
@@ -128,7 +128,7 @@ public class MongodbDestinationStrictEncryptAcceptanceTest extends DestinationAc
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     final var credentials = String.format("%s:%s@", config.get(AUTH_TYPE).get(JdbcUtils.USERNAME_KEY).asText(),
         config.get(AUTH_TYPE).get(JdbcUtils.PASSWORD_KEY).asText());
     final String connectionString = String.format("mongodb+srv://%s%s/%s?retryWrites=true&w=majority&tls=true",
@@ -140,7 +140,7 @@ public class MongodbDestinationStrictEncryptAcceptanceTest extends DestinationAc
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
     for (final String collectionName : mongoDatabase.getCollectionNames()) {
       mongoDatabase.getDatabase().getCollection(collectionName).drop();
     }

--- a/airbyte-integrations/connectors/destination-mongodb/src/test-integration/java/io/airbyte/integrations/destination/mongodb/MongodbDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mongodb/src/test-integration/java/io/airbyte/integrations/destination/mongodb/MongodbDestinationAcceptanceTest.java
@@ -181,13 +181,13 @@ public class MongodbDestinationAcceptanceTest extends DestinationAcceptanceTest 
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     container = new MongoDBContainer(DOCKER_IMAGE_NAME);
     container.start();
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     container.stop();
     container.close();
   }

--- a/airbyte-integrations/connectors/destination-mongodb/src/test-integration/java/io/airbyte/integrations/destination/mongodb/SshMongoDbDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mongodb/src/test-integration/java/io/airbyte/integrations/destination/mongodb/SshMongoDbDestinationAcceptanceTest.java
@@ -32,7 +32,7 @@ public abstract class SshMongoDbDestinationAcceptanceTest extends MongodbDestina
   public abstract SshTunnel.TunnelMethod getTunnelMethod();
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     container = new MongoDBContainer(DOCKER_IMAGE_NAME)
         .withNetwork(network)
         .withExposedPorts(DEFAULT_PORT);
@@ -82,7 +82,7 @@ public abstract class SshMongoDbDestinationAcceptanceTest extends MongodbDestina
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     container.stop();
     container.close();
     bastion.getContainer().stop();

--- a/airbyte-integrations/connectors/destination-mqtt/src/test-integration/java/io/airbyte/integrations/destination/mqtt/MqttDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mqtt/src/test-integration/java/io/airbyte/integrations/destination/mqtt/MqttDestinationAcceptanceTest.java
@@ -134,13 +134,13 @@ public class MqttDestinationAcceptanceTest extends DestinationAcceptanceTest {
           .map(InetAddress::getHostAddress)
           .filter(InetAddresses::isUriInetAddress)
           .findFirst().orElse(InetAddress.getLocalHost().getHostAddress());
-    } catch (SocketException e) {
+    } catch (final SocketException e) {
       return InetAddress.getLocalHost().getHostAddress();
     }
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws MqttException {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws MqttException {
     recordsPerTopic.clear();
     client = new MqttClient("tcp://" + extension.getHost() + ":" + extension.getMqttPort(), UUID.randomUUID().toString(), new MemoryPersistence());
 
@@ -150,14 +150,14 @@ public class MqttDestinationAcceptanceTest extends DestinationAcceptanceTest {
     client.connect(options);
 
     client.subscribe(TOPIC_PREFIX + "#", (topic, msg) -> {
-      List<JsonNode> records = recordsPerTopic.getOrDefault(topic, new ArrayList<>());
+      final List<JsonNode> records = recordsPerTopic.getOrDefault(topic, new ArrayList<>());
       records.add(READER.readTree(msg.getPayload()).get(MqttDestination.COLUMN_NAME_DATA));
       recordsPerTopic.put(topic, records);
     });
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws MqttException {
+  protected void tearDown(final TestDestinationEnv testEnv) throws MqttException {
     client.disconnectForcibly();
     client.close();
   }

--- a/airbyte-integrations/connectors/destination-mssql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/mssql_strict_encrypt/MssqlStrictEncryptDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mssql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/mssql_strict_encrypt/MssqlStrictEncryptDestinationAcceptanceTest.java
@@ -147,7 +147,7 @@ public class MssqlStrictEncryptDestinationAcceptanceTest extends DestinationAcce
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws SQLException {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws SQLException {
     final JsonNode configWithoutDbName = getConfig(db);
     final String dbName = Strings.addRandomSuffix("db", "_", 10);
     dslContext = getDslContext(configWithoutDbName);
@@ -166,7 +166,7 @@ public class MssqlStrictEncryptDestinationAcceptanceTest extends DestinationAcce
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     dslContext.close();
   }
 

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTest.java
@@ -131,7 +131,7 @@ public class MSSQLDestinationAcceptanceTest extends JdbcDestinationAcceptanceTes
   // 1. exec into mssql container (not the test container container)
   // 2. /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "A_Str0ng_Required_Password"
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws SQLException {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws SQLException {
     final JsonNode configWithoutDbName = getConfig(db);
     final String dbName = Strings.addRandomSuffix("db", "_", 10);
     dslContext = getDslContext(configWithoutDbName);
@@ -150,7 +150,7 @@ public class MSSQLDestinationAcceptanceTest extends JdbcDestinationAcceptanceTes
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     dslContext.close();
   }
 

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTestSSL.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTestSSL.java
@@ -161,7 +161,7 @@ public class MSSQLDestinationAcceptanceTestSSL extends JdbcDestinationAcceptance
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     dslContext.close();
   }
 

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/SshMSSQLDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/SshMSSQLDestinationAcceptanceTest.java
@@ -115,7 +115,7 @@ public abstract class SshMSSQLDestinationAcceptanceTest extends JdbcDestinationA
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     startTestContainers();
 
     SshTunnel.sshWrap(
@@ -147,7 +147,7 @@ public abstract class SshMSSQLDestinationAcceptanceTest extends JdbcDestinationA
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     bastion.stopAndCloseContainers(db);
   }
 

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/mysql/MySQLStrictEncryptDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/mysql/MySQLStrictEncryptDestinationAcceptanceTest.java
@@ -180,7 +180,7 @@ public class MySQLStrictEncryptDestinationAcceptanceTest extends JdbcDestination
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     db.stop();
     db.close();
   }

--- a/airbyte-integrations/connectors/destination-mysql/src/test-integration/java/io/airbyte/integrations/destination/mysql/MySQLDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mysql/src/test-integration/java/io/airbyte/integrations/destination/mysql/MySQLDestinationAcceptanceTest.java
@@ -149,7 +149,7 @@ public class MySQLDestinationAcceptanceTest extends JdbcDestinationAcceptanceTes
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     db = new MySQLContainer<>("mysql:8.0");
     db.start();
     setLocalInFileToTrue();
@@ -188,7 +188,7 @@ public class MySQLDestinationAcceptanceTest extends JdbcDestinationAcceptanceTes
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     db.stop();
     db.close();
   }

--- a/airbyte-integrations/connectors/destination-mysql/src/test-integration/java/io/airbyte/integrations/destination/mysql/SshMySQLDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mysql/src/test-integration/java/io/airbyte/integrations/destination/mysql/SshMySQLDestinationAcceptanceTest.java
@@ -136,7 +136,7 @@ public abstract class SshMySQLDestinationAcceptanceTest extends JdbcDestinationA
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     schemaName = RandomStringUtils.randomAlphabetic(8).toLowerCase();
     final var config = getConfig();
     SshTunnel.sshWrap(
@@ -149,7 +149,7 @@ public abstract class SshMySQLDestinationAcceptanceTest extends JdbcDestinationA
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
     SshTunnel.sshWrap(
         getConfig(),
         JdbcUtils.HOST_LIST_KEY,

--- a/airbyte-integrations/connectors/destination-mysql/src/test-integration/java/io/airbyte/integrations/destination/mysql/SslMySQLDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mysql/src/test-integration/java/io/airbyte/integrations/destination/mysql/SslMySQLDestinationAcceptanceTest.java
@@ -85,7 +85,7 @@ public class SslMySQLDestinationAcceptanceTest extends MySQLDestinationAcceptanc
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     db = new MySQLContainer<>("mysql:8.0");
     db.start();
 
@@ -105,7 +105,7 @@ public class SslMySQLDestinationAcceptanceTest extends MySQLDestinationAcceptanc
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     dslContext.close();
     db.stop();
     db.close();

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/oracle_strict_encrypt/OracleStrictEncryptDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/oracle_strict_encrypt/OracleStrictEncryptDestinationAcceptanceTest.java
@@ -142,7 +142,7 @@ public class OracleStrictEncryptDestinationAcceptanceTest extends DestinationAcc
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     final String dbName = Strings.addRandomSuffix("db", "_", 10);
     db = new OracleContainer()
         .withUsername("test")
@@ -163,7 +163,7 @@ public class OracleStrictEncryptDestinationAcceptanceTest extends DestinationAcc
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     db.stop();
     db.close();
   }

--- a/airbyte-integrations/connectors/destination-oracle/src/test-integration/java/io/airbyte/integrations/destination/oracle/SshOracleDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-oracle/src/test-integration/java/io/airbyte/integrations/destination/oracle/SshOracleDestinationAcceptanceTest.java
@@ -132,7 +132,7 @@ public abstract class SshOracleDestinationAcceptanceTest extends DestinationAcce
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     startTestContainers();
     SshTunnel.sshWrap(
         getConfig(),
@@ -171,7 +171,7 @@ public abstract class SshOracleDestinationAcceptanceTest extends DestinationAcce
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
     SshTunnel.sshWrap(
         getConfig(),
         JdbcUtils.HOST_LIST_KEY,

--- a/airbyte-integrations/connectors/destination-oracle/src/test-integration/java/io/airbyte/integrations/destination/oracle/UnencryptedOracleDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-oracle/src/test-integration/java/io/airbyte/integrations/destination/oracle/UnencryptedOracleDestinationAcceptanceTest.java
@@ -171,7 +171,7 @@ public class UnencryptedOracleDestinationAcceptanceTest extends DestinationAccep
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     db.stop();
     db.close();
   }

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresDestinationStrictEncryptAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresDestinationStrictEncryptAcceptanceTest.java
@@ -141,7 +141,7 @@ public class PostgresDestinationStrictEncryptAcceptanceTest extends DestinationA
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     db = new PostgreSQLContainer<>(DockerImageName.parse("postgres:bullseye")
         .asCompatibleSubstituteFor("postgres"));
     db.start();
@@ -149,7 +149,7 @@ public class PostgresDestinationStrictEncryptAcceptanceTest extends DestinationA
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     db.stop();
     db.close();
   }

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresDestinationAcceptanceTest.java
@@ -128,13 +128,13 @@ public class PostgresDestinationAcceptanceTest extends JdbcDestinationAcceptance
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     db = new PostgreSQLContainer<>("postgres:13-alpine");
     db.start();
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     db.stop();
     db.close();
   }

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresDestinationSSLFullCertificateAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresDestinationSSLFullCertificateAcceptanceTest.java
@@ -142,7 +142,7 @@ public class PostgresDestinationSSLFullCertificateAcceptanceTest extends JdbcDes
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
     db.stop();
     db.close();
   }

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/SshPostgresDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/SshPostgresDestinationAcceptanceTest.java
@@ -160,7 +160,7 @@ public abstract class SshPostgresDestinationAcceptanceTest extends JdbcDestinati
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
     // blow away the test schema at the end.
     SshTunnel.sshWrap(
         getConfig(),

--- a/airbyte-integrations/connectors/destination-pubsub/src/test-integration/java/io/airbyte/integrations/destination/pubsub/PubsubDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-pubsub/src/test-integration/java/io/airbyte/integrations/destination/pubsub/PubsubDestinationAcceptanceTest.java
@@ -186,7 +186,7 @@ public class PubsubDestinationAcceptanceTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     if (!Files.exists(CREDENTIALS_PATH)) {
       throw new IllegalStateException(
           "Must provide path to a gcp service account credentials file. By default {module-root}/"
@@ -244,7 +244,7 @@ public class PubsubDestinationAcceptanceTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     // delete subscription
     if (subscriptionAdminClient != null && subscriptionName != null) {
       subscriptionAdminClient.deleteSubscription(subscriptionName);

--- a/airbyte-integrations/connectors/destination-pulsar/src/test-integration/java/io/airbyte/integrations/destination/pulsar/PulsarDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-pulsar/src/test-integration/java/io/airbyte/integrations/destination/pulsar/PulsarDestinationAcceptanceTest.java
@@ -186,7 +186,7 @@ public class PulsarDestinationAcceptanceTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     PULSAR.close();
   }
 

--- a/airbyte-integrations/connectors/destination-redis/src/test-integration/java/io/airbyte/integrations/destination/redis/RedisDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redis/src/test-integration/java/io/airbyte/integrations/destination/redis/RedisDestinationAcceptanceTest.java
@@ -40,7 +40,7 @@ class RedisDestinationAcceptanceTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(TestDestinationEnv testEnv) {
     redisCache.flushAll();
   }
 

--- a/airbyte-integrations/connectors/destination-redis/src/test-integration/java/io/airbyte/integrations/destination/redis/SshRedisDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redis/src/test-integration/java/io/airbyte/integrations/destination/redis/SshRedisDestinationAcceptanceTest.java
@@ -58,7 +58,7 @@ public abstract class SshRedisDestinationAcceptanceTest extends DestinationAccep
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     redisCache.flushAll();
   }
 

--- a/airbyte-integrations/connectors/destination-redpanda/src/test-integration/java/io/airbyte/integrations/destination/redpanda/RedpandaDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redpanda/src/test-integration/java/io/airbyte/integrations/destination/redpanda/RedpandaDestinationAcceptanceTest.java
@@ -52,7 +52,7 @@ public class RedpandaDestinationAcceptanceTest extends DestinationAcceptanceTest
   }
 
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     this.redpandaNameTransformer = new RedpandaNameTransformer();
     this.adminClient = AdminClient.create(Map.of(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, redpandaContainer.getBootstrapServers(),
@@ -62,8 +62,8 @@ public class RedpandaDestinationAcceptanceTest extends DestinationAcceptanceTest
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws ExecutionException, InterruptedException {
-    var topics = adminClient.listTopics().listings().get().stream()
+  protected void tearDown(final TestDestinationEnv testEnv) throws ExecutionException, InterruptedException {
+    final var topics = adminClient.listTopics().listings().get().stream()
         .filter(tl -> !tl.isInternal())
         .map(TopicListing::name)
         .collect(Collectors.toSet());
@@ -132,15 +132,15 @@ public class RedpandaDestinationAcceptanceTest extends DestinationAcceptanceTest
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema) {
-    List<JsonNode> records = new ArrayList<>();
-    String bootstrapServers = redpandaContainer.getBootstrapServers();
-    String groupId = redpandaNameTransformer.getIdentifier(namespace + "-" + streamName);
-    try (RedpandaConsumer<String, JsonNode> redpandaConsumer = RedpandaConsumerFactory.getInstance(bootstrapServers, groupId)) {
-      String topicName = redpandaNameTransformer.topicName(namespace, streamName);
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema) {
+    final List<JsonNode> records = new ArrayList<>();
+    final String bootstrapServers = redpandaContainer.getBootstrapServers();
+    final String groupId = redpandaNameTransformer.getIdentifier(namespace + "-" + streamName);
+    try (final RedpandaConsumer<String, JsonNode> redpandaConsumer = RedpandaConsumerFactory.getInstance(bootstrapServers, groupId)) {
+      final String topicName = redpandaNameTransformer.topicName(namespace, streamName);
       redpandaConsumer.subscribe(Collections.singletonList(topicName));
       redpandaConsumer.poll(Duration.ofSeconds(5)).iterator()
           .forEachRemaining(r -> records.add(r.value().get(JavaBaseConstants.COLUMN_NAME_DATA)));

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftStagingS3DestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftStagingS3DestinationAcceptanceTest.java
@@ -26,11 +26,9 @@ import io.airbyte.protocol.models.v0.AirbyteConnectionStatus;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.jooq.impl.DSL;
@@ -211,7 +209,7 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
 
   // for each test we create a new schema in the database. run the test in there and then remove it.
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     final String schemaName = Strings.addRandomSuffix("integration_test", "_", 5);
     final String createSchemaQuery = String.format("CREATE SCHEMA %s", schemaName);
     baseConfig = getStaticConfig();
@@ -228,10 +226,10 @@ public abstract class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDes
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
     System.out.println("TEARING_DOWN_SCHEMAS: " + TEST_SCHEMAS);
     getDatabase().query(ctx -> ctx.execute(String.format("DROP SCHEMA IF EXISTS %s CASCADE", config.get("schema").asText())));
-    for (String schema : TEST_SCHEMAS) {
+    for (final String schema : TEST_SCHEMAS) {
       getDatabase().query(ctx -> ctx.execute(String.format("DROP SCHEMA IF EXISTS %s CASCADE", schema)));
     }
     getDatabase().query(ctx -> ctx.execute(String.format("drop user if exists %s;", USER_WITHOUT_CREDS)));

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/SshRedshiftDestinationBaseAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/SshRedshiftDestinationBaseAcceptanceTest.java
@@ -18,8 +18,6 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.db.factory.ConnectionFactory;
-import io.airbyte.db.factory.DSLContextFactory;
-import io.airbyte.db.factory.DataSourceFactory;
 import io.airbyte.db.factory.DatabaseDriver;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.base.JavaBaseConstants;
@@ -29,15 +27,11 @@ import io.airbyte.integrations.standardtest.destination.JdbcDestinationAcceptanc
 import io.airbyte.integrations.standardtest.destination.comparator.TestDataComparator;
 import org.jooq.impl.DSL;
 
-import javax.sql.DataSource;
 import java.io.IOException;
 import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.stream.Collectors;
 
 public abstract class SshRedshiftDestinationBaseAcceptanceTest extends JdbcDestinationAcceptanceTest {
@@ -171,7 +165,7 @@ public abstract class SshRedshiftDestinationBaseAcceptanceTest extends JdbcDesti
   }
 
   @Override
-  protected void setup(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     baseConfig = getStaticConfig();
     final JsonNode configForSchema = Jsons.clone(baseConfig);
     schemaName = Strings.addRandomSuffix("integration_test", "_", 5);
@@ -201,7 +195,7 @@ public abstract class SshRedshiftDestinationBaseAcceptanceTest extends JdbcDesti
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
     // blow away the test schema at the end.
     SshTunnel.sshWrap(
         getConfig(),

--- a/airbyte-integrations/connectors/destination-rockset/src/test-integration/java/io/airbyte/integrations/destination/rockset/RocksetDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-rockset/src/test-integration/java/io/airbyte/integrations/destination/rockset/RocksetDestinationAcceptanceTest.java
@@ -153,7 +153,7 @@ public class RocksetDestinationAcceptanceTest extends DestinationAcceptanceTest 
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(TestDestinationEnv testEnv) {
     try {
       final ApiClient client = RocksetUtils.apiClientFromConfig(getConfig());
       String workspace = getConfig().get("workspace").asText();

--- a/airbyte-integrations/connectors/destination-s3-glue/src/test-integration/java/io/airbyte/integrations/destination/s3_glue/S3GlueJsonlDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/test-integration/java/io/airbyte/integrations/destination/s3_glue/S3GlueJsonlDestinationAcceptanceTest.java
@@ -6,18 +6,17 @@ package io.airbyte.integrations.destination.s3_glue;
 
 import io.airbyte.integrations.destination.s3.S3BaseJsonlDestinationAcceptanceTest;
 import io.airbyte.integrations.standardtest.destination.argproviders.DataTypeTestArgumentProvider;
-import java.util.HashSet;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 public class S3GlueJsonlDestinationAcceptanceTest extends S3BaseJsonlDestinationAcceptanceTest {
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
-    super.tearDown(testEnv, TEST_SCHEMAS);
+  protected void tearDown(final TestDestinationEnv testEnv) {
+    super.tearDown(testEnv);
 
-    GlueDestinationConfig glueDestinationConfig = GlueDestinationConfig.getInstance(configJson);
-    try (var glueTestClient = new GlueTestClient(glueDestinationConfig.getAWSGlueInstance())) {
+    final GlueDestinationConfig glueDestinationConfig = GlueDestinationConfig.getInstance(configJson);
+    try (final var glueTestClient = new GlueTestClient(glueDestinationConfig.getAWSGlueInstance())) {
 
       glueTestClient.purgeDatabase(glueDestinationConfig.getDatabase());
 

--- a/airbyte-integrations/connectors/destination-s3-glue/src/test-integration/java/io/airbyte/integrations/destination/s3_glue/S3GlueJsonlGzipDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/test-integration/java/io/airbyte/integrations/destination/s3_glue/S3GlueJsonlGzipDestinationAcceptanceTest.java
@@ -5,16 +5,15 @@
 package io.airbyte.integrations.destination.s3_glue;
 
 import io.airbyte.integrations.destination.s3.S3BaseJsonlGzipDestinationAcceptanceTest;
-import java.util.HashSet;
 
 public class S3GlueJsonlGzipDestinationAcceptanceTest extends S3BaseJsonlGzipDestinationAcceptanceTest {
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
-    super.tearDown(testEnv, TEST_SCHEMAS);
+  protected void tearDown(final TestDestinationEnv testEnv) {
+    super.tearDown(testEnv);
 
-    GlueDestinationConfig glueDestinationConfig = GlueDestinationConfig.getInstance(configJson);
-    try (var glueTestClient = new GlueTestClient(glueDestinationConfig.getAWSGlueInstance())) {
+    final GlueDestinationConfig glueDestinationConfig = GlueDestinationConfig.getInstance(configJson);
+    try (final var glueTestClient = new GlueTestClient(glueDestinationConfig.getAWSGlueInstance())) {
 
       glueTestClient.purgeDatabase(glueDestinationConfig.getDatabase());
 

--- a/airbyte-integrations/connectors/destination-scylla/src/test-integration/java/io/airbyte/integrations/destination/scylla/ScyllaDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-scylla/src/test-integration/java/io/airbyte/integrations/destination/scylla/ScyllaDestinationAcceptanceTest.java
@@ -38,21 +38,21 @@ class ScyllaDestinationAcceptanceTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     configJson = TestDataFactory.jsonConfig(
         HostPortResolver.resolveHost(scyllaContainer),
         HostPortResolver.resolvePort(scyllaContainer));
-    var scyllaConfig = new ScyllaConfig(configJson);
+    final var scyllaConfig = new ScyllaConfig(configJson);
     this.scyllaCqlProvider = new ScyllaCqlProvider(scyllaConfig);
     this.nameTransformer = new ScyllaNameTransformer(scyllaConfig);
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     scyllaCqlProvider.metadata().stream()
         .filter(m -> !m.value1().startsWith("system"))
         .forEach(meta -> {
-          var keyspace = meta.value1();
+          final var keyspace = meta.value1();
           meta.value2().forEach(table -> scyllaCqlProvider.truncate(keyspace, table));
         });
   }
@@ -93,12 +93,12 @@ class ScyllaDestinationAcceptanceTest extends DestinationAcceptanceTest {
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema) {
-    var keyspace = nameTransformer.outputKeyspace(namespace);
-    var table = nameTransformer.outputTable(streamName);
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema) {
+    final var keyspace = nameTransformer.outputKeyspace(namespace);
+    final var table = nameTransformer.outputTable(streamName);
     return scyllaCqlProvider.select(keyspace, table).stream()
         .sorted(Comparator.comparing(Triplet::value3))
         .map(Triplet::value2)

--- a/airbyte-integrations/connectors/destination-selectdb/src/test-integration/java/io/airbyte/integrations/destination/selectdb/SelectdbDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-selectdb/src/test-integration/java/io/airbyte/integrations/destination/selectdb/SelectdbDestinationAcceptanceTest.java
@@ -112,7 +112,7 @@ public class SelectdbDestinationAcceptanceTest extends DestinationAcceptanceTest
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(TestDestinationEnv testEnv) {
     // TODO Implement this method to run any cleanup actions needed after every test case
   }
 

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
@@ -186,11 +186,14 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
 
   @Override
   protected void tearDown(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
-    String dropSchemaQuery = String.format("DROP SCHEMA IF EXISTS %s", config.get("schema").asText());
-    database.execute(dropSchemaQuery);
-
+    TEST_SCHEMAS.add(config.get("schema").asText());
     for (final String schema : TEST_SCHEMAS) {
-      dropSchemaQuery = String.format("DROP SCHEMA IF EXISTS %s", schema);
+      // we need to wrap namespaces in quotes, but that means we have to manually upcase them.
+      // thanks, v1 destinations!
+      // this probably doesn't actually work, because v1 destinations are mangling namespaces and names
+      // but it's approximately correct and maybe works for some things.
+      final String mangledSchema = schema.toUpperCase();
+      final String dropSchemaQuery = String.format("DROP SCHEMA IF EXISTS \"%s\"", mangledSchema);
       database.execute(dropSchemaQuery);
     }
 

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
@@ -185,7 +185,7 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
     TEST_SCHEMAS.add(config.get("schema").asText());
     for (final String schema : TEST_SCHEMAS) {
       // we need to wrap namespaces in quotes, but that means we have to manually upcase them.

--- a/airbyte-integrations/connectors/destination-starburst-galaxy/src/test-integration/java/io/airbyte/integrations/destination/starburst_galaxy/StarburstGalaxyDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-starburst-galaxy/src/test-integration/java/io/airbyte/integrations/destination/starburst_galaxy/StarburstGalaxyDestinationAcceptanceTest.java
@@ -68,7 +68,7 @@ public abstract class StarburstGalaxyDestinationAcceptanceTest extends Destinati
   private Database database;
 
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) {
     dslContext = create(galaxyDestinationConfig.galaxyUsername(), galaxyDestinationConfig.galaxyPassword(), STARBURST_GALAXY_DRIVER_CLASS,
         getGalaxyConnectionString(galaxyDestinationConfig), SQLDialect.DEFAULT);
     database = new Database(dslContext);
@@ -107,23 +107,23 @@ public abstract class StarburstGalaxyDestinationAcceptanceTest extends Destinati
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws SQLException {
+  protected void tearDown(final TestDestinationEnv testEnv) throws SQLException {
     // clean up database
-    List<JsonNode> schemas = executeQuery(format("SHOW SCHEMAS LIKE '%s'", galaxyDestinationConfig.galaxyCatalogSchema().toLowerCase(ENGLISH)));
+    final List<JsonNode> schemas = executeQuery(format("SHOW SCHEMAS LIKE '%s'", galaxyDestinationConfig.galaxyCatalogSchema().toLowerCase(ENGLISH)));
     schemas.stream().map(node -> node.get("Schema").asText())
         .forEach(schema -> {
           try {
-            List<JsonNode> tables = executeQuery(format("SHOW TABLES FROM %s", galaxyDestinationConfig.galaxyCatalogSchema()));
+            final List<JsonNode> tables = executeQuery(format("SHOW TABLES FROM %s", galaxyDestinationConfig.galaxyCatalogSchema()));
             tables.forEach(table -> {
               try {
-                String tableName = table.get("Table").asText();
+                final String tableName = table.get("Table").asText();
                 LOGGER.info("Dropping table : {}.{}", schema, tableName);
                 executeQuery(format("DROP TABLE IF EXISTS %s.%s", schema, tableName));
-              } catch (SQLException e) {
+              } catch (final SQLException e) {
                 throw new RuntimeException(e);
               }
             });
-          } catch (SQLException e) {
+          } catch (final SQLException e) {
             throw new RuntimeException(e);
           }
         });
@@ -132,12 +132,12 @@ public abstract class StarburstGalaxyDestinationAcceptanceTest extends Destinati
     dslContext.close();
   }
 
-  private List<JsonNode> executeQuery(ContextQueryFunction<List<JsonNode>> transform)
+  private List<JsonNode> executeQuery(final ContextQueryFunction<List<JsonNode>> transform)
       throws SQLException {
     return database.query(transform);
   }
 
-  private List<JsonNode> executeQuery(String query)
+  private List<JsonNode> executeQuery(final String query)
       throws SQLException {
     return executeQuery(ctx -> ctx.resultQuery(query)
         .stream()
@@ -147,31 +147,31 @@ public abstract class StarburstGalaxyDestinationAcceptanceTest extends Destinati
 
   @Test
   public void testPromoteSourceSchemaChanges() throws Exception {
-    String sampleStream = "sample_stream_1";
+    final String sampleStream = "sample_stream_1";
     testStreamSync(OVERWRITE, sampleStream, "schema-overwrite.json", "data-overwrite.json", "expected-schema-overwrite.json");
     testStreamSync(APPEND, sampleStream, "schema-append.json", "data-append.json", "expected-schema-append.json");
     assertEquals(2,
         executeQuery(format("SELECT COUNT(*) FROM %s.%s", galaxyDestinationConfig.galaxyCatalogSchema(), sampleStream)).get(0).get("_col0").asInt());
   }
 
-  private void testStreamSync(DestinationSyncMode syncMode,
-                              String streamName,
-                              String schemaFileName,
-                              String dataFileName,
-                              String expectedSchemaFileName)
+  private void testStreamSync(final DestinationSyncMode syncMode,
+                              final String streamName,
+                              final String schemaFileName,
+                              final String dataFileName,
+                              final String expectedSchemaFileName)
       throws Exception {
-    JsonNode overwriteSchema = getTestDataFromResourceJson(schemaFileName);
-    AirbyteMessage overwriteMessage = createRecordMessage(streamName, getTestDataFromResourceJson(dataFileName));
+    final JsonNode overwriteSchema = getTestDataFromResourceJson(schemaFileName);
+    final AirbyteMessage overwriteMessage = createRecordMessage(streamName, getTestDataFromResourceJson(dataFileName));
     runDestinationWrite(getCommonCatalog(streamName, overwriteSchema, syncMode), configJson, overwriteMessage);
     validateTableSchema(streamName, expectedSchemaFileName);
   }
 
-  private void validateTableSchema(String streamName, String expectedSchemaFileName)
+  private void validateTableSchema(final String streamName, final String expectedSchemaFileName)
       throws SQLException {
-    List<JsonNode> describeRecords = executeQuery(format("DESCRIBE %s.%s", galaxyDestinationConfig.galaxyCatalogSchema(), streamName));
-    Map<String, String> actualDataTypes =
+    final List<JsonNode> describeRecords = executeQuery(format("DESCRIBE %s.%s", galaxyDestinationConfig.galaxyCatalogSchema(), streamName));
+    final Map<String, String> actualDataTypes =
         describeRecords.stream().collect(Collectors.toMap(column -> column.get("Column").asText(), column -> column.get("Type").asText()));
-    JsonNode expectedDataTypes = getTestDataFromResourceJson(expectedSchemaFileName);
+    final JsonNode expectedDataTypes = getTestDataFromResourceJson(expectedSchemaFileName);
     assertEquals(expectedDataTypes.size(), actualDataTypes.size());
     expectedDataTypes.fields().forEachRemaining(field -> assertEquals(field.getValue().asText(), actualDataTypes.get(field.getKey())));
   }
@@ -186,17 +186,17 @@ public abstract class StarburstGalaxyDestinationAcceptanceTest extends Destinati
     testDifferentTypes("sample_stream_3", "datatypeV1.json", "dataV1.json", "expected-datatypeV1.json", "expected-dataV1.json");
   }
 
-  private void testDifferentTypes(String streamName, String dataTypeFile, String dataFile, String expectedDataTypeFile, String expectedDataFile)
+  private void testDifferentTypes(final String streamName, final String dataTypeFile, final String dataFile, final String expectedDataTypeFile, final String expectedDataFile)
       throws Exception {
 
-    JsonNode datatypeSchema = getTestDataFromResourceJson(dataTypeFile);
-    AirbyteMessage datatypeMessage = createRecordMessage(streamName, getTestDataFromResourceJson(dataFile));
+    final JsonNode datatypeSchema = getTestDataFromResourceJson(dataTypeFile);
+    final AirbyteMessage datatypeMessage = createRecordMessage(streamName, getTestDataFromResourceJson(dataFile));
     runDestinationWrite(getCommonCatalog(streamName, datatypeSchema, OVERWRITE), configJson, datatypeMessage);
     final JsonFieldNameUpdater nameUpdater =
         AvroRecordHelper.getFieldNameUpdater(streamName, galaxyDestinationConfig.galaxyCatalogSchema(), datatypeSchema);
     validateTableSchema(streamName, expectedDataTypeFile);
 
-    List<JsonNode> records = executeQuery(ctx -> ctx.select(asterisk())
+    final List<JsonNode> records = executeQuery(ctx -> ctx.select(asterisk())
         .from(format("%s.%s", galaxyDestinationConfig.galaxyCatalogSchema(), streamName))
         .orderBy(field(COLUMN_NAME_EMITTED_AT).asc())
         .fetch().stream()
@@ -206,30 +206,30 @@ public abstract class StarburstGalaxyDestinationAcceptanceTest extends Destinati
           return pruneAirbyteJson(jsonWithOriginalFields);
         })
         .collect(toList()));
-    JsonNode actualData = records.get(0);
-    JsonNode expectedData = getTestDataFromResourceJson(expectedDataFile);
+    final JsonNode actualData = records.get(0);
+    final JsonNode expectedData = getTestDataFromResourceJson(expectedDataFile);
     assertEquals(expectedData.size(), actualData.size());
     expectedData.fields().forEachRemaining(field -> assertEquals(field.getValue(), actualData.get(field.getKey())));
   }
 
-  private static AirbyteMessage createRecordMessage(String streamName, final JsonNode data) {
+  private static AirbyteMessage createRecordMessage(final String streamName, final JsonNode data) {
     return new AirbyteMessage()
         .withType(RECORD)
         .withRecord(new AirbyteRecordMessage().withStream(streamName).withData(data).withEmittedAt(Instant.now().toEpochMilli()));
   }
 
-  public static ConfiguredAirbyteCatalog getCommonCatalog(String stream, final JsonNode schema, DestinationSyncMode destinationSyncMode) {
+  public static ConfiguredAirbyteCatalog getCommonCatalog(final String stream, final JsonNode schema, final DestinationSyncMode destinationSyncMode) {
     return new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(new ConfiguredAirbyteStream()
         .withStream(new AirbyteStream().withName(stream).withJsonSchema(schema)
             .withSupportedSyncModes(Lists.newArrayList(FULL_REFRESH)))
         .withSyncMode(FULL_REFRESH).withDestinationSyncMode(destinationSyncMode)));
   }
 
-  private static void runDestinationWrite(ConfiguredAirbyteCatalog catalog, JsonNode config, AirbyteMessage... messages) throws Exception {
+  private static void runDestinationWrite(final ConfiguredAirbyteCatalog catalog, final JsonNode config, final AirbyteMessage... messages) throws Exception {
     final StarburstGalaxyDestination destination = new StarburstGalaxyDestination();
     final AirbyteMessageConsumer consumer = destination.getConsumer(config, catalog, Destination::defaultOutputRecordCollector);
     consumer.start();
-    for (AirbyteMessage message : messages) {
+    for (final AirbyteMessage message : messages) {
       consumer.accept(message);
     }
     consumer.close();
@@ -237,7 +237,7 @@ public abstract class StarburstGalaxyDestinationAcceptanceTest extends Destinati
 
   private static JsonNode getTestDataFromResourceJson(final String fileName) {
     try {
-      String fileContent = readString(Path.of(Objects.requireNonNull(StarburstGalaxyDestinationAcceptanceTest.class.getClassLoader()
+      final String fileContent = readString(Path.of(Objects.requireNonNull(StarburstGalaxyDestinationAcceptanceTest.class.getClassLoader()
           .getResource(INPUT_FILES_BASE_LOCATION + fileName)).getPath()));
       return Jsons.deserialize(fileContent);
     } catch (final IOException e) {

--- a/airbyte-integrations/connectors/destination-teradata/src/test-integration/java/io/airbyte/integrations/destination/teradata/TeradataDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-teradata/src/test-integration/java/io/airbyte/integrations/destination/teradata/TeradataDestinationAcceptanceTest.java
@@ -155,7 +155,7 @@ public class TeradataDestinationAcceptanceTest extends JdbcDestinationAcceptance
     }
 
     @Override
-    protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+    protected void tearDown(TestDestinationEnv testEnv) throws Exception {
         final String deleteQuery = String.format(String.format(DELETE_DATABASE, SCHEMA_NAME));
         final String dropQuery = String.format(String.format(DROP_DATABASE, SCHEMA_NAME));
         try {

--- a/airbyte-integrations/connectors/destination-tidb/src/test-integration/java/io/airbyte/integrations/destination/tidb/TiDBDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-tidb/src/test-integration/java/io/airbyte/integrations/destination/tidb/TiDBDestinationAcceptanceTest.java
@@ -143,7 +143,7 @@ public class TiDBDestinationAcceptanceTest extends JdbcDestinationAcceptanceTest
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(TestDestinationEnv testEnv) {
     container.stop();
     container.close();
   }

--- a/airbyte-integrations/connectors/destination-vertica/src/test-integration/java/io/airbyte/integrations/destination/vertica/VerticaDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-vertica/src/test-integration/java/io/airbyte/integrations/destination/vertica/VerticaDestinationAcceptanceTest.java
@@ -125,7 +125,7 @@ public class VerticaDestinationAcceptanceTest extends JdbcDestinationAcceptanceT
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) {
+  protected void tearDown(TestDestinationEnv testEnv) {
     // TODO Implement this method to run any cleanup actions needed after every test case
   }
 

--- a/airbyte-integrations/connectors/destination-yugabytedb/src/test-integration/java/io/airbyte/integrations/destination/yugabytedb/YugabytedbDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-yugabytedb/src/test-integration/java/io/airbyte/integrations/destination/yugabytedb/YugabytedbDestinationAcceptanceTest.java
@@ -49,7 +49,7 @@ public class YugabytedbDestinationAcceptanceTest extends JdbcDestinationAcceptan
   }
 
   @Override
-  protected void setup(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     jsonConfig = Jsons.jsonNode(ImmutableMap.builder()
         .put("host", yugabytedbContainer.getHost())
         .put("port", yugabytedbContainer.getMappedPort(5433))
@@ -69,13 +69,13 @@ public class YugabytedbDestinationAcceptanceTest extends JdbcDestinationAcceptan
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv, HashSet<String> TEST_SCHEMAS) throws Exception {
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
     database.execute(connection -> {
-      var statement = connection.createStatement();
+      final var statement = connection.createStatement();
       cleanupTables.forEach(tb -> {
         try {
           statement.execute("DROP TABLE " + tb + ";");
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
           throw new RuntimeException(e);
         }
       });
@@ -126,14 +126,14 @@ public class YugabytedbDestinationAcceptanceTest extends JdbcDestinationAcceptan
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
-                                           String streamName,
-                                           String namespace,
-                                           JsonNode streamSchema)
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+                                           final String streamName,
+                                           final String namespace,
+                                           final JsonNode streamSchema)
       throws SQLException {
 
-    String tableName = namingResolver.getRawTableName(streamName);
-    String schemaName = namingResolver.getNamespace(namespace);
+    final String tableName = namingResolver.getRawTableName(streamName);
+    final String schemaName = namingResolver.getNamespace(namespace);
     cleanupTables.add(schemaName + "." + tableName);
     return retrieveRecordsFromTable(tableName, schemaName);
   }
@@ -143,7 +143,7 @@ public class YugabytedbDestinationAcceptanceTest extends JdbcDestinationAcceptan
 
     return database.bufferedResultSetQuery(
         connection -> {
-          var statement = connection.createStatement();
+          final var statement = connection.createStatement();
           return statement.executeQuery(
               String.format("SELECT * FROM %s.%s ORDER BY %s ASC;", schemaName, tableName,
                   JavaBaseConstants.COLUMN_NAME_EMITTED_AT));


### PR DESCRIPTION
There are two false negatives happening in destination-snowflake tests.
1. On master - `testNamespaces` is failing, because `assertNamespaceNormalization` fails (because the namespace has a random suffix on it, but the normalized namespace does not have that suffix).
2. In https://github.com/airbytehq/airbyte/pull/29636#issuecomment-1688935644 - tearDown is failing (because the namespace contains special characters).

This PR:
1. Updates NamespaceTestCaseProvider to use the same random suffix for both namespace and normalizedNamespace
2. tweaks the teardown method to wrap namespaces in quotes. This definitely does not always work (i.e. doesn't always drop the right namespace), but at least means we're not spuriously failing tests.

I would also love to understand why https://github.com/airbytehq/airbyte/pull/29652#issuecomment-1685451850 was successful, given that it's failing on master... but that's a problem for another week.