### PR TITLE
Use shallow clone in local deployment

### DIFF
--- a/docs/deploying-airbyte/local-deployment.md
+++ b/docs/deploying-airbyte/local-deployment.md
@@ -12,7 +12,7 @@ These instructions have been tested on MacOS, Windows 10 and Ubuntu 22.04.
 
 ```bash
 # clone Airbyte from GitHub
-git clone https://github.com/airbytehq/airbyte.git
+git clone --depth=1 https://github.com/airbytehq/airbyte.git
 
 # switch into Airbyte directory
 cd airbyte
@@ -56,7 +56,7 @@ Make sure to select the options:
 **3. You're done!**
 
 ```bash
-git clone https://github.com/airbytehq/airbyte.git
+git clone --depth=1 https://github.com/airbytehq/airbyte.git
 cd airbyte
 bash run-ab-platform.sh
 ```


### PR DESCRIPTION
## What

Airbyte repo is getting big and not all of us require all the commit history for local deployment.

## How

Use `git clone --depth=1` when cloning the repository which truncates the commit history to just 1 commit. (Faster clone)