### PR TITLE
destinations/platform interface sketch

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/iface/StreamDestination.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/iface/StreamDestination.java
@@ -1,0 +1,20 @@
+package io.airbyte.integrations.destination.snowflake.demo.file_based.iface;
+
+import java.io.File;
+
+public interface StreamDestination extends AutoCloseable {
+
+  /**
+   * Do any setup prior to writing data. For example, setting up destination tables, etc.
+   */
+  void setup() throws Exception;
+
+  /**
+   * Commit the data in this file to the destination. This method may consume additional
+   * memory proportional to the size of the incoming file and all uncommitted files,
+   * and/or the number of uncommitted files.
+   * <p>
+   * This method <b>MUST</b> be thread-safe.
+   */
+  void upload(File file, int numRecords, int numBytes) throws Exception;
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/iface/StreamDestination.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/iface/StreamDestination.java
@@ -16,5 +16,5 @@ public interface StreamDestination extends AutoCloseable {
    * <p>
    * This method <b>MUST</b> be thread-safe.
    */
-  void upload(File file, int numRecords, int numBytes) throws Exception;
+  void upload(String file, int numRecords, int numBytes) throws Exception;
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/iface/StreamDestinationFactory.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/iface/StreamDestinationFactory.java
@@ -1,0 +1,9 @@
+package io.airbyte.integrations.destination.snowflake.demo.file_based.iface;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig;
+
+public interface StreamDestinationFactory extends AutoCloseable {
+  void setup(JsonNode config);
+  StreamDestination build(StreamConfig stream);
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/platform/CsvV2RecordWriter.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/platform/CsvV2RecordWriter.java
@@ -1,0 +1,31 @@
+package io.airbyte.integrations.destination.snowflake.demo.file_based.platform;
+
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import java.util.UUID;
+
+/**
+ * Other implementations exist, e.g. avro, parquet, jsonl. Platform would provide generic implementations,
+ * though destinations could provide their own implementations if they want to do something fancy.
+ * <p>
+ * This implementation would write the DV2 CSV format (raw_id, extracted_at, data, loaded_at; loaded_at is always null).
+ */
+public class CsvV2RecordWriter implements RecordWriter {
+  private final String path;
+  private String filename;
+  @Override
+  public String getCurrentFilename() {
+    return path + "/" + filename + ".csv";
+  }
+
+  @Override
+  public void write(final AirbyteRecordMessage record) {
+    // do something like StagingDatabaseCsvSheetGenerator
+  }
+
+  @Override
+  public void rotateFile() {
+    // flush to the current file
+
+    filename = UUID.randomUUID().toString();
+  }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/platform/PlatformStuff.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/platform/PlatformStuff.java
@@ -68,15 +68,21 @@ public class PlatformStuff {
       switch (message.getType()) {
         case RECORD -> {
           // Write record to file, track memory, etc.
+          RecordWriter writer = streamWriters.get(message.getRecord().getStream());
+          writer.write(message.getRecord());
 
           // whenever we finish a file (either by reaching the target size, or by hitting a 15-minute deadline)
           // push it into the destination code
+          // This would need to actually be threadsafe; I'm writing it dumbly to keep the intentions clear.
           final boolean fileReadyToUpload = false;
           if (fileReadyToUpload) {
             final StreamDestination streamDestination = streamDestinations.get(message.getRecord().getStream());
-            streamDestination.upload(null, 42, 42);
+            streamDestination.upload(writer.getCurrentFilename(), 42, 42);
+
             // emit state messages
             // update last commit time = now()
+
+            writer.rotateFile();
           }
         }
         case STATE -> {

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/platform/PlatformStuff.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/platform/PlatformStuff.java
@@ -1,0 +1,97 @@
+package io.airbyte.integrations.destination.snowflake.demo.file_based.platform;
+
+import static java.util.stream.Collectors.toMap;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.integrations.base.destination.typing_deduping.CatalogParser;
+import io.airbyte.integrations.base.destination.typing_deduping.ParsedCatalog;
+import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig;
+import io.airbyte.integrations.base.destination.typing_deduping.StreamId;
+import io.airbyte.integrations.destination.snowflake.demo.file_based.iface.StreamDestination;
+import io.airbyte.integrations.destination.snowflake.demo.file_based.iface.StreamDestinationFactory;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class PlatformStuff {
+
+  private final ParsedCatalog catalog;
+  private final JsonNode config;
+  private final StreamDestinationFactory streamDestinationFactory;
+  private final Supplier<RecordWriter> recordWriterFactory;
+  private final int targetByteSizePerFile;
+
+  // There are probably a ton more parameters here. In reality we would make this a builder.
+  public PlatformStuff(final ConfiguredAirbyteCatalog inputCatalog,
+                       final JsonNode config,
+                       final StreamDestinationFactory streamDestinationFactory,
+                       final Supplier<RecordWriter> recordWriterFactory,
+                       final int targetByteSizePerFile) {
+    this.recordWriterFactory = recordWriterFactory;
+    // TODO: remove the sqlgenerator argument from this constructor
+    final CatalogParser parser = new CatalogParser(null);
+
+    this.catalog = parser.parseCatalog(inputCatalog);
+    this.config = config;
+    this.streamDestinationFactory = streamDestinationFactory;
+    this.targetByteSizePerFile = targetByteSizePerFile;
+  }
+
+  public void doTheSyncThing() throws Exception {
+    streamDestinationFactory.setup(config);
+
+    // Parallel maps :( the StreamDestination and RecordWriter should probably be bundled together under a single class.
+    // I'm guessing the existing async framework already does something like this.
+    final Map<StreamId, StreamDestination> streamDestinations = catalog.streams().stream()
+        .collect(toMap(
+            StreamConfig::id,
+            streamDestinationFactory::build
+        ));
+    final Map<StreamId, RecordWriter> streamWriters = catalog.streams().stream()
+        .collect(toMap(
+            StreamConfig::id,
+            stream -> recordWriterFactory.get()
+        ));
+
+    // do these setups in parallel.
+    for (final StreamDestination streamDestination : streamDestinations.values()) {
+      streamDestination.setup();
+    }
+
+    // while we have messages on stdin, process those messages
+    // This basically represents AsyncFlush, I just wanted to demo how it hooks into the destinations code.
+    while (true) {
+      // Read a thing from stdin
+      final AirbyteMessage message = null;
+
+      switch (message.getType()) {
+        case RECORD -> {
+          // Write record to file, track memory, etc.
+
+          // whenever we finish a file (either by reaching the target size, or by hitting a 15-minute deadline)
+          // push it into the destination code
+          final boolean fileReadyToUpload = false;
+          if (fileReadyToUpload) {
+            final StreamDestination streamDestination = streamDestinations.get(message.getRecord().getStream());
+            streamDestination.upload(null, 42, 42);
+            // emit state messages
+            // update last commit time = now()
+          }
+        }
+        case STATE -> {
+          // do the state stuff
+        }
+      }
+    }
+
+    // Close all the stream destinations.
+    // In reality, these should be done in parallel.
+    for (final StreamDestination streamDestination : streamDestinations.values()) {
+      streamDestination.close();
+    }
+
+    // Close any shared resources
+    streamDestinationFactory.close();
+  }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/platform/RecordWriter.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/platform/RecordWriter.java
@@ -1,0 +1,27 @@
+package io.airbyte.integrations.destination.snowflake.demo.file_based.platform;
+
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+
+/**
+ * Writes airbyte records to a local file (i.e. within the connector container).
+ * <p>
+ * I don't love this interface, it's mostly illustrative. The existing SerializedBuffer stuff is
+ * approximately equivalent - I just didn't want to wire up all the dependencies.
+ */
+public interface RecordWriter {
+
+  /**
+   * Get the name of the file we're currently writing to.
+   */
+  String getCurrentFilename();
+  /**
+   * Append a record to the current file. This method must be threadsafe.
+   */
+  void write(AirbyteRecordMessage record);
+
+  /**
+   * Flushes the current file and creates a new file. The new file must have a unique filename,
+   * for example using a UUID. This method must be threadsafe.
+   */
+  void rotateFile();
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/snowflake/SnowflakeDestination.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/snowflake/SnowflakeDestination.java
@@ -1,0 +1,31 @@
+package io.airbyte.integrations.destination.snowflake.demo.file_based.snowflake;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.integrations.destination.snowflake.demo.file_based.platform.CsvV2RecordWriter;
+import io.airbyte.integrations.destination.snowflake.demo.file_based.platform.PlatformStuff;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
+
+public class SnowflakeDestination {
+
+  public static void main(final String[] args) throws Exception {
+    final ConfiguredAirbyteCatalog inputCatalog = null;
+    final JsonNode inputConfig = null;
+
+    // Top-level destination code is our usual IOC setup. Instantiate the platform, configure it for
+    // this destination, and then run it.
+    // Might be a little tricky to wire this up directly within the jvm, but it's the easiest thing to describe
+    // and gives us an easy solution for old versions of platform. We could also define a new interface for destinations
+    // to implement, and have main() just call that method.
+    final PlatformStuff platform = new PlatformStuff(
+        inputCatalog,
+        inputConfig,
+        new SnowflakeStreamDestinationFactory(),
+        CsvV2RecordWriter::new,
+        // Various destination-specific parameters can be hardcoded here.
+        // For example, maybe Snowflake wants 200MB files.
+        200 * 1024 * 1024
+    );
+
+    platform.doTheSyncThing();
+  }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/snowflake/SnowflakeStreamDestination.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/snowflake/SnowflakeStreamDestination.java
@@ -1,0 +1,70 @@
+package io.airbyte.integrations.destination.snowflake.demo.file_based.snowflake;
+
+import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig;
+import io.airbyte.integrations.base.destination.typing_deduping.TypeAndDedupeOperationValve;
+import io.airbyte.integrations.base.destination.typing_deduping.TyperDeduper;
+import io.airbyte.integrations.destination.snowflake.demo.file_based.iface.StreamDestination;
+import java.io.File;
+
+public class SnowflakeStreamDestination implements StreamDestination {
+
+  private final String originalStreamName;
+  private final String originalStreamNamespace;
+  private final String rawTableSchema;
+  private final String rawTableName;
+  private final String finalTableSchema;
+  private final String finalTableName;
+  private final String stageName;
+  private final StreamConfig streamConfig;
+
+  private final TypeAndDedupeOperationValve tdValve;
+  private final TyperDeduper typerDeduper;
+
+  public SnowflakeStreamDestination(final StreamConfig stream, final TypeAndDedupeOperationValve tdValve, final TyperDeduper typerDeduper) {
+    this.originalStreamNamespace = stream.id().originalNamespace();
+    this.originalStreamName = stream.id().originalName();
+    this.rawTableName = originalStreamNamespace + "_raw__stream_" + originalStreamName;
+    // generate the other table/schema names, etc.
+
+    // also grab the T+D stuff. These are currently implemented for many-streams,
+    // so we would need to swap them to be single-stream objects.
+    this.tdValve = tdValve;
+    this.typerDeduper = typerDeduper;
+  }
+
+  @Override
+  public void setup() throws Exception {
+    // CREATE STAGE <stage>
+    // CREATE TABLE airbyte_internal.<rawTableName>
+
+    // T+D setup (create final table, etc.)
+    typerDeduper.prepareTables();
+  }
+
+  @Override
+  public void upload(final File file, final int numRecords, final int numBytes) throws Exception {
+    // Snowflake's T+D code isn't safe to run concurrently with COPY INTO. Lock out other threads.
+    typerDeduper.getRawTableWriteLock().lock();
+    try {
+      // TODO snowflake-jdbc opens a gcs/s3 upload object when running the PUT query - how can we track that memory usage?
+      // PUT file:///.... INTO STAGE <stage>
+      // COPY INTO <table> FROM STAGE <stage>
+    } finally {
+      typerDeduper.getRawTableWriteLock().lock();
+    }
+
+    if (tdValve.readyToTypeAndDedupe()) {
+      // typeAndDedupe is threadsafe, so we don't need to explicity lock here.
+      typerDeduper.typeAndDedupe(originalStreamNamespace, originalStreamName);
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    // PUT file:///.... INTO STAGE <stage>
+    // COPY INTO <table> FROM STAGE <stage>
+    // DROP STAGE <stage>
+
+    typerDeduper.typeAndDedupe(originalStreamNamespace, originalStreamName);
+  }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/snowflake/SnowflakeStreamDestination.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/snowflake/SnowflakeStreamDestination.java
@@ -42,7 +42,7 @@ public class SnowflakeStreamDestination implements StreamDestination {
   }
 
   @Override
-  public void upload(final File file, final int numRecords, final int numBytes) throws Exception {
+  public void upload(final String file, final int numRecords, final int numBytes) throws Exception {
     // Snowflake's T+D code isn't safe to run concurrently with COPY INTO. Lock out other threads.
     typerDeduper.getRawTableWriteLock().lock();
     try {

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/snowflake/SnowflakeStreamDestinationFactory.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/demo/file_based/snowflake/SnowflakeStreamDestinationFactory.java
@@ -1,0 +1,25 @@
+package io.airbyte.integrations.destination.snowflake.demo.file_based.snowflake;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig;
+import io.airbyte.integrations.destination.snowflake.demo.file_based.iface.StreamDestination;
+import io.airbyte.integrations.destination.snowflake.demo.file_based.iface.StreamDestinationFactory;
+
+public class SnowflakeStreamDestinationFactory implements StreamDestinationFactory {
+
+  @Override
+  public void setup(final JsonNode config) {
+    // open a connection pool, etc.
+  }
+
+  @Override
+  public StreamDestination build(final StreamConfig stream) {
+    // Pass the connection pool into this constructor
+    return new SnowflakeStreamDestination(stream, null, null);
+  }
+
+  @Override
+  public void close() throws Exception {
+    // close the connection pool, etc.
+  }
+}


### PR DESCRIPTION
from https://whimsical.com/architecture-LbgyoWp7fGXQDf3mfqnRZ3; see also https://github.com/airbytehq/airbyte/pull/30335

this looks pretty similar to the existing async framework / destinations interface. Major differences:
* The unit of work for destinations is explicitly a file on disk.
    * `PlatformStuff` is responsible for taking in record/state messages, writing the records to file, and calling destinations code to commit the file.
    * Destinations no longer needs to handle anything (with a big caveat) about buffering or state messages.
    * This works great for DB/DW destinations. Even traditional DBs (postgres, mysql) have the ability to copy a local file into a table.
        * for destinations where we can't upload a file for some reason, it's less great. We end up needing to reread from file, possibly deser stuff, and then do standard inserts.
    * It works fine for file destinations, where it's somewhat redundant (i.e. why not just write to GCS directly?)
    * It's maybe kind of dumb for message queue / API destinations, where we end up just reading records off of disk and shoving them somewhere else
* Destinations code is now stream-oriented.
    * I think this is obviously correct, but happy to summarize why if anyone is curious.

`iface` + `platform` directories are the core pieces. `snowflake` is a demo of what destination-snowflake would look like in this new world.

Open questions:
* `StreamDestination#upload` might consume additional memory. How can we tell platform about that? Is this actually relevant?