### PR TITLE
Move connectorAcceptanceTest skip to IntegrationTests:GradleTask

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/gradle.py
@@ -23,7 +23,7 @@ class GradleTask(Step, ABC):
         title (str): The step title.
     """
 
-    DEFAULT_TASKS_TO_EXCLUDE = ["assemble", "airbyteDocker", "connectorAcceptanceTest"]
+    DEFAULT_TASKS_TO_EXCLUDE = ["assemble", "airbyteDocker"]
     BIND_TO_DOCKER_HOST = True
     gradle_task_name: ClassVar
     gradle_task_options: Tuple[str, ...] = ()

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/java_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/java_connectors.py
@@ -25,6 +25,10 @@ class IntegrationTests(GradleTask):
     gradle_task_name = "integrationTest"
     title = "Java Connector Integration Tests"
 
+    # skip the connector acceptance tests run by gradle
+    # as we run them in the AcceptanceTests step
+    gradle_task_options = ("-x", "connectorAcceptanceTest")
+
     async def _load_normalization_image(self, normalization_tar_file: File):
         normalization_image_tag = f"{self.context.connector.normalization_repository}:dev"
         self.context.logger.info("Load the normalization image to the docker host.")


### PR DESCRIPTION
## Overview
Fixes an issue with the build step where a gradle command will fail if a task that it has been asked to skip does not exist.

## Appendix
Alternative solutions were to modify the gradle file itself but that seems like too much bug surface area to me
https://stackoverflow.com/questions/60616066/skip-a-task-in-gradle-but-only-if-the-task-exists