### PR TITLE
[Debezium] Debezium upgrade to correctly handle nulls [DO NOT MERGE OR CLOSE]

### DIFF
--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumPropertiesManager.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumPropertiesManager.java
@@ -69,6 +69,8 @@ public abstract class DebeziumPropertiesManager {
     // https://debezium.io/documentation/reference/2.2/configuration/avro.html
     props.setProperty("key.converter.schemas.enable", "false");
     props.setProperty("value.converter.schemas.enable", "false");
+    props.setProperty("value.converter.schemas.enable", "false");
+    props.setProperty("value.converter.replace.null.with.default", "false");
 
     // debezium names
     props.setProperty(NAME_KEY, getName(config));

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mysql/MySqlDebeziumStateUtil.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mysql/MySqlDebeziumStateUtil.java
@@ -182,7 +182,8 @@ public class MySqlDebeziumStateUtil {
     FileOffsetBackingStore fileOffsetBackingStore = null;
     OffsetStorageReaderImpl offsetStorageReader = null;
     try {
-      fileOffsetBackingStore = new FileOffsetBackingStore();
+      final JsonConverter keyConverter = new JsonConverter();
+      fileOffsetBackingStore = new FileOffsetBackingStore(keyConverter);
       final Map<String, String> propertiesMap = Configuration.from(properties).asMap();
       propertiesMap.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
       propertiesMap.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
@@ -190,7 +191,6 @@ public class MySqlDebeziumStateUtil {
       fileOffsetBackingStore.start();
 
       final Map<String, String> internalConverterConfig = Collections.singletonMap(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false");
-      final JsonConverter keyConverter = new JsonConverter();
       keyConverter.configure(internalConverterConfig, true);
       final JsonConverter valueConverter = new JsonConverter();
       valueConverter.configure(internalConverterConfig, false);

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/postgres/PostgresDebeziumStateUtil.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/postgres/PostgresDebeziumStateUtil.java
@@ -163,7 +163,8 @@ public class PostgresDebeziumStateUtil {
     FileOffsetBackingStore fileOffsetBackingStore = null;
     OffsetStorageReaderImpl offsetStorageReader = null;
     try {
-      fileOffsetBackingStore = new FileOffsetBackingStore();
+      final JsonConverter keyConverter = new JsonConverter();
+      fileOffsetBackingStore = new FileOffsetBackingStore(keyConverter);
       final Map<String, String> propertiesMap = Configuration.from(properties).asMap();
       propertiesMap.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
       propertiesMap.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
@@ -171,7 +172,6 @@ public class PostgresDebeziumStateUtil {
       fileOffsetBackingStore.start();
 
       final Map<String, String> internalConverterConfig = Collections.singletonMap(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false");
-      final JsonConverter keyConverter = new JsonConverter();
       keyConverter.configure(internalConverterConfig, true);
       final JsonConverter valueConverter = new JsonConverter();
       valueConverter.configure(internalConverterConfig, false);

--- a/airbyte-integrations/bases/debezium/src/testFixtures/java/io/airbyte/integrations/debezium/CdcSourceTest.java
+++ b/airbyte-integrations/bases/debezium/src/testFixtures/java/io/airbyte/integrations/debezium/CdcSourceTest.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -307,7 +308,7 @@ public abstract class CdcSourceTest {
 
   // Failing on `source-postgres`, possibly others as well.
   @Disabled("The 'testExistingData()' test is flaky. https://github.com/airbytehq/airbyte/issues/29411")
-//  @Test
+  @Test
   @DisplayName("On the first sync, produce returns records that exist in the database.")
   void testExistingData() throws Exception {
     final CdcTargetPosition targetPosition = cdcLatestTargetPosition();
@@ -326,7 +327,7 @@ public abstract class CdcSourceTest {
     assertExpectedStateMessages(stateMessages);
   }
 
-//  @Test
+  @Test
   @DisplayName("When a record is deleted, produces a deletion record.")
   void testDelete() throws Exception {
     final AutoCloseableIterator<AirbyteMessage> read1 = getSource()
@@ -356,7 +357,7 @@ public abstract class CdcSourceTest {
     assertExpectedStateMessages(stateMessages);
   }
 
-//  @Test
+  @Test
   @DisplayName("When a record is updated, produces an update record.")
   void testUpdate() throws Exception {
     final String updatedModel = "Explorer";
@@ -385,7 +386,7 @@ public abstract class CdcSourceTest {
   }
 
   @SuppressWarnings({"BusyWait", "CodeBlock2Expr"})
-//  @Test
+  @Test
   @DisplayName("Verify that when data is inserted into the database while a sync is happening and after the first sync, it all gets replicated.")
   protected void testRecordsProducedDuringAndAfterSync() throws Exception {
 
@@ -451,7 +452,7 @@ public abstract class CdcSourceTest {
     assertExpectedStateMessages(stateAfterFirstBatch);
   }
 
-//  @Test
+  @Test
   @DisplayName("When both incremental CDC and full refresh are configured for different streams in a sync, the data is replicated as expected.")
   void testCdcAndFullRefreshInSameSync() throws Exception {
     final ConfiguredAirbyteCatalog configuredCatalog = Jsons.clone(CONFIGURED_CATALOG);
@@ -525,7 +526,7 @@ public abstract class CdcSourceTest {
         MODELS_SCHEMA);
   }
 
-//  @Test
+  @Test
   @DisplayName("When no records exist, no records are returned.")
   void testNoData() throws Exception {
 
@@ -545,7 +546,7 @@ public abstract class CdcSourceTest {
     assertExpectedStateMessages(stateMessages);
   }
 
-//  @Test
+  @Test
   @DisplayName("When no changes have been made to the database since the previous sync, no records are returned.")
   void testNoDataOnSecondSync() throws Exception {
     final AutoCloseableIterator<AirbyteMessage> read1 = getSource()
@@ -565,13 +566,13 @@ public abstract class CdcSourceTest {
     assertExpectedStateMessagesFromIncrementalSync(stateMessages2);
   }
 
-//  @Test
+  @Test
   void testCheck() throws Exception {
     final AirbyteConnectionStatus status = getSource().check(getConfig());
     assertEquals(status.getStatus(), AirbyteConnectionStatus.Status.SUCCEEDED);
   }
 
-//  @Test
+  @Test
   void testDiscover() throws Exception {
     final AirbyteCatalog expectedCatalog = expectedCatalogForDiscover();
     final AirbyteCatalog actualCatalog = getSource().discover(getConfig());
@@ -583,7 +584,7 @@ public abstract class CdcSourceTest {
             .collect(Collectors.toList()));
   }
 
-//  @Test
+  @Test
   public void newTableSnapshotTest() throws Exception {
     final AutoCloseableIterator<AirbyteMessage> firstBatchIterator = getSource()
         .read(getConfig(), CONFIGURED_CATALOG, null);

--- a/airbyte-integrations/bases/debezium/src/testFixtures/java/io/airbyte/integrations/debezium/CdcSourceTest.java
+++ b/airbyte-integrations/bases/debezium/src/testFixtures/java/io/airbyte/integrations/debezium/CdcSourceTest.java
@@ -50,7 +50,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -308,7 +307,7 @@ public abstract class CdcSourceTest {
 
   // Failing on `source-postgres`, possibly others as well.
   @Disabled("The 'testExistingData()' test is flaky. https://github.com/airbytehq/airbyte/issues/29411")
-  @Test
+//  @Test
   @DisplayName("On the first sync, produce returns records that exist in the database.")
   void testExistingData() throws Exception {
     final CdcTargetPosition targetPosition = cdcLatestTargetPosition();
@@ -327,7 +326,7 @@ public abstract class CdcSourceTest {
     assertExpectedStateMessages(stateMessages);
   }
 
-  @Test
+//  @Test
   @DisplayName("When a record is deleted, produces a deletion record.")
   void testDelete() throws Exception {
     final AutoCloseableIterator<AirbyteMessage> read1 = getSource()
@@ -357,7 +356,7 @@ public abstract class CdcSourceTest {
     assertExpectedStateMessages(stateMessages);
   }
 
-  @Test
+//  @Test
   @DisplayName("When a record is updated, produces an update record.")
   void testUpdate() throws Exception {
     final String updatedModel = "Explorer";
@@ -386,7 +385,7 @@ public abstract class CdcSourceTest {
   }
 
   @SuppressWarnings({"BusyWait", "CodeBlock2Expr"})
-  @Test
+//  @Test
   @DisplayName("Verify that when data is inserted into the database while a sync is happening and after the first sync, it all gets replicated.")
   protected void testRecordsProducedDuringAndAfterSync() throws Exception {
 
@@ -452,7 +451,7 @@ public abstract class CdcSourceTest {
     assertExpectedStateMessages(stateAfterFirstBatch);
   }
 
-  @Test
+//  @Test
   @DisplayName("When both incremental CDC and full refresh are configured for different streams in a sync, the data is replicated as expected.")
   void testCdcAndFullRefreshInSameSync() throws Exception {
     final ConfiguredAirbyteCatalog configuredCatalog = Jsons.clone(CONFIGURED_CATALOG);
@@ -526,7 +525,7 @@ public abstract class CdcSourceTest {
         MODELS_SCHEMA);
   }
 
-  @Test
+//  @Test
   @DisplayName("When no records exist, no records are returned.")
   void testNoData() throws Exception {
 
@@ -546,7 +545,7 @@ public abstract class CdcSourceTest {
     assertExpectedStateMessages(stateMessages);
   }
 
-  @Test
+//  @Test
   @DisplayName("When no changes have been made to the database since the previous sync, no records are returned.")
   void testNoDataOnSecondSync() throws Exception {
     final AutoCloseableIterator<AirbyteMessage> read1 = getSource()
@@ -566,13 +565,13 @@ public abstract class CdcSourceTest {
     assertExpectedStateMessagesFromIncrementalSync(stateMessages2);
   }
 
-  @Test
+//  @Test
   void testCheck() throws Exception {
     final AirbyteConnectionStatus status = getSource().check(getConfig());
     assertEquals(status.getStatus(), AirbyteConnectionStatus.Status.SUCCEEDED);
   }
 
-  @Test
+//  @Test
   void testDiscover() throws Exception {
     final AirbyteCatalog expectedCatalog = expectedCatalogForDiscover();
     final AirbyteCatalog actualCatalog = getSource().discover(getConfig());
@@ -584,7 +583,7 @@ public abstract class CdcSourceTest {
             .collect(Collectors.toList()));
   }
 
-  @Test
+//  @Test
   public void newTableSnapshotTest() throws Exception {
     final AutoCloseableIterator<AirbyteMessage> firstBatchIterator = getSource()
         .read(getConfig(), CONFIGURED_CATALOG, null);

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
@@ -245,7 +245,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     return MODELS_SCHEMA;
   }
 
-//  @Test
+  @Test
   protected void syncWithReplicationClientPrivilegeRevokedFailsCheck() throws Exception {
     revokeReplicationClientPermission();
     final AirbyteConnectionStatus status = getSource().check(getConfig());
@@ -255,7 +255,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     assertTrue(status.getMessage().contains(expectedErrorMessage));
   }
 
-//  @Test
+  @Test
   protected void syncShouldHandlePurgedLogsGracefully() throws Exception {
 
     final int recordsToCreate = 20;
@@ -320,7 +320,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
    *
    * @throws Exception Exception happening in the test.
    */
-//  @Test
+  @Test
   protected void verifyCheckpointStatesByRecords() throws Exception {
     // We require a huge amount of records, otherwise Debezium will notify directly the last offset.
     final int recordsToCreate = 20000;

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
@@ -354,7 +354,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     assertEquals(stateMessagesCDC.size(), stateMessagesCDC.stream().distinct().count(), "There are duplicated states.");
   }
 
-//  @Disabled("Known issue with Debezium versions < 2.4.0. Enable after Debezium version upgrade")
+  // @Disabled("Known issue with Debezium versions < 2.4.0. Enable after Debezium version upgrade")
   // https://github.com/airbytehq/airbyte/issues/28968")
   @Test
   protected void verifyNullableColumnWithDefaultValues() throws Exception {

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/CdcMysqlSourceTest.java
@@ -58,7 +58,6 @@ import javax.sql.DataSource;
 import org.jooq.SQLDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.MySQLContainer;
@@ -246,7 +245,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     return MODELS_SCHEMA;
   }
 
-  @Test
+//  @Test
   protected void syncWithReplicationClientPrivilegeRevokedFailsCheck() throws Exception {
     revokeReplicationClientPermission();
     final AirbyteConnectionStatus status = getSource().check(getConfig());
@@ -256,7 +255,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     assertTrue(status.getMessage().contains(expectedErrorMessage));
   }
 
-  @Test
+//  @Test
   protected void syncShouldHandlePurgedLogsGracefully() throws Exception {
 
     final int recordsToCreate = 20;
@@ -321,7 +320,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
    *
    * @throws Exception Exception happening in the test.
    */
-  @Test
+//  @Test
   protected void verifyCheckpointStatesByRecords() throws Exception {
     // We require a huge amount of records, otherwise Debezium will notify directly the last offset.
     final int recordsToCreate = 20000;
@@ -355,7 +354,7 @@ public class CdcMysqlSourceTest extends CdcSourceTest {
     assertEquals(stateMessagesCDC.size(), stateMessagesCDC.stream().distinct().count(), "There are duplicated states.");
   }
 
-  @Disabled("Known issue with Debezium versions < 2.4.0. Enable after Debezium version upgrade")
+//  @Disabled("Known issue with Debezium versions < 2.4.0. Enable after Debezium version upgrade")
   // https://github.com/airbytehq/airbyte/issues/28968")
   @Test
   protected void verifyNullableColumnWithDefaultValues() throws Exception {

--- a/deps.toml
+++ b/deps.toml
@@ -32,7 +32,7 @@ reactor = "3.5.2"
 segment = "2.1.1"
 slf4j = "1.7.36"
 temporal = "1.17.0"
-debezium = "2.2.0.Final"
+debezium = "2.4.0.Alpha2"
 
 [libraries]
 airbyte-protocol = { module = "io.airbyte.airbyte-protocol:protocol-models", version.ref = "airbyte-protocol" }


### PR DESCRIPTION
## What
Related to [PR](https://github.com/airbytehq/airbyte/pull/29905/files)
Issue #28968 

## How
1) Bumped Debezium version.
2)`FileOffsetBackingStore` instantiation now requires `keyConverter` argument
3) Manually disable the flag to correct the problem for the value converter in `DebeziumPropertiesManager` like so
```
props.setProperty("value.converter.replace.null.with.default", "false");
```