### PR TITLE
Source Posthog: add optional field in spec: `events_time_step`

### DIFF
--- a/airbyte-integrations/connectors/source-posthog/Dockerfile
+++ b/airbyte-integrations/connectors/source-posthog/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.13
+LABEL io.airbyte.version=0.1.14
 LABEL io.airbyte.name=airbyte/source-posthog

--- a/airbyte-integrations/connectors/source-posthog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-posthog/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: af6d50ee-dddf-4126-a8ee-7faee990774f
-  dockerImageTag: 0.1.13
+  dockerImageTag: 0.1.14
   dockerRepository: airbyte/source-posthog
   githubIssueLabel: source-posthog
   icon: posthog.svg

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
@@ -118,7 +118,7 @@ definitions:
             datetime_format: "%Y-%m-%dT%H:%M:%S%z"
           datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
           cursor_granularity: "PT0.000001S"
-          step: "P30D"
+          step: "P{{ config.get('events_time_step', 30) }}D"
           cursor_field: timestamp
           start_time_option:
             field_name: after

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/spec.json
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/spec.json
@@ -26,6 +26,16 @@
         "title": "Base URL",
         "description": "Base PostHog url. Defaults to PostHog Cloud (https://app.posthog.com).",
         "examples": ["https://posthog.example.com"]
+      },
+      "events_time_step": {
+        "type": "integer",
+        "order": 3,
+        "default": 30,
+        "minimum": 1,
+        "maximum": 91,
+        "title": "Events stream slice step size (in days)",
+        "description": "Set lower value in case of failing long running sync of events stream.",
+        "examples": [30, 10, 5]
       }
     }
   }

--- a/docs/integrations/sources/posthog.md
+++ b/docs/integrations/sources/posthog.md
@@ -53,6 +53,7 @@ Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                            |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------|
+| 0.1.14  | 2023-08-29 | [29947](https://github.com/airbytehq/airbyte/pull/29947) | Add optional field to spec: `events_time_step`                                                                     |
 | 0.1.13  | 2023-07-19 | [28461](https://github.com/airbytehq/airbyte/pull/28461) | Fixed EventsSimpleRetriever declaration                                                                            |
 | 0.1.12  | 2023-06-28 | [27764](https://github.com/airbytehq/airbyte/pull/27764) | Update following state breaking changes                                                                            |
 | 0.1.11  | 2023-06-09 | [27135](https://github.com/airbytehq/airbyte/pull/27135) | Fix custom EventsSimpleRetriever                                                                                   |


### PR DESCRIPTION
## What

Resolving https://github.com/airbytehq/alpha-beta-issues/issues/2191

## How

add optional field in spec: `events_time_step`

NOTE:  Adding `checkpointing` during the slice by setting `state_checkpoint_interval` property is not a solution because the records come in `DESC` order

## Recommended reading order
1. `spec.json`
2. `manifest.yaml`

## 🚨 User Impact 🚨

no breaking changes


## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
