### PR TITLE
source-plaid: fix sandbox institution for oauth setup docs

### DIFF
--- a/docs/integrations/sources/plaid.md
+++ b/docs/integrations/sources/plaid.md
@@ -47,7 +47,7 @@ This guide will walk through how to create the credentials you need to run this 
           --data-raw '{
               "client_id": "<your-client-id>",
               "secret": "<your-sandbox-api-key>",
-              "institution_id": "ins_43",
+              "institution_id": "ins_127287",
               "initial_products": ["auth", "transactions"]
           }'
     ```


### PR DESCRIPTION
## What
Docs change. The current sandbox oauth setup instructions use an institution that doesn't actually support oauth. I've added [Platypus OAuth Bank from Plaid's sandbox institutions doc](https://plaid.com/docs/sandbox/institutions/#institution-details) since it worked for me locally.