### PR TITLE
🐛 Source Notion: fix duplicates during Incremental sync

### DIFF
--- a/airbyte-integrations/connectors/source-notion/Dockerfile
+++ b/airbyte-integrations/connectors/source-notion/Dockerfile
@@ -34,5 +34,5 @@ COPY source_notion ./source_notion
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.1.2
+LABEL io.airbyte.version=1.1.3
 LABEL io.airbyte.name=airbyte/source-notion

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6e00b415-b02e-4160-bf02-58176a0ae687
-  dockerImageTag: 1.1.2
+  dockerImageTag: 1.1.3
   dockerRepository: airbyte/source-notion
   githubIssueLabel: source-notion
   icon: notion.svg

--- a/airbyte-integrations/connectors/source-notion/source_notion/streams.py
+++ b/airbyte-integrations/connectors/source-notion/source_notion/streams.py
@@ -89,7 +89,7 @@ class StateValueWrapper(pydantic.BaseModel):
 
     stream: T
     state_value: str
-    max_cursor_time = ""
+    max_cursor_time: str = ""
 
     def __repr__(self):
         """Overrides print view"""
@@ -158,7 +158,7 @@ class IncrementalNotionStream(NotionStream, ABC):
             state_lmd = stream_state.get(self.cursor_field, "")
             if isinstance(state_lmd, StateValueWrapper):
                 state_lmd = state_lmd.value
-            if not stream_state or record_lmd >= state_lmd:
+            if not stream_state or record_lmd > state_lmd:
                 yield from transform_properties(record)
 
     def get_updated_state(
@@ -168,7 +168,7 @@ class IncrementalNotionStream(NotionStream, ABC):
     ) -> Mapping[str, Any]:
         state_value = (current_stream_state or {}).get(self.cursor_field, "")
         if not isinstance(state_value, StateValueWrapper):
-            state_value = StateValueWrapper(stream=self, state_value=state_value)
+            state_value = StateValueWrapper(stream=self, state_value=state_value, max_cursor_time=state_value)
 
         record_time = latest_record.get(self.cursor_field, self.start_date)
         state_value.max_cursor_time = max(state_value.max_cursor_time, record_time)

--- a/airbyte-integrations/connectors/source-notion/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-notion/unit_tests/test_incremental_streams.py
@@ -5,7 +5,7 @@
 from unittest.mock import MagicMock, patch
 
 from airbyte_cdk.models import SyncMode
-from pytest import fixture
+from pytest import fixture, mark
 from source_notion.streams import Blocks, IncrementalNotionStream, Pages
 
 
@@ -42,26 +42,28 @@ def test_cursor_field(stream):
     assert stream.cursor_field == expected_cursor_field
 
 
-def test_get_updated_state(stream):
-    stream.is_finished = False
-
-    inputs = {
-        "current_stream_state": {"last_edited_time": "2021-10-10T00:00:00.000Z"},
-        "latest_record": {"last_edited_time": "2021-10-20T00:00:00.000Z"},
-    }
-    expected_state = "2021-10-10T00:00:00.000Z"
-    state = stream.get_updated_state(**inputs)
-    assert state["last_edited_time"].value == expected_state
-
-    inputs = {"current_stream_state": state, "latest_record": {"last_edited_time": "2021-10-30T00:00:00.000Z"}}
-    state = stream.get_updated_state(**inputs)
-    assert state["last_edited_time"].value == expected_state
-
-    # after stream sync is finished, state should output the max cursor time
-    stream.is_finished = True
-    inputs = {"current_stream_state": state, "latest_record": {"last_edited_time": "2021-10-10T00:00:00.000Z"}}
-    expected_state = "2021-10-30T00:00:00.000Z"
-    state = stream.get_updated_state(**inputs)
+@mark.parametrize(
+    "is_finished, current_stream_state, latest_record, expected_state",
+    [
+        # Stream not finished, latest record is later than current state
+        (False, {"last_edited_time": "2021-10-10T00:00:00.000Z"}, {"last_edited_time": "2021-10-20T00:00:00.000Z"}, "2021-10-10T00:00:00.000Z"),
+        # Stream not finished, latest record is equal to current state
+        (False, {"last_edited_time": "2021-10-10T00:00:00.000Z"}, {"last_edited_time": "2021-10-10T00:00:00.000Z"}, "2021-10-10T00:00:00.000Z"),
+        # Stream not finished, latest record is earlier than current state
+        (False, {"last_edited_time": "2021-10-10T00:00:00.000Z"}, {"last_edited_time": "2021-10-01T00:00:00.000Z"}, "2021-10-10T00:00:00.000Z"),
+        # Stream is finished, latest record is later than current state
+        (True, {"last_edited_time": "2021-10-10T00:00:00.000Z"}, {"last_edited_time": "2021-10-30T00:00:00.000Z"}, "2021-10-30T00:00:00.000Z"),
+        # Stream is finished, latest record is earlier than current state
+        (True, {"last_edited_time": "2021-10-20T00:00:00.000Z"}, {"last_edited_time": "2021-10-10T00:00:00.000Z"}, "2021-10-20T00:00:00.000Z"),
+        # Current stream state is empty
+        (False, None, {"last_edited_time": "2021-10-01T00:00:00.000Z"}, ""),
+        # Current stream state is empty and stream is finished
+        (True, None, {"last_edited_time": "2021-10-01T00:00:00.000Z"}, "2021-10-01T00:00:00.000Z"),
+    ]
+)
+def test_get_updated_state(stream, is_finished, current_stream_state, latest_record, expected_state):
+    stream.is_finished = is_finished
+    state = stream.get_updated_state(current_stream_state=current_stream_state, latest_record=latest_record)
     assert state["last_edited_time"].value == expected_state
 
 

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -107,7 +107,8 @@ The connector is restricted by Notion [request limits](https://developers.notion
 
 | Version | Date       | Pull Request                                             | Subject                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------- |
-| 1.1.2   | 2023-08-30 | [29999](https://github.com/airbytehq/airbyte/pull/29999) | Update error handling during connection check
+| 1.1.3   | 2023-08-31 | [30051](https://github.com/airbytehq/airbyte/pull/30051) | Fix duplicates during Incremental sync                                       |
+| 1.1.2   | 2023-08-30 | [29999](https://github.com/airbytehq/airbyte/pull/29999) | Update error handling during connection check                                |
 | 1.1.1   | 2023-06-14 | [26535](https://github.com/airbytehq/airbyte/pull/26535) | Migrate from deprecated `authSpecification` to `advancedAuth`                |
 | 1.1.0   | 2023-06-08 | [27170](https://github.com/airbytehq/airbyte/pull/27170) | Fix typo in `blocks` schema                                                  |
 | 1.0.9   | 2023-06-08 | [27062](https://github.com/airbytehq/airbyte/pull/27062) | Skip streams with `invalid_start_cursor` error                               |


### PR DESCRIPTION
## What
Small bugfix. In our current implementation, during Incremental syncs any records with the most recent `last_edited_time` are being appended regardless of changes in data.

## How
- Updated the operator comparing Last Modified Date of state and stream to only yield record when record `>` state
- Updated the logic in `get_updated_state` to initialize `max_cursor_time` in a new `StateValueWrapper` to the current `state_value`, rather than an empty string. I believe this should prevent edge cases where the `max_cursor_value` is incorrectly set to the value of `record_time` even if `state_value` is higher (as an empty string will always evaluate to `<` any other value):

```py
record_time = latest_record.get(self.cursor_field, self.start_date)
state_value.max_cursor_time = max(state_value.max_cursor_time, record_time)
```



