### PR TITLE
Destination snowflake: table casing migration

### DIFF
--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/DefaultTyperDeduper.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/DefaultTyperDeduper.java
@@ -37,7 +37,7 @@ public class DefaultTyperDeduper<DialectTableDefinition> implements TyperDeduper
   private final DestinationHandler<DialectTableDefinition> destinationHandler;
 
   private final DestinationV1V2Migrator<DialectTableDefinition> v1V2Migrator;
-  private final V2RawTableMigrator<DialectTableDefinition> v2RawTableMigrator;
+  private final V2TableMigrator<DialectTableDefinition> v2TableMigrator;
   private final ParsedCatalog parsedCatalog;
   private Set<StreamId> overwriteStreamsWithTmpTable;
   private final Set<StreamId> streamsWithSuccesfulSetup;
@@ -46,12 +46,12 @@ public class DefaultTyperDeduper<DialectTableDefinition> implements TyperDeduper
                              final DestinationHandler<DialectTableDefinition> destinationHandler,
                              final ParsedCatalog parsedCatalog,
                              final DestinationV1V2Migrator<DialectTableDefinition> v1V2Migrator,
-                             final V2RawTableMigrator<DialectTableDefinition> v2RawTableMigrator) {
+                             final V2TableMigrator<DialectTableDefinition> v2TableMigrator) {
     this.sqlGenerator = sqlGenerator;
     this.destinationHandler = destinationHandler;
     this.parsedCatalog = parsedCatalog;
     this.v1V2Migrator = v1V2Migrator;
-    this.v2RawTableMigrator = v2RawTableMigrator;
+    this.v2TableMigrator = v2TableMigrator;
     this.streamsWithSuccesfulSetup = new HashSet<>();
   }
 
@@ -60,7 +60,7 @@ public class DefaultTyperDeduper<DialectTableDefinition> implements TyperDeduper
                              final DestinationHandler<DialectTableDefinition> destinationHandler,
                              final ParsedCatalog parsedCatalog,
                              final DestinationV1V2Migrator<DialectTableDefinition> v1V2Migrator) {
-    this(sqlGenerator, destinationHandler, parsedCatalog, v1V2Migrator, new NoopV2RawTableMigrator<>());
+    this(sqlGenerator, destinationHandler, parsedCatalog, v1V2Migrator, new NoopV2TableMigrator<>());
   }
 
   /**
@@ -82,7 +82,7 @@ public class DefaultTyperDeduper<DialectTableDefinition> implements TyperDeduper
     for (final StreamConfig stream : parsedCatalog.streams()) {
       // Migrate the Raw Tables if this is the first v2 sync after a v1 sync
       v1V2Migrator.migrateIfNecessary(sqlGenerator, destinationHandler, stream);
-      v2RawTableMigrator.migrateIfNecessary(stream);
+      v2TableMigrator.migrateIfNecessary(stream);
 
       final Optional<DialectTableDefinition> existingTable = destinationHandler.findExistingTable(stream.id());
       if (existingTable.isPresent()) {

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/NoopV2TableMigrator.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/NoopV2TableMigrator.java
@@ -4,7 +4,7 @@
 
 package io.airbyte.integrations.base.destination.typing_deduping;
 
-public class NoopV2RawTableMigrator<DialectTableDefinition> implements V2RawTableMigrator<DialectTableDefinition> {
+public class NoopV2TableMigrator<DialectTableDefinition> implements V2TableMigrator<DialectTableDefinition> {
 
   @Override
   public void migrateIfNecessary(final StreamConfig streamConfig) {

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/V2TableMigrator.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/V2TableMigrator.java
@@ -4,7 +4,7 @@
 
 package io.airbyte.integrations.base.destination.typing_deduping;
 
-public interface V2RawTableMigrator<DialectTableDefinition> {
+public interface V2TableMigrator<DialectTableDefinition> {
 
   void migrateIfNecessary(final StreamConfig streamConfig) throws InterruptedException;
 

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/V2TableMigrator.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/V2TableMigrator.java
@@ -6,6 +6,6 @@ package io.airbyte.integrations.base.destination.typing_deduping;
 
 public interface V2TableMigrator<DialectTableDefinition> {
 
-  void migrateIfNecessary(final StreamConfig streamConfig) throws InterruptedException;
+  void migrateIfNecessary(final StreamConfig streamConfig) throws Exception;
 
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -36,7 +36,7 @@ import io.airbyte.integrations.destination.bigquery.formatter.GcsCsvBigQueryReco
 import io.airbyte.integrations.destination.bigquery.typing_deduping.BigQueryDestinationHandler;
 import io.airbyte.integrations.destination.bigquery.typing_deduping.BigQuerySqlGenerator;
 import io.airbyte.integrations.destination.bigquery.typing_deduping.BigQueryV1V2Migrator;
-import io.airbyte.integrations.destination.bigquery.typing_deduping.BigQueryV2RawTableMigrator;
+import io.airbyte.integrations.destination.bigquery.typing_deduping.BigQueryV2TableMigrator;
 import io.airbyte.integrations.destination.bigquery.uploader.AbstractBigQueryUploader;
 import io.airbyte.integrations.destination.bigquery.uploader.BigQueryUploaderFactory;
 import io.airbyte.integrations.destination.bigquery.uploader.UploaderType;
@@ -242,7 +242,7 @@ public class BigQueryDestination extends BaseConnector implements Destination {
     final TyperDeduper typerDeduper;
     parsedCatalog = catalogParser.parseCatalog(catalog);
     final BigQueryV1V2Migrator migrator = new BigQueryV1V2Migrator(bigquery, namingResolver);
-    final BigQueryV2RawTableMigrator v2RawTableMigrator = new BigQueryV2RawTableMigrator(bigquery);
+    final BigQueryV2TableMigrator v2RawTableMigrator = new BigQueryV2TableMigrator(bigquery);
     typerDeduper = new DefaultTyperDeduper<>(
         sqlGenerator,
         new BigQueryDestinationHandler(bigquery, datasetLocation),

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryV2TableMigrator.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryV2TableMigrator.java
@@ -15,19 +15,19 @@ import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig;
-import io.airbyte.integrations.base.destination.typing_deduping.V2RawTableMigrator;
+import io.airbyte.integrations.base.destination.typing_deduping.V2TableMigrator;
 import java.util.Map;
 import org.apache.commons.text.StringSubstitutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class BigQueryV2RawTableMigrator implements V2RawTableMigrator<TableDefinition> {
+public class BigQueryV2TableMigrator implements V2TableMigrator<TableDefinition> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryV2RawTableMigrator.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryV2TableMigrator.class);
 
   private final BigQuery bq;
 
-  public BigQueryV2RawTableMigrator(final BigQuery bq) {
+  public BigQueryV2TableMigrator(final BigQuery bq) {
     this.bq = bq;
   }
 

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestination.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestination.java
@@ -22,6 +22,7 @@ import io.airbyte.integrations.destination.jdbc.AbstractJdbcDestination;
 import io.airbyte.integrations.destination.snowflake.typing_deduping.SnowflakeDestinationHandler;
 import io.airbyte.integrations.destination.snowflake.typing_deduping.SnowflakeSqlGenerator;
 import io.airbyte.integrations.destination.snowflake.typing_deduping.SnowflakeV1V2Migrator;
+import io.airbyte.integrations.destination.snowflake.typing_deduping.SnowflakeV2TableMigrator;
 import io.airbyte.integrations.destination.staging.StagingConsumerFactory;
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
@@ -39,7 +40,7 @@ import org.slf4j.LoggerFactory;
 public class SnowflakeInternalStagingDestination extends AbstractJdbcDestination implements Destination {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SnowflakeInternalStagingDestination.class);
-  private static final String RAW_SCHEMA_OVERRIDE = "raw_data_schema";
+  public static final String RAW_SCHEMA_OVERRIDE = "raw_data_schema";
   private final String airbyteEnvironment;
 
   public SnowflakeInternalStagingDestination(final String airbyteEnvironment) {
@@ -143,7 +144,8 @@ public class SnowflakeInternalStagingDestination extends AbstractJdbcDestination
     }
     parsedCatalog = catalogParser.parseCatalog(catalog);
     final SnowflakeV1V2Migrator migrator = new SnowflakeV1V2Migrator(getNamingResolver(), database, databaseName);
-    typerDeduper = new DefaultTyperDeduper<>(sqlGenerator, snowflakeDestinationHandler, parsedCatalog, migrator);
+    final SnowflakeV2TableMigrator v2TableMigrator = new SnowflakeV2TableMigrator(database, databaseName, sqlGenerator, snowflakeDestinationHandler);
+    typerDeduper = new DefaultTyperDeduper<>(sqlGenerator, snowflakeDestinationHandler, parsedCatalog, migrator, v2TableMigrator);
 
     return new StagingConsumerFactory().createAsync(
         outputRecordCollector,

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
@@ -42,21 +42,21 @@ public class SnowflakeV2TableMigrator implements V2TableMigrator<SnowflakeTableD
 
   @Override
   public void migrateIfNecessary(final StreamConfig streamConfig) throws Exception {
-    final StreamId lowercasedStreamId = buildStreamId_lowercase(
+    final StreamId caseSensitiveStreamId = buildStreamId_caseSensitive(
         streamConfig.id().originalNamespace(),
         streamConfig.id().originalName(),
         rawNamespace);
     final boolean syncModeRequiresMigration = streamConfig.destinationSyncMode() != DestinationSyncMode.OVERWRITE;
-    final boolean existingTableLowercaseExists = findExistingTable_lowercase(lowercasedStreamId).isPresent();
+    final boolean existingTableCaseSensitiveExists = findExistingTable_caseSensitive(caseSensitiveStreamId).isPresent();
     final boolean existingTableUppercaseDoesNotExist = !handler.findExistingTable(streamConfig.id()).isPresent();
     LOGGER.info(
-        "Checking whether upcasing migration is necessary for {}.{}. Sync mode requires migration: {}; existing lowercased table exists: {}; existing uppercased table does not exist: {}",
+        "Checking whether upcasing migration is necessary for {}.{}. Sync mode requires migration: {}; existing case-sensitive table exists: {}; existing uppercased table does not exist: {}",
         streamConfig.id().originalNamespace(),
         streamConfig.id().originalName(),
         syncModeRequiresMigration,
-        existingTableLowercaseExists,
+        existingTableCaseSensitiveExists,
         existingTableUppercaseDoesNotExist);
-    if (syncModeRequiresMigration && existingTableLowercaseExists && existingTableUppercaseDoesNotExist) {
+    if (syncModeRequiresMigration && existingTableCaseSensitiveExists && existingTableUppercaseDoesNotExist) {
       LOGGER.info(
           "Executing upcasing migration for {}.{}",
           streamConfig.id().originalNamespace(),
@@ -67,20 +67,20 @@ public class SnowflakeV2TableMigrator implements V2TableMigrator<SnowflakeTableD
 
   // These methods were copied from
   // https://github.com/airbytehq/airbyte/blob/d5fdb1b982d464f54941bf9a830b9684fb47d249/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeSqlGenerator.java
-  // which is the highest version of destination-snowflake that still uses quoted+lowercased
+  // which is the highest version of destination-snowflake that still uses quoted+case-sensitive
   // identifiers
-  private static StreamId buildStreamId_lowercase(final String namespace, final String name, final String rawNamespaceOverride) {
+  private static StreamId buildStreamId_caseSensitive(final String namespace, final String name, final String rawNamespaceOverride) {
     // No escaping needed, as far as I can tell. We quote all our identifier names.
     return new StreamId(
-        escapeIdentifier_lowercase(namespace),
-        escapeIdentifier_lowercase(name),
-        escapeIdentifier_lowercase(rawNamespaceOverride),
-        escapeIdentifier_lowercase(StreamId.concatenateRawTableName(namespace, name)),
+        escapeIdentifier_caseSensitive(namespace),
+        escapeIdentifier_caseSensitive(name),
+        escapeIdentifier_caseSensitive(rawNamespaceOverride),
+        escapeIdentifier_caseSensitive(StreamId.concatenateRawTableName(namespace, name)),
         namespace,
         name);
   }
 
-  private static String escapeIdentifier_lowercase(final String identifier) {
+  private static String escapeIdentifier_caseSensitive(final String identifier) {
     // Note that we don't need to escape backslashes here!
     // The only special character in an identifier is the double-quote, which needs to be doubled.
     return identifier.replace("\"", "\"\"");
@@ -88,7 +88,7 @@ public class SnowflakeV2TableMigrator implements V2TableMigrator<SnowflakeTableD
 
   // And this was taken from
   // https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeDestinationHandler.java
-  public Optional<SnowflakeTableDefinition> findExistingTable_lowercase(final StreamId id) throws SQLException {
+  public Optional<SnowflakeTableDefinition> findExistingTable_caseSensitive(final StreamId id) throws SQLException {
     // The obvious database.getMetaData().getColumns() solution doesn't work, because JDBC translates
     // VARIANT as VARCHAR
     final LinkedHashMap<String, String> columns = database.queryJsons(

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
@@ -51,9 +51,9 @@ public class SnowflakeV2TableMigrator implements V2TableMigrator<SnowflakeTableD
     final boolean existingTableUppercaseDoesNotExist = !handler.findExistingTable(streamConfig.id()).isPresent();
     LOGGER.info(
         "Checking whether upcasing migration is necessary for {}.{}. Sync mode requires migration: {}; existing lowercased table exists: {}; existing uppercased table does not exist: {}",
-        syncModeRequiresMigration,
         streamConfig.id().originalNamespace(),
         streamConfig.id().originalName(),
+        syncModeRequiresMigration,
         existingTableLowercaseExists,
         existingTableUppercaseDoesNotExist);
     if (syncModeRequiresMigration && existingTableLowercaseExists && existingTableUppercaseDoesNotExist) {

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
@@ -1,0 +1,96 @@
+package io.airbyte.integrations.destination.snowflake.typing_deduping;
+
+import static io.airbyte.integrations.base.JavaBaseConstants.DEFAULT_AIRBYTE_INTERNAL_NAMESPACE;
+import static io.airbyte.integrations.destination.snowflake.SnowflakeInternalStagingDestination.RAW_SCHEMA_OVERRIDE;
+
+import io.airbyte.db.jdbc.JdbcDatabase;
+import io.airbyte.integrations.base.TypingAndDedupingFlag;
+import io.airbyte.integrations.base.destination.typing_deduping.ColumnId;
+import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig;
+import io.airbyte.integrations.base.destination.typing_deduping.StreamId;
+import io.airbyte.integrations.base.destination.typing_deduping.V2TableMigrator;
+import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.Optional;
+
+public class SnowflakeV2TableMigrator implements V2TableMigrator<SnowflakeTableDefinition> {
+  private final JdbcDatabase database;
+  private final String rawNamespace;
+  private final String databaseName;
+  private final SnowflakeSqlGenerator generator;
+  private final SnowflakeDestinationHandler handler;
+
+  public SnowflakeV2TableMigrator(final JdbcDatabase database, final String databaseName, final SnowflakeSqlGenerator generator, final SnowflakeDestinationHandler handler) {
+    this.database = database;
+    this.databaseName = databaseName;
+    this.generator = generator;
+    this.handler = handler;
+    this.rawNamespace = TypingAndDedupingFlag.getRawNamespaceOverride(RAW_SCHEMA_OVERRIDE).orElse(DEFAULT_AIRBYTE_INTERNAL_NAMESPACE);
+  }
+
+  @Override
+  public void migrateIfNecessary(final StreamConfig streamConfig) throws Exception {
+    final StreamId lowercasedStreamId = buildStreamId_lowercase(
+        streamConfig.id().originalNamespace(),
+        streamConfig.id().originalName(),
+        rawNamespace);
+    final Optional<SnowflakeTableDefinition> existingTableLowercase = findExistingTable_lowercase(lowercasedStreamId);
+
+    if (existingTableLowercase.isPresent()) {
+      handler.execute(generator.softReset(streamConfig));
+    }
+  }
+
+  // These methods were copied from https://github.com/airbytehq/airbyte/blob/d5fdb1b982d464f54941bf9a830b9684fb47d249/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeSqlGenerator.java
+  // which is the highest version of destination-snowflake that still uses quoted+lowercased identifiers
+  private static StreamId buildStreamId_lowercase(final String namespace, final String name, final String rawNamespaceOverride) {
+    // No escaping needed, as far as I can tell. We quote all our identifier names.
+    return new StreamId(
+        escapeIdentifier_lowercase(namespace),
+        escapeIdentifier_lowercase(name),
+        escapeIdentifier_lowercase(rawNamespaceOverride),
+        escapeIdentifier_lowercase(StreamId.concatenateRawTableName(namespace, name)),
+        namespace,
+        name);
+  }
+
+  public ColumnId buildColumnId_lowercase(final String name) {
+    // No escaping needed, as far as I can tell. We quote all our identifier names.
+    return new ColumnId(escapeIdentifier_lowercase(name), name, name);
+  }
+
+  private static String escapeIdentifier_lowercase(final String identifier) {
+    // Note that we don't need to escape backslashes here!
+    // The only special character in an identifier is the double-quote, which needs to be doubled.
+    return identifier.replace("\"", "\"\"");
+  }
+
+  // And this was taken from https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeDestinationHandler.java
+  public Optional<SnowflakeTableDefinition> findExistingTable_lowercase(final StreamId id) throws SQLException {
+    // The obvious database.getMetaData().getColumns() solution doesn't work, because JDBC translates
+    // VARIANT as VARCHAR
+    final LinkedHashMap<String, String> columns = database.queryJsons(
+            """
+            SELECT column_name, data_type
+            FROM information_schema.columns
+            WHERE table_catalog = ?
+              AND table_schema = ?
+              AND table_name = ?
+            ORDER BY ordinal_position;
+            """,
+            databaseName.toUpperCase(),
+            id.finalNamespace(),
+            id.finalName()).stream()
+        .collect(LinkedHashMap::new,
+            (map, row) -> map.put(row.get("COLUMN_NAME").asText(), row.get("DATA_TYPE").asText()),
+            LinkedHashMap::putAll);
+    // TODO query for indexes/partitioning/etc
+
+    if (columns.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(new SnowflakeTableDefinition(columns));
+    }
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
@@ -54,11 +54,6 @@ public class SnowflakeV2TableMigrator implements V2TableMigrator<SnowflakeTableD
         name);
   }
 
-  public ColumnId buildColumnId_lowercase(final String name) {
-    // No escaping needed, as far as I can tell. We quote all our identifier names.
-    return new ColumnId(escapeIdentifier_lowercase(name), name, name);
-  }
-
   private static String escapeIdentifier_lowercase(final String identifier) {
     // Note that we don't need to escape backslashes here!
     // The only special character in an identifier is the double-quote, which needs to be doubled.

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.snowflake.typing_deduping;
 
 import static io.airbyte.integrations.base.JavaBaseConstants.DEFAULT_AIRBYTE_INTERNAL_NAMESPACE;
@@ -5,7 +9,6 @@ import static io.airbyte.integrations.destination.snowflake.SnowflakeInternalSta
 
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.base.TypingAndDedupingFlag;
-import io.airbyte.integrations.base.destination.typing_deduping.ColumnId;
 import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig;
 import io.airbyte.integrations.base.destination.typing_deduping.StreamId;
 import io.airbyte.integrations.base.destination.typing_deduping.V2TableMigrator;
@@ -14,13 +17,17 @@ import java.util.LinkedHashMap;
 import java.util.Optional;
 
 public class SnowflakeV2TableMigrator implements V2TableMigrator<SnowflakeTableDefinition> {
+
   private final JdbcDatabase database;
   private final String rawNamespace;
   private final String databaseName;
   private final SnowflakeSqlGenerator generator;
   private final SnowflakeDestinationHandler handler;
 
-  public SnowflakeV2TableMigrator(final JdbcDatabase database, final String databaseName, final SnowflakeSqlGenerator generator, final SnowflakeDestinationHandler handler) {
+  public SnowflakeV2TableMigrator(final JdbcDatabase database,
+                                  final String databaseName,
+                                  final SnowflakeSqlGenerator generator,
+                                  final SnowflakeDestinationHandler handler) {
     this.database = database;
     this.databaseName = databaseName;
     this.generator = generator;
@@ -41,8 +48,10 @@ public class SnowflakeV2TableMigrator implements V2TableMigrator<SnowflakeTableD
     }
   }
 
-  // These methods were copied from https://github.com/airbytehq/airbyte/blob/d5fdb1b982d464f54941bf9a830b9684fb47d249/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeSqlGenerator.java
-  // which is the highest version of destination-snowflake that still uses quoted+lowercased identifiers
+  // These methods were copied from
+  // https://github.com/airbytehq/airbyte/blob/d5fdb1b982d464f54941bf9a830b9684fb47d249/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeSqlGenerator.java
+  // which is the highest version of destination-snowflake that still uses quoted+lowercased
+  // identifiers
   private static StreamId buildStreamId_lowercase(final String namespace, final String name, final String rawNamespaceOverride) {
     // No escaping needed, as far as I can tell. We quote all our identifier names.
     return new StreamId(
@@ -60,22 +69,23 @@ public class SnowflakeV2TableMigrator implements V2TableMigrator<SnowflakeTableD
     return identifier.replace("\"", "\"\"");
   }
 
-  // And this was taken from https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeDestinationHandler.java
+  // And this was taken from
+  // https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeDestinationHandler.java
   public Optional<SnowflakeTableDefinition> findExistingTable_lowercase(final StreamId id) throws SQLException {
     // The obvious database.getMetaData().getColumns() solution doesn't work, because JDBC translates
     // VARIANT as VARCHAR
     final LinkedHashMap<String, String> columns = database.queryJsons(
-            """
-            SELECT column_name, data_type
-            FROM information_schema.columns
-            WHERE table_catalog = ?
-              AND table_schema = ?
-              AND table_name = ?
-            ORDER BY ordinal_position;
-            """,
-            databaseName.toUpperCase(),
-            id.finalNamespace(),
-            id.finalName()).stream()
+        """
+        SELECT column_name, data_type
+        FROM information_schema.columns
+        WHERE table_catalog = ?
+          AND table_schema = ?
+          AND table_name = ?
+        ORDER BY ordinal_position;
+        """,
+        databaseName.toUpperCase(),
+        id.finalNamespace(),
+        id.finalName()).stream()
         .collect(LinkedHashMap::new,
             (map, row) -> map.put(row.get("COLUMN_NAME").asText(), row.get("DATA_TYPE").asText()),
             LinkedHashMap::putAll);

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SnowflakeV2TableMigrator implements V2TableMigrator<SnowflakeTableDefinition> {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(SnowflakeV2TableMigrator.class);
 
   private final JdbcDatabase database;

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/AbstractSnowflakeTypingDedupingTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/AbstractSnowflakeTypingDedupingTest.java
@@ -143,6 +143,7 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
       database.execute("DROP SCHEMA IF EXISTS \"" + streamNamespace + "\" CASCADE");
     }
   }
+
   @Test
   public void testFinalTableUppercasingMigration_overwrite() throws Exception {
     try {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/AbstractSnowflakeTypingDedupingTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/AbstractSnowflakeTypingDedupingTest.java
@@ -138,7 +138,8 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
       verifySyncResult(expectedRawRecords2, expectedFinalRecords2);
     } finally {
       // manually drop the lowercased schema, since we no longer have the code to do it automatically
-      // (the raw table is still in lowercase "airbyte_internal"."whatever", so the auto-cleanup code handles it fine)
+      // (the raw table is still in lowercase "airbyte_internal"."whatever", so the auto-cleanup code
+      // handles it fine)
       database.execute("DROP SCHEMA IF EXISTS \"" + streamNamespace + "\" CASCADE");
     }
   }


### PR DESCRIPTION
based on top of https://github.com/airbytehq/airbyte/pull/30056.

Add the migration, which detects an existing lowercased table and runs a soft reset to create the uppercased table. First commit (https://github.com/airbytehq/airbyte/commit/7f71d1c7082f12fd7d39dfaa60a992805e078e50) is just renaming a class, and can be reviewed in isolation.

Reminder: This leaves the raw tables and lowercased tables untouched.

(I'm being kind of sloppy; there's now a generic V2TableMigrator class where I guess we can dump all these changes, i.e. the bigquery raw table change + this snowflake casing change? ideally I think we'd want separate migrators per migration type :shrug: but that's a refactor for the future, I think)

Example:
after 3.0.0 sync
![image](https://github.com/airbytehq/airbyte/assets/5741425/5ed1f17c-f2c2-4d98-a33f-c8ed968075f4)
after `dev` image sync
![image](https://github.com/airbytehq/airbyte/assets/5741425/6a6f537d-3ef5-4018-b76e-b406ef0a8413)
