### PR TITLE
slash-commands: use GH_PAT_MAINTENANCE_OCTAVIA

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -19,7 +19,7 @@ jobs:
         id: scd
         uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           permission: write
           commands: |
             test


### PR DESCRIPTION
I believe the `Command 'legacy-test' is not configured for the user's permission level 'none'.` problem on test command execution is due to  the `GITHUB_TOKEN` use that does not have sufficient permission. 

Context: we made this workflow use `GITHUB_TOKEN` to workaround a global rate limiting issue on python install. If this workflow is the single one using the PAT_MAINTENANCE token the rate should be more reasonable.
