### PR TITLE
🚨 Pinecone destination: Fix dedup bug

### DIFF
--- a/airbyte-integrations/connectors/destination-pinecone/Dockerfile
+++ b/airbyte-integrations/connectors/destination-pinecone/Dockerfile
@@ -38,5 +38,5 @@ COPY destination_pinecone ./destination_pinecone
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.2
+LABEL io.airbyte.version=0.0.3
 LABEL io.airbyte.name=airbyte/destination-pinecone

--- a/airbyte-integrations/connectors/destination-pinecone/destination_pinecone/document_processor.py
+++ b/airbyte-integrations/connectors/destination-pinecone/destination_pinecone/document_processor.py
@@ -75,7 +75,7 @@ class DocumentProcessor:
         current_stream: ConfiguredAirbyteStream = self.streams[stream_identifier]
         metadata[METADATA_STREAM_FIELD] = stream_identifier
         if current_stream.primary_key and current_stream.destination_sync_mode == DestinationSyncMode.append_dedup:
-            metadata[METADATA_RECORD_ID_FIELD] = self._extract_primary_key(record, current_stream)
+            metadata[METADATA_RECORD_ID_FIELD] = f"{stream_identifier}_{self._extract_primary_key(record, current_stream)}"
 
         return metadata
 

--- a/airbyte-integrations/connectors/destination-pinecone/integration_tests/pinecone_integration_test.py
+++ b/airbyte-integrations/connectors/destination-pinecone/integration_tests/pinecone_integration_test.py
@@ -63,7 +63,7 @@ class PineconeIntegrationTest(BaseIntegrationTest):
         incremental_catalog = self._get_configured_catalog(DestinationSyncMode.append_dedup)
         list(destination.write(self.config, incremental_catalog, [self._record("mystream", "Cats are nice", 2), first_state_message]))
         result = self.pinecone_index.query(
-            vector=[0] * OPEN_AI_VECTOR_SIZE, top_k=10, filter={"_ab_record_id": "2"}, include_metadata=True
+            vector=[0] * OPEN_AI_VECTOR_SIZE, top_k=10, filter={"_ab_record_id": "mystream_2"}, include_metadata=True
         )
         assert len(result.matches) == 1
         assert result.matches[0].metadata["text"] == "str_col: Cats are nice"
@@ -73,4 +73,4 @@ class PineconeIntegrationTest(BaseIntegrationTest):
         self._init_pinecone()
         vector_store = Pinecone(self.pinecone_index, embeddings.embed_query, "text")
         result = vector_store.similarity_search("feline animals", 1)
-        assert result[0].metadata["_ab_record_id"] == "2"
+        assert result[0].metadata["_ab_record_id"] == "mystream_2"

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 3d2b6f84-7f0d-4e3f-a5e5-7c7d4b50eabd
-  dockerImageTag: 0.0.2
+  dockerImageTag: 0.0.3
   dockerRepository: airbyte/destination-pinecone
   githubIssueLabel: destination-pinecone
   icon: pinecone.svg

--- a/airbyte-integrations/connectors/destination-pinecone/unit_tests/document_processor_test.py
+++ b/airbyte-integrations/connectors/destination-pinecone/unit_tests/document_processor_test.py
@@ -221,11 +221,11 @@ def test_process_multiple_chunks_with_relevant_fields():
 @pytest.mark.parametrize(
     "primary_key_value, stringified_primary_key, primary_key",
     [
-        ({"id": 99}, "99", [["id"]]),
-        ({"id": 99, "name": "John Doe"}, "99_John Doe", [["id"], ["name"]]),
-        ({"id": 99, "name": "John Doe", "age": 25}, "99_John Doe_25", [["id"], ["name"], ["age"]]),
-        ({"nested": {"id": "abc"}, "name": "John Doe"}, "abc_John Doe", [["nested", "id"], ["name"]]),
-        ({"nested": {"id": "abc"}}, "abc___not_found__", [["nested", "id"], ["name"]]),
+        ({"id": 99}, "namespace1_stream1_99", [["id"]]),
+        ({"id": 99, "name": "John Doe"}, "namespace1_stream1_99_John Doe", [["id"], ["name"]]),
+        ({"id": 99, "name": "John Doe", "age": 25}, "namespace1_stream1_99_John Doe_25", [["id"], ["name"], ["age"]]),
+        ({"nested": {"id": "abc"}, "name": "John Doe"}, "namespace1_stream1_abc_John Doe", [["nested", "id"], ["name"]]),
+        ({"nested": {"id": "abc"}}, "namespace1_stream1_abc___not_found__", [["nested", "id"], ["name"]]),
     ]
 )
 def test_process_multiple_chunks_with_dedupe_mode(primary_key_value: Mapping[str, Any], stringified_primary_key: str, primary_key: List[List[str]]):

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -68,11 +68,12 @@ For testing purposes, it's also possible to use the [Fake embeddings](https://py
 
 To get started, use the [Pinecone web UI or API](https://docs.pinecone.io/docs/quickstart) to create a project and an index before running the destination. All streams will be indexed into the same index, the `_ab_stream` metadata field is used to distinguish between streams. Overall, the size of the metadata fields is limited to 30KB per document. 
 
-OpenAI and Fake embeddings produce vectors with 1536 dimensions, and the Cohere embeddings produce vectors with 1024 dimensions. Make sure to configure the index accordingly.
+OpenAI and Fake embeddings produce vectors with 1536 dimensions, and the Cohere embeddings produce vectors with 1024 dimensions. Make sure to configure the index accordi../../../docs/integrations/destinations/pinecone.mdngly.
 
 ## CHANGELOG
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.0.2   | 2023-09-01 | [#29442](https://github.com/airbytehq/airbyte/pull/29946)     | Improve test coverage  | 
+| 0.0.3   | 2023-09-01 | [#30079](https://github.com/airbytehq/airbyte/pull/30079)     | Fix bug with potential data loss on append+dedup syncing. 🚨 Streams using append+dedup mode need to be reset after upgrade.  | 
+| 0.0.2   | 2023-08-31 | [#29442](https://github.com/airbytehq/airbyte/pull/29946)     | Improve test coverage  | 
 | 0.0.1   | 2023-08-29 | [#29539](https://github.com/airbytehq/airbyte/pull/29539)     | Pinecone connector with some embedders  | 

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -68,7 +68,7 @@ For testing purposes, it's also possible to use the [Fake embeddings](https://py
 
 To get started, use the [Pinecone web UI or API](https://docs.pinecone.io/docs/quickstart) to create a project and an index before running the destination. All streams will be indexed into the same index, the `_ab_stream` metadata field is used to distinguish between streams. Overall, the size of the metadata fields is limited to 30KB per document. 
 
-OpenAI and Fake embeddings produce vectors with 1536 dimensions, and the Cohere embeddings produce vectors with 1024 dimensions. Make sure to configure the index accordi../../../docs/integrations/destinations/pinecone.mdngly.
+OpenAI and Fake embeddings produce vectors with 1536 dimensions, and the Cohere embeddings produce vectors with 1024 dimensions. Make sure to configure the index accordingly.
 
 ## CHANGELOG
 


### PR DESCRIPTION

## What

To do append+dedup syncs, this destination is storing the id per record in a special metadata field in the index to be able to delete chunks of this record before indexing a new version of chunks related to this record. However, if multiple streams are synced into the same index (either in a single connection or in multiple ones), it's possible for the ids to overlap in case multiple streams have the same id naming scheme, resulting in data loss as documents belonging to other streams are deleted.

## How


This PR fixes the problem by appending the namespace and stream name to the `_ab_record_id` field to disambiguate between units of data originating from different streams.

## 🚨 User Impact 🚨

Users using the Pinecone destination and sync data in append+dedup mode, have to reset those streams when upgrading.

