### PR TITLE
cat: fix skip_backward_compatibility fixture for discovery

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.4
+Fix edge case in skip_backward_compatibility_tests_fixture on discovery: if the current config structure is not compatible with the previous connector version, the discovery command failing and the previous connector version catalog could not be retrieved.
+
 ## 1.0.3
 Add tests for display_type property
 

--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -24,7 +24,7 @@ RUN poetry install --no-root --only main --no-interaction --no-ansi
 COPY . /app
 RUN poetry install --only main --no-cache --no-interaction --no-ansi
 
-LABEL io.airbyte.version=1.0.3
+LABEL io.airbyte.version=1.0.4
 LABEL io.airbyte.name=airbyte/connector-acceptance-test
 WORKDIR /test_input
 ENTRYPOINT ["python", "-m", "pytest", "-p", "connector_acceptance_test.plugin", "-r", "fEsx", "--show-capture=log"]


### PR DESCRIPTION
## What
When a connector implement a breaking change in the configuration the  catalog can't be discovered for the previous connector version. This was making `skip_backward_compatibility_fixture` fail even if the `acceptance-test-config.yaml` states that the backward compatibility tests should be skipped. 

## How
Make the `skip_backward_compatibility_fixture` depend on an upstream fixture that will skip the backward compatibility test when they're explicitly being skipped in the config. 

