### PR TITLE
airbyte-ci: group shell commands for better layering

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -403,6 +403,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                        | Description                                                                                               |
 |---------| --------------------------------------------------------- |-----------------------------------------------------------------------------------------------------------|
+| 1.1.2   | [#30279](https://github.com/airbytehq/airbyte/pull/30279) | Fix correctness issues in layer caching by making atomic execution groupings                              |
 | 1.1.1   | [#30252](https://github.com/airbytehq/airbyte/pull/30252) | Fix redundancies and broken logic in GradleTask, to speed up the CI runs.                                 |
 | 1.1.0   | [#29509](https://github.com/airbytehq/airbyte/pull/29509) | Refactor the airbyte-ci test command to run tests on any poetry package.                                  |
 | 1.0.0   | [#28000](https://github.com/airbytehq/airbyte/pull/29232) | Remove release stages in favor of support level from airbyte-ci.                                          |

--- a/airbyte-ci/connectors/pipelines/pipelines/commands/groups/tests.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/commands/groups/tests.py
@@ -13,6 +13,7 @@ import sys
 import anyio
 import click
 import dagger
+from pipelines.consts import DOCKER_VERSION
 from pipelines.utils import sh_dash_c
 
 
@@ -65,7 +66,7 @@ async def run_test(poetry_package_path: str, test_directory: str) -> bool:
                         ]
                     )
                 )
-                .with_env_variable("VERSION", "24.0.2")
+                .with_env_variable("VERSION", DOCKER_VERSION)
                 .with_exec(sh_dash_c(["curl -fsSL https://get.docker.com | sh"]))
                 .with_mounted_directory(
                     "/airbyte",

--- a/airbyte-ci/connectors/pipelines/pipelines/commands/groups/tests.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/commands/groups/tests.py
@@ -13,6 +13,7 @@ import sys
 import anyio
 import click
 import dagger
+from pipelines.utils import sh_dash_c
 
 
 @click.command()
@@ -52,14 +53,20 @@ async def run_test(poetry_package_path: str, test_directory: str) -> bool:
             pytest_container = await (
                 dagger_client.container()
                 .from_("python:3.10.12")
-                .with_exec(["apt-get", "update"])
-                .with_exec(["apt-get", "install", "-y", "bash", "git", "curl"])
-                .with_env_variable("VERSION", "24.0.2")
-                .with_exec(["sh", "-c", "curl -fsSL https://get.docker.com | sh"])
-                .with_exec(["pip", "install", "pipx"])
-                .with_exec(["pipx", "ensurepath"])
                 .with_env_variable("PIPX_BIN_DIR", "/usr/local/bin")
-                .with_exec(["pipx", "install", "poetry"])
+                .with_exec(
+                    sh_dash_c(
+                        [
+                            "apt-get update",
+                            "apt-get install -y bash git curl",
+                            "pip install pipx",
+                            "pipx ensurepath",
+                            "pipx install poetry",
+                        ]
+                    )
+                )
+                .with_env_variable("VERSION", "24.0.2")
+                .with_exec(sh_dash_c(["curl -fsSL https://get.docker.com | sh"]))
                 .with_mounted_directory(
                     "/airbyte",
                     dagger_client.host().directory(

--- a/airbyte-ci/connectors/pipelines/pipelines/git.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/git.py
@@ -6,6 +6,7 @@ from dagger import Client, Directory, Secret
 from pipelines.actions import environments
 from pipelines.bases import Step, StepResult
 from pipelines.github import AIRBYTE_GITHUB_REPO
+from pipelines.utils import sh_dash_c
 
 
 class GitPushChanges(Step):
@@ -109,7 +110,7 @@ class GitPushEmptyCommit(GitPushChanges):
             .with_mounted_directory("/airbyte", self.airbyte_repo)
             .with_workdir("/airbyte")
             .with_exec(["git", "checkout", self.git_branch])
-            .with_exec(["sh", "-c", "git remote set-url origin $AUTHENTICATED_REPO_URL"])
+            .with_exec(sh_dash_c(["git remote set-url origin $AUTHENTICATED_REPO_URL"]))
             .with_exec(["git", "commit", "--allow-empty", "-m", self.get_commit_message(commit_message, skip_ci)])
             .with_exec(["git", "pull", "--rebase", "origin", self.git_branch])
             .with_exec(["git", "push"])

--- a/airbyte-ci/connectors/pipelines/pipelines/utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/utils.py
@@ -623,6 +623,11 @@ def upload_to_gcs(file_path: Path, bucket_name: str, object_name: str, credentia
     return gcs_uri, public_url
 
 
+def sh_dash_c(lines: List[str]) -> List[str]:
+    """Wrap sequence of commands in shell for safe usage of dagger Container's with_exec method."""
+    return ["sh", "-c", " && ".join(["set -o xtrace"] + lines)]
+
+
 def transform_strs_to_paths(str_paths: List[str]) -> List[Path]:
     """Transform a list of string paths to a list of Path objects.
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.1.1"
+version = "1.1.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_utils.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_utils.py
@@ -181,3 +181,9 @@ async def test_check_path_in_workdir(dagger_client):
     assert await utils.check_path_in_workdir(container, "setup.py")
     assert await utils.check_path_in_workdir(container, "requirements.txt")
     assert await utils.check_path_in_workdir(container, "not_existing_file") is False
+
+
+def test_sh_dash_c():
+    assert utils.sh_dash_c(["foo", "bar"]) == ["sh", "-c", "set -o xtrace && foo && bar"]
+    assert utils.sh_dash_c(["foo"]) == ["sh", "-c", "set -o xtrace && foo"]
+    assert utils.sh_dash_c([]) == ["sh", "-c", "set -o xtrace"]


### PR DESCRIPTION
This PR introduces a `sh_dash_c` utility function to pass to `.with_exec` to avoid chaining these in cases where we actually want the commands to pass or fail atomically.

The commands are grouped together by &&-ing them and the group is prefixed with a `set -o xtrace` which makes the logs easier to understand.

Fixes https://github.com/airbytehq/airbyte/issues/29735