### PR TITLE
Prefix all tests with Connector ops ci

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -1,4 +1,4 @@
-name: Airbyte CI pipeline tests
+name: Connector Ops CI - Pipeline Unit Test
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cat-tests.yml
+++ b/.github/workflows/cat-tests.yml
@@ -1,4 +1,4 @@
-name: CAT unit tests
+name: Connector Ops CI - CAT Unit Tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/connectors_nightly_build.yml
+++ b/.github/workflows/connectors_nightly_build.yml
@@ -1,4 +1,4 @@
-name: Connectors nightly build
+name: Connector Ops CI - Connectors Nightly Tests
 
 on:
   schedule:

--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -1,4 +1,4 @@
-name: Connectors tests
+name: Connector Ops CI - Connectors Acceptance Tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/connectors_weekly_build.yml
+++ b/.github/workflows/connectors_weekly_build.yml
@@ -1,4 +1,4 @@
-name: Connectors weekly build
+name: Connector Ops CI - Connectors Weekly Tests
 
 on:
   schedule:

--- a/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
+++ b/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
@@ -1,4 +1,4 @@
-name: Connector metadata service deploy orchestrator
+name: Connector Ops CI - Metadata Service Deploy Orchestrator
 
 on:
   workflow_dispatch:

--- a/.github/workflows/metadata_service_tests_dagger.yml
+++ b/.github/workflows/metadata_service_tests_dagger.yml
@@ -1,4 +1,4 @@
-name: Connector metadata service CI
+name: Connector Ops CI -  Metadata Service Tests
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -1,4 +1,4 @@
-name: Publish connectors on merge to master
+name: Connector Ops CI - Publish Connectors
 
 on:
   push:

--- a/.github/workflows/run-qa-engine.yml
+++ b/.github/workflows/run-qa-engine.yml
@@ -1,4 +1,4 @@
-name: Run QA Engine
+name: Connector Ops CI - QA Engine
 
 on:
   workflow_dispatch:

--- a/.github/workflows/upload-metadata-files.yml
+++ b/.github/workflows/upload-metadata-files.yml
@@ -1,4 +1,4 @@
-name: "Upload any Changed Metadata Files [Exceptional Use!]"
+name: "Connector Ops CI - Upload Changed Metadata Files [Emergency Use!]"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## overview
Standardizes the naming of all GHA related to `airbyte-ci`

closes #29865

