### PR TITLE
Up pydantic version in order to fix destination tests

### DIFF
--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -63,7 +63,7 @@ setup(
         "jsonref~=0.2",
         "pendulum",
         "genson==1.2.2",
-        "pydantic>=1.9.2,<2.0.0",
+        "pydantic>=1.10.8,<2.0.0",
         "python-dateutil",
         "PyYAML>=6.0.1",
         "requests",


### PR DESCRIPTION
## What
Using any allowed version of pydantic below `1.10.8` will cause the following error:

```
batcher_test.py:8: in <module>
    from airbyte_cdk.destinations.vector_db_based.batcher import Batcher
../../../airbyte_cdk/destinations/vector_db_based/__init__.py:6: in <module>
    from .config import CohereEmbeddingConfigModel, FakeEmbeddingConfigModel, OpenAIEmbeddingConfigModel, ProcessingConfigModel
../../../airbyte_cdk/destinations/vector_db_based/config.py:41: in <module>
    class OpenAIEmbeddingConfigModel(BaseModel):
pydantic/main.py:197: in pydantic.main.ModelMetaclass.__new__
    ???
pydantic/fields.py:506: in pydantic.fields.ModelField.infer
    ???
pydantic/fields.py:436: in pydantic.fields.ModelField.__init__
    ???
pydantic/fields.py:552: in pydantic.fields.ModelField.prepare
    ???
pydantic/fields.py:668: in pydantic.fields.ModelField._type_analysis
    ???
<...>/.pyenv/versions/3.9.11/lib/python3.9/typing.py:852: in __subclasscheck__
    return issubclass(cls, self.__origin__)
E   TypeError: issubclass() arg 1 must be a class
```

## How
Increasing the lower boundary


## 🚨 User Impact 🚨
If a user is importing the airbyte_cdk to this new version and pydantic with an upper boundary 1.9.3 and 1.10.7, he will not be able to install dependencies and will either have to upper bound the airbyte_cdk or change the upper boundary for pydantic
