### PR TITLE
Fix Langchain docs

### DIFF
--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -18,7 +18,7 @@ When specifying text fields, you can access nested fields in the record by using
 
 The chunk length is measured in tokens produced by the `tiktoken` library. The maximum is 8191 tokens, which is the maximum length supported by the `text-embedding-ada-002` model.
 
-The stream name gets added as a metadata field `_airbyte_stream` to each document. If available, the primary key of the record is used to identify the document to avoid duplications when updated versions of records are indexed. It is added as the `_natural_id` metadata field.
+The stream name gets added as a metadata field `_airbyte_stream` to each document. If available, the primary key of the record is used to identify the document to avoid duplications when updated versions of records are indexed. It is added as the `_record_id` metadata field.
 
 ### Embedding
 
@@ -59,6 +59,7 @@ For Pinecone pods of type starter, only up to 10,000 chunks can be indexed. For 
 
 :::
 
+<!-- env:oss -->
 #### Chroma vector store
 
 The [Chroma vector store](https://trychroma.com) is running the Chroma embedding database as persistent client and stores the vectors in a local file.
@@ -133,7 +134,7 @@ DocArrayHnswSearch is meant to be used on a local workstation and won't work on 
 Please make sure that Docker Desktop has access to `/tmp` (and `/private` on a MacOS, as /tmp has a symlink that points to /private. It will not work otherwise). You allow it with "File sharing" in `Settings -> Resources -> File sharing -> add the one or two above folder` and hit the "Apply & restart" button.
 
 :::
-
+<!-- /env:oss -->
 
 ## CHANGELOG
 


### PR DESCRIPTION
* `_natural_id` is actually `_record_id`
* Hide OSS-stuff in cloud docs