### PR TITLE
gradle: fix airbyteDocker task inputs

### DIFF
--- a/airbyte-cdk/python/build.gradle
+++ b/airbyte-cdk/python/build.gradle
@@ -11,7 +11,7 @@ tasks.register('generateComponentManifestClassFiles', Exec) {
     environment 'ROOT_DIR', rootDir.absolutePath
     commandLine 'bin/generate-component-manifest-files.sh'
 }.configure {
-    dependsOn project(':tools:code-generator').tasks.named('airbyteDocker')
+    dependsOn project(':tools:code-generator').tasks.named('assemble')
 }
 
 tasks.register('validateSourceYamlManifest', Exec) {

--- a/airbyte-integrations/bases/base-java/build.gradle
+++ b/airbyte-integrations/bases/base-java/build.gradle
@@ -28,3 +28,7 @@ dependencies {
     testImplementation 'commons-lang:commons-lang:2.6'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-layout-template-json', version: '2.17.2'
 }
+
+tasks.named('airbyteDocker').configure {
+    dependsOn project(':airbyte-integrations:bases:base').tasks.named('assemble')
+}

--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -37,9 +37,6 @@ checkSshScriptCopy.configure {
 tasks.named('airbyteDocker').configure {
     dependsOn checkSshScriptCopy
 }
-tasks.named('assemble').configure {
-    dependsOn checkSshScriptCopy
-}
 tasks.named('check').configure {
     dependsOn checkSshScriptCopy
 }
@@ -97,7 +94,6 @@ def buildAirbyteDocker(String customConnector) {
     }
     task.configure {
         dependsOn checkSshScriptCopy
-        dependsOn tasks.named('assemble')
     }
     tasks.named('airbyteDocker').configure {
         dependsOn task
@@ -150,4 +146,4 @@ def mypyCheck = tasks.register('mypyCheck', PythonTask) {
     module = "mypy"
     command = "normalization --config-file ${project.rootProject.file('pyproject.toml').absolutePath}"
 }
-tasks.named('airbytePythonChecks').configure { dependsOn mypyCheck }
+tasks.named('check').configure { dependsOn mypyCheck }

--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -47,7 +47,7 @@ def customIntegrationTestPython = tasks.register('customIntegrationTestPython', 
 }
 customIntegrationTestPython.configure {
     dependsOn tasks.named('installTestReqs')
-    dependsOn tasks.named('airbyteDocker')
+    dependsOn tasks.named('assemble')
 }
 
 static def getDockerfile(String customConnector) {
@@ -95,14 +95,14 @@ def buildAirbyteDocker(String customConnector) {
     task.configure {
         dependsOn checkSshScriptCopy
     }
-    tasks.named('airbyteDocker').configure {
+    tasks.named('assemble').configure {
         dependsOn task
     }
 }
 
 def customIntegrationTestsCoverage = tasks.named('_customIntegrationTestsCoverage')
 customIntegrationTestsCoverage.configure {
-    dependsOn tasks.named('airbyteDocker')
+    dependsOn tasks.named('assemble')
 }
 
 [
@@ -119,12 +119,12 @@ customIntegrationTestsCoverage.configure {
 ].each {destinationName ->
     def destinationProject = project(":airbyte-integrations:connectors:destination-$destinationName")
     customIntegrationTestPython.configure {
-        dependsOn destinationProject.tasks.named('airbyteDocker')
+        dependsOn destinationProject.tasks.named('assemble')
     }
     // Not really sure what this task does differently from customIntegrationTestPython,
     // but it seems to also run integration tests and as such it depends on the docker images.
     customIntegrationTestsCoverage.configure {
-        dependsOn destinationProject.tasks.named('airbyteDocker')
+        dependsOn destinationProject.tasks.named('assemble')
     }
 }
 

--- a/airbyte-integrations/bases/standard-source-test/.dockerignore
+++ b/airbyte-integrations/bases/standard-source-test/.dockerignore
@@ -1,4 +1,4 @@
 *
 !Dockerfile
-!build
+!build/distributions
 !entrypoint.sh

--- a/airbyte-integrations/bases/standard-source-test/build.gradle
+++ b/airbyte-integrations/bases/standard-source-test/build.gradle
@@ -76,10 +76,6 @@ def generateSourceTestDocs = tasks.register('generateSourceTestDocs', Javadoc) {
     outputs.upToDateWhen { false }
 }
 
-tasks.named('build').configure {
-    dependsOn generateSourceTestDocs
-}
-
 application {
     mainClass = 'io.airbyte.integrations.standardtest.source.PythonSourceAcceptanceTest'
 }

--- a/airbyte-integrations/connector-templates/generator/build.gradle
+++ b/airbyte-integrations/connector-templates/generator/build.gradle
@@ -1,19 +1,3 @@
-plugins {
-    id "base"
-    id "com.github.node-gradle.node" version "3.5.1"
-}
-
-def nodeVersion = System.getenv('NODE_VERSION') ?: '16.13.0'
-
-node {
-    download = true
-    version = nodeVersion
-}
-
-tasks.named('assemble').configure {
-    dependsOn tasks.named('npmInstall')
-}
-
 def generateScaffolds = tasks.register('generateScaffolds')
 
 def addScaffoldTemplateTask(name, packageName, outputDirName, scaffoldParams=[]) {

--- a/airbyte-integrations/connector-templates/source-java-jdbc/.dockerignore
+++ b/airbyte-integrations/connector-templates/source-java-jdbc/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors-performance/destination-harness/.dockerignore
+++ b/airbyte-integrations/connectors-performance/destination-harness/.dockerignore
@@ -1,4 +1,4 @@
 *
 !Dockerfile
-!build
+!build/distributions
 !base.sh

--- a/airbyte-integrations/connectors-performance/source-harness/.dockerignore
+++ b/airbyte-integrations/connectors-performance/source-harness/.dockerignore
@@ -1,4 +1,4 @@
 *
 !Dockerfile
-!build
+!build/distributions
 !base.sh

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/.dockerignore
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/.dockerignore
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-bigquery/.dockerignore
+++ b/airbyte-integrations/connectors/destination-bigquery/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-cassandra/.dockerignore
+++ b/airbyte-integrations/connectors/destination-cassandra/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-clickhouse/.dockerignore
+++ b/airbyte-integrations/connectors/destination-clickhouse/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-csv/.dockerignore
+++ b/airbyte-integrations/connectors/destination-csv/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-databricks/.dockerignore
+++ b/airbyte-integrations/connectors/destination-databricks/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-dev-null/.dockerignore
+++ b/airbyte-integrations/connectors/destination-dev-null/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-doris/.dockerignore
+++ b/airbyte-integrations/connectors/destination-doris/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-dynamodb/.dockerignore
+++ b/airbyte-integrations/connectors/destination-dynamodb/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-e2e-test/.dockerignore
+++ b/airbyte-integrations/connectors/destination-e2e-test/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-elasticsearch/.dockerignore
+++ b/airbyte-integrations/connectors/destination-elasticsearch/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-exasol/.dockerignore
+++ b/airbyte-integrations/connectors/destination-exasol/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-gcs/.dockerignore
+++ b/airbyte-integrations/connectors/destination-gcs/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-iceberg/.dockerignore
+++ b/airbyte-integrations/connectors/destination-iceberg/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-kafka/.dockerignore
+++ b/airbyte-integrations/connectors/destination-kafka/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-keen/.dockerignore
+++ b/airbyte-integrations/connectors/destination-keen/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-kinesis/.dockerignore
+++ b/airbyte-integrations/connectors/destination-kinesis/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-local-json/.dockerignore
+++ b/airbyte-integrations/connectors/destination-local-json/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/.dockerignore
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-mongodb/.dockerignore
+++ b/airbyte-integrations/connectors/destination-mongodb/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-mqtt/.dockerignore
+++ b/airbyte-integrations/connectors/destination-mqtt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-mssql-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/destination-mssql-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-mssql/.dockerignore
+++ b/airbyte-integrations/connectors/destination-mssql/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-mysql/.dockerignore
+++ b/airbyte-integrations/connectors/destination-mysql/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-oracle/.dockerignore
+++ b/airbyte-integrations/connectors/destination-oracle/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-postgres/.dockerignore
+++ b/airbyte-integrations/connectors/destination-postgres/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-pubsub/.dockerignore
+++ b/airbyte-integrations/connectors/destination-pubsub/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-pulsar/.dockerignore
+++ b/airbyte-integrations/connectors/destination-pulsar/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-r2/.dockerignore
+++ b/airbyte-integrations/connectors/destination-r2/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-redis/.dockerignore
+++ b/airbyte-integrations/connectors/destination-redis/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-redpanda/.dockerignore
+++ b/airbyte-integrations/connectors/destination-redpanda/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-redshift/.dockerignore
+++ b/airbyte-integrations/connectors/destination-redshift/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-rockset/.dockerignore
+++ b/airbyte-integrations/connectors/destination-rockset/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-s3-glue/.dockerignore
+++ b/airbyte-integrations/connectors/destination-s3-glue/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-s3/.dockerignore
+++ b/airbyte-integrations/connectors/destination-s3/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-scylla/.dockerignore
+++ b/airbyte-integrations/connectors/destination-scylla/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-selectdb/.dockerignore
+++ b/airbyte-integrations/connectors/destination-selectdb/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-snowflake/.dockerignore
+++ b/airbyte-integrations/connectors/destination-snowflake/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -63,8 +63,8 @@ dependencies {
 }
 
 tasks.named('airbyteDocker').configure {
-    // this is really inefficent (because base-normalization:airbyteDocker builds 9 docker images)
+    // this is really inefficent (because base-normalization:assemble builds 9 docker images)
     // but it's also just simple to implement.
     // this also goes away once airbyte-ci becomes a reality.
-    dependsOn project(':airbyte-integrations:bases:base-normalization').tasks.named('airbyteDocker')
+    dependsOn project(':airbyte-integrations:bases:base-normalization').tasks.named('assemble')
 }

--- a/airbyte-integrations/connectors/destination-starburst-galaxy/.dockerignore
+++ b/airbyte-integrations/connectors/destination-starburst-galaxy/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-teradata/.dockerignore
+++ b/airbyte-integrations/connectors/destination-teradata/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-tidb/.dockerignore
+++ b/airbyte-integrations/connectors/destination-tidb/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-vertica/.dockerignore
+++ b/airbyte-integrations/connectors/destination-vertica/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/destination-yugabytedb/.dockerignore
+++ b/airbyte-integrations/connectors/destination-yugabytedb/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-alloydb-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/source-alloydb-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-alloydb/.dockerignore
+++ b/airbyte-integrations/connectors/source-alloydb/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-clickhouse/.dockerignore
+++ b/airbyte-integrations/connectors/source-clickhouse/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-db2/.dockerignore
+++ b/airbyte-integrations/connectors/source-db2/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/.dockerignore
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-e2e-test/.dockerignore
+++ b/airbyte-integrations/connectors/source-e2e-test/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-elasticsearch/.dockerignore
+++ b/airbyte-integrations/connectors/source-elasticsearch/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-jdbc/.dockerignore
+++ b/airbyte-integrations/connectors/source-jdbc/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/.dockerignore
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-mongodb-v2/.dockerignore
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-mssql/.dockerignore
+++ b/airbyte-integrations/connectors/source-mssql/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-mysql/.dockerignore
+++ b/airbyte-integrations/connectors/source-mysql/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-oracle/.dockerignore
+++ b/airbyte-integrations/connectors/source-oracle/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/.dockerignore
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-postgres/.dockerignore
+++ b/airbyte-integrations/connectors/source-postgres/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-redshift/.dockerignore
+++ b/airbyte-integrations/connectors/source-redshift/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-relational-db/.dockerignore
+++ b/airbyte-integrations/connectors/source-relational-db/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-sftp/.dockerignore
+++ b/airbyte-integrations/connectors/source-sftp/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/airbyte-integrations/connectors/source-snowflake/.dockerignore
+++ b/airbyte-integrations/connectors/source-snowflake/.dockerignore
@@ -1,3 +1,3 @@
 *
 !Dockerfile
-!build
+!build/distributions

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,8 @@ allprojects {
 
     tasks.withType(Zip).configureEach {
         duplicatesStrategy DuplicatesStrategy.INCLUDE
+        // Disabling distZip causes the build to break for some reason, so: instead of disabling it, make it fast.
+        entryCompression ZipEntryCompression.STORED
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -459,6 +459,9 @@ tasks.named('spotlessStyling').configure {
     dependsOn tasks.named('nodeSetup')
     dependsOn tasks.named('npmSetup')
 }
+tasks.matching { it.name =~ /spotless.*Check/ }.configureEach {
+    enabled = false
+}
 
 // python is required by the root project to apply python formatters like isort or black.
 python {

--- a/buildSrc/src/main/groovy/airbyte-connector-acceptance-test.gradle
+++ b/buildSrc/src/main/groovy/airbyte-connector-acceptance-test.gradle
@@ -47,11 +47,10 @@ class AirbyteConnectorAcceptanceTestPlugin implements Plugin<Project> {
             outputs.upToDateWhen { false }
         }
         connectorAcceptanceTest.configure {
-            dependsOn project.tasks.named('airbyteDocker')
+            dependsOn project.tasks.named('assemble')
             if (project.connectorAcceptanceTestVersion == 'dev') {
-                dependsOn project(':airbyte-integrations:bases:connector-acceptance-test').tasks.named('airbyteDocker')
+                dependsOn project(':airbyte-integrations:bases:connector-acceptance-test').tasks.named('assemble')
             }
-            dependsOn project.tasks.matching { it.name == 'airbyteDockerTest' }
         }
     }
 }

--- a/buildSrc/src/main/groovy/airbyte-connector-acceptance-test.gradle
+++ b/buildSrc/src/main/groovy/airbyte-connector-acceptance-test.gradle
@@ -47,7 +47,6 @@ class AirbyteConnectorAcceptanceTestPlugin implements Plugin<Project> {
             outputs.upToDateWhen { false }
         }
         connectorAcceptanceTest.configure {
-            dependsOn project.tasks.named('build')
             dependsOn project.tasks.named('airbyteDocker')
             if (project.connectorAcceptanceTestVersion == 'dev') {
                 dependsOn project(':airbyte-integrations:bases:connector-acceptance-test').tasks.named('airbyteDocker')

--- a/buildSrc/src/main/groovy/airbyte-docker.gradle
+++ b/buildSrc/src/main/groovy/airbyte-docker.gradle
@@ -1,85 +1,69 @@
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.slf4j.Logger
 
-import java.nio.file.Path
 import java.security.MessageDigest
 import java.nio.file.Paths
 
 @CacheableTask
-abstract class AirbyteDockerTask extends DefaultTask {
-    @Internal
-    abstract File rootDir
+abstract class AirbyteDockerBaseTask extends DefaultTask {
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    abstract FileCollection projectFiles
+    FileCollection filesInDockerImage
 
     @Input
-    abstract Set<String> baseImageHashes
+    Set<String> baseImageHashes
 
-    @InputDirectory
-    @PathSensitive(PathSensitivity.RELATIVE)
-    abstract File projectDir
-
-    @Input
-    String dockerfileName
-
-    @Input
-    boolean followSymlinks = false
+    @InputFile
+    File dockerFile
 
     @OutputFile
-    abstract File idFileOutput
+    File idFileOutput
+}
 
-    def buildDockerfile(String scriptPath, String fileName) {
-        if (project.file(fileName).exists()) {
-            def tag = DockerHelpers.getDevTaggedImage(projectDir, dockerfileName)
+abstract class AirbyteDockerTask extends AirbyteDockerBaseTask {
 
-            def arch = System.getProperty("os.arch").toLowerCase()
-            def isArm64 = arch == "aarch64" || arch == "arm64"
-            def buildPlatform = System.getenv('DOCKER_BUILD_PLATFORM') ?: isArm64 ? 'linux/arm64' : 'amd64'
-
-            project.exec {
-                commandLine scriptPath, rootDir.absolutePath, projectDir.absolutePath, dockerfileName, tag, idFileOutput.absolutePath, followSymlinks, buildPlatform
-            }
-        }
-    }
-
-    def buildDockerfileWithLocalCdk(String scriptPath, String fileName) {
-        if (project.file(fileName).exists()) {
-            def tag = DockerHelpers.getDevTaggedImage(projectDir, dockerfileName)
-            project.exec {
-                environment "CONNECTOR_TAG", tag
-                environment "CONNECTOR_NAME", project.findProperty('connectorAcceptanceTest.connectorName')
-                commandLine scriptPath
-            }
-        }
-    }
+    @InputFile
+    File buildScript = project.rootProject.file('tools/bin/build_image.sh')
 
     @TaskAction
     def dockerTask() {
-        if (
-            project.hasProperty('connectorAcceptanceTest.useLocalCdk') &&
-            project.properties["connectorAcceptanceTest.useLocalCdk"] &&
-            project.parent.project.name.equals("connectors")
-        ) {
-            def scriptPath = Paths.get(rootDir.absolutePath, 'airbyte-integrations/scripts/build-connector-image-with-local-cdk.sh').toString()
-            buildDockerfileWithLocalCdk(scriptPath, dockerfileName)
+        project.exec {
+            commandLine(
+                    buildScript.absolutePath,
+                    project.rootDir.absolutePath,
+                    project.projectDir.absolutePath,
+                    dockerFile.name,
+                    DockerHelpers.getDevTaggedImage(project.projectDir, dockerFile.name),
+                    idFileOutput.absolutePath,
+           )
         }
-        else {
-            def scriptPath = Paths.get(rootDir.absolutePath, 'tools/bin/build_image.sh').toString()
-            buildDockerfile(scriptPath, dockerfileName)
+    }
+}
+
+abstract class AirbyteDockerWithLocalCDKLegacyTask extends AirbyteDockerBaseTask {
+
+    @InputFile
+    File buildScript = project.rootProject.file('airbyte-integrations/scripts/build-connector-image-with-local-cdk.sh')
+
+    @TaskAction
+    def dockerTask() {
+        project.exec {
+            environment "CONNECTOR_TAG", DockerHelpers.getDevTaggedImage(project.projectDir, dockerFile.name)
+            environment "CONNECTOR_NAME", project.findProperty('connectorAcceptanceTest.connectorName')
+            commandLine buildScript.absolutePath
         }
     }
 }
@@ -151,9 +135,9 @@ class AirbyteDockerPlugin implements Plugin<Project> {
         return "$stdout".toString().trim()
     }
 
-    static boolean isUpToDate(Logger logger, File idFileOutput, Project project, String dockerFile, Path dockerPath) {
+    static boolean isUpToDate(Logger logger, File idFileOutput, Project project, File dockerFile) {
         if (idFileOutput.exists()) {
-            def taggedImage = DockerHelpers.getDevTaggedImage(project.projectDir, dockerFile)
+            def taggedImage = DockerHelpers.getDevTaggedImage(project.projectDir, dockerFile.name)
             logger.debug "taggedImage " + taggedImage
 
             def current = getImageHash(project, taggedImage)
@@ -161,7 +145,7 @@ class AirbyteDockerPlugin implements Plugin<Project> {
             def stored = (String) project.rootProject.imageToHash.get(taggedImage)
             logger.debug "stored " + stored
 
-            def notUpToDate = new ArrayList<String>(getBaseTaggedImages(dockerPath.toFile())).any { baseImage ->
+            def notUpToDate = new ArrayList<String>(getBaseTaggedImages(dockerFile)).any { baseImage ->
                 logger.debug "checking base image " + baseImage
                 def storedBase = (String) project.rootProject.imageToHash.get(resolveEnvironmentVariables(project, baseImage))
                 def currentBase = getImageHash(project, baseImage)
@@ -193,36 +177,57 @@ class AirbyteDockerPlugin implements Plugin<Project> {
         }
     }
 
-    static def createTask(Project project, String taskName, String dockerFile) {
-        if (project.file(dockerFile).exists()) {
-            def filteredProjectFiles = project.fileTree(project.projectDir).filter {
+    static FileCollection filteredProjectFiles(Project project) {
+        ConfigurableFileTree files = project.fileTree(project.projectDir).asFileTree
+        def dockerignore = project.file('.dockerignore')
+        if (!dockerignore.exists()) {
+            return files.filter {
                 file -> !file.toString().contains(".venv")
             }
+        }
+        for (def rule : dockerignore.readLines()) {
+            if (rule.startsWith("#")) {
+                continue
+            }
+            rule = rule.trim()
+            files = (rule.startsWith("!") ? files.include(rule.substring(1)) : files.exclude(rule)) as ConfigurableFileTree
+        }
+        return files
+    }
 
-            def airbyteDockerTask = project.tasks.register(taskName, AirbyteDockerTask) {
-                def dockerPath = Paths.get(project.projectDir.absolutePath, dockerFile)
-                def hash = MessageDigest.getInstance("MD5").digest(dockerPath.getBytes()).encodeHex().toString()
-                dockerfileName = dockerFile
-                rootDir = project.rootProject.rootDir
-                projectDir = project.projectDir
-                projectFiles = filteredProjectFiles
-                idFileOutput = project.file(Paths.get(project.rootProject.rootDir.absolutePath, '.dockerversions', hash).toString())
-                baseImageHashes = getBaseImageHashes(project.rootProject.imageToHash, dockerPath.toFile())
 
-                outputs.upToDateWhen {
-                    return isUpToDate(logger, idFileOutput, project, dockerFile, dockerPath)
-                }
-            }
-            airbyteDockerTask.configure {
-                dependsOn project.tasks.named('assemble')
-            }
-            project.tasks.named('build').configure {
-                dependsOn airbyteDockerTask
-            }
-        } else {
+    static def createTask(Project project, String taskName, String dockerFileName) {
+        def dockerFile = project.file(dockerFileName)
+        if (!dockerFile.exists()) {
             project.tasks.register(taskName) {
                 logger.info "Skipping ${taskName} because ${dockerFile} does not exist."
             }
+            return
+        }
+        Class<? extends AirbyteDockerBaseTask> taskClass = AirbyteDockerTask
+        if (project.hasProperty('connectorAcceptanceTest.useLocalCdk') && project.parent.project.name == "connectors") {
+            taskClass = AirbyteDockerWithLocalCDKLegacyTask
+        }
+        def airbyteDockerTask = project.tasks.register(taskName, taskClass) {
+            def dockerfilePathHash = MessageDigest.getInstance("MD5")
+                    .digest(dockerFile.absolutePath.getBytes())
+                    .encodeHex()
+                    .toString()
+
+            it.filesInDockerImage = filteredProjectFiles(project)
+            it.dockerFile = dockerFile
+            it.baseImageHashes = getBaseImageHashes(project.rootProject.imageToHash, dockerFile)
+            it.idFileOutput = Paths.get(project.rootProject.rootDir.absolutePath, '.dockerversions', dockerfilePathHash).toFile()
+
+            it.outputs.upToDateWhen {
+                return isUpToDate(logger, it.idFileOutput, project, dockerFile)
+            }
+        }
+        airbyteDockerTask.configure {
+            dependsOn project.tasks.named('assemble')
+        }
+        project.tasks.named('build').configure {
+            dependsOn airbyteDockerTask
         }
     }
 

--- a/buildSrc/src/main/groovy/airbyte-docker.gradle
+++ b/buildSrc/src/main/groovy/airbyte-docker.gradle
@@ -224,9 +224,9 @@ class AirbyteDockerPlugin implements Plugin<Project> {
             }
         }
         airbyteDockerTask.configure {
-            dependsOn project.tasks.named('assemble')
+            dependsOn project.tasks.matching { it.name == 'distTar' }
         }
-        project.tasks.named('build').configure {
+        project.tasks.named('assemble').configure {
             dependsOn airbyteDockerTask
         }
     }

--- a/buildSrc/src/main/groovy/airbyte-docker.gradle
+++ b/buildSrc/src/main/groovy/airbyte-docker.gradle
@@ -225,6 +225,7 @@ class AirbyteDockerPlugin implements Plugin<Project> {
         }
         airbyteDockerTask.configure {
             dependsOn project.tasks.matching { it.name == 'distTar' }
+            dependsOn project.tasks.named('generate')
         }
         project.tasks.named('assemble').configure {
             dependsOn airbyteDockerTask

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -57,7 +57,7 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
         }
         integrationTestJava.configure {
             mustRunAfter project.tasks.named('test')
-            dependsOn project.tasks.matching { it.name == 'airbyteDocker' }
+            dependsOn project.tasks.matching { it.name == 'assemble' }
             dependsOn project.tasks.matching { it.name == 'spotbugsMain' }
         }
     }

--- a/buildSrc/src/main/groovy/airbyte-performance-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-performance-test-java.gradle
@@ -41,7 +41,7 @@ class AirbytePerformanceTestJavaPlugin implements Plugin<Project> {
         }
         performanceTestJava.configure {
             mustRunAfter project.tasks.named('test')
-            dependsOn project.tasks.matching { it.name == 'airbyteDocker' }
+            dependsOn project.tasks.matching { it.name == 'assemble' }
         }
     }
 }

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -196,8 +196,7 @@ class AirbytePythonPlugin implements Plugin<Project> {
             dependsOn installLocalReqs
         }
 
-        def airbytePythonChecks = project.tasks.register('airbytePythonChecks') {}
-        airbytePythonChecks.configure {
+        project.tasks.named('check').configure {
             dependsOn installReqs
             dependsOn flakeCheck
         }
@@ -208,13 +207,9 @@ class AirbytePythonPlugin implements Plugin<Project> {
                 command = "-m ${extension.moduleDirectory} --config-file ${project.rootProject.file('pyproject.toml').absolutePath}"
             }
 
-            airbytePythonChecks.configure {
+            project.tasks.named('check').configure {
                 dependsOn mypyCheck
             }
-        }
-
-        project.tasks.named('assemble').configure {
-            dependsOn airbytePythonChecks
         }
 
         def installTestReqs = project.tasks.register('installTestReqs', PythonTask) {
@@ -227,11 +222,8 @@ class AirbytePythonPlugin implements Plugin<Project> {
             dependsOn installReqs
         }
 
-
-
         Helpers.addTestTaskIfTestFilesFound(project, 'unit_tests', 'unitTest', installTestReqs)
         project.tasks.named('check').configure {
-            dependsOn airbytePythonChecks
             dependsOn project.tasks.matching { it.name == 'unitTest' }
         }
 

--- a/buildSrc/src/main/groovy/airbyte-standard-source-test-file.gradle
+++ b/buildSrc/src/main/groovy/airbyte-standard-source-test-file.gradle
@@ -65,10 +65,8 @@ class AirbyteStandardSourceTestFilePlugin implements Plugin<Project> {
             outputs.upToDateWhen { false }
         }
         standardSourceTestFile.configure {
-            dependsOn project.project(':airbyte-integrations:bases:base-standard-source-test-file').tasks.named('airbyteDocker')
-            dependsOn project.tasks.named('build')
-            dependsOn project.tasks.matching { it.name == 'airbyteDocker' }
-            dependsOn project.tasks.matching { it.name == 'airbyteDockerTest' }
+            dependsOn project.project(':airbyte-integrations:bases:base-standard-source-test-file').tasks.named('assemble')
+            dependsOn project.tasks.named('assemble')
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tools/bin/build_image.sh
+++ b/tools/bin/build_image.sh
@@ -7,7 +7,6 @@ PROJECT_DIR="$2"
 DOCKERFILE="$3"
 TAGGED_IMAGE="$4"
 ID_FILE="$5"
-FOLLOW_SYMLINKS="$6"
 DOCKER_BUILD_ARCH="${DOCKER_BUILD_ARCH:-amd64}"
 # https://docs.docker.com/develop/develop-images/build_enhancements/
 export DOCKER_BUILDKIT=1
@@ -18,34 +17,15 @@ assert_root
 
 cd "$PROJECT_DIR"
 
-function validate_dockerignore() {
-  excludes_all=$(grep -w '^\*$' .dockerignore || true)
-  excludes_except=$(grep -w '^!.*' .dockerignore || true)
-  if [ -n "$excludes_all" ] || [ -n "$excludes_except" ]; then
-    error "Cannot include exclusion exceptions when following symlinks. Please use an exclude pattern that doesn't use exclude-all (e.g: *) or exclude-except (e.g: !/some/pattern)"
-  fi
-}
-
 args=(
     -f "$DOCKERFILE"
     -t "$TAGGED_IMAGE"
     --iidfile "$ID_FILE"
 )
 
-if [ "$FOLLOW_SYMLINKS" == "true" ]; then
-  exclusions=()
-  if [ -f ".dockerignore" ]; then
-    validate_dockerignore
-    exclusions+=(--exclude-from .dockerignore)
-  fi
-  # Docker does not follow symlinks in the build context. So we create a tar of the directory, following symlinks, and provide the archive to Docker
-  # to use as the build context
-  tar cL "${exclusions[@]}" . | docker build - "${args[@]}"
+JDK_VERSION="${JDK_VERSION:-17.0.4}"
+if [[ -z "${DOCKER_BUILD_PLATFORM}" ]]; then
+  docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" . "${args[@]}"
 else
-  JDK_VERSION="${JDK_VERSION:-17.0.4}"
-  if [[ -z "${DOCKER_BUILD_PLATFORM}" ]]; then
-    docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" . "${args[@]}"
-  else
-    docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" --platform="$DOCKER_BUILD_PLATFORM" . "${args[@]}"
-  fi
+  docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" --platform="$DOCKER_BUILD_PLATFORM" . "${args[@]}"
 fi


### PR DESCRIPTION
This PR follows up on https://github.com/airbytehq/airbyte/pull/30060 and this time the changes are mostly centered on the airbyte-docker plugin:
- its tasks no longer declare the whole project directory as an input, instead it uses the already-existing `.dockerignore` files;
- its tasks are now a dependency of the `assemble` step instead of `build`, because building a docker image shouldn't depend on unit tests passing (the main reason being, the docker image may itself be a transitive dependency);
- its tasks now depend on `generate`;
- as far as airbyte-python in concerned, `airbyteDocker` would depend on flake checks and the like, which in turn depended on an expensive local venv setup; these checks still exist but have been moved from `assemble` to `check`, so that for a python project `assemble` really only consists of `generate` followed by `airbyteDocker`.

This PR also bumps to the latest gradle major version. This has been useful to track bad task inputs because the latest gradle is much more strict about these things.