### PR TITLE
Revert "Bump Airbyte version from 0.50.24 to 0.0.99"

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.99-test
+current_version = 0.50.24
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -117,7 +117,7 @@ If you are upgrading from (i.e. your current version of Airbyte is) Airbyte vers
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.0.99 --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.50.24 --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION=0.0.99
+VERSION=0.50.24
 
 # NOTE: some of these values are overwritten in CI!
 # NOTE: if you want to override this for your local machine, set overrides in ~/.gradle/gradle.properties

--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.0.99
+VERSION=0.50.24
 # Run away from anything even a little scary
 set -o nounset # -u exit if a variable is not set
 set -o errexit # -f exit for any command failure"


### PR DESCRIPTION
This reverts commit ea47c52b7b93ba9a4fc4f893edba58097a5b4be7.

Revert a test bump of releases