### PR TITLE
Airbyte Connectors & Octavia CI: remove format step caching

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -102,10 +102,11 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Cache Build Artifacts
-        uses: ./.github/actions/cache-build-artifacts
-        with:
-          cache-key: ${{ secrets.CACHE_VERSION }}-format
+      # Caching causes occasional failure of the checkPython step which can't find the venv
+      # - name: Cache Build Artifacts
+      #   uses: ./.github/actions/cache-build-artifacts
+      #   with:
+      #     cache-key: ${{ secrets.CACHE_VERSION }}-format
 
       - uses: actions/setup-java@v3
         with:

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
@@ -22,7 +22,10 @@ def output_dataframe(result_df: pd.DataFrame) -> Output[pd.DataFrame]:
     is_truncated = len(result_df) > MAX_PREVIEW_ROWS
     preview_result_df = result_df.head(MAX_PREVIEW_ROWS)
 
-    return Output(result_df, metadata={"count": len(result_df), "preview": MetadataValue.md(preview_result_df.to_markdown()), "is_truncated": is_truncated})
+    return Output(
+        result_df,
+        metadata={"count": len(result_df), "preview": MetadataValue.md(preview_result_df.to_markdown()), "is_truncated": is_truncated},
+    )
 
 
 def string_array_to_hash(strings: List[str]) -> str:


### PR DESCRIPTION

## What
Caching build artifact on the `format` step occasionally lead to failure of the `checkPython` step, not finding the venv.


## How
Remove caching on this step.
