### PR TITLE
🚨 Langchain destination: Fix dedup bug

### DIFF
--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -42,5 +42,5 @@ COPY destination_langchain ./destination_langchain
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.8
+LABEL io.airbyte.version=0.0.9
 LABEL io.airbyte.name=airbyte/destination-langchain

--- a/airbyte-integrations/connectors/destination-langchain/Dockerfile
+++ b/airbyte-integrations/connectors/destination-langchain/Dockerfile
@@ -42,5 +42,5 @@ COPY destination_langchain ./destination_langchain
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.9
+LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/destination-langchain

--- a/airbyte-integrations/connectors/destination-langchain/destination_langchain/document_processor.py
+++ b/airbyte-integrations/connectors/destination-langchain/destination_langchain/document_processor.py
@@ -84,7 +84,7 @@ class DocumentProcessor:
         metadata[METADATA_STREAM_FIELD] = stream_identifier
         # if the sync mode is deduping, use the primary key to upsert existing records instead of appending new ones
         if current_stream.primary_key and current_stream.destination_sync_mode == DestinationSyncMode.append_dedup:
-            metadata[METADATA_RECORD_ID_FIELD] = self._extract_primary_key(record, current_stream)
+            metadata[METADATA_RECORD_ID_FIELD] = f"{stream_identifier}_{self._extract_primary_key(record, current_stream)}"
         return metadata
 
     def _extract_primary_key(self, record: AirbyteRecordMessage, stream: ConfiguredAirbyteStream) -> dict:

--- a/airbyte-integrations/connectors/destination-langchain/integration_tests/chroma_integration_test.py
+++ b/airbyte-integrations/connectors/destination-langchain/integration_tests/chroma_integration_test.py
@@ -44,7 +44,7 @@ class ChromaLocalIntegrationTest(LocalIntegrationTest):
         incremental_catalog = self._get_configured_catalog(DestinationSyncMode.append_dedup)
         list(destination.write(self.config, incremental_catalog, [self._record("mystream", "Cats are nice", 2), first_state_message]))
         chroma_result: QueryResult = self.chroma_client.get_collection("langchain").query(
-            query_embeddings=[0] * OPEN_AI_VECTOR_SIZE, n_results=10, where={"_record_id": "2"}, include=["documents"]
+            query_embeddings=[0] * OPEN_AI_VECTOR_SIZE, n_results=10, where={"_record_id": "mystream_2"}, include=["documents"]
         )
         assert len(chroma_result["documents"][0]) == 1
         assert chroma_result["documents"][0] == ["str_col: Cats are nice"]
@@ -53,4 +53,4 @@ class ChromaLocalIntegrationTest(LocalIntegrationTest):
         embeddings = OpenAIEmbeddings(openai_api_key=self.config["embedding"]["openai_key"])
         vector_store = Chroma(embedding_function=embeddings, persist_directory=self.temp_dir)
         result = vector_store.similarity_search("feline animals", 1)
-        assert result[0].metadata["_record_id"] == "2"
+        assert result[0].metadata["_record_id"] == "mystream_2"

--- a/airbyte-integrations/connectors/destination-langchain/integration_tests/pinecone_integration_test.py
+++ b/airbyte-integrations/connectors/destination-langchain/integration_tests/pinecone_integration_test.py
@@ -77,7 +77,7 @@ class PineconeIntegrationTest(BaseIntegrationTest):
             # Documents might not be available right away because Pinecone is handling them async
             sleep(20)
         result = self._index.query(
-            vector=[0] * OPEN_AI_VECTOR_SIZE, top_k=10, filter={"_record_id": "2"}, include_metadata=True
+            vector=[0] * OPEN_AI_VECTOR_SIZE, top_k=10, filter={"_record_id": "mystream_2"}, include_metadata=True
         )
         assert len(result.matches) == 1
         assert result.matches[0].metadata["text"] == "str_col: Cats are nice"
@@ -87,4 +87,4 @@ class PineconeIntegrationTest(BaseIntegrationTest):
         pinecone.init(api_key=self.config["indexing"]["pinecone_key"], environment=self.config["indexing"]["pinecone_environment"])
         vector_store = Pinecone(self._index, embeddings.embed_query, "text")
         result = vector_store.similarity_search("feline animals", 1)
-        assert result[0].metadata["_record_id"] == "2"
+        assert result[0].metadata["_record_id"] == "mystream_2"

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: cf98d52c-ba5a-4dfd-8ada-c1baebfa6e73
-  dockerImageTag: 0.0.9
+  dockerImageTag: 0.1.0
   dockerRepository: airbyte/destination-langchain
   githubIssueLabel: destination-langchain
   icon: langchain.svg
@@ -22,4 +22,9 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  breakingChanges:
+    0.1.0:
+      message: >
+        This version changes the way record ids are tracked internally. If you are using a stream in **append-dedup** mode, you need to reset the connection after doing the upgrade to avoid duplicates.
+      upgradeDeadline: "2023-09-18"
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: cf98d52c-ba5a-4dfd-8ada-c1baebfa6e73
-  dockerImageTag: 0.0.8
+  dockerImageTag: 0.0.9
   dockerRepository: airbyte/destination-langchain
   githubIssueLabel: destination-langchain
   icon: langchain.svg

--- a/airbyte-integrations/connectors/destination-langchain/unit_tests/document_processor_test.py
+++ b/airbyte-integrations/connectors/destination-langchain/unit_tests/document_processor_test.py
@@ -210,11 +210,11 @@ def test_process_multiple_chunks_with_relevant_fields():
 @pytest.mark.parametrize(
     "primary_key_value, stringified_primary_key, primary_key",
     [
-        ({"id": 99}, "99", [["id"]]),
-        ({"id": 99, "name": "John Doe"}, "99_John Doe", [["id"], ["name"]]),
-        ({"id": 99, "name": "John Doe", "age": 25}, "99_John Doe_25", [["id"], ["name"], ["age"]]),
-        ({"nested": {"id": "abc"}, "name": "John Doe"}, "abc_John Doe", [["nested", "id"], ["name"]]),
-        ({"nested": {"id": "abc"}}, "abc___not_found__", [["nested", "id"], ["name"]]),
+        ({"id": 99}, "namespace1_stream1_99", [["id"]]),
+        ({"id": 99, "name": "John Doe"}, "namespace1_stream1_99_John Doe", [["id"], ["name"]]),
+        ({"id": 99, "name": "John Doe", "age": 25}, "namespace1_stream1_99_John Doe_25", [["id"], ["name"], ["age"]]),
+        ({"nested": {"id": "abc"}, "name": "John Doe"}, "namespace1_stream1_abc_John Doe", [["nested", "id"], ["name"]]),
+        ({"nested": {"id": "abc"}}, "namespace1_stream1_abc___not_found__", [["nested", "id"], ["name"]]),
     ]
 )
 def test_process_multiple_chunks_with_dedupe_mode(primary_key_value: Mapping[str, Any], stringified_primary_key: str, primary_key: List[List[str]]):

--- a/docs/integrations/destinations/langchain-migrations.md
+++ b/docs/integrations/destinations/langchain-migrations.md
@@ -1,0 +1,9 @@
+# Langchain Migration Guide
+
+## Upgrading to 0.1.0
+
+This version changes the way record ids are tracked internally. If you are using a stream in **append-dedup** mode, you need to reset the connection after doing the upgrade to avoid duplicates.
+
+Prior to this version, deduplication only considered the primary key per record, without disambiugating between streams. This could lead to data loss if records from two different streams had the same primary key.
+
+The problem is fixed by appending the namespace and stream name to the `_ab_record_id` field to disambiguate between records originating from different streams. If a connection using **append-dedup** mode is not reset after the upgrade, it will consider all records as new and will not deduplicate them, leading to stale vectors in the destination.

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -139,7 +139,7 @@ Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a M
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.0.9   | 2023-09-01 | [#30079](https://github.com/airbytehq/airbyte/pull/30079)     | Fix bug with potential data loss on append+dedup syncing. 🚨 Streams using append+dedup mode need to be reset after upgrade.  | 
+| 0.0.9   | 2023-09-01 | [#30080](https://github.com/airbytehq/airbyte/pull/30080)     | Fix bug with potential data loss on append+dedup syncing. 🚨 Streams using append+dedup mode need to be reset after upgrade.  | 
 | 0.0.8   | 2023-08-21 | [#29515](https://github.com/airbytehq/airbyte/pull/29515)     | Clean up generated schema spec  |
 | 0.0.7   | 2023-08-18 | [#29513](https://github.com/airbytehq/airbyte/pull/29513)     | Fix for starter pods  |
 | 0.0.6   | 2023-08-02 | [#28977](https://github.com/airbytehq/airbyte/pull/28977)     | Validate pinecone index dimensions during check  |

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -139,7 +139,7 @@ Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a M
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.0.9   | 2023-09-01 | [#30080](https://github.com/airbytehq/airbyte/pull/30080)     | Fix bug with potential data loss on append+dedup syncing. 🚨 Streams using append+dedup mode need to be reset after upgrade.  | 
+| 0.1.0   | 2023-09-01 | [#30080](https://github.com/airbytehq/airbyte/pull/30080)     | Fix bug with potential data loss on append+dedup syncing. 🚨 Streams using append+dedup mode need to be reset after upgrade.  | 
 | 0.0.8   | 2023-08-21 | [#29515](https://github.com/airbytehq/airbyte/pull/29515)     | Clean up generated schema spec  |
 | 0.0.7   | 2023-08-18 | [#29513](https://github.com/airbytehq/airbyte/pull/29513)     | Fix for starter pods  |
 | 0.0.6   | 2023-08-02 | [#28977](https://github.com/airbytehq/airbyte/pull/28977)     | Validate pinecone index dimensions during check  |

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -139,6 +139,7 @@ Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a M
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.0.9   | 2023-09-01 | [#30079](https://github.com/airbytehq/airbyte/pull/30079)     | Fix bug with potential data loss on append+dedup syncing. 🚨 Streams using append+dedup mode need to be reset after upgrade.  | 
 | 0.0.8   | 2023-08-21 | [#29515](https://github.com/airbytehq/airbyte/pull/29515)     | Clean up generated schema spec  |
 | 0.0.7   | 2023-08-18 | [#29513](https://github.com/airbytehq/airbyte/pull/29513)     | Fix for starter pods  |
 | 0.0.6   | 2023-08-02 | [#28977](https://github.com/airbytehq/airbyte/pull/28977)     | Validate pinecone index dimensions during check  |


### PR DESCRIPTION
## What

To do append+dedup syncs, this destination is storing the id per record in a special metadata field in the index to be able to delete chunks of this record before indexing a new version of chunks related to this record. However, if multiple streams are synced into the same index (either in a single connection or in multiple ones), it's possible for the ids to overlap in case multiple streams have the same id naming scheme, resulting in data loss as documents belonging to other streams are deleted.

## How


This PR fixes the problem by appending the namespace and stream name to the `_ab_record_id` field to disambiguate between units of data originating from different streams.

## 🚨 User Impact 🚨

Users using the Langchain destination and sync data in append+dedup mode, have to reset those streams when upgrading.

