### PR TITLE
source-zendesk-sell: fix phone_number type from number to string #29828

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-sell/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-sell/Dockerfile
@@ -34,5 +34,5 @@ COPY source_zendesk_sell ./source_zendesk_sell
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-zendesk-sell

--- a/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 982eaa4c-bba1-4cce-a971-06a41f700b8c
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/source-zendesk-sell
   githubIssueLabel: source-zendesk-sell
   icon: zendesk.svg

--- a/airbyte-integrations/connectors/source-zendesk-sell/source_zendesk_sell/schemas/calls.json
+++ b/airbyte-integrations/connectors/source-zendesk-sell/source_zendesk_sell/schemas/calls.json
@@ -21,7 +21,7 @@
       "type": ["null", "number"]
     },
     "phone_number": {
-      "type": ["null", "number"]
+      "type": ["null", "string"]
     },
     "incoming": {
       "type": ["null", "boolean"]

--- a/docs/integrations/sources/zendesk-sell.md
+++ b/docs/integrations/sources/zendesk-sell.md
@@ -76,4 +76,5 @@ We recommend creating a restricted, read-only key specifically for Airbyte acces
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
 | 0.1.0 | 2022-10-27 | [17888](https://github.com/airbytehq/airbyte/pull/17888) | Initial Release |
+| 0.1.1 | 2023-08-30 | [29830](https://github.com/airbytehq/airbyte/pull/29830) | Change phone_number in Calls to string (bug in zendesk sell api documentation) |
 


### PR DESCRIPTION
## What
This patch updates the definition of the calls entity in source-zendesk

## How
The patch updates the calls.json file of source-zendesk-sell and changes the type from number to string

## 🚨 User Impact 🚨
This change could impact users, where the target relies on the type number.