### PR TITLE
Add copy-connector-from-prod script

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/README.md
+++ b/airbyte-ci/connectors/metadata_service/lib/README.md
@@ -48,8 +48,17 @@ _⚠️ Warning: Its important to know that this will remove ANY files you have 
 TARGET_BUCKET=<YOUR-DEV_BUCKET> poetry poe replicate-prod
 ```
 
+### Copy specific connector version to your Development Bucket
+This will copy the specified connector version to your development bucket. This is useful for testing the metadata service with a specific version of a connector.
+
+_💡 Note: A prerequisite is you have [gsutil](https://cloud.google.com/storage/docs/gsutil) installed and have run `gsutil auth login`_
+
+```bash
+TARGET_BUCKET=<YOUR-DEV_BUCKET> CONNECTOR="airbyte/source-stripe" VERSION="3.17.0-dev.ea013c8741" poetry poe copy-connector-from-prod
+```
+
 ### Promote Connector Version to Latest
-This will promote the specified connector version to the latest version in the registry. This is useful for creating a mocked registry in which a prerelease connector is treated as if it was already published. 
+This will promote the specified connector version to the latest version in the registry. This is useful for creating a mocked registry in which a prerelease connector is treated as if it was already published.
 
 _💡 Note: A prerequisite is you have [gsutil](https://cloud.google.com/storage/docs/gsutil) installed and have run `gsutil auth login`_
 

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -33,6 +33,7 @@ metadata_service = "metadata_service.commands:metadata_service"
 [tool.poe.tasks]
 generate-models = { shell = "./bin/generate-python-classes.sh" }
 replicate-prod = "gsutil -m rsync -r -d gs://prod-airbyte-cloud-connector-metadata-service gs://$TARGET_BUCKET"
+copy-connector-from-prod = "gsutil  -m rsync -r -d gs://prod-airbyte-cloud-connector-metadata-service/metadata/$CONNECTOR/$VERSION gs://$TARGET_BUCKET/metadata/$CONNECTOR/$VERSION"
 promote-connector-to-latest = "gsutil  -m rsync -r -d gs://$TARGET_BUCKET/metadata/$CONNECTOR/$VERSION gs://$TARGET_BUCKET/metadata/$CONNECTOR/latest"
 
 [build-system]


### PR DESCRIPTION
## Overview
Adds a dev command to help copy new connector versions one at a time without have to replicate the entire bucket