### PR TITLE
update redshift tests to use schema names that follow airbyte conventions

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/SshRedshiftDestinationBaseAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/SshRedshiftDestinationBaseAcceptanceTest.java
@@ -24,6 +24,7 @@ import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.base.ssh.SshTunnel;
 import io.airbyte.integrations.destination.redshift.operations.RedshiftSqlOperations;
 import io.airbyte.integrations.standardtest.destination.JdbcDestinationAcceptanceTest;
+import io.airbyte.integrations.standardtest.destination.TestingNamespaces;
 import io.airbyte.integrations.standardtest.destination.comparator.TestDataComparator;
 import java.io.IOException;
 import java.sql.Connection;
@@ -167,7 +168,7 @@ public abstract class SshRedshiftDestinationBaseAcceptanceTest extends JdbcDesti
   protected void setup(final TestDestinationEnv testEnv, final HashSet<String> TEST_SCHEMAS) throws Exception {
     baseConfig = getStaticConfig();
     final JsonNode configForSchema = Jsons.clone(baseConfig);
-    schemaName = Strings.addRandomSuffix("integration_test", "_", 5);
+    schemaName = TestingNamespaces.generate();
     TEST_SCHEMAS.add(schemaName);
     ((ObjectNode) configForSchema).put("schema", schemaName);
     config = configForSchema;


### PR DESCRIPTION
## What
* The schema names that follow airbyte conventions (see `TestingNamespaces.java`) allow us to embed the date of the schema was created in the name so that another process can come in and delete them if they aren't properly cleaned up by the test.