### PR TITLE
Source Github: add support for self-hosted Github instances

### DIFF
--- a/airbyte-integrations/connectors/source-github/Dockerfile
+++ b/airbyte-integrations/connectors/source-github/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.0.4
+LABEL io.airbyte.version=1.1.4
 LABEL io.airbyte.name=airbyte/source-github

--- a/airbyte-integrations/connectors/source-github/integration_tests/invalid_config.json
+++ b/airbyte-integrations/connectors/source-github/integration_tests/invalid_config.json
@@ -1,4 +1,5 @@
 {
+  "api_url": "WRONG URL",
   "credentials": { "access_token": "WRONG KEY" },
   "repository": "airbytehq/integration-test",
   "start_date": "2021-06-30T11:30:03Z"

--- a/airbyte-integrations/connectors/source-github/integration_tests/invalid_config.json
+++ b/airbyte-integrations/connectors/source-github/integration_tests/invalid_config.json
@@ -1,5 +1,5 @@
 {
-  "api_url": "WRONG URL",
+  "api_url": "https://WRONG.URL",
   "credentials": { "access_token": "WRONG KEY" },
   "repository": "airbytehq/integration-test",
   "start_date": "2021-06-30T11:30:03Z"

--- a/airbyte-integrations/connectors/source-github/integration_tests/sample_config.json
+++ b/airbyte-integrations/connectors/source-github/integration_tests/sample_config.json
@@ -1,4 +1,5 @@
 {
+  "api_url": "https://api.github.com",
   "access_token": "<user's_access_token>",
   "repository": "<your_repository>",
   "start_date": "2021-06-29T03:46:25Z"

--- a/airbyte-integrations/connectors/source-github/integration_tests/sample_config.json
+++ b/airbyte-integrations/connectors/source-github/integration_tests/sample_config.json
@@ -1,5 +1,5 @@
 {
-  "api_url": "https://api.github.com",
+  "api_url": "https://api.github.com/",
   "access_token": "<user's_access_token>",
   "repository": "<your_repository>",
   "start_date": "2021-06-29T03:46:25Z"

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -2,10 +2,11 @@ data:
   allowedHosts:
     hosts:
       - api.github.com
+      - "${api_url}"
   connectorSubtype: api
   connectorType: source
   definitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
-  dockerImageTag: 1.0.4
+  dockerImageTag: 1.1.4
   maxSecondsBetweenMessages: 5400
   dockerRepository: airbyte/source-github
   githubIssueLabel: source-github

--- a/airbyte-integrations/connectors/source-github/source_github/source.py
+++ b/airbyte-integrations/connectors/source-github/source_github/source.py
@@ -91,7 +91,11 @@ class SourceGithub(AbstractSource):
                 unchecked_repos.add(org_repos)
 
         if unchecked_orgs:
-            stream = Repositories(authenticator=authenticator, organizations=unchecked_orgs)
+            stream = Repositories(
+                authenticator=authenticator, 
+                organizations=unchecked_orgs,
+                api_url=config["api_url"]
+            )
             for record in read_full_refresh(stream):
                 repositories.add(record["full_name"])
                 organizations.add(record["organization"])
@@ -101,6 +105,7 @@ class SourceGithub(AbstractSource):
             stream = RepositoryStats(
                 authenticator=authenticator,
                 repositories=unchecked_repos,
+                api_url=config["api_url"],
                 # This parameter is deprecated and in future will be used sane default, page_size: 10
                 page_size_for_large_streams=config.get("page_size_for_large_streams", constants.DEFAULT_PAGE_SIZE_FOR_LARGE_STREAM),
             )
@@ -232,10 +237,11 @@ class SourceGithub(AbstractSource):
         page_size = config.get("page_size_for_large_streams", constants.DEFAULT_PAGE_SIZE_FOR_LARGE_STREAM)
         access_token_type, _ = self.get_access_token(config)
 
-        organization_args = {"authenticator": authenticator, "organizations": organizations, "access_token_type": access_token_type}
+        organization_args = {"authenticator": authenticator, "organizations": organizations, "access_token_type": access_token_type, "api_url": config["api_url"]}
         organization_args_with_start_date = {**organization_args, "start_date": config["start_date"]}
 
         repository_args = {
+            "api_url": config["api_url"],
             "authenticator": authenticator,
             "repositories": repositories,
             "page_size_for_large_streams": page_size,

--- a/airbyte-integrations/connectors/source-github/source_github/source.py
+++ b/airbyte-integrations/connectors/source-github/source_github/source.py
@@ -54,7 +54,7 @@ from .streams import (
 )
 from .utils import read_full_refresh
 
-GITHUB_API_DEFAULT = "https://api.github.com"
+GITHUB_API_DEFAULT = "https://api.github.com/"
 
 class SourceGithub(AbstractSource):
     @staticmethod

--- a/airbyte-integrations/connectors/source-github/source_github/source.py
+++ b/airbyte-integrations/connectors/source-github/source_github/source.py
@@ -54,6 +54,7 @@ from .streams import (
 )
 from .utils import read_full_refresh
 
+GITHUB_API_DEFAULT = "https://api.github.com"
 
 class SourceGithub(AbstractSource):
     @staticmethod
@@ -94,7 +95,7 @@ class SourceGithub(AbstractSource):
             stream = Repositories(
                 authenticator=authenticator, 
                 organizations=unchecked_orgs,
-                api_url=config["api_url"]
+                api_url=config.get("api_url", GITHUB_API_DEFAULT)
             )
             for record in read_full_refresh(stream):
                 repositories.add(record["full_name"])
@@ -105,7 +106,7 @@ class SourceGithub(AbstractSource):
             stream = RepositoryStats(
                 authenticator=authenticator,
                 repositories=unchecked_repos,
-                api_url=config["api_url"],
+               api_url=config.get("api_url", GITHUB_API_DEFAULT),
                 # This parameter is deprecated and in future will be used sane default, page_size: 10
                 page_size_for_large_streams=config.get("page_size_for_large_streams", constants.DEFAULT_PAGE_SIZE_FOR_LARGE_STREAM),
             )

--- a/airbyte-integrations/connectors/source-github/source_github/spec.json
+++ b/airbyte-integrations/connectors/source-github/source_github/spec.json
@@ -67,12 +67,12 @@
       "api_url": {
         "type": "string",
         "examples": [
-          "https://api.github.com",
-          "https://source.selfhosted.com/api/v3"
+          "https://api.github.com/",
+          "https://source.selfhosted.com/api/v3/"
         ],
-        "pattern": "^https?:\\\/\\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\\/=]*)$",
+        "pattern": "^https?:\\\/\\\/[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\\/=]*)\\\/$",
         "title": "API URL",
-        "default": "https://api.github.com",
+        "default": "https://api.github.com/",
         "description": "The API URL to your self-hosted Github instance.",
         "order": 99
       },

--- a/airbyte-integrations/connectors/source-github/source_github/spec.json
+++ b/airbyte-integrations/connectors/source-github/source_github/spec.json
@@ -64,6 +64,18 @@
           }
         ]
       },
+      "api_url": {
+        "type": "string",
+        "examples": [
+          "https://api.github.com",
+          "https://source.selfhosted.com/api/v3"
+        ],
+        "pattern": "^https?:\\\/\\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\\/=]*)$",
+        "title": "API URL",
+        "default": "https://api.github.com",
+        "description": "The API URL to your self-hosted Github instance.",
+        "order": 99
+      },
       "start_date": {
         "type": "string",
         "title": "Start date",

--- a/airbyte-integrations/connectors/source-github/source_github/streams.py
+++ b/airbyte-integrations/connectors/source-github/source_github/streams.py
@@ -21,7 +21,6 @@ from .utils import getter
 
 
 class GithubStream(HttpStream, ABC):
-    url_base = "https://api.github.com/"
 
     primary_key = "id"
 
@@ -30,8 +29,9 @@ class GithubStream(HttpStream, ABC):
 
     stream_base_params = {}
 
-    def __init__(self, repositories: List[str], page_size_for_large_streams: int, access_token_type: str = "", **kwargs):
+    def __init__(self, repositories: List[str], page_size_for_large_streams: int, access_token_type: str = "", api_url: str = "", **kwargs):
         super().__init__(**kwargs)
+        self.api_url = api_url
         self.repositories = repositories
         self.access_token_type = access_token_type
 
@@ -42,6 +42,10 @@ class GithubStream(HttpStream, ABC):
         MAX_RETRIES = 3
         adapter = requests.adapters.HTTPAdapter(max_retries=MAX_RETRIES)
         self._session.mount("https://", adapter)
+
+    @property
+    def url_base(self) -> str:
+        return self.api_url
 
     @property
     def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
@@ -378,10 +382,11 @@ class Organizations(GithubStream):
     # GitHub pagination could be from 1 to 100.
     page_size = 100
 
-    def __init__(self, organizations: List[str], access_token_type: str = "", **kwargs):
+    def __init__(self, organizations: List[str], access_token_type: str = "", api_url: str = "", **kwargs):
         super(GithubStream, self).__init__(**kwargs)
         self.organizations = organizations
         self.access_token_type = access_token_type
+        self.api_url = api_url
 
     def stream_slices(self, **kwargs) -> Iterable[Optional[Mapping[str, Any]]]:
         for organization in self.organizations:

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_source.py
@@ -130,7 +130,7 @@ def test_get_org_repositories():
     )
 
     config = {
-        "api_url": "https://api.github.com",
+        "api_url": "https://api.github.com/",
         "repository": "airbytehq/integration-test docker/*"
     }
     organisations, repositories = source._get_org_repositories(config, authenticator=None)

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_source.py
@@ -20,7 +20,7 @@ from .utils import command_check
 
 def check_source(repo_line: str) -> AirbyteConnectionStatus:
     source = SourceGithub()
-    config = {"access_token": "test_token", "repository": repo_line}
+    config = {"api_url": "https://api.github.com/", "access_token": "test_token", "repository": repo_line}
     logger_mock = MagicMock()
     return source.check(logger_mock, config)
 
@@ -70,7 +70,10 @@ def test_check_connection_org_only():
 @responses.activate
 def test_get_branches_data():
 
-    repository_args = {"repositories": ["airbytehq/integration-test"], "page_size_for_large_streams": 10}
+    repository_args = {
+        "api_url": "https://api.github.com/",
+        "repositories": ["airbytehq/integration-test"], 
+        "page_size_for_large_streams": 10}
 
     source = SourceGithub()
 
@@ -126,7 +129,10 @@ def test_get_org_repositories():
         ],
     )
 
-    config = {"repository": "airbytehq/integration-test docker/*"}
+    config = {
+        "api_url": "https://api.github.com",
+        "repository": "airbytehq/integration-test docker/*"
+    }
     organisations, repositories = source._get_org_repositories(config, authenticator=None)
 
     assert set(repositories) == {"airbytehq/integration-test", "docker/docker-py", "docker/compose"}
@@ -259,6 +265,7 @@ def test_streams_page_size():
     responses.get("https://api.github.com/repos/airbytehq/airbyte/branches", json=[{"repository": "airbytehq/airbyte", "name": "master"}])
 
     config = {
+        "api_url": "https://api.github.com/",
         "credentials": {"access_token": "access_token"},
         "repository": "airbytehq/airbyte",
         "start_date": "1900-07-12T00:00:00Z",

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_stream.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_stream.py
@@ -56,7 +56,7 @@ DEFAULT_BACKOFF_DELAYS = [5, 10, 20, 40, 80]
 @responses.activate
 @patch("time.sleep")
 def test_internal_server_error_retry(time_mock):
-    args = {"api_url": "https://api.github.com", "authenticator": None, "repositories": ["airbytehq/airbyte"], "start_date": "start_date", "page_size_for_large_streams": 30}
+    args = {"api_url": "https://api.github.com/", "authenticator": None, "repositories": ["airbytehq/airbyte"], "start_date": "start_date", "page_size_for_large_streams": 30}
     stream = CommitCommentReactions(**args)
     stream_slice = {"repository": "airbytehq/airbyte", "comment_id": "id"}
 
@@ -929,7 +929,7 @@ def test_stream_team_members_full_refresh():
     repository_args = {
         "repositories": [], 
         "page_size_for_large_streams": 100,
-        "api_url": "https://api.github.com"
+        "api_url": "https://api.github.com/"
     }
 
     responses.add("GET", "https://api.github.com/orgs/org1/teams", json=[{"slug": "team1"}, {"slug": "team2"}])
@@ -966,7 +966,7 @@ def test_stream_commit_comment_reactions_incremental_read():
     repository_args = {
         "repositories": ["airbytehq/integration-test"], 
         "page_size_for_large_streams": 100,
-        "api_url": "https://api.github.com"
+        "api_url": "https://api.github.com/"
     }
     stream = CommitCommentReactions(**repository_args)
 
@@ -1051,7 +1051,7 @@ def test_stream_workflow_runs_read_incremental(monkeypatch):
         "repositories": ["org/repos"],
         "page_size_for_large_streams": 30,
         "start_date": "2022-01-01T00:00:00Z",
-        "api_url": "https://api.github.com"
+        "api_url": "https://api.github.com/"
     }
 
     monkeypatch.setattr(constants, "DEFAULT_PAGE_SIZE", 1)
