### PR TITLE
[oncall #2838] migrate parsing errors as config errors

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
@@ -54,6 +54,10 @@ class MissingSchemaError(BaseFileBasedSourceError):
     pass
 
 
+class NoFilesMatchingError(BaseFileBasedSourceError):
+    pass
+
+
 class RecordParseError(BaseFileBasedSourceError):
     pass
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from airbyte_cdk.sources.file_based.exceptions import ConfigValidationError, FileBasedSourceError, SchemaInferenceError
+from airbyte_cdk.sources.file_based.exceptions import ConfigValidationError, FileBasedSourceError
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 from unit_tests.sources.file_based.helpers import EmptySchemaParser, LowInferenceLimitDiscoveryPolicy
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -3,6 +3,7 @@
 #
 
 from airbyte_cdk.sources.file_based.exceptions import ConfigValidationError, FileBasedSourceError, SchemaInferenceError
+from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 from unit_tests.sources.file_based.helpers import EmptySchemaParser, LowInferenceLimitDiscoveryPolicy
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder
 
@@ -582,7 +583,7 @@ invalid_csv_scenario = (
         }
     )
     .set_expected_records([])
-    .set_expected_discover_error(SchemaInferenceError, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
+    .set_expected_discover_error(AirbyteTracedException, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
     .set_expected_logs(
         {
             "read": [
@@ -1096,7 +1097,7 @@ empty_schema_inference_scenario = (
         }
     )
     .set_parsers({"csv": EmptySchemaParser()})
-    .set_expected_discover_error(SchemaInferenceError, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
+    .set_expected_discover_error(AirbyteTracedException, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
     .set_expected_records(
         [
             {
@@ -1885,7 +1886,7 @@ csv_newline_in_values_not_quoted_scenario = (
             ]
         }
     )
-    .set_expected_discover_error(SchemaInferenceError, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
+    .set_expected_discover_error(AirbyteTracedException, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
 ).build()
 
 csv_escape_char_is_set_scenario = (
@@ -2630,5 +2631,5 @@ earlier_csv_scenario = (
         }
     )
     .set_expected_records([])
-    .set_expected_discover_error(SchemaInferenceError, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
+    .set_expected_discover_error(AirbyteTracedException, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
 ).build()

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/jsonl_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/jsonl_scenarios.py
@@ -3,6 +3,7 @@
 #
 
 from airbyte_cdk.sources.file_based.exceptions import FileBasedSourceError, SchemaInferenceError
+from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 from unit_tests.sources.file_based.helpers import LowInferenceBytesJsonlParser, LowInferenceLimitDiscoveryPolicy
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder
 
@@ -367,7 +368,7 @@ invalid_jsonl_scenario = (
         {"data": {"col1": "val1", "_ab_source_file_last_modified": "2023-06-05T03:54:07.000000Z",
                   "_ab_source_file_url": "a.jsonl"}, "stream": "stream1"},
     ])
-    .set_expected_discover_error(SchemaInferenceError, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
+    .set_expected_discover_error(AirbyteTracedException, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
     .set_expected_logs(
         {
             "read": [

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/jsonl_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/jsonl_scenarios.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from airbyte_cdk.sources.file_based.exceptions import FileBasedSourceError, SchemaInferenceError
+from airbyte_cdk.sources.file_based.exceptions import FileBasedSourceError
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 from unit_tests.sources.file_based.helpers import LowInferenceBytesJsonlParser, LowInferenceLimitDiscoveryPolicy
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/parquet_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/parquet_scenarios.py
@@ -6,7 +6,7 @@ import datetime
 import decimal
 
 import pyarrow as pa
-from airbyte_cdk.sources.file_based.exceptions import SchemaInferenceError
+from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 from unit_tests.sources.file_based.in_memory_files_source import TemporaryParquetFilesStreamReader
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder
 
@@ -730,7 +730,7 @@ parquet_with_invalid_config_scenario = (
             "message": "Error parsing record"
         }
     ]})
-    .set_expected_discover_error(SchemaInferenceError, "Error inferring schema from files")
+    .set_expected_discover_error(AirbyteTracedException, "Error inferring schema from files")
     .set_expected_catalog(
         {
             "streams": [

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -13,6 +13,7 @@ from _pytest.reports import ExceptionInfo
 from airbyte_cdk.entrypoint import launch
 from airbyte_cdk.logger import AirbyteLogFormatter
 from airbyte_cdk.models import SyncMode
+from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 from freezegun import freeze_time
 from pytest import LogCaptureFixture
 from unit_tests.sources.file_based.scenarios.avro_scenarios import (
@@ -422,4 +423,6 @@ def make_file(path: Path, file_contents: Optional[Union[Mapping[str, Any], List[
 
 
 def get_error_message_from_exc(exc: ExceptionInfo[Any]) -> str:
+    if isinstance(exc.value, AirbyteTracedException):
+        return exc.value.message
     return str(exc.value.args[0])


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/oncall/issues/2838 where glob patterns that didn't match any file would create Sentry issues. We want this to be config errors. 

The same applies for malformed files (JSONL and CSV are covered in this PR) and empty schemas

## How
Raise exceptions from threads and raise an `AirbyteTracedException` when it makes sense