### PR TITLE
PoC: Comparing aiohttp to requests

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -3,9 +3,11 @@
 #
 
 
+import asyncio
+import aiohttp
+from aiohttp import ClientSession, ClientResponse
 import logging
 import os
-import urllib
 from abc import ABC, abstractmethod
 from contextlib import suppress
 from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
@@ -18,8 +20,9 @@ from airbyte_cdk.sources.streams.availability_strategy import AvailabilityStrate
 from airbyte_cdk.sources.streams.core import Stream, StreamData
 from airbyte_cdk.sources.streams.http.availability_strategy import HttpAvailabilityStrategy
 from requests.auth import AuthBase
+from requests_cache.session import CachedSession
 
-from ...utils.types import JsonType
+
 from .auth.core import HttpAuthenticator, NoAuth
 from .exceptions import DefaultBackoffException, RequestBodyException, UserDefinedBackoffException
 from .rate_limiting import default_backoff_handler, user_defined_backoff_handler
@@ -37,12 +40,13 @@ class HttpStream(Stream, ABC):
     page_size: Optional[int] = None  # Use this variable to define page size for API http requests with pagination support
 
     # TODO: remove legacy HttpAuthenticator authenticator references
-    def __init__(self, authenticator: Optional[Union[AuthBase, HttpAuthenticator]] = None):
+    def __init__(self, authenticator: Union[AuthBase, HttpAuthenticator] = None):
         if self.use_cache:
             self._session = self.request_cache()
         else:
             self._session = requests.Session()
 
+        self.client_session = None
         self._authenticator: HttpAuthenticator = NoAuth()
         if isinstance(authenticator, AuthBase):
             self._session.auth = authenticator
@@ -50,24 +54,24 @@ class HttpStream(Stream, ABC):
             self._authenticator = authenticator
 
     @property
-    def cache_filename(self) -> str:
+    def cache_filename(self):
         """
         Override if needed. Return the name of cache file
         """
         return f"{self.name}.sqlite"
 
     @property
-    def use_cache(self) -> bool:
+    def use_cache(self):
         """
         Override if needed. If True, all records will be cached.
         """
         return False
 
-    def request_cache(self) -> requests.Session:
+    def request_cache(self) -> CachedSession:
         self.clear_cache()
         return requests_cache.CachedSession(self.cache_filename)
 
-    def clear_cache(self) -> None:
+    def clear_cache(self):
         """
         remove cache file only once
         """
@@ -134,9 +138,9 @@ class HttpStream(Stream, ABC):
     def path(
         self,
         *,
-        stream_state: Optional[Mapping[str, Any]] = None,
-        stream_slice: Optional[Mapping[str, Any]] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
+        stream_state: Mapping[str, Any] = None,
+        stream_slice: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None,
     ) -> str:
         """
         Returns the URL path for the API endpoint e.g: if you wanted to hit https://myapi.com/v1/some_entity then this should return "some_entity"
@@ -144,9 +148,9 @@ class HttpStream(Stream, ABC):
 
     def request_params(
         self,
-        stream_state: Optional[Mapping[str, Any]],
-        stream_slice: Optional[Mapping[str, Any]] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
+        stream_state: Mapping[str, Any],
+        stream_slice: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None,
     ) -> MutableMapping[str, Any]:
         """
         Override this method to define the query parameters that should be set on an outgoing HTTP request given the inputs.
@@ -156,10 +160,7 @@ class HttpStream(Stream, ABC):
         return {}
 
     def request_headers(
-        self,
-        stream_state: Optional[Mapping[str, Any]],
-        stream_slice: Optional[Mapping[str, Any]] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
+        self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
     ) -> Mapping[str, Any]:
         """
         Override to return any non-auth headers. Authentication headers will overwrite any overlapping headers returned from this method.
@@ -168,10 +169,10 @@ class HttpStream(Stream, ABC):
 
     def request_body_data(
         self,
-        stream_state: Optional[Mapping[str, Any]],
-        stream_slice: Optional[Mapping[str, Any]] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
-    ) -> Optional[Union[Mapping[str, Any], str]]:
+        stream_state: Mapping[str, Any],
+        stream_slice: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None,
+    ) -> Optional[Union[Mapping, str]]:
         """
         Override when creating POST/PUT/PATCH requests to populate the body of the request with a non-JSON payload.
 
