### PR TITLE
Registry: Only delete latest registry entries

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -446,10 +446,15 @@ def registry_entry(context: OpExecutionContext, metadata_entry: Optional[LatestM
         for registry_name in enabled_registries
     }
 
-    deleted_registry_entries = {
-        registry_name: delete_registry_entry(registry_name, metadata_entry, root_metadata_directory_manager)
-        for registry_name in disabled_registries
-    }
+    # Only delete the registry entry if it is the latest version
+    # This is to preserve any registry specific overrides even if they were removed
+    deleted_registry_entries = {}
+    if metadata_entry.is_latest_version_path:
+        context.log.debug(f"Deleting previous registry entries enabled {metadata_entry.file_path}")
+        deleted_registry_entries = {
+            registry_name: delete_registry_entry(registry_name, metadata_entry, root_metadata_directory_manager)
+            for registry_name in disabled_registries
+        }
 
     dagster_metadata_persist = {
         f"create_{registry_name}": MetadataValue.url(registry_url) for registry_name, registry_url in persisted_registry_entries.items()

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/models/metadata.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/models/metadata.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from dataclasses import dataclass
 from typing import Any, Optional, Tuple
 
+from metadata_service.constants import METADATA_FILE_NAME
 from metadata_service.models.generated.ConnectorMetadataDefinitionV0 import ConnectorMetadataDefinitionV0
 from pydantic import BaseModel, ValidationError
 
@@ -51,3 +51,11 @@ class LatestMetadataEntry(BaseModel):
     icon_url: Optional[str] = None
     bucket_name: Optional[str] = None
     file_path: Optional[str] = None
+
+    @property
+    def is_latest_version_path(self) -> bool:
+        """
+        Path is considered a latest version path if the subfolder containing METADATA_FILE_NAME is "latest"
+        """
+        ending_path = f"latest/{METADATA_FILE_NAME}"
+        return self.file_path.endswith(ending_path)


### PR DESCRIPTION
## Overview
Quick fix to resolve a race condition where the processing of the versioned strict encrypt would sometimes cause the prerelease overrides to be overwritten

closes #30221