### PR TITLE
pass in set of fields to exclude to debezium

### DIFF
--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/AirbyteDebeziumHandler.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/AirbyteDebeziumHandler.java
@@ -60,18 +60,19 @@ public class AirbyteDebeziumHandler<T> {
   }
 
   public AutoCloseableIterator<AirbyteMessage> getRelationalDatabaseSnapshotIterators(
-                                                                    final ConfiguredAirbyteCatalog catalogContainingStreamsToSnapshot,
-                                                                    final CdcMetadataInjector cdcMetadataInjector,
-                                                                    final Properties snapshotProperties,
-                                                                    final CdcStateHandler cdcStateHandler,
-                                                                    final Instant emittedAt) {
+                                                                                      final ConfiguredAirbyteCatalog catalogContainingStreamsToSnapshot,
+                                                                                      final CdcMetadataInjector cdcMetadataInjector,
+                                                                                      final Properties snapshotProperties,
+                                                                                      final CdcStateHandler cdcStateHandler,
+                                                                                      final Instant emittedAt) {
 
     LOGGER.info("Running snapshot for " + catalogContainingStreamsToSnapshot.getStreams().size() + " new tables");
     final LinkedBlockingQueue<ChangeEvent<String, String>> queue = new LinkedBlockingQueue<>(queueSize.orElse(QUEUE_CAPACITY));
 
     final AirbyteFileOffsetBackingStore offsetManager = AirbyteFileOffsetBackingStore.initializeDummyStateForSnapshotPurpose();
     final DebeziumRecordPublisher tableSnapshotPublisher = new DebeziumRecordPublisher(
-    new RelationalDbDebeziumPropertiesManager(snapshotProperties, config, catalogContainingStreamsToSnapshot, offsetManager,schemaHistoryManager(new EmptySavedInfo())));
+        new RelationalDbDebeziumPropertiesManager(snapshotProperties, config, catalogContainingStreamsToSnapshot, offsetManager,
+            schemaHistoryManager(new EmptySavedInfo())));
     tableSnapshotPublisher.start(queue);
 
     final AutoCloseableIterator<ChangeEventWithMetadata> eventIterator = new DebeziumRecordIterator<>(
@@ -89,7 +90,6 @@ public class AirbyteDebeziumHandler<T> {
             .fromIterator(MoreIterators.singletonIteratorFromSupplier(cdcStateHandler::saveStateAfterCompletionOfSnapshotOfNewStreams)));
   }
 
-
   public AutoCloseableIterator<AirbyteMessage> getRelationalDatabaseIncrementalIterator(final ConfiguredAirbyteCatalog catalog,
                                                                                         final CdcSavedInfoFetcher cdcSavedInfoFetcher,
                                                                                         final CdcStateHandler cdcStateHandler,
@@ -105,22 +105,23 @@ public class AirbyteDebeziumHandler<T> {
         cdcSavedInfoFetcher,
         cdcStateHandler,
         cdcMetadataInjector,
-        new RelationalDbDebeziumPropertiesManager(connectorProperties, config, catalog, offsetManager,schemaHistoryManager),
+        new RelationalDbDebeziumPropertiesManager(connectorProperties, config, catalog, offsetManager, schemaHistoryManager),
         emittedAt,
-        offsetManager
-    );
+        offsetManager);
   }
 