@@ -185,10 +186,10 @@ class HttpStream(Stream, ABC):
 
     def request_body_json(
         self,
-        stream_state: Optional[Mapping[str, Any]],
-        stream_slice: Optional[Mapping[str, Any]] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
-    ) -> Optional[Mapping[str, Any]]:
+        stream_state: Mapping[str, Any],
+        stream_slice: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None,
+    ) -> Optional[Mapping]:
         """
         Override when creating POST/PUT/PATCH requests to populate the body of the request with a JSON payload.
 
@@ -198,9 +199,9 @@ class HttpStream(Stream, ABC):
 
     def request_kwargs(
         self,
-        stream_state: Optional[Mapping[str, Any]],
-        stream_slice: Optional[Mapping[str, Any]] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
+        stream_state: Mapping[str, Any],
+        stream_slice: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None,
     ) -> Mapping[str, Any]:
         """
         Override to return a mapping of keyword arguments to be used when creating the HTTP request.
@@ -215,9 +216,9 @@ class HttpStream(Stream, ABC):
         response: requests.Response,
         *,
         stream_state: Mapping[str, Any],
-        stream_slice: Optional[Mapping[str, Any]] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
-    ) -> Iterable[Mapping[str, Any]]:
+        stream_slice: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None,
+    ) -> Iterable[Mapping]:
         """
         Parses the raw response object into a list of records.
         By default, this returns an iterable containing the input. Override to parse differently.
@@ -262,38 +263,15 @@ class HttpStream(Stream, ABC):
         """
         return ""
 
-    def must_deduplicate_query_params(self) -> bool:
-        return False
-
-    def deduplicate_query_params(self, url: str, params: Optional[Mapping[str, Any]]) -> Mapping[str, Any]:
-        """
-        Remove query parameters from params mapping if they are already encoded in the URL.
-        :param url: URL with
-        :param params:
-        :return:
-        """
-        if params is None:
-            params = {}
-        query_string = urllib.parse.urlparse(url).query
-        query_dict = {k: v[0] for k, v in urllib.parse.parse_qs(query_string).items()}
-
-        duplicate_keys_with_same_value = {k for k in query_dict.keys() if str(params.get(k)) == str(query_dict[k])}
-        return {k: v for k, v in params.items() if k not in duplicate_keys_with_same_value}
-
     def _create_prepared_request(
         self,
         path: str,
-        headers: Optional[Mapping[str, str]] = None,
-        params: Optional[Mapping[str, str]] = None,
-        json: Optional[Mapping[str, Any]] = None,
-        data: Optional[Union[str, Mapping[str, Any]]] = None,
+        headers: Mapping = None,
+        params: Mapping = None,
+        json: Any = None,
+        data: Any = None,
     ) -> requests.PreparedRequest:
-        url = self._join_url(self.url_base, path)
-        if self.must_deduplicate_query_params():
-            query_params = self.deduplicate_query_params(url, params)
-        else:
-            query_params = params or {}
-        args = {"method": self.http_method, "url": url, "headers": headers, "params": query_params}
+        args = {"method": self.http_method, "url": self._join_url(self.url_base, path), "headers": headers, "params": params}
         if self.http_method.upper() in BODY_REQUEST_METHODS:
             if json and data:
                 raise RequestBodyException(
@@ -303,11 +281,41 @@ class HttpStream(Stream, ABC):
                 args["json"] = json
             elif data:
                 args["data"] = data
+
         return self._session.prepare_request(requests.Request(**args))
 
     @classmethod
-    def _join_url(cls, url_base: str, path: str) -> str:
+    def _join_url(cls, url_base: str, path: str):
         return urljoin(url_base, path)
+
+    async def aiohttp_to_requests_response(self, aiohttp_resp: ClientResponse) -> requests.Response:
+        # Create a new requests.Response object
+        requests_resp = requests.Response()
+
+        # Transfer basic attributes
+        requests_resp.status_code = aiohttp_resp.status
+        requests_resp.url = str(aiohttp_resp.url)
+        requests_resp.headers = {k: v for k, v in aiohttp_resp.headers.items()}
+        requests_resp.encoding = aiohttp_resp.get_encoding()
+
+        # Set the content
+        content = await aiohttp_resp.read()
+        requests_resp._content = content
+
+        # Since 'requests' uses the 'requests.sessions' attribute for some operations,
+        # we'll set it to None to avoid AttributeError. This may not support all operations.
+        requests_resp.raw = None
+        requests_resp.reason = aiohttp_resp.reason
+        return requests_resp
+
+    async def _async_send(self, request: requests.PreparedRequest, **request_kwargs) -> requests.Response:
+        # print("Entering Async Send")
+        # print(request_kwargs)
+        print("HERE")
+        async with aiohttp.request(request.method, url=request.url, headers=request.headers) as response:
+            response = await self.aiohttp_to_requests_response(response)
+            return response
+
 
     def _send(self, request: requests.PreparedRequest, request_kwargs: Mapping[str, Any]) -> requests.Response:
         """
@@ -331,6 +339,14 @@ class HttpStream(Stream, ABC):
         self.logger.debug(
             "Making outbound API request", extra={"headers": request.headers, "url": request.url, "request_body": request.body}
         )
+
+        # print("MOOSE")
+        # print(request_kwargs)
+        # print(request.__dict__)
+
+        # response = asyncio.run(self._async_send(request, **request_kwargs))
+        # print(res)
+        # raise Exception("Hold it right there")
         response: requests.Response = self._session.send(request, **request_kwargs)
 
         # Evaluation of response.text can be heavy, for example, if streaming a large response
@@ -400,12 +416,11 @@ class HttpStream(Stream, ABC):
         """
 
         # default logic to grab error from common fields
-        def _try_get_error(value: Optional[JsonType]) -> Optional[str]:
+        def _try_get_error(value):
             if isinstance(value, str):
                 return value
             elif isinstance(value, list):
-                errors_in_value = [_try_get_error(v) for v in value]
-                return ", ".join(v for v in errors_in_value if v is not None)
+                return ", ".join(_try_get_error(v) for v in value)
             elif isinstance(value, dict):
                 new_value = (
                     value.get("message")
@@ -443,9 +458,9 @@ class HttpStream(Stream, ABC):
     def read_records(
         self,
         sync_mode: SyncMode,
-        cursor_field: Optional[List[str]] = None,
-        stream_slice: Optional[Mapping[str, Any]] = None,
-        stream_state: Optional[Mapping[str, Any]] = None,
+        cursor_field: List[str] = None,
+        stream_slice: Mapping[str, Any] = None,
+        stream_state: Mapping[str, Any] = None,
     ) -> Iterable[StreamData]:
         yield from self._read_pages(
             lambda req, res, state, _slice: self.parse_response(res, stream_slice=_slice, stream_state=state), stream_slice, stream_state
@@ -454,10 +469,10 @@ class HttpStream(Stream, ABC):
     def _read_pages(
         self,
         records_generator_fn: Callable[
-            [requests.PreparedRequest, requests.Response, Mapping[str, Any], Optional[Mapping[str, Any]]], Iterable[StreamData]
+            [requests.PreparedRequest, requests.Response, Mapping[str, Any], Mapping[str, Any]], Iterable[StreamData]
         ],
-        stream_slice: Optional[Mapping[str, Any]] = None,
-        stream_state: Optional[Mapping[str, Any]] = None,
+        stream_slice: Mapping[str, Any] = None,
+        stream_state: Mapping[str, Any] = None,
     ) -> Iterable[StreamData]:
         stream_state = stream_state or {}
         pagination_complete = False
@@ -474,10 +489,7 @@ class HttpStream(Stream, ABC):
         yield from []
 
     def _fetch_next_page(
-        self,
-        stream_slice: Optional[Mapping[str, Any]] = None,
-        stream_state: Optional[Mapping[str, Any]] = None,
-        next_page_token: Optional[Mapping[str, Any]] = None,
+        self, stream_slice: Mapping[str, Any] = None, stream_state: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
     ) -> Tuple[requests.PreparedRequest, requests.Response]:
         request_headers = self.request_headers(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
         request = self._create_prepared_request(
@@ -494,7 +506,7 @@ class HttpStream(Stream, ABC):
 
 
 class HttpSubStream(HttpStream, ABC):
-    def __init__(self, parent: HttpStream, **kwargs: Any):
+    def __init__(self, parent: HttpStream, **kwargs):
         """
         :param parent: should be the instance of HttpStream class
         """
@@ -502,7 +514,7 @@ class HttpSubStream(HttpStream, ABC):
         self.parent = parent
 
     def stream_slices(
-        self, sync_mode: SyncMode, cursor_field: Optional[List[str]] = None, stream_state: Optional[Mapping[str, Any]] = None
+        self, sync_mode: SyncMode, cursor_field: List[str] = None, stream_state: Mapping[str, Any] = None
     ) -> Iterable[Optional[Mapping[str, Any]]]:
         parent_stream_slices = self.parent.stream_slices(
             sync_mode=SyncMode.full_refresh, cursor_field=cursor_field, stream_state=stream_state

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -170,7 +170,7 @@ class Customers(IncrementalStripeStream):
     """
 
     cursor_field = "created"
-    use_cache = True
+    use_cache = False
 
     def path(self, **kwargs) -> str:
         return "customers"


### PR DESCRIPTION
it seems like running aiohttp is naively much faster than requests within a threadpool with an equivalent number of workers. I ran 1000 requests

concurrency = 1, requests with ThreadPool took 212.26 seconds, aiohttp took 49.51seconds :exploding_head:
concurrency = 5, requests with ThreadPool took 41.72 seconds, aiohttp took 12.21 seconds
concurrency = 10, requests with ThreadPool took 21.49 seconds, aiohttp took 6.18 seconds

The test script was: 
```python
import time
import requests
from concurrent.futures import ThreadPoolExecutor
import aiohttp
import asyncio

URL = "https://api.stripe.com/v1/customers"  # Replace with the URL you want to test
API_KEY="<>"
h={"Authorization": "Basic " + f"{API_KEY}:".encode("utf-8").hex()}
qparams = {"limit": 100}
NUM_REQUESTS = 1000
CONCURRENCY = 5 

# Using requests with ThreadPool
def fetch_with_requests(url):
    try:
        response = requests.get(url, headers=h, params=qparams)
        return response.status_code
    except requests.RequestException as e:
        print(e)
        return None

def run_requests_threadpool():
    with ThreadPoolExecutor(max_workers=CONCURRENCY) as executor:
        futures = [executor.submit(fetch_with_requests, URL) for _ in range(NUM_REQUESTS)]
        return [f.result() for f in futures]

# Using aiohttp
async def fetch_with_aiohttp(session, url, semaphore: asyncio.Semaphore):
    async with semaphore:
        async with session.get(url, headers=h, params=qparams) as response:
            return response.status

async def run_aiohttp():
    semaphore = asyncio.Semaphore(CONCURRENCY)
    async with aiohttp.ClientSession() as session:
        tasks = [fetch_with_aiohttp(session, URL, semaphore) for _ in range(NUM_REQUESTS)]
        return await asyncio.gather(*tasks)

def main():
    # Test requests with ThreadPool
    start_time = time.time()
    run_requests_threadpool()
    requests_time = time.time() - start_time
    print(f"requests with ThreadPool took {requests_time:.2f} seconds")

    # Test aiohttp
    start_time = time.time()
    asyncio.run(run_aiohttp())
    aiohttp_time = time.time() - start_time
    print(f"aiohttp took {aiohttp_time:.2f} seconds")

if __name__ == "__main__":
    main()
```

I wondered if this meant we can get a 4x improvement for free by transparently swapping out aiohttp for requests under the hood. It doesn’t seem like it. 

For the same stripe dataset (pulling data for 1300 customers) a pure requests approach took 11seconds and the sequential aiohttp approach took 14seconds

I suspected this might be because I’m spinning up one event loop per request

The profiling didn’t give a clear explanation

Profiling of the `requests` based approach within the CDK
```
(.venv) ➜  source-stripe git:(sherif/aiohttp-to-requests-test) ✗ awk '/^[ ]*[0-9]/ { print $0 }' async.perf | sort -k2,2n | tail -n 30

      601    0.015    0.000    0.015    0.000 {built-in method io.open_code}
    65150    0.015    0.000    0.026    0.000 validators.py:76(type_check)
     6666    0.016    0.000    0.025    0.000 parse.py:437(urlsplit)
    65201    0.017    0.000    0.077    0.000 _pmap.py:168(__getitem__)
    65201    0.017    0.000    0.148    0.000 validators.py:355(is_type)
    87367    0.017    0.000    0.136    0.000 _validators.py:272(<genexpr>)
      739    0.018    0.000   12.215    0.017 selectors.py:554(select)
    32575    0.018    0.000    0.065    0.000 transform.py:75(__normalize)
    65/40    0.018    0.000    0.064    0.002 {built-in method _imp.exec_dynamic}
7825/1305    0.019    0.000    0.325    0.000 _validators.py:276(properties)
     1304    0.023    0.000   12.134    0.009 abstract_source.py:301(_read_full_refresh)
     1316    0.023    0.000    0.030    0.000 encoder.py:204(iterencode)
    65202    0.024    0.000    0.060    0.000 _pmap.py:158(_getitem)
1544/1505    0.024    0.000    0.068    0.000 {built-in method builtins.__build_class__}
    32575    0.025    0.000    0.035    0.000 transform.py:89(default_convert)
    65205    0.026    0.000    0.036    0.000 _pmap.py:152(_get_bucket)
    65201    0.028    0.000    0.131    0.000 _types.py:66(is_type)
330286/330248    0.028    0.000    0.032    0.000 {built-in method builtins.isinstance}
      594    0.030    0.000    0.030    0.000 {built-in method marshal.loads}
    33911    0.031    0.000    0.185    0.000 _validators.py:269(type)
      447    0.035    0.000    0.035    0.000 {method 'recv' of '_socket.socket' objects}
       38    0.042    0.001    0.043    0.001 decoder.py:343(raw_decode)
33944/1305    0.046    0.000    0.424    0.000 validators.py:296(iter_errors)
44302/2606    0.046    0.000    0.419    0.000 transform.py:136(normalizator)
    65/62    0.053    0.001    0.055    0.001 {built-in method _imp.create_dynamic}
     1306    0.064    0.000    0.104    0.000 entrypoint.py:148(airbyte_message_to_string)
     1303    0.082    0.000    0.593    0.000 record_helper.py:14(stream_data_to_airbyte_message)
      796    0.083    0.000    0.083    0.000 {method 'read' of '_io.BufferedReader' objects}
     1321    0.214    0.000    0.214    0.000 {built-in method builtins.print}
      814   12.195    0.015   12.195    0.015 {method 'control' of 'select.kqueue' objects}
```
Profiling of the synchronous approach
```
(.venv) ➜  source-stripe git:(sherif/aiohttp-to-requests-test) ✗ awk '/^[ ]*[0-9]/ { print $0 }' sync.perf | sort -k2,2n | tail -n 30

      601    0.013    0.000    0.013    0.000 {built-in method io.open_code}
     6801    0.013    0.000    0.022    0.000 parse.py:437(urlsplit)
      423    0.015    0.000    0.015    0.000 {built-in method builtins.compile}
    65150    0.015    0.000    0.025    0.000 validators.py:76(type_check)
    65201    0.017    0.000    0.074    0.000 _pmap.py:168(__getitem__)
    65201    0.017    0.000    0.144    0.000 validators.py:355(is_type)
    87367    0.017    0.000    0.135    0.000 _validators.py:272(<genexpr>)
    32575    0.018    0.000    0.062    0.000 transform.py:75(__normalize)
        1    0.022    0.022    0.022    0.022 {built-in method _socket.getaddrinfo}
       38    0.022    0.001    0.022    0.001 decoder.py:343(raw_decode)
    65202    0.022    0.000    0.058    0.000 _pmap.py:158(_getitem)
1541/1502    0.023    0.000    0.065    0.000 {built-in method builtins.__build_class__}
     1316    0.024    0.000    0.030    0.000 encoder.py:204(iterencode)
    32575    0.024    0.000    0.033    0.000 transform.py:89(default_convert)
      592    0.025    0.000    0.025    0.000 {built-in method marshal.loads}
    65205    0.026    0.000    0.035    0.000 _pmap.py:152(_get_bucket)
334272/334264    0.026    0.000    0.030    0.000 {built-in method builtins.isinstance}
    33911    0.027    0.000    0.179    0.000 _validators.py:269(type)
    65201    0.027    0.000    0.127    0.000 _types.py:66(is_type)
        1    0.035    0.035    0.035    0.035 {method 'do_handshake' of '_ssl._SSLSocket' objects}
7825/1305    0.040    0.000    0.338    0.000 _validators.py:276(properties)
    65/62    0.041    0.001    0.044    0.001 {built-in method _imp.create_dynamic}
44302/2606    0.043    0.000    0.426    0.000 transform.py:136(normalizator)
        1    0.045    0.045    0.045    0.045 {method 'connect' of '_socket.socket' objects}
33944/1305    0.047    0.000    0.431    0.000 validators.py:296(iter_errors)
     1306    0.063    0.000    0.104    0.000 entrypoint.py:148(airbyte_message_to_string)
      796    0.079    0.000    0.079    0.000 {method 'read' of '_io.BufferedReader' objects}
     1303    0.079    0.000    0.592    0.000 record_helper.py:14(stream_data_to_airbyte_message)
     1306    0.181    0.000    0.181    0.000 {built-in method builtins.print}
      141   11.436    0.081   11.436    0.081 {method 'read' of '_ssl._SSLSocket' objects}
```