### PR TITLE
Fix: Truncate dagster dataframe previews

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_report.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_report.py
@@ -324,7 +324,6 @@ def connector_registry_report(context, all_destinations_dataframe, all_sources_d
 
     metadata = {
         "first_10_preview": MetadataValue.md(all_connectors_dataframe.head(10).to_markdown()),
-        "json": MetadataValue.json(json_string),
         "json_gcs_url": MetadataValue.url(json_file_handle.public_url),
         "html_gcs_url": MetadataValue.url(html_file_handle.public_url),
     }

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
@@ -16,7 +16,13 @@ def output_dataframe(result_df: pd.DataFrame) -> Output[pd.DataFrame]:
     """
     Returns a Dagster Output object with a dataframe as the result and a markdown preview.
     """
-    return Output(result_df, metadata={"count": len(result_df), "preview": MetadataValue.md(result_df.to_markdown())})
+
+    # Truncate to 100 rows to avoid dagster throwing a "too large" error
+    MAX_PREVIEW_ROWS = 100
+    is_truncated = len(result_df) > MAX_PREVIEW_ROWS
+    preview_result_df = result_df.head(MAX_PREVIEW_ROWS)
+
+    return Output(result_df, metadata={"count": len(result_df), "preview": MetadataValue.md(preview_result_df.to_markdown()), "is_truncated": is_truncated})
 
 
 def string_array_to_hash(strings: List[str]) -> str:

--- a/airbyte-ci/connectors/pipelines/tests/test_actions/test_environments.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_actions/test_environments.py
@@ -30,7 +30,7 @@ def context(dagger_client):
 
 
 async def test_with_installed_python_package(context, python_connector):
-    python_environment = context.dagger_client.container().from_("python:3.9")
+    python_environment = context.dagger_client.container().from_("python:3.10")
     installed_connector_package = await environments.with_installed_python_package(
         context,
         python_environment,


### PR DESCRIPTION
## Overview
Fixes an issue where the dataframe preview was too large
![image](https://github.com/airbytehq/airbyte/assets/1325608/f27ebdfc-283a-4d92-92a9-c65698d47090)