@@ -1170,7 +1170,7 @@ def test_stream_workflow_jobs_read():
     repository_args = {
         "repositories": ["org/repo"],
         "page_size_for_large_streams": 100,
-        "api_url": "https://api.github.com"
+        "api_url": "https://api.github.com/"
     }
     repository_args_with_start_date = {**repository_args, "start_date": "2022-09-02T09:05:00Z"}
 
@@ -1273,7 +1273,7 @@ def test_stream_pull_request_comment_reactions_read():
         "start_date": "2022-01-01T00:00:00Z",
         "page_size_for_large_streams": 2,
         "repositories": ["airbytehq/airbyte"],
-        "api_url": "https://api.github.com"
+        "api_url": "https://api.github.com/"
     }
     stream = PullRequestCommentReactions(**repository_args_with_start_date)
     stream.page_size = 2


### PR DESCRIPTION
## What

Closes [24007](https://github.com/airbytehq/airbyte/issues/24007).

## How

1. defined optional `api_url` input parameter in `spec.json` with default set to `https://api.github.com`
2. added `api_url` as keyword parameter to `GithubStream` and `Organizations`
3. added supporting arguments to method invocations in `source.py`
4. updated all unit tests with necessary arguments

## Recommended reading order

1. `spec.json`
5. `streams.py`
6. `unit_tests/test_streams.py`
7. `source.py`
8. `unit_tests/test_source.py`

## 🚨 User Impact 🚨

There are no breaking changes. The `api_url` parameter is optional and defaults to `https://api.github.com`. 

Bumped MINOR version since PR closes issue [24007](https://github.com/airbytehq/airbyte/issues/24007) which is marked as an enhancement.

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))

- [x] Unit & integration tests added

```
python -m pytest unit_tests/ 
============================================== test session starts ===============================================
platform darwin -- Python 3.10.0, pytest-6.2.5, py-1.11.0, pluggy-1.3.0 -- /Users/pat/src/airbyte/airbyte-integrations/connectors/source-github/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/pat/src/airbyte, configfile: pytest.ini
plugins: requests-mock-1.9.3, mock-3.6.1
collected 53 items                                                                                               

unit_tests/test_source.py::test_check_connection_repos_only PASSED
unit_tests/test_source.py::test_check_connection_repos_and_org_repos PASSED
unit_tests/test_source.py::test_check_connection_org_only PASSED
unit_tests/test_source.py::test_get_branches_data PASSED
unit_tests/test_source.py::test_get_org_repositories PASSED
unit_tests/test_source.py::test_organization_or_repo_available PASSED
unit_tests/test_source.py::tests_get_and_prepare_repositories_config PASSED
unit_tests/test_source.py::test_check_config_repository PASSED
unit_tests/test_source.py::test_streams_no_streams_available_error PASSED
unit_tests/test_source.py::test_multiple_token_authenticator_with_rate_limiter {"type": "LOG", "log": {"level": "WARN", "message": "Sleeping for 3594.0 seconds to enforce the limit of 4 requests per hour."}}
PASSED
unit_tests/test_source.py::test_streams_page_size PASSED
unit_tests/test_stream.py::test_internal_server_error_retry {"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 5.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: )"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Caught retryable error 'Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: ' after 1 tries. Waiting 5 seconds then retrying..."}}
{"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 10.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: )"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Caught retryable error 'Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: ' after 2 tries. Waiting 10 seconds then retrying..."}}
{"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 20.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: )"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Caught retryable error 'Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: ' after 3 tries. Waiting 20 seconds then retrying..."}}
{"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 40.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: )"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Caught retryable error 'Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: ' after 4 tries. Waiting 40 seconds then retrying..."}}
{"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 80.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: )"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Caught retryable error 'Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: ' after 5 tries. Waiting 80 seconds then retrying..."}}
{"type": "LOG", "log": {"level": "ERROR", "message": "Giving up _send(...) after 6 tries (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/repos/airbytehq/airbyte/comments/id/reactions?per_page=100, Response Code: 500, Response Text: )"}}
{"type": "LOG", "log": {"level": "ERROR", "message": "Undefined error while reading records: "}}
PASSED
unit_tests/test_stream.py::test_backoff_time[HTTPStatus.BAD_GATEWAY-response_headers0-None] PASSED
unit_tests/test_stream.py::test_backoff_time[HTTPStatus.INTERNAL_SERVER_ERROR-response_headers1-None] PASSED
unit_tests/test_stream.py::test_backoff_time[HTTPStatus.SERVICE_UNAVAILABLE-response_headers2-None] PASSED
unit_tests/test_stream.py::test_backoff_time[HTTPStatus.FORBIDDEN-response_headers3-60] PASSED
unit_tests/test_stream.py::test_backoff_time[HTTPStatus.FORBIDDEN-response_headers4-60] PASSED
unit_tests/test_stream.py::test_backoff_time[HTTPStatus.FORBIDDEN-response_headers5-120] PASSED
unit_tests/test_stream.py::test_backoff_time[HTTPStatus.FORBIDDEN-response_headers6-60.0] PASSED
unit_tests/test_stream.py::test_backoff_time[HTTPStatus.FORBIDDEN-response_headers7-300.0] PASSED
unit_tests/test_stream.py::test_should_retry[HTTPStatus.OK-response_headers0-{"errors": [{"type": "RATE_LIMITED"}]}] {"type": "LOG", "log": {"level": "INFO", "message": "Rate limit handling for stream `repository_stats` for the response with 200 status code, HTTP headers: X-RateLimit-Resource: graphql, with message: {\"errors\": [{\"type\": \"RATE_LIMITED\"}]}"}}
PASSED
unit_tests/test_stream.py::test_should_retry[HTTPStatus.FORBIDDEN-response_headers1-] {"type": "LOG", "log": {"level": "INFO", "message": "Rate limit handling for stream `repository_stats` for the response with 403 status code, HTTP headers: X-RateLimit-Remaining: 0, with message: "}}
PASSED
unit_tests/test_stream.py::test_should_retry[HTTPStatus.FORBIDDEN-response_headers2-] {"type": "LOG", "log": {"level": "INFO", "message": "Rate limit handling for stream `repository_stats` for the response with 403 status code, HTTP headers: Retry-After: 0, with message: "}}
PASSED
unit_tests/test_stream.py::test_should_retry[HTTPStatus.FORBIDDEN-response_headers3-] {"type": "LOG", "log": {"level": "INFO", "message": "Rate limit handling for stream `repository_stats` for the response with 403 status code, HTTP headers: Retry-After: 60, with message: "}}
PASSED
unit_tests/test_stream.py::test_should_retry[HTTPStatus.INTERNAL_SERVER_ERROR-response_headers4-] PASSED
unit_tests/test_stream.py::test_should_retry[HTTPStatus.BAD_GATEWAY-response_headers5-] PASSED
unit_tests/test_stream.py::test_should_retry[HTTPStatus.SERVICE_UNAVAILABLE-response_headers6-] PASSED
unit_tests/test_stream.py::test_retry_after {"type": "LOG", "log": {"level": "INFO", "message": "Rate limit handling for stream `organizations` for the response with 403 status code, HTTP headers: Retry-After: 60, with message: "}}
{"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 0.0s (airbyte_cdk.sources.streams.http.exceptions.UserDefinedBackoffException: Request URL: https://api.github.com/orgs/airbytehq?per_page=100, Response Code: 403, Response Text: )"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Retrying. Sleeping for 60.0 seconds"}}
PASSED
unit_tests/test_stream.py::test_graphql_rate_limited {"type": "LOG", "log": {"level": "INFO", "message": "Rate limit handling for stream `pull_request_stats` for the response with 200 status code, HTTP headers: X-RateLimit-Resource: graphql, X-RateLimit-Reset: 1655804724, X-RateLimit-Limit: 5000, with message: {\"errors\": [{\"type\": \"RATE_LIMITED\"}]}"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 0.0s (airbyte_cdk.sources.streams.http.exceptions.UserDefinedBackoffException: Request URL: https://api.github.com/graphql, Response Code: 200, Response Text: {\"errors\": [{\"type\": \"RATE_LIMITED\"}]})"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Status code: 200, Response Content: b'{\"errors\": [{\"type\": \"RATE_LIMITED\"}]}'"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Retrying. Sleeping for 300.0 seconds"}}
PASSED
unit_tests/test_stream.py::test_stream_teams_404 {"type": "LOG", "log": {"level": "ERROR", "message": "{\"message\": \"Not Found\", \"documentation_url\": \"https://docs.github.com/rest/reference/teams#list-teams\"}"}}
{"type": "LOG", "log": {"level": "WARN", "message": "Syncing `Teams` stream isn't available for organization `org_name`."}}
PASSED
unit_tests/test_stream.py::test_stream_teams_502 {"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 5.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"})"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Caught retryable error 'Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"}' after 1 tries. Waiting 5 seconds then retrying..."}}
{"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 10.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"})"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Caught retryable error 'Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"}' after 2 tries. Waiting 10 seconds then retrying..."}}
{"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 20.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"})"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Caught retryable error 'Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"}' after 3 tries. Waiting 20 seconds then retrying..."}}
{"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 40.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"})"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Caught retryable error 'Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"}' after 4 tries. Waiting 40 seconds then retrying..."}}
{"type": "LOG", "log": {"level": "INFO", "message": "Backing off _send(...) for 80.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"})"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Caught retryable error 'Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"}' after 5 tries. Waiting 80 seconds then retrying..."}}
{"type": "LOG", "log": {"level": "ERROR", "message": "Giving up _send(...) after 6 tries (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: Request URL: https://api.github.com/orgs/org_name/teams?per_page=100, Response Code: 502, Response Text: {\"message\": \"Server Error\"})"}}
{"type": "LOG", "log": {"level": "WARN", "message": "Stream teams temporary failed. Try to re-run sync later"}}
PASSED
unit_tests/test_stream.py::test_stream_organizations_read PASSED
unit_tests/test_stream.py::test_stream_teams_read PASSED
unit_tests/test_stream.py::test_stream_users_read PASSED
unit_tests/test_stream.py::test_stream_repositories_404 {"type": "LOG", "log": {"level": "ERROR", "message": "{\"message\": \"Not Found\", \"documentation_url\": \"https://docs.github.com/rest/reference/repos#list-organization-repositories\"}"}}
{"type": "LOG", "log": {"level": "WARN", "message": "Syncing `Repositories` stream isn't available for organization `org_name`."}}
PASSED
unit_tests/test_stream.py::test_stream_repositories_401 {"type": "LOG", "log": {"level": "ERROR", "message": "{\"message\": \"Bad credentials\", \"documentation_url\": \"https://docs.github.com/rest\"}"}}
{"type": "LOG", "log": {"level": "ERROR", "message": "Personal Access Token renewal is required: Bad credentials"}}
PASSED
unit_tests/test_stream.py::test_stream_repositories_read PASSED
unit_tests/test_stream.py::test_stream_projects_disabled {"type": "LOG", "log": {"level": "ERROR", "message": "{\"message\": \"Projects are disabled for this repository\", \"documentation_url\": \"https://docs.github.com/v3/projects\"}"}}
{"type": "LOG", "log": {"level": "WARN", "message": "Syncing `Projects` stream isn't available for repository `test_repo`."}}
PASSED
unit_tests/test_stream.py::test_stream_pull_requests_incremental_read PASSED
unit_tests/test_stream.py::test_stream_commits_incremental_read PASSED
unit_tests/test_stream.py::test_stream_pull_request_commits PASSED
unit_tests/test_stream.py::test_stream_project_columns {"type": "LOG", "log": {"level": "INFO", "message": "Clearing all items from the cache"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Clearing all items from the cache"}}
PASSED
unit_tests/test_stream.py::test_stream_project_cards {"type": "LOG", "log": {"level": "INFO", "message": "Clearing all items from the cache"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Clearing all items from the cache"}}
PASSED
unit_tests/test_stream.py::test_stream_comments PASSED
unit_tests/test_stream.py::test_streams_read_full_refresh PASSED
unit_tests/test_stream.py::test_stream_reviews_incremental_read PASSED
unit_tests/test_stream.py::test_stream_team_members_full_refresh {"type": "LOG", "log": {"level": "INFO", "message": "Clearing all items from the cache"}}
PASSED
unit_tests/test_stream.py::test_stream_commit_comment_reactions_incremental_read {"type": "LOG", "log": {"level": "INFO", "message": "Clearing all items from the cache"}}
PASSED
unit_tests/test_stream.py::test_stream_workflow_runs_read_incremental PASSED
unit_tests/test_stream.py::test_stream_workflow_jobs_read PASSED
unit_tests/test_stream.py::test_stream_pull_request_comment_reactions_read PASSED
unit_tests/unit_test.py::test_single_token PASSED
unit_tests/unit_test.py::test_multiple_tokens PASSED

================================================ warnings summary ================================================
airbyte-integrations/connectors/source-github/unit_tests/test_source.py: 6 warnings
airbyte-integrations/connectors/source-github/unit_tests/unit_test.py: 4 warnings
  /Users/pat/src/airbyte/airbyte-integrations/connectors/source-github/source_github/source.py:144: DeprecationWarning: Call to deprecated class MultipleTokenAuthenticator. (Use airbyte_cdk.sources.streams.http.requests_native_auth.MultipleTokenAuthenticator instead) -- Deprecated since version 0.1.20.
    return MultipleTokenAuthenticator(tokens=tokens, auth_method="token")

airbyte-integrations/connectors/source-github/unit_tests/test_source.py: 57 warnings
airbyte-integrations/connectors/source-github/unit_tests/test_stream.py: 58 warnings
airbyte-integrations/connectors/source-github/unit_tests/unit_test.py: 4 warnings
  /Users/pat/src/airbyte/airbyte-integrations/connectors/source-github/.venv/lib/python3.10/site-packages/deprecated/classic.py:173: DeprecationWarning: Call to deprecated class HttpAuthenticator. (Use requests.auth.AuthBase instead) -- Deprecated since version 0.1.20.
    return old_new1(cls, *args, **kwargs)

airbyte-integrations/connectors/source-github/unit_tests/test_source.py: 51 warnings
airbyte-integrations/connectors/source-github/unit_tests/test_stream.py: 58 warnings
  /Users/pat/src/airbyte/airbyte-integrations/connectors/source-github/.venv/lib/python3.10/site-packages/airbyte_cdk/sources/streams/http/http.py:46: DeprecationWarning: Call to deprecated class NoAuth. (Set `authenticator=None` instead) -- Deprecated since version 0.1.20.
    self._authenticator: HttpAuthenticator = NoAuth()

airbyte-integrations/connectors/source-github/unit_tests/test_stream.py::test_stream_teams_404
airbyte-integrations/connectors/source-github/unit_tests/test_stream.py::test_stream_teams_502
airbyte-integrations/connectors/source-github/unit_tests/test_stream.py::test_stream_repositories_404
airbyte-integrations/connectors/source-github/unit_tests/test_stream.py::test_stream_projects_disabled
  /Users/pat/src/airbyte/airbyte-integrations/connectors/source-github/source_github/streams.py:195: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self.logger.warn(error_msg)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================================== 53 passed, 242 warnings in 0.53s ========================================
```

```
 python -m pytest integration_tests
============================================== test session starts ===============================================
platform darwin -- Python 3.10.0, pytest-6.2.5, py-1.11.0, pluggy-1.3.0 -- /Users/pat/src/airbyte/airbyte-integrations/connectors/source-github/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/pat/src/airbyte, configfile: pytest.ini
plugins: requests-mock-1.9.3, mock-3.6.1
collected 0 items                                                                                                

============================================= no tests ran in 0.01s ==============================================
```


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it

- [ ] Build is successful

- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>