### PR TITLE
🐛 Source Shopify: correct `upgradeDeadline` in `metadata.yaml`

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -63,5 +63,5 @@ data:
     breakingChanges:
       1.0.0:
         message: "This upgrade brings changes to certain streams after migration to Shopify API version `2023-07`, more details in this PR: https://github.com/airbytehq/airbyte/pull/29361."
-        upgradeDeadline: "2024-07-01" # the full year after the api version was introduced
+        upgradeDeadline: "2023-09-17"
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What
Based on this Slack thread: https://airbyte-globallogic.slack.com/archives/C05Q85LEY8Z/p1693254148580569
and this doc: https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/connector-metadata-file.md
Need to change the `upgradeDeadline` value to 3-week forward from `2023-08-28`

## How
- edited `metadata.yaml > releases > breakingChanges > 1.0.0 > upgradeDeadline` to `2023-09-17`