### PR TITLE
Airbyte-ci: do not fail pipeline on slack outage

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/slack.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/slack.py
@@ -3,12 +3,17 @@
 #
 
 import json
-
 import requests
+
+from pipelines import main_logger
 
 
 def send_message_to_webhook(message: str, channel: str, webhook: str) -> dict:
     payload = {"channel": f"#{channel}", "username": "Connectors CI/CD Bot", "text": message}
     response = requests.post(webhook, data={"payload": json.dumps(payload)})
-    response.raise_for_status()
+
+    # log if the request failed, but don't fail the pipeline
+    if not response.ok:
+        main_logger.error(f"Failed to send message to slack webhook: {response.text}")
+
     return response


### PR DESCRIPTION
## Overview
Resolves https://airbytehq.sentry.io/issues/4418816657/?referrer=slack&alert_rule_id=14570850&alert_type=issue
<img width="727" alt="image" src="https://github.com/airbytehq/airbyte/assets/1325608/717a19a7-a4b3-4f2f-8df2-fd77b7321d97">

Which caused a pipeline to fail because slack was mad