### PR TITLE
Improve CATs diff output

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -1067,7 +1067,9 @@ class TestBasicRead(BaseTest):
                         break
 
             cleaned_actual = cleaned_actual or actual
-            complete_diff = "\n".join(diff_dicts(cleaned_actual, expected, use_markup=False))
+            complete_diff = "\n".join(
+                diff_dicts(cleaned_actual if not extra_records else cleaned_actual[:len(expected)], expected, use_markup=False)
+            )
             for r1, r2 in zip(expected, cleaned_actual):
                 if r1 is None:
                     assert extra_records, f"Stream {stream_name}: There are more records than expected, but extra_records is off"


### PR DESCRIPTION
## What
Extra records are shown in the diff which is very confusing as they are not use for the equality assertion. Hence, instead of :

```
>   ???
E   AssertionError: Stream test: Mismatch of record order or values
E     Diff actual vs expected:equals failed
E                     'valid': False,             'valid': False,
E                   },                          },
E                   {                           {
E                      '_ab_source_file_last_mo    '_ab_source_file_last_mo
E                    dified': '2021-07-25T15:33  dified': '2021-07-25T15:33
E                    :04Z',                      :04Z',
E                      '_ab_source_file_url': '    '_ab_source_file_url': '
E                    simple_test.csv',           simple_test.csv',
E                      'id': 8,                    'id': 8+2,
E                      'name': 'M2t286iJ',         'name': 'M2t286iJ',
E                      'valid': False,             'valid': False,
E                    },                          },
E                 - {                                                     
E                 -  '_ab_source_file_last_mo                             
E                 -dified': '2021-12-20T12:35                             
E                 -:05.000000Z',                                          
E                 -  '_ab_source_file_url': '                             
E                 -simple_test_2.csv',                                    
E                 -  'id': 1,                                             
E                 -  'name': 'PVdhmjb1',                                  
E                 -  'valid': False,                                      
E                 - },                                                    
E                 - {                                                     
E                 -  '_ab_source_file_last_mo                             
E                 -dified': '2021-12-20T12:35                             
E                 -:05.000000Z',                                          
E                 -  '_ab_source_file_url': '                             
E                 -simple_test_2.csv',            

<...>

E     ]                           ]
E   assert False
```

We would like to have only the records that are considered like:
```
>   ???
E   AssertionError: Stream test: Mismatch of record order or values
E     Diff actual vs expected:equals failed
E       'valid': False,             'valid': False,
E      },                          },
E      {                           {
E       '_ab_source_file_last_mo    '_ab_source_file_last_mo
E     dified': '2021-07-25T15:33  dified': '2021-07-25T15:33
E     :04Z',                      :04Z',
E       '_ab_source_file_url': '    '_ab_source_file_url': '
E     simple_test.csv',           simple_test.csv',
E       'id': 8,                    'id': 8+2,
E       'name': 'M2t286iJ',         'name': 'M2t286iJ',
E       'valid': False,             'valid': False,
E      },                          },
E     ]                           ]
E   assert False
```

## How
Given we don't allow for extra records, we take the cleaned_actual as they are. Else, we truncate