-  // debezium's mongodb connector doesn't let you specify a list of fields to include, so we can't filter fields
-  // solely using the configured catalog. Instead, we need to specify a list of fields to exclude (in addition to the catalog)
+  // debezium's mongodb connector doesn't let you specify a list of fields to include, so we can't
+  // filter fields
+  // solely using the configured catalog. Instead, we need to specify a list of fields to exclude (in
+  // addition to the catalog)
   public AutoCloseableIterator<AirbyteMessage> getMongoDbIncrementalIterator(final ConfiguredAirbyteCatalog catalog,
-                                                                                        final CdcSavedInfoFetcher cdcSavedInfoFetcher,
-                                                                                        final CdcStateHandler cdcStateHandler,
-                                                                                        final CdcMetadataInjector cdcMetadataInjector,
-                                                                                        final Properties connectorProperties,
-                                                                                        final Instant emittedAt,
-                                                                                        final Set<CollectionAndField> fieldsToExclude,
-                                                                                        final boolean addDbNameToState) {
+                                                                             final CdcSavedInfoFetcher cdcSavedInfoFetcher,
+                                                                             final CdcStateHandler cdcStateHandler,
+                                                                             final CdcMetadataInjector cdcMetadataInjector,
+                                                                             final Properties connectorProperties,
+                                                                             final Instant emittedAt,
+                                                                             final Set<CollectionAndField> fieldsToExclude,
+                                                                             final boolean addDbNameToState) {
 
     final AirbyteFileOffsetBackingStore offsetManager = AirbyteFileOffsetBackingStore.initializeState(cdcSavedInfoFetcher.getSavedOffset(),
         addDbNameToState ? Optional.ofNullable(config.get(JdbcUtils.DATABASE_KEY).asText()) : Optional.empty());
@@ -129,19 +130,18 @@ public class AirbyteDebeziumHandler<T> {
         cdcSavedInfoFetcher,
         cdcStateHandler,
         cdcMetadataInjector,
-        new MongoDbDebeziumPropertiesManager(connectorProperties, config,fieldsToExclude , catalog, offsetManager,schemaHistoryManager),
+        new MongoDbDebeziumPropertiesManager(connectorProperties, config, fieldsToExclude, catalog, offsetManager, schemaHistoryManager),
         emittedAt,
-        offsetManager
-    );
+        offsetManager);
   }
 
   private AutoCloseableIterator<AirbyteMessage> getIncrementalIterator(
-                                                                             final CdcSavedInfoFetcher cdcSavedInfoFetcher,
-                                                                             final CdcStateHandler cdcStateHandler,
-                                                                             final CdcMetadataInjector cdcMetadataInjector,
-                                                                             final DebeziumPropertiesManager debeziumPropertiesManager,
-                                                                             final Instant emittedAt,
-                                                                             final AirbyteFileOffsetBackingStore offsetManager) {
+                                                                       final CdcSavedInfoFetcher cdcSavedInfoFetcher,
+                                                                       final CdcStateHandler cdcStateHandler,
+                                                                       final CdcMetadataInjector cdcMetadataInjector,
+                                                                       final DebeziumPropertiesManager debeziumPropertiesManager,
+                                                                       final Instant emittedAt,
+                                                                       final AirbyteFileOffsetBackingStore offsetManager) {
     LOGGER.info("Using CDC: {}", true);
     final LinkedBlockingQueue<ChangeEvent<String, String>> queue = new LinkedBlockingQueue<>(queueSize.orElse(QUEUE_CAPACITY));
     final Optional<AirbyteSchemaHistoryStorage> schemaHistoryManager = schemaHistoryManager(cdcSavedInfoFetcher);

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumPropertiesManager.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumPropertiesManager.java
@@ -100,4 +100,5 @@ public abstract class DebeziumPropertiesManager {
   protected abstract String getName(final JsonNode config);
 
   protected abstract Properties getCustomConfiguration(final ConfiguredAirbyteCatalog catalog, final JsonNode config);
+
 }

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumPropertiesManager.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumPropertiesManager.java
@@ -90,8 +90,7 @@ public abstract class DebeziumPropertiesManager {
     // scratch
     props.setProperty(TOPIC_PREFIX_KEY, getName(config));
 
-    // includes
-    props.putAll(getIncludeConfiguration(catalog, config));
+    props.putAll(getCustomConfiguration(catalog, config));
 
     return props;
   }
@@ -100,11 +99,10 @@ public abstract class DebeziumPropertiesManager {
 
   protected abstract String getName(final JsonNode config);
 
-  protected abstract Properties getIncludeConfiguration(final ConfiguredAirbyteCatalog catalog, final JsonNode config);
-
   public enum DebeziumConnectorType {
     RELATIONALDB,
     MONGODB;
   }
 
+  protected abstract Properties getCustomConfiguration(final ConfiguredAirbyteCatalog catalog, final JsonNode config);
 }

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumPropertiesManager.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumPropertiesManager.java
@@ -99,10 +99,5 @@ public abstract class DebeziumPropertiesManager {
 
   protected abstract String getName(final JsonNode config);
 
-  public enum DebeziumConnectorType {
-    RELATIONALDB,
-    MONGODB;
-  }
-
   protected abstract Properties getCustomConfiguration(final ConfiguredAirbyteCatalog catalog, final JsonNode config);
 }

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/RelationalDbDebeziumPropertiesManager.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/RelationalDbDebeziumPropertiesManager.java
@@ -28,7 +28,7 @@ public class RelationalDbDebeziumPropertiesManager extends DebeziumPropertiesMan
   }
 
   @Override
