### PR TITLE
:bug: Source Amazon Ads: added 404 handling for sponsored_product_ad_group_bid_recommendations…

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
@@ -13,5 +13,5 @@ ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
 
-LABEL io.airbyte.version=3.1.0
+LABEL io.airbyte.version=3.1.1
 LABEL io.airbyte.name=airbyte/source-amazon-ads

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 3.1.0
+  dockerImageTag: 3.1.1
   dockerRepository: airbyte/source-amazon-ads
   githubIssueLabel: source-amazon-ads
   icon: amazonads.svg

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/sponsored_products.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/sponsored_products.py
@@ -104,6 +104,13 @@ class SponsoredProductAdGroupWithSlicesABC(AmazonAdsStream, ABC):
                 f"Skip current AdGroup because it does not support request {response.request.url} for "
                 f"{response.request.headers['Amazon-Advertising-API-Scope']} profile: {response.text}"
             )
+        elif response.status_code == HTTPStatus.NOT_FOUND:
+            # 404 Either the specified ad group identifier was not found,
+            # or the specified ad group was found but no associated bid was found.
+            self.logger.warning(
+                f"Skip current AdGroup because the specified ad group has no associated bid {response.request.url} for "
+                f"{response.request.headers['Amazon-Advertising-API-Scope']} profile: {response.text}"
+            )
 
         else:
             response.raise_for_status()

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -103,7 +103,7 @@ Information about expected report generation waiting time you may find [here](ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
-| 3.1.1   | 2023-08-28 |                                                          | Add 404 handling for no assotiated with bid ad groups                                                           |
+| 3.1.1   | 2023-08-28 | [29900](https://github.com/airbytehq/airbyte/pull/29900) | Add 404 handling for no assotiated with bid ad groups                                                           |
 | 3.1.0   | 2023-08-08 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add `T00030` tactic support for `sponsored_display_report_stream`                                               |
 | 3.0.0   | 2023-07-24 | [27868](https://github.com/airbytehq/airbyte/pull/27868) | Fix attribution report stream schemas                                                                           |
 | 2.3.1   | 2023-07-11 | [28155](https://github.com/airbytehq/airbyte/pull/28155) | Bugfix: validation error when record values are missing                                                         |

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -103,6 +103,7 @@ Information about expected report generation waiting time you may find [here](ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 3.1.1   | 2023-08-28 |                                                          | Add 404 handling for no assotiated with bid ad groups                                                           |
 | 3.1.0   | 2023-08-08 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add `T00030` tactic support for `sponsored_display_report_stream`                                               |
 | 3.0.0   | 2023-07-24 | [27868](https://github.com/airbytehq/airbyte/pull/27868) | Fix attribution report stream schemas                                                                           |
 | 2.3.1   | 2023-07-11 | [28155](https://github.com/airbytehq/airbyte/pull/28155) | Bugfix: validation error when record values are missing                                                         |


### PR DESCRIPTION
## What
resolved: https://github.com/airbytehq/oncall/issues/2536
stream failed with 404 error 

## How
According to [doc](https://advertising.amazon.com/API/docs/en-us/sponsored-products/2-0/openapi#/Bid%20recommendations/getAdGroupBidRecommendations) 404 error occurs in case "404 Either the specified ad group identifier was not found, or the specified ad group was found but no associated bid was found." Stream receives groupId from parent stream, which is exists, so the problem that is specified ad group was found but no associated bid. So skipping was added for this case.