### PR TITLE
📃 Nest migration docs

### DIFF
--- a/docs/integrations/sources/shopify.inapp.md
+++ b/docs/integrations/sources/shopify.inapp.md
@@ -3,7 +3,7 @@
 * An Active [Shopify store](https://www.shopify.com)
 * Granted permissions to [Access Client's store](https://help.shopify.com/en/partners/dashboard/managing-stores/request-access#request-access) (not required for account owners and mandatory for partners)
 
-::: note
+:::note
 
 If you previously used the `API Password` authentication method, please switch to the `OAuth2.0`, as the API Password will be deprecated shortly. If you prefer to continue using `API Password`, the option will remain available in `Airbyte Open-Source`.
 

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -3,13 +3,13 @@ description: >-
   Shopify is a proprietary e-commerce platform for online stores and retail point-of-sale systems.
 ---
 
-::: note
+# Shopify
+
+:::note
 
 If you are already a Cloud user but still use the `API PASSWORD` authentication method (option), please make sure you've switched to the `OAuth2.0`, as far as the `API PASSWORD` is going to be deprecated soon for Cloud Users, but this option remains for `OSS` users.
 
 :::
-
-# Shopify
 
 This page contains the setup guide and reference information for the Shopify source connector.
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const { parseMarkdownContentTitle, parseFrontMatter } = require('@docusaurus/utils');
 
 const connectorsDocsRoot = "../docs/integrations";
 const sourcesDocs = `${connectorsDocsRoot}/sources`;
@@ -10,11 +11,30 @@ function getFilenamesInDir(prefix, dir, excludes) {
     .readdirSync(dir)
     .filter(
       (fileName) =>
-        !(fileName.endsWith(".inapp.md") || fileName.endsWith("postgres.md"))
+        !(fileName.endsWith(".inapp.md") || fileName.endsWith("postgres.md") || fileName.endsWith("-migrations.md"))
     )
     .map((fileName) => fileName.replace(".md", ""))
     .filter((fileName) => excludes.indexOf(fileName.toLowerCase()) === -1)
     .map((filename) => {
+      // If there is a migration doc for this connector nest this under the original doc as "Migration Guide"
+      const migrationDocPath = path.join(dir, `${filename}-migrations.md`);
+      if(fs.existsSync(migrationDocPath)) {
+        // Get the first header of the markdown document
+        const { contentTitle } = parseMarkdownContentTitle(parseFrontMatter(fs.readFileSync(path.join(dir, `${filename}.md`))).content);
+        if (!contentTitle) {
+          throw new Error(`Could not parse title from ${path.join(prefix, filename)}. Make sure there's no content above the first heading!`);
+        }
+
+        return {
+          type: "category",
+          label: contentTitle,
+          link: { type: "doc", id: path.join(prefix, filename) },
+          items: [
+            { type: "doc", id: path.join(prefix, `${filename}-migrations`), label: "Migration Guide" }
+          ]
+        };
+      }
+
       return { type: "doc", id: path.join(prefix, filename) };
     });
 }


### PR DESCRIPTION
This PR nests migration docs (`x-migrations.md`) under the corresponding connector doc instead of making it it's own sidebar entry.

![screenshot-20230831-202514](https://github.com/airbytehq/airbyte/assets/877229/8f2d731d-ddc2-4562-9720-dad920956df3)

This was feedback from @nataliekwong who felt this would be cleaner. @evantahler would love to hear your opinion (and ideally review) as well :)