-  protected Properties getConnectionConfiguration(JsonNode config) {
+  protected Properties getConnectionConfiguration(final JsonNode config) {
     final Properties properties = new Properties();
 
     // db connection configuration
@@ -45,12 +45,12 @@ public class RelationalDbDebeziumPropertiesManager extends DebeziumPropertiesMan
   }
 
   @Override
-  protected String getName(JsonNode config) {
+  protected String getName(final JsonNode config) {
     return config.get(JdbcUtils.DATABASE_KEY).asText();
   }
 
   @Override
-  protected Properties getIncludeConfiguration(ConfiguredAirbyteCatalog catalog, JsonNode config) {
+  protected Properties getCustomConfiguration(final ConfiguredAirbyteCatalog catalog, final JsonNode config) {
     final Properties properties = new Properties();
 
     // table selection

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbDebeziumPropertiesManager.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbDebeziumPropertiesManager.java
@@ -76,7 +76,7 @@ public class MongoDbDebeziumPropertiesManager extends DebeziumPropertiesManager 
   }
 
   @Override
-  protected Properties getIncludeConfiguration(final ConfiguredAirbyteCatalog catalog, final JsonNode config) {
+  protected Properties getCustomConfiguration(final ConfiguredAirbyteCatalog catalog, final JsonNode config) {
     final Properties properties = new Properties();
 
     // Database/collection selection

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbDebeziumPropertiesManager.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbDebeziumPropertiesManager.java
@@ -95,7 +95,7 @@ public class MongoDbDebeziumPropertiesManager extends DebeziumPropertiesManager 
     return properties;
   }
 
-  private String createFieldsToExcludeString(final Set<CollectionAndField>  fieldsToExclude, final String databaseName) {
+  private String createFieldsToExcludeString(final Set<CollectionAndField> fieldsToExclude, final String databaseName) {
     return fieldsToExclude.stream()
         .map(field -> databaseName + "." + field.collection() + "." + field.field())
         .collect(Collectors.joining(","));

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbDebeziumStateUtil.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbDebeziumStateUtil.java
@@ -10,6 +10,7 @@ import com.mongodb.client.MongoClient;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.debezium.internals.AirbyteFileOffsetBackingStore;
 import io.airbyte.integrations.debezium.internals.DebeziumPropertiesManager;
+import io.airbyte.integrations.debezium.internals.mongodb.MongoDbDebeziumPropertiesManager.CollectionAndField;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.MongoDbConnectorConfig;
@@ -28,6 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Properties;
+import java.util.Set;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.runtime.WorkerConfig;
@@ -123,9 +125,13 @@ public class MongoDbDebeziumStateUtil {
                                   final ConfiguredAirbyteCatalog catalog,
                                   final JsonNode cdcState,
                                   final JsonNode config,
+                                  final Set<CollectionAndField> fieldsToExclude,
                                   final MongoClient mongoClient) {
-    final DebeziumPropertiesManager debeziumPropertiesManager = new MongoDbDebeziumPropertiesManager(baseProperties,
-        config, catalog,
+    final DebeziumPropertiesManager debeziumPropertiesManager = new MongoDbDebeziumPropertiesManager(
+        baseProperties,
+        config,
+        fieldsToExclude,
+        catalog,
         AirbyteFileOffsetBackingStore.initializeState(cdcState, Optional.empty()), Optional.empty());
     final Properties debeziumProperties = debeziumPropertiesManager.getDebeziumProperties();
     return parseSavedOffset(debeziumProperties, mongoClient);

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mysql/MySqlDebeziumStateUtil.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mysql/MySqlDebeziumStateUtil.java
@@ -149,7 +149,7 @@ public class MySqlDebeziumStateUtil {
           }
           return Optional.empty();
         })) {
-      List<Optional<GtidSet>> gtidSet = stream.toList();
+      final List<Optional<GtidSet>> gtidSet = stream.toList();
       if (gtidSet.isEmpty()) {
         return Optional.empty();
       } else if (gtidSet.size() == 1) {
@@ -257,12 +257,8 @@ public class MySqlDebeziumStateUtil {
         Optional.empty());
     final AirbyteSchemaHistoryStorage schemaHistoryStorage = AirbyteSchemaHistoryStorage.initializeDBHistory(Optional.empty());
     final LinkedBlockingQueue<ChangeEvent<String, String>> queue = new LinkedBlockingQueue<>();
-    try (final DebeziumRecordPublisher publisher = new DebeziumRecordPublisher(properties,
-        database.getSourceConfig(),
-        catalog,
-        offsetManager,
-        Optional.of(schemaHistoryStorage),
-        DebeziumPropertiesManager.DebeziumConnectorType.RELATIONALDB)) {
+    try (final DebeziumRecordPublisher publisher = new DebeziumRecordPublisher(
+        new RelationalDbDebeziumPropertiesManager(properties, database.getSourceConfig(), catalog, offsetManager,Optional.of(schemaHistoryStorage)))) {
       publisher.start(queue);
       while (!publisher.hasClosed()) {
         final ChangeEvent<String, String> event = queue.poll(10, TimeUnit.SECONDS);

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mysql/MySqlDebeziumStateUtil.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mysql/MySqlDebeziumStateUtil.java
@@ -258,7 +258,8 @@ public class MySqlDebeziumStateUtil {
     final AirbyteSchemaHistoryStorage schemaHistoryStorage = AirbyteSchemaHistoryStorage.initializeDBHistory(Optional.empty());
     final LinkedBlockingQueue<ChangeEvent<String, String>> queue = new LinkedBlockingQueue<>();
     try (final DebeziumRecordPublisher publisher = new DebeziumRecordPublisher(
-        new RelationalDbDebeziumPropertiesManager(properties, database.getSourceConfig(), catalog, offsetManager,Optional.of(schemaHistoryStorage)))) {
+        new RelationalDbDebeziumPropertiesManager(properties, database.getSourceConfig(), catalog, offsetManager,
+            Optional.of(schemaHistoryStorage)))) {
       publisher.start(queue);
       while (!publisher.hasClosed()) {
         final ChangeEvent<String, String> event = queue.poll(10, TimeUnit.SECONDS);

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbCdcInitializer.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbCdcInitializer.java
@@ -126,13 +126,13 @@ public class MongoDbCdcInitializer {
     final MongoDbCdcConnectorMetadataInjector cdcMetadataInjector = MongoDbCdcConnectorMetadataInjector.getInstance(emittedAt);
     final MongoDbCdcSavedInfoFetcher cdcSavedInfoFetcher = new MongoDbCdcSavedInfoFetcher(stateToBeUsed);
 
-    final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getIncrementalIterators(catalog,
+    final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getMongoDbIncrementalIterator(catalog,
         cdcSavedInfoFetcher,
         mongoDbCdcStateHandler,
         cdcMetadataInjector,
         defaultDebeziumProperties,
-        DebeziumPropertiesManager.DebeziumConnectorType.MONGODB,
         emittedAt,
+        fieldsToExclude,
         false);
 
     return Stream
@@ -140,5 +140,4 @@ public class MongoDbCdcInitializer {
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
   }
-
 }

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbCdcInitializer.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbCdcInitializer.java
@@ -145,4 +145,5 @@ public class MongoDbCdcInitializer {
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
   }
+
 }

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbDebeziumFieldsUtil.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbDebeziumFieldsUtil.java
@@ -1,0 +1,46 @@
+package io.airbyte.integrations.source.mongodb.internal.cdc;
+
+import autovalue.shaded.com.google.common.collect.Sets;
+import com.mongodb.client.MongoClient;
+import io.airbyte.integrations.debezium.internals.mongodb.MongoDbDebeziumPropertiesManager.CollectionAndField;
+import io.airbyte.integrations.source.mongodb.internal.MongoUtil;
+import io.airbyte.protocol.models.v0.AirbyteStream;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MongoDbDebeziumFieldsUtil {
+
+  /**
+   * Catalog contains the list of fields to include. In order to get the list of fields to exclude, we need to get the list of all fields in the source
+   * database and subtract the list of fields to include.
+   */
+  public Set<CollectionAndField> getFieldsToExclude(final ConfiguredAirbyteCatalog catalog, final String databaseName, final MongoClient mongoClient) {
+    final List<AirbyteStream> sourceAirbyteStreams = MongoUtil.getAirbyteStreams(mongoClient, databaseName);
+
+    return getFieldsToExclude(
+        catalog.getStreams().stream().map(ConfiguredAirbyteStream::getStream).collect(Collectors.toList()), sourceAirbyteStreams);
+  }
+
+  private static Set<CollectionAndField> getFieldsToExclude(final List<AirbyteStream> configuredAirbyteStreams, final List<AirbyteStream> sourceAirbyteStreams) {
+    final Set<CollectionAndField> fieldsToInclude = configuredAirbyteStreams.stream().map(MongoDbDebeziumFieldsUtil::getCollectionAndFields).flatMap(Set::stream)
+        .collect(Collectors.toSet());
+
+    final Set<CollectionAndField> allFields = sourceAirbyteStreams.stream().map(MongoDbDebeziumFieldsUtil::getCollectionAndFields).flatMap(Set::stream)
+        .collect(Collectors.toSet());
+
+    return Sets.difference(allFields, fieldsToInclude);
+  }
+
+  private static Set<CollectionAndField> getCollectionAndFields(final AirbyteStream stream) {
+    return getTopLevelFieldNames(stream).stream().map(fieldName -> new CollectionAndField(stream.getName(), fieldName)).collect(Collectors.toSet());
+  }
+
+  private static Set<String> getTopLevelFieldNames(final AirbyteStream stream) {
+    final Map<String, Object> object = (Map) io.airbyte.protocol.models.Jsons.object(stream.getJsonSchema().get("properties"), Map.class);
+    return object.keySet();
+  }
+}

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbDebeziumFieldsUtil.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbDebeziumFieldsUtil.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.source.mongodb.internal.cdc;
 
 import autovalue.shaded.com.google.common.collect.Sets;
@@ -15,22 +19,28 @@ import java.util.stream.Collectors;
 public class MongoDbDebeziumFieldsUtil {
 
   /**
-   * Catalog contains the list of fields to include. In order to get the list of fields to exclude, we need to get the list of all fields in the source
-   * database and subtract the list of fields to include.
+   * Catalog contains the list of fields to include. In order to get the list of fields to exclude, we
+   * need to get the list of all fields in the source database and subtract the list of fields to
+   * include.
    */
-  public Set<CollectionAndField> getFieldsToExclude(final ConfiguredAirbyteCatalog catalog, final String databaseName, final MongoClient mongoClient) {
+  public Set<CollectionAndField> getFieldsToExclude(final ConfiguredAirbyteCatalog catalog,
+                                                    final String databaseName,
+                                                    final MongoClient mongoClient) {
     final List<AirbyteStream> sourceAirbyteStreams = MongoUtil.getAirbyteStreams(mongoClient, databaseName);
 
     return getFieldsToExclude(
         catalog.getStreams().stream().map(ConfiguredAirbyteStream::getStream).collect(Collectors.toList()), sourceAirbyteStreams);
   }
 
-  private static Set<CollectionAndField> getFieldsToExclude(final List<AirbyteStream> configuredAirbyteStreams, final List<AirbyteStream> sourceAirbyteStreams) {
-    final Set<CollectionAndField> fieldsToInclude = configuredAirbyteStreams.stream().map(MongoDbDebeziumFieldsUtil::getCollectionAndFields).flatMap(Set::stream)
-        .collect(Collectors.toSet());
+  private static Set<CollectionAndField> getFieldsToExclude(final List<AirbyteStream> configuredAirbyteStreams,
+                                                            final List<AirbyteStream> sourceAirbyteStreams) {
+    final Set<CollectionAndField> fieldsToInclude =
+        configuredAirbyteStreams.stream().map(MongoDbDebeziumFieldsUtil::getCollectionAndFields).flatMap(Set::stream)
+            .collect(Collectors.toSet());
 
-    final Set<CollectionAndField> allFields = sourceAirbyteStreams.stream().map(MongoDbDebeziumFieldsUtil::getCollectionAndFields).flatMap(Set::stream)
-        .collect(Collectors.toSet());
+    final Set<CollectionAndField> allFields =
+        sourceAirbyteStreams.stream().map(MongoDbDebeziumFieldsUtil::getCollectionAndFields).flatMap(Set::stream)
+            .collect(Collectors.toSet());
 
     return Sets.difference(allFields, fieldsToInclude);
   }
@@ -43,4 +53,5 @@ public class MongoDbDebeziumFieldsUtil {
     final Map<String, Object> object = (Map) io.airbyte.protocol.models.Jsons.object(stream.getJsonSchema().get("properties"), Map.class);
     return object.keySet();
   }
+
 }

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -459,12 +459,11 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
 
       final MssqlCdcConnectorMetadataInjector mssqlCdcConnectorMetadataInjector = MssqlCdcConnectorMetadataInjector.getInstance(emittedAt);
 
-      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getIncrementalIterators(catalog,
+      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
           new MssqlCdcSavedInfoFetcher(stateManager.getCdcStateManager().getCdcState()),
           new MssqlCdcStateHandler(stateManager),
           mssqlCdcConnectorMetadataInjector,
           MssqlCdcHelper.getDebeziumProperties(database, catalog),
-          DebeziumPropertiesManager.DebeziumConnectorType.RELATIONALDB,
           emittedAt, true);
 
       return Collections.singletonList(incrementalIteratorSupplier.get());

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -32,7 +32,6 @@ import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.base.ssh.SshWrappedSource;
 import io.airbyte.integrations.debezium.AirbyteDebeziumHandler;
-import io.airbyte.integrations.debezium.internals.DebeziumPropertiesManager;
 import io.airbyte.integrations.debezium.internals.FirstRecordWaitTimeUtil;
 import io.airbyte.integrations.debezium.internals.mssql.MssqlCdcTargetPosition;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
@@ -459,12 +458,13 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
 
       final MssqlCdcConnectorMetadataInjector mssqlCdcConnectorMetadataInjector = MssqlCdcConnectorMetadataInjector.getInstance(emittedAt);
 
-      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
-          new MssqlCdcSavedInfoFetcher(stateManager.getCdcStateManager().getCdcState()),
-          new MssqlCdcStateHandler(stateManager),
-          mssqlCdcConnectorMetadataInjector,
-          MssqlCdcHelper.getDebeziumProperties(database, catalog),
-          emittedAt, true);
+      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier =
+          () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
+              new MssqlCdcSavedInfoFetcher(stateManager.getCdcStateManager().getCdcState()),
+              new MssqlCdcStateHandler(stateManager),
+              mssqlCdcConnectorMetadataInjector,
+              MssqlCdcHelper.getDebeziumProperties(database, catalog),
+              emittedAt, true);
 
       return Collections.singletonList(incrementalIteratorSupplier.get());
     } else {

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -350,12 +350,11 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
       final List<ConfiguredAirbyteStream> streamsToSnapshot = identifyStreamsToSnapshot(catalog, stateManager);
       final Optional<CdcState> cdcState = Optional.ofNullable(stateManager.getCdcStateManager().getCdcState());
 
-      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getIncrementalIterators(catalog,
+      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
           new MySqlCdcSavedInfoFetcher(cdcState.orElse(null)),
           new MySqlCdcStateHandler(stateManager),
           mySqlCdcConnectorMetadataInjector,
           MySqlCdcProperties.getDebeziumProperties(database),
-          DebeziumPropertiesManager.DebeziumConnectorType.RELATIONALDB,
           emittedAt,
           false);
 
@@ -363,12 +362,11 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
         return Collections.singletonList(incrementalIteratorSupplier.get());
       }
 
-      final AutoCloseableIterator<AirbyteMessage> snapshotIterator = handler.getSnapshotIterators(
+      final AutoCloseableIterator<AirbyteMessage> snapshotIterator = handler.getRelationalDatabaseSnapshotIterators(
           new ConfiguredAirbyteCatalog().withStreams(streamsToSnapshot),
           mySqlCdcConnectorMetadataInjector,
           MySqlCdcProperties.getSnapshotProperties(database),
           mySqlCdcStateHandler,
-          DebeziumPropertiesManager.DebeziumConnectorType.RELATIONALDB,
           emittedAt);
 
       return Collections.singletonList(

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -38,7 +38,6 @@ import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.base.ssh.SshWrappedSource;
 import io.airbyte.integrations.debezium.AirbyteDebeziumHandler;
-import io.airbyte.integrations.debezium.internals.DebeziumPropertiesManager;
 import io.airbyte.integrations.debezium.internals.FirstRecordWaitTimeUtil;
 import io.airbyte.integrations.debezium.internals.mysql.MySqlCdcPosition;
 import io.airbyte.integrations.debezium.internals.mysql.MySqlCdcTargetPosition;
@@ -350,13 +349,14 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
       final List<ConfiguredAirbyteStream> streamsToSnapshot = identifyStreamsToSnapshot(catalog, stateManager);
       final Optional<CdcState> cdcState = Optional.ofNullable(stateManager.getCdcStateManager().getCdcState());
 
-      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
-          new MySqlCdcSavedInfoFetcher(cdcState.orElse(null)),
-          new MySqlCdcStateHandler(stateManager),
-          mySqlCdcConnectorMetadataInjector,
-          MySqlCdcProperties.getDebeziumProperties(database),
-          emittedAt,
-          false);
+      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier =
+          () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
+              new MySqlCdcSavedInfoFetcher(cdcState.orElse(null)),
+              new MySqlCdcStateHandler(stateManager),
+              mySqlCdcConnectorMetadataInjector,
+              MySqlCdcProperties.getDebeziumProperties(database),
+              emittedAt,
+              false);
 
       if (streamsToSnapshot.isEmpty()) {
         return Collections.singletonList(incrementalIteratorSupplier.get());

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/initialsync/MySqlInitialReadUtil.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/initialsync/MySqlInitialReadUtil.java
@@ -149,12 +149,11 @@ public class MySqlInitialReadUtil {
     final AirbyteDebeziumHandler<MySqlCdcPosition> handler =
         new AirbyteDebeziumHandler<>(sourceConfig, MySqlCdcTargetPosition.targetPosition(database), true, firstRecordWaitTime, OptionalInt.empty());
 
-    final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getIncrementalIterators(catalog,
+    final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
         new MySqlCdcSavedInfoFetcher(stateToBeUsed),
         new MySqlCdcStateHandler(stateManager),
         metadataInjector,
         MySqlCdcProperties.getDebeziumProperties(database),
-        DebeziumPropertiesManager.DebeziumConnectorType.RELATIONALDB,
         emittedAt,
         false);
 

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/initialsync/MySqlInitialReadUtil.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/initialsync/MySqlInitialReadUtil.java
@@ -18,7 +18,6 @@ import io.airbyte.commons.util.AutoCloseableIterators;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.base.AirbyteTraceMessageUtility;
 import io.airbyte.integrations.debezium.AirbyteDebeziumHandler;
-import io.airbyte.integrations.debezium.internals.DebeziumPropertiesManager;
 import io.airbyte.integrations.debezium.internals.FirstRecordWaitTimeUtil;
 import io.airbyte.integrations.debezium.internals.mysql.MySqlCdcPosition;
 import io.airbyte.integrations.debezium.internals.mysql.MySqlCdcTargetPosition;
@@ -149,13 +148,14 @@ public class MySqlInitialReadUtil {
     final AirbyteDebeziumHandler<MySqlCdcPosition> handler =
         new AirbyteDebeziumHandler<>(sourceConfig, MySqlCdcTargetPosition.targetPosition(database), true, firstRecordWaitTime, OptionalInt.empty());
 
-    final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
-        new MySqlCdcSavedInfoFetcher(stateToBeUsed),
-        new MySqlCdcStateHandler(stateManager),
-        metadataInjector,
-        MySqlCdcProperties.getDebeziumProperties(database),
-        emittedAt,
-        false);
+    final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier =
+        () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
+            new MySqlCdcSavedInfoFetcher(stateToBeUsed),
+            new MySqlCdcStateHandler(stateManager),
+            metadataInjector,
+            MySqlCdcProperties.getDebeziumProperties(database),
+            emittedAt,
+            false);
 
     // This starts processing the binglogs as soon as initial sync is complete, this is a bit different
     // from the current cdc syncs.

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcCtidInitializer.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcCtidInitializer.java
@@ -159,12 +159,11 @@ public class PostgresCdcCtidInitializer {
           PostgresCdcTargetPosition.targetPosition(database), false, firstRecordWaitTime, queueSize);
       final PostgresCdcStateHandler postgresCdcStateHandler = new PostgresCdcStateHandler(stateManager);
 
-      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getIncrementalIterators(catalog,
+      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
           new PostgresCdcSavedInfoFetcher(stateToBeUsed),
           postgresCdcStateHandler,
           new PostgresCdcConnectorMetadataInjector(),
           PostgresCdcProperties.getDebeziumDefaultProperties(database),
-          DebeziumPropertiesManager.DebeziumConnectorType.RELATIONALDB,
           emittedAt,
           false);
 

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcCtidInitializer.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcCtidInitializer.java
@@ -14,7 +14,6 @@ import io.airbyte.commons.util.AutoCloseableIterators;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.debezium.AirbyteDebeziumHandler;
-import io.airbyte.integrations.debezium.internals.DebeziumPropertiesManager;
 import io.airbyte.integrations.debezium.internals.postgres.PostgresCdcTargetPosition;
 import io.airbyte.integrations.debezium.internals.postgres.PostgresDebeziumStateUtil;
 import io.airbyte.integrations.source.postgres.PostgresQueryUtils;
@@ -159,13 +158,14 @@ public class PostgresCdcCtidInitializer {
           PostgresCdcTargetPosition.targetPosition(database), false, firstRecordWaitTime, queueSize);
       final PostgresCdcStateHandler postgresCdcStateHandler = new PostgresCdcStateHandler(stateManager);
 
-      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier = () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
-          new PostgresCdcSavedInfoFetcher(stateToBeUsed),
-          postgresCdcStateHandler,
-          new PostgresCdcConnectorMetadataInjector(),
-          PostgresCdcProperties.getDebeziumDefaultProperties(database),
-          emittedAt,
-          false);
+      final Supplier<AutoCloseableIterator<AirbyteMessage>> incrementalIteratorSupplier =
+          () -> handler.getRelationalDatabaseIncrementalIterator(catalog,
+              new PostgresCdcSavedInfoFetcher(stateToBeUsed),
+              postgresCdcStateHandler,
+              new PostgresCdcConnectorMetadataInjector(),
+              PostgresCdcProperties.getDebeziumDefaultProperties(database),
+              emittedAt,
+              false);
 
       if (ctidIterator.isEmpty()) {
         return Collections.singletonList(incrementalIteratorSupplier.get());


### PR DESCRIPTION
Unit tests pending
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Setting [field.exclude.list](https://debezium.io/documentation/reference/stable/connectors/mongodb.html#mongodb-property-field-exclude-list) property so that debezium filters out fields that are not relevant for the sync based the given configured catalog.

## How
- setting the new property in `MongoDbDebeziumPropertiesManager`
- move the property manager creation out of the publisher and pass it in as a constructor arg. This is so that we have an easy way to pass the excluded fields from the `MongoDbCdcInitializer` to the `MongoDbDebeziumPropertiesManager`

## Recommended reading order
commit by commit is probably the easiest way

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
