### PR TITLE
[Source-MsSQL] Rollback to 1.1.1 in case 2.0.0 fails [DO NOT MERGE]

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
-  dockerImageTag: 1.1.1
+  dockerImageTag: 2.0.0
   dockerRepository: airbyte/source-mssql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mssql
   githubIssueLabel: source-mssql
@@ -19,8 +19,10 @@ data:
   registries:
     cloud:
       dockerRepository: airbyte/source-mssql-strict-encrypt
+      dockerImageTag: 1.1.1
       enabled: true
     oss:
+      dockerImageTag: 1.1.1
       enabled: true
   releaseStage: alpha
   supportLevel: community


### PR DESCRIPTION

## What
In the case that we need to rollback this [PR](https://github.com/airbytehq/airbyte/pull/29493). This PR redirects version 2.0.0 to point at 1.1.1. In the case that we need to rollback, this PR will be merged, and another PR will be submitted with version 2.0.1 that removes the previous changes. Also, mssql.md changelog will be updated with version 2.0.1 stating the rollback.