### PR TITLE
File-based CDK: update record parse error message

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
@@ -22,6 +22,8 @@ class FileBasedSourceError(Enum):
     ERROR_PARSING_RECORD = "Error parsing record. This could be due to a mismatch between the config's file type and the actual file type, or because the file or record is not parseable."
     ERROR_PARSING_USER_PROVIDED_SCHEMA = "The provided schema could not be transformed into valid JSON Schema."
     ERROR_VALIDATING_RECORD = "One or more records do not pass the schema validation policy. Please modify your input schema, or select a more lenient validation policy."
+    ERROR_PARSING_RECORD_MISMATCHED_COLUMNS = "A header field has resolved to `None`. This indicates that the CSV has more rows than the number of header fields. If you input your schema or headers, please verify that the number of columns corresponds to the number of columns in your CSV's rows."
+    ERROR_PARSING_RECORD_MISMATCHED_ROWS = "A row's value has resolved to `None`. This indicates that the CSV has more columns in the header field than the number of columns in the row(s). If you input your schema or headers, please verify that the number of columns corresponds to the number of columns in your CSV's rows."
     STOP_SYNC_PER_SCHEMA_VALIDATION_POLICY = (
         "Stopping sync in accordance with the configured validation policy. Records in file did not conform to the schema."
     )


### PR DESCRIPTION
Update the record parse error messages that arise when there's a mismatch between the number of header fields and the number of columns in a row for a given CSV.

Related: https://github.com/airbytehq/oncall/issues/2923.