### PR TITLE
fix langchain breaking change metadata

### DIFF
--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -22,9 +22,10 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
-  breakingChanges:
-    0.1.0:
-      message: >
-        This version changes the way record ids are tracked internally. If you are using a stream in **append-dedup** mode, you need to reset the connection after doing the upgrade to avoid duplicates.
-      upgradeDeadline: "2023-09-18"
+  releases:
+    breakingChanges:
+      0.1.0:
+        message: >
+          This version changes the way record ids are tracked internally. If you are using a stream in **append-dedup** mode, you need to reset the connection after doing the upgrade to avoid duplicates.
+        upgradeDeadline: "2023-09-18"
 metadataSpecVersion: "1.0"

--- a/docs/integrations/destinations/langchain-migrations.md
+++ b/docs/integrations/destinations/langchain-migrations.md
@@ -1,4 +1,4 @@
-# Langchain Migration Guide
+# Vector Database (powered by LangChain) Migration Guide
 
 ## Upgrading to 0.1.0
 


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

#30080 introduced a breaking change for langchain but an error in the metadata meant it wasn't properly rolled out. The metadata has been fixed in the metadata bucket and registry entries regenerated, but this corrects the metadata in the github repo.

## How

Properly nest the `breakingChanges` section within `releases`

