### PR TITLE
File-based CDK: Remove excessive logging when there are more fields i…

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
@@ -276,8 +276,6 @@ class CsvParser(FileTypeParser):
                         warnings.append(_format_warning(key, value, prop_type))
 
                 result[key] = cast_value
-            else:
-                warnings.append(_format_warning(key, value, prop_type))
 
         if warnings:
             logger.warning(


### PR DESCRIPTION
…n the record than in the schema

## What
The webapp crashed when viewing logs for a sync of 9,000,000 records where the schema did not match the data because there were more fields in the records

## How
Remove logging

