### PR TITLE
fix empty collections bugs

### DIFF
--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/AirbyteDebeziumHandler.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/AirbyteDebeziumHandler.java
@@ -132,8 +132,7 @@ public class AirbyteDebeziumHandler<T> {
         schemaHistoryManager.orElse(null),
         syncCheckpointDuration,
         syncCheckpointRecords,
-        debeziumConnectorType
-        ));
+        debeziumConnectorType));
   }
 
   private Optional<AirbyteSchemaHistoryStorage> schemaHistoryManager(final CdcSavedInfoFetcher cdcSavedInfoFetcher) {

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumEventUtils.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumEventUtils.java
@@ -79,9 +79,9 @@ public class DebeziumEventUtils {
    * @return The record that represents the change.
    */
   private static ObjectNode getBaseNode(
-      final JsonNode after,
-      final JsonNode before,
-      final DebeziumPropertiesManager.DebeziumConnectorType debeziumConnectorType) {
+                                        final JsonNode after,
+                                        final JsonNode before,
+                                        final DebeziumPropertiesManager.DebeziumConnectorType debeziumConnectorType) {
     final JsonNode baseNode = after.isNull() ? before : after;
     return switch (debeziumConnectorType) {
       case MONGODB -> (ObjectNode) Jsons.deserialize(baseNode.asText());

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumStateDecoratingIterator.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/DebeziumStateDecoratingIterator.java
@@ -81,13 +81,14 @@ public class DebeziumStateDecoratingIterator<T> extends AbstractIterator<Airbyte
   private final DebeziumConnectorType debeziumConnectorType;
 
   /**
-   * @param changeEventIterator   Base iterator that we want to enrich with checkpoint messages
-   * @param cdcStateHandler       Handler to save the offset and schema history
-   * @param offsetManager         Handler to read and write debezium offset file
-   * @param trackSchemaHistory    Set true if the schema needs to be tracked
-   * @param schemaHistoryManager  Handler to write schema. Needs to be initialized if trackSchemaHistory is set to true
-   * @param checkpointDuration    Duration object with time between syncs
-   * @param checkpointRecords     Number of records between syncs
+   * @param changeEventIterator Base iterator that we want to enrich with checkpoint messages
+   * @param cdcStateHandler Handler to save the offset and schema history
+   * @param offsetManager Handler to read and write debezium offset file
+   * @param trackSchemaHistory Set true if the schema needs to be tracked
+   * @param schemaHistoryManager Handler to write schema. Needs to be initialized if
+   *        trackSchemaHistory is set to true
+   * @param checkpointDuration Duration object with time between syncs
+   * @param checkpointRecords Number of records between syncs
    * @param debeziumConnectorType type of connector that debezium will be capturing changes from
    */
   public DebeziumStateDecoratingIterator(final Iterator<ChangeEventWithMetadata> changeEventIterator,

--- a/airbyte-integrations/bases/debezium/src/test/java/io/airbyte/integrations/debezium/DebeziumEventUtilsTest.java
+++ b/airbyte-integrations/bases/debezium/src/test/java/io/airbyte/integrations/debezium/DebeziumEventUtilsTest.java
@@ -33,9 +33,12 @@ class DebeziumEventUtilsTest {
     final ChangeEventWithMetadata updateChangeEvent = mockChangeEvent("update_change_event.json");
     final ChangeEventWithMetadata deleteChangeEvent = mockChangeEvent("delete_change_event.json");
 
-    final AirbyteMessage actualInsert = DebeziumEventUtils.toAirbyteMessage(insertChangeEvent, cdcMetadataInjector, emittedAt, DebeziumConnectorType.RELATIONALDB);
-    final AirbyteMessage actualUpdate = DebeziumEventUtils.toAirbyteMessage(updateChangeEvent, cdcMetadataInjector, emittedAt, DebeziumConnectorType.RELATIONALDB);
-    final AirbyteMessage actualDelete = DebeziumEventUtils.toAirbyteMessage(deleteChangeEvent, cdcMetadataInjector, emittedAt, DebeziumConnectorType.RELATIONALDB);
+    final AirbyteMessage actualInsert =
+        DebeziumEventUtils.toAirbyteMessage(insertChangeEvent, cdcMetadataInjector, emittedAt, DebeziumConnectorType.RELATIONALDB);
+    final AirbyteMessage actualUpdate =
+        DebeziumEventUtils.toAirbyteMessage(updateChangeEvent, cdcMetadataInjector, emittedAt, DebeziumConnectorType.RELATIONALDB);
+    final AirbyteMessage actualDelete =
+        DebeziumEventUtils.toAirbyteMessage(deleteChangeEvent, cdcMetadataInjector, emittedAt, DebeziumConnectorType.RELATIONALDB);
 
     final AirbyteMessage expectedInsert = createAirbyteMessage(stream, emittedAt, "insert_message.json");
     final AirbyteMessage expectedUpdate = createAirbyteMessage(stream, emittedAt, "update_message.json");
@@ -54,7 +57,8 @@ class DebeziumEventUtilsTest {
     final ChangeEventWithMetadata changeEventWithMetadata = mockChangeEvent("mongodb/change_event_after.json");
     final AirbyteMessage expectedMessage = createAirbyteMessage(stream, emittedAt, "mongodb/after_airbyte_message.json");
 
-    final AirbyteMessage airbyteMessage = DebeziumEventUtils.toAirbyteMessage(changeEventWithMetadata, cdcMetadataInjector, emittedAt, DebeziumConnectorType.MONGODB);
+    final AirbyteMessage airbyteMessage =
+        DebeziumEventUtils.toAirbyteMessage(changeEventWithMetadata, cdcMetadataInjector, emittedAt, DebeziumConnectorType.MONGODB);
     deepCompare(expectedMessage, airbyteMessage);
   }
 

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/InitialSnapshotHandler.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/InitialSnapshotHandler.java
@@ -68,13 +68,15 @@ public class InitialSnapshotHandler {
           final var fields = Projections.fields(Projections.include(CatalogHelpers.getTopLevelFieldNames(airbyteStream).stream().toList()));
 
           final var idTypes = aggregateIdField(collection);
-          if (idTypes.size() != 1) {
+          if (idTypes.size() > 1) {
             throw new ConfigErrorException("The _id fields in a collection must be consistently typed.");
           }
 
-          if (IdType.findByBsonType(idTypes.get(0)).isEmpty()) {
-            throw new ConfigErrorException("Only _id fields with the following types are currently supported: " + IdType.SUPPORTED);
-          }
+          idTypes.stream().findFirst().ifPresent(idType -> {
+            if (IdType.findByBsonType(idType).isEmpty()) {
+              throw new ConfigErrorException("Only _id fields with the following types are currently supported: " + IdType.SUPPORTED);
+            }
+          });
 
           // find the existing state, if there is one, for this stream
           final Optional<MongoDbStreamState> existingState =

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java
@@ -117,6 +117,12 @@ public class MongoDbStateIterator implements Iterator<AirbyteMessage> {
       LOGGER.info("hasNext threw an exception for stream {}: {}", getStream(), e.getMessage(), e);
     }
 
+    //no more records in cursor + no record messages have been emitted => collection is empty
+    if(lastId == null) {
+      return false;
+    }
+
+    //no more records in cursor + record messages have been emitted => we should emit a final state message.
     if (!finalStateNext) {
       finalStateNext = true;
       LOGGER.debug("Final state is now true for stream {}...", getStream());

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java
@@ -117,12 +117,13 @@ public class MongoDbStateIterator implements Iterator<AirbyteMessage> {
       LOGGER.info("hasNext threw an exception for stream {}: {}", getStream(), e.getMessage(), e);
     }
 
-    //no more records in cursor + no record messages have been emitted => collection is empty
-    if(lastId == null) {
+    // no more records in cursor + no record messages have been emitted => collection is empty
+    if (lastId == null) {
       return false;
     }
 
-    //no more records in cursor + record messages have been emitted => we should emit a final state message.
+    // no more records in cursor + record messages have been emitted => we should emit a final state
+    // message.
     if (!finalStateNext) {
       finalStateNext = true;
       LOGGER.debug("Final state is now true for stream {}...", getStream());

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbCdcProperties.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbCdcProperties.java
@@ -54,10 +54,11 @@ public class MongoDbCdcProperties {
      * debezium adds support for an include list, we should move this property to
      * {@link MongoDbDebeziumPropertiesManager}.
      *
-     * Also, when there are no fields to exclude we do not set this property. If we set this property to an
-     * empty string then we would get an error from debezium.
+     * Also, when there are no fields to exclude we do not set this property. If we set this property to
+     * an empty string then we would get an error from debezium.
      */
-    if(!fieldsToExclude.isEmpty()) props.setProperty(FIELD_EXCLUDE_LIST_KEY, createFieldsToExcludeString(fieldsToExclude));
+    if (!fieldsToExclude.isEmpty())
+      props.setProperty(FIELD_EXCLUDE_LIST_KEY, createFieldsToExcludeString(fieldsToExclude));
 
     return props;
   }

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test/java/io/airbyte/integrations/source/mongodb/internal/InitialSnapshotHandlerTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test/java/io/airbyte/integrations/source/mongodb/internal/InitialSnapshotHandlerTest.java
@@ -324,7 +324,8 @@ class InitialSnapshotHandlerTest {
 
     assertFalse(collection1.hasNext());
 
-    //collection2
+    // collection2
     assertFalse(collection2.hasNext());
   }
+
 }

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIteratorTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIteratorTest.java
@@ -71,7 +71,7 @@ class MongoDbStateIteratorTest {
       private int count = 0;
 
       @Override
-      public Boolean answer(InvocationOnMock invocation) {
+      public Boolean answer(final InvocationOnMock invocation) {
         count++;
         // hasNext will be called for each doc plus for each state message
         return count <= (docs.size() + (docs.size() % CHECKPOINT_INTERVAL));
@@ -326,6 +326,16 @@ class MongoDbStateIteratorTest {
         "state status should be final");
 
     assertFalse(iter.hasNext(), "should have no more records");
+  }
+
+  @Test
+  void hasNextNoInitialStateAndNoMoreRecordsInCursor() {
+    when(mongoCursor.hasNext()).thenReturn(false);
+    final var stream = catalog().getStreams().stream().findFirst().orElseThrow();
+    final var iter = new MongoDbStateIterator(mongoCursor, stateManager, Optional.of(cdcConnectorMetadataInjector), stream, Instant.now(), 1000000,
+        Duration.of(1, SECONDS));
+
+    assertFalse(iter.hasNext());
   }
 
   private ConfiguredAirbyteCatalog catalog() {

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbCdcPropertiesTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test/java/io/airbyte/integrations/source/mongodb/internal/cdc/MongoDbCdcPropertiesTest.java
@@ -65,11 +65,11 @@ class MongoDbCdcPropertiesTest {
     assertTrue(actualFullyQualifiedExcludedFields.contains(FULLY_QUALIFIED_FIELD4));
   }
 
-
   @Test
   void testEmptyExcludeFieldList() {
     final Set<ExcludedField> fieldsToExclude = Collections.emptySet();
     final Properties debeziumProperties = MongoDbCdcProperties.getDebeziumProperties(fieldsToExclude);
     assertFalse(debeziumProperties.containsKey(FIELD_EXCLUDE_LIST_KEY));
   }
+
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Fixing 2 issues with empty collections:
1. `InitialSnapshotHandler` was assuming that we were always going to get at least one `_id` type from a collection
2. `MongoDbStateIterator` was throwing a NPE [here](https://github.com/airbytehq/airbyte/blob/6e91d4ae0786ca2445347953891da2699b130ef9/airbyte-integrations/connectors/source-mongodb-internal-poc/src/main/java/io/airbyte/integrations/source/mongodb/internal/MongoDbStateIterator.java#L150) since `lastId` is null when dealing with an empty collection


## How
1. `InitialSnapshotHandler`:  throws an exception if there are more than `_id` types (0 `_id` types are allowed)
2. `MongoDbStateIterator`: `hasNext` returns false right away if we are dealing with an empty collection

## Recommended reading order
1. `x.java`
3. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
