### PR TITLE
OC: rollback typeform to 1.0.0 on cloud

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -5,7 +5,7 @@ data:
   registries:
     cloud:
       enabled: true
-      dockerImageTag: 1.1.0
+      dockerImageTag: 1.0.0
     oss:
       enabled: true
   connectorSubtype: api


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

Rollsback typeform on Cloud due to a KeyError issue on existing connections.
