### PR TITLE
Vector DB CDK: Fix id generation, improve config spec, add base test case

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/README.md
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/README.md
@@ -35,4 +35,4 @@ This is how the components interact:
 └────────┘                             
 ```
 
-Normally, only the `MyDestination` class and the `MyIndexer` calss has to be implemented specifically for the destination. The other classes are provided as is by the helpers.
+Normally, only the `MyDestination` class and the `MyIndexer` class has to be implemented specifically for the destination. The other classes are provided as is by the helpers.

--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/config.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/config.py
@@ -20,14 +20,14 @@ class ProcessingConfigModel(BaseModel):
         default=0,
     )
     text_fields: Optional[List[str]] = Field(
-        ...,
+        default=[],
         title="Text fields to embed",
         description="List of fields in the record that should be used to calculate the embedding. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered text fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array.",
         always_show=True,
         examples=["text", "user.name", "users.*.name"],
     )
     metadata_fields: Optional[List[str]] = Field(
-        ...,
+        default=[],
         title="Fields to store as metadata",
         description="List of fields in the record that should be stored as metadata. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered metadata fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array. When specifying nested paths, all matching values are flattened into an array set to a field named by the path.",
         always_show=True,

--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/document_processor.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/document_processor.py
@@ -102,7 +102,7 @@ class DocumentProcessor:
         metadata[METADATA_STREAM_FIELD] = stream_identifier
         # if the sync mode is deduping, use the primary key to upsert existing records instead of appending new ones
         if current_stream.primary_key and current_stream.destination_sync_mode == DestinationSyncMode.append_dedup:
-            metadata[METADATA_RECORD_ID_FIELD] = self._extract_primary_key(record, current_stream)
+            metadata[METADATA_RECORD_ID_FIELD] = f"{stream_identifier}_{self._extract_primary_key(record, current_stream)}"
         return metadata
 
     def _extract_primary_key(self, record: AirbyteRecordMessage, stream: ConfiguredAirbyteStream) -> str:

--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
@@ -45,7 +45,7 @@ class OpenAIEmbedder(Embedder):
     def __init__(self, config: OpenAIEmbeddingConfigModel):
         super().__init__()
         # Client is set internally
-        self.embeddings = OpenAIEmbeddings(openai_api_key=config.openai_key, chunk_size=8191)  # type: ignore
+        self.embeddings = OpenAIEmbeddings(openai_api_key=config.openai_key, chunk_size=8191, max_retries=15)  # type: ignore
 
     def check(self) -> Optional[str]:
         try:

--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/test_utils.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/test_utils.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import json
+import unittest
+from typing import Any, Dict
+
+from airbyte_cdk.models import (
+    AirbyteMessage,
+    AirbyteRecordMessage,
+    AirbyteStateMessage,
+    AirbyteStream,
+    ConfiguredAirbyteCatalog,
+    ConfiguredAirbyteStream,
+    DestinationSyncMode,
+    SyncMode,
+    Type,
+)
+
+
+class BaseIntegrationTest(unittest.TestCase):
+    """
+    BaseIntegrationTest is a base class for integration tests for vector db destinations.
+
+    It provides helper methods to create Airbyte catalogs, records and state messages.
+    """
+
+    def _get_configured_catalog(self, destination_mode: DestinationSyncMode) -> ConfiguredAirbyteCatalog:
+        stream_schema = {"type": "object", "properties": {"str_col": {"type": "str"}, "int_col": {"type": "integer"}}}
+
+        overwrite_stream = ConfiguredAirbyteStream(
+            stream=AirbyteStream(
+                name="mystream", json_schema=stream_schema, supported_sync_modes=[SyncMode.incremental, SyncMode.full_refresh]
+            ),
+            primary_key=[["int_col"]],
+            sync_mode=SyncMode.incremental,
+            destination_sync_mode=destination_mode,
+        )
+
+        return ConfiguredAirbyteCatalog(streams=[overwrite_stream])
+
+    def _state(self, data: Dict[str, Any]) -> AirbyteMessage:
+        return AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(data=data))
+
+    def _record(self, stream: str, str_value: str, int_value: int) -> AirbyteMessage:
+        return AirbyteMessage(
+            type=Type.RECORD, record=AirbyteRecordMessage(stream=stream, data={"str_col": str_value, "int_col": int_value}, emitted_at=0)
+        )
+
+    def setUp(self):
+        with open("secrets/config.json", "r") as f:
+            self.config = json.loads(f.read())

--- a/airbyte-cdk/python/unit_tests/destinations/vector_db_based/document_processor_test.py
+++ b/airbyte-cdk/python/unit_tests/destinations/vector_db_based/document_processor_test.py
@@ -214,11 +214,11 @@ def test_process_multiple_chunks_with_relevant_fields():
 @pytest.mark.parametrize(
     "primary_key_value, stringified_primary_key, primary_key",
     [
-        ({"id": 99}, "99", [["id"]]),
-        ({"id": 99, "name": "John Doe"}, "99_John Doe", [["id"], ["name"]]),
-        ({"id": 99, "name": "John Doe", "age": 25}, "99_John Doe_25", [["id"], ["name"], ["age"]]),
-        ({"nested": {"id": "abc"}, "name": "John Doe"}, "abc_John Doe", [["nested", "id"], ["name"]]),
-        ({"nested": {"id": "abc"}}, "abc___not_found__", [["nested", "id"], ["name"]]),
+        ({"id": 99}, "namespace1_stream1_99", [["id"]]),
+        ({"id": 99, "name": "John Doe"}, "namespace1_stream1_99_John Doe", [["id"], ["name"]]),
+        ({"id": 99, "name": "John Doe", "age": 25}, "namespace1_stream1_99_John Doe_25", [["id"], ["name"], ["age"]]),
+        ({"nested": {"id": "abc"}, "name": "John Doe"}, "namespace1_stream1_abc_John Doe", [["nested", "id"], ["name"]]),
+        ({"nested": {"id": "abc"}}, "namespace1_stream1_abc___not_found__", [["nested", "id"], ["name"]]),
     ]
 )
 def test_process_multiple_chunks_with_dedupe_mode(primary_key_value: Mapping[str, Any], stringified_primary_key: str, primary_key: List[List[str]]):


### PR DESCRIPTION
## What

This PR does a few small adjustments in the vector db CDK:
* Fix id generation to disambiguate between streams - see https://github.com/airbytehq/airbyte/pull/30079
* Improve config spec to allow no text fields / metadata fields - the code is already able to handle this, but so far the UI did not allow specifying an empty list. This change makes it possible
* Add base test case that can be re-used effectively in destination connectors
* Increase retries for OpenAI embedder (in some cases the rate limit is very low and the default retry logic will hit its max retries and fail)
