### PR TITLE
Remediates OS vulnerabilities for Snowflake normalization - Premium support

### DIFF
--- a/airbyte-integrations/bases/base-normalization/snowflake.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/snowflake.Dockerfile
@@ -44,7 +44,9 @@ WORKDIR /airbyte/base_python_structs
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code
-RUN pip install .
+RUN pip install . && \
+    # patch for https://nvd.nist.gov/vuln/detail/CVE-2023-30608
+    pip install sqlparse==0.4.4
 
 WORKDIR /airbyte/normalization_code/dbt-template/
 # Download external dbt dependencies
@@ -56,11 +58,6 @@ ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
 LABEL io.airbyte.version=0.2.5
 LABEL io.airbyte.name=airbyte/normalization-snowflake
-
-# patch for https://nvd.nist.gov/vuln/detail/CVE-2023-30608
-RUN pip install sqlparse==0.4.4 && \
-    # ensures `yaml` module is found
-    pip install "Cython<3.0" "PyYAML==5.4" --no-build-isolation
 
 RUN pip uninstall setuptools -y && \
     PATH=$ROOTPATH pip uninstall setuptools -y && \

--- a/airbyte-integrations/bases/base-normalization/snowflake.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/snowflake.Dockerfile
@@ -1,8 +1,33 @@
-FROM fishtownanalytics/dbt:1.0.0
+FROM python:3.9-alpine3.18
+
+RUN apk add --update --no-cache \
+    build-base \
+    openssl-dev \
+    libffi-dev \
+    zlib-dev \
+    bzip2-dev \
+    bash \
+    git
+
+ENV ROOTPATH="/usr/local/bin:$PATH"
+ENV REQUIREPATH="/opt/.venv/bin:$PATH"
+
+RUN PATH=$ROOTPATH python -m venv /opt/.venv
+
+ENV PATH=$REQUIREPATH
+
+RUN pip install --upgrade pip setuptools wheel
+
+# workaround for https://github.com/yaml/pyyaml/issues/601
+# this should be fixed in the airbyte/base-airbyte-protocol-python image
+RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation && \
+    pip install snowflake-connector-python --no-use-pep517 && \
+    pip install dbt-core dbt-snowflake --no-build-isolation
+
 COPY --from=airbyte/base-airbyte-protocol-python:0.1.1 /airbyte /airbyte
 
 # Install SSH Tunneling dependencies
-RUN apt-get update && apt-get install -y jq sshpass
+RUN apk add --update jq sshpass
 
 WORKDIR /airbyte
 COPY entrypoint.sh .
@@ -16,11 +41,6 @@ COPY dbt-project-template-snowflake/* ./dbt-template/
 
 # Install python dependencies
 WORKDIR /airbyte/base_python_structs
-
-# workaround for https://github.com/yaml/pyyaml/issues/601
-# this should be fixed in the airbyte/base-airbyte-protocol-python image
-RUN pip install "Cython<3.0" "pyyaml==5.4" --no-build-isolation
-
 RUN pip install .
 
 WORKDIR /airbyte/normalization_code
@@ -28,7 +48,7 @@ RUN pip install .
 
 WORKDIR /airbyte/normalization_code/dbt-template/
 # Download external dbt dependencies
-RUN dbt deps
+RUN touch profiles.yml && dbt deps --profiles-dir .
 
 WORKDIR /airbyte
 ENV AIRBYTE_ENTRYPOINT "/airbyte/entrypoint.sh"
@@ -36,3 +56,14 @@ ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
 LABEL io.airbyte.version=0.2.5
 LABEL io.airbyte.name=airbyte/normalization-snowflake
+
+# patch for https://nvd.nist.gov/vuln/detail/CVE-2023-30608
+RUN pip install sqlparse==0.4.4 && \
+    # ensures `yaml` module is found
+    pip install "Cython<3.0" "PyYAML==5.4" --no-build-isolation
+
+RUN pip uninstall setuptools -y && \
+    PATH=$ROOTPATH pip uninstall setuptools -y && \
+    pip uninstall pip -y && \
+    PATH=$ROOTPATH pip uninstall pip -y && \
+    apk --purge del apk-tools py-pip


### PR DESCRIPTION
Remediates several OS vulnerabilities in `fishtownanalytics/dbt` image by replacing it with an alpine-based image.

<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Remediates several OS vulnerabilities in `fishtownanalytics/dbt` debian-based image.

Here is a list of some of the OS vulnerabilities our scanner identified:
CVE ID | Description
--- | ---
CVE-2018-25032 | zlib before 1.2.12 allows memory corruption when deflating (i.e., when compressing) if the input has many distant matches.
CVE-2021-22945 | When sending data to an MQTT server, libcurl <= 7.73.0 and 7.78.0 could in some circumstances erroneously keep a pointer to an already freed memory area and both use that again in a subsequent call to send data and also free it *again*.
CVE-2021-22946 | A user can tell curl >= 7.20.0 and <= 7.78.0 to require a successful upgrade to TLS when speaking to an IMAP, POP3 or FTP server (`--ssl-reqd` on the command line or`CURLOPT_USE_SSL` set to `CURLUSESSL_CONTROL` or `CURLUSESSL_ALL` withlibcurl). This requirement could be bypassed if the server would return a properly crafted but perfectly legitimate response.This flaw would then make curl silently continue its operations **withoutTLS** contrary to the instructions and expectations, exposing possibly sensitive data in clear text over the network.
CVE-2021-33574 | The mq_notify function in the GNU C Library (aka glibc) versions 2.32 and 2.33 has a use-after-free. It may use the notification thread attributes object (passed through its struct sigevent parameter) after it has been freed by the caller, leading to a denial of service (application crash) or possibly unspecified other impact.
CVE-2021-3999 | A flaw was found in glibc. An off-by-one buffer overflow and underflow in getcwd() may lead to memory corruption when the size of the buffer is exactly 1. A local attacker who can control the input buffer and size passed to getcwd() in a setuid program could use this flaw to potentially execute arbitrary code and escalate their privileges on the system.
CVE-2021-43618 | GNU Multiple Precision Arithmetic Library (GMP) through 6.2.1 has an mpz/inp_raw.c integer overflow and resultant buffer overflow via crafted input, leading to a segmentation fault on 32-bit platforms.
CVE-2021-45960 | In Expat (aka libexpat) before 2.4.3, a left shift by 29 (or more) places in the storeAtts function in xmlparse.c can lead to realloc misbehavior (e.g., allocating too few bytes, or only freeing memory).
CVE-2021-46143 | In doProlog in xmlparse.c in Expat (aka libexpat) before 2.4.3, an integer overflow exists for m_groupSize.
CVE-2021-46828 | In libtirpc before 1.3.3rc1, remote attackers could exhaust the file descriptors of a process that uses libtirpc because idle TCP connections are mishandled. This can, in turn, lead to an svc_run infinite loop without accepting new connections.
CVE-2021-46848 | GNU Libtasn1 before 4.19.0 has an ETYPE_OK off-by-one array size check that affects asn1_encode_simple_der.


## How
By replacing it with an alpine-based image.

## Recommended reading order
`snowflake.Dockerfile`

## 🚨 User Impact 🚨

No known breaking changes.

Smaller image sizes, less vulnerabilities. Normalization with this image is running without issues in our environment.

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
