### PR TITLE
Source Amazon Ads: add stream SponsoredProductNegativeTargetingClauses

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
@@ -13,5 +13,5 @@ ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
 
-LABEL io.airbyte.version=3.1.2
+LABEL io.airbyte.version=3.2.0
 LABEL io.airbyte.name=airbyte/source-amazon-ads

--- a/airbyte-integrations/connectors/source-amazon-ads/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-amazon-ads/integration_tests/configured_catalog.json
@@ -112,6 +112,16 @@
     },
     {
       "stream": {
+        "name": "sponsored_product_negative_targeting_clauses",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"],
+        "source_defined_primary_key": [["targetId"]]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
         "name": "sponsored_product_targetings",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh"],

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 3.1.2
+  dockerImageTag: 3.2.0
   dockerRepository: airbyte/source-amazon-ads
   githubIssueLabel: source-amazon-ads
   icon: amazonads.svg

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/__init__.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/__init__.py
@@ -7,6 +7,7 @@ from .profile import Profile
 from .sponsored_brands import BrandsAdGroup, BrandsCampaign
 from .sponsored_display import DisplayAdGroup, DisplayBudgetRules, DisplayCampaign, DisplayProductAds, DisplayTargeting
 from .sponsored_products import (
+    NegativeProductTargeting,
     ProductAd,
     ProductAdGroupBidRecommendations,
     ProductAdGroups,
@@ -34,6 +35,7 @@ __all__ = [
     "ProductAdGroupSuggestedKeywords",
     "ProductCampaign",
     "ProductTargeting",
+    "NegativeProductTargeting",
     "Profile",
     "AttributionReportModel",
 ]

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/sponsored_products.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/sponsored_products.py
@@ -76,3 +76,9 @@ class ProductTargeting(Targeting):
     campaignId: Decimal
     expression: List[Dict[str, str]]
     resolvedExpression: List[Dict[str, str]]
+
+
+class NegativeProductTargeting(Targeting):
+    totalResults: int
+    nextToken: str
+    negativeTargetingClauses: List[Dict[str, str]]

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/source.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/source.py
@@ -39,6 +39,7 @@ from .streams import (
     SponsoredProductCampaigns,
     SponsoredProductKeywords,
     SponsoredProductNegativeKeywords,
+    SponsoredProductNegativeTargetingClauses,
     SponsoredProductsReportStream,
     SponsoredProductTargetings,
 )
@@ -117,6 +118,7 @@ class SourceAmazonAds(AbstractSource):
             SponsoredProductCampaignNegativeKeywords,
             SponsoredProductAds,
             SponsoredProductTargetings,
+            SponsoredProductNegativeTargetingClauses,
             SponsoredProductsReportStream,
             SponsoredBrandsCampaigns,
             SponsoredBrandsAdGroups,

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/__init__.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/__init__.py
@@ -33,6 +33,7 @@ from .sponsored_products import (
     SponsoredProductCampaigns,
     SponsoredProductKeywords,
     SponsoredProductNegativeKeywords,
+    SponsoredProductNegativeTargetingClauses,
     SponsoredProductTargetings,
 )
 
@@ -53,6 +54,7 @@ __all__ = [
     "SponsoredProductNegativeKeywords",
     "SponsoredProductCampaignNegativeKeywords",
     "SponsoredProductTargetings",
+    "SponsoredProductNegativeTargetingClauses",
     "SponsoredBrandsCampaigns",
     "SponsoredBrandsAdGroups",
     "SponsoredBrandsKeywords",

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/sponsored_products.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/sponsored_products.py
@@ -11,6 +11,7 @@ from airbyte_protocol.models import SyncMode
 from source_amazon_ads.schemas import (
     Keywords,
     NegativeKeywords,
+    NegativeProductTargeting,
     ProductAd,
     ProductAdGroupBidRecommendations,
     ProductAdGroups,
@@ -212,3 +213,16 @@ class SponsoredProductTargetings(SubProfilesStream):
 
     def path(self, **kvargs) -> str:
         return "v2/sp/targets"
+
+
+class SponsoredProductNegativeTargetingClauses(SubProfilesStream):
+    """
+    This stream corresponds to Amazon Advertising API - Sponsored Products Targetings
+    https://advertising.amazon.com/API/docs/en-us/sponsored-products/3-0/openapi/prod#tag/NegativeTargetingClauses/operation/ListSponsoredProductsNegativeTargetingClauses
+    """
+
+    primary_key = "targetId"
+    model = NegativeProductTargeting
+
+    def path(self, **kvargs) -> str:
+        return "v2/sp/negativeTargets/list"

--- a/airbyte-integrations/connectors/source-amazon-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/unit_tests/test_source.py
@@ -92,7 +92,7 @@ def test_source_streams(config):
     setup_responses()
     source = SourceAmazonAds()
     streams = source.streams(config)
-    assert len(streams) == 28
+    assert len(streams) == 29
     actual_stream_names = {stream.name for stream in streams}
     expected_stream_names = set(
         [
@@ -108,6 +108,7 @@ def test_source_streams(config):
             "sponsored_product_campaign_negative_keywords",
             "sponsored_product_ads",
             "sponsored_product_targetings",
+            "sponsored_product_negative_targeting_clauses",
             "sponsored_products_report_stream",
             "sponsored_brands_campaigns",
             "sponsored_brands_ad_groups",

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -109,6 +109,7 @@ Information about expected report generation waiting time you may find [here](ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 3.2.0   | 2023-08-30 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add `SponsoredProductNegativeTargetingClauses` stream                                                           |
 | 3.1.2   | 2023-08-16 | [29233](https://github.com/airbytehq/airbyte/pull/29233) | Add filter for Marketplace IDs                                                                                  |
 | 3.1.1   | 2023-08-28 | [29900](https://github.com/airbytehq/airbyte/pull/29900) | Add 404 handling for no assotiated with bid ad groups                                                           |
 | 3.1.0   | 2023-08-08 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add `T00030` tactic support for `sponsored_display_report_stream`                                               |

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -109,7 +109,7 @@ Information about expected report generation waiting time you may find [here](ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
-| 3.2.0   | 2023-08-30 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add `SponsoredProductNegativeTargetingClauses` stream                                                           |
+| 3.2.0   | 2023-08-30 | [29990](https://github.com/airbytehq/airbyte/pull/29990) | Add `SponsoredProductNegativeTargetingClauses` stream                                                           |
 | 3.1.2   | 2023-08-16 | [29233](https://github.com/airbytehq/airbyte/pull/29233) | Add filter for Marketplace IDs                                                                                  |
 | 3.1.1   | 2023-08-28 | [29900](https://github.com/airbytehq/airbyte/pull/29900) | Add 404 handling for no assotiated with bid ad groups                                                           |
 | 3.1.0   | 2023-08-08 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add `T00030` tactic support for `sponsored_display_report_stream`                                               |


### PR DESCRIPTION
## What
Adding a new stream based on this issue:
https://github.com/airbytehq/airbyte-internal-issues/issues/1796

## How
Added code to support new stream `SponsoredProductNegativeTargetingClauses`, based on [this endpoint](https://advertising.amazon.com/API/docs/en-us/sponsored-products/3-0/openapi/prod#tag/NegativeTargetingClauses/operation/ListSponsoredProductsNegativeTargetingClauses)

