### PR TITLE
fetch resume token once

### DIFF
--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbCdcTargetPosition.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbCdcTargetPosition.java
@@ -46,7 +46,7 @@ public class MongoDbCdcTargetPosition implements CdcTargetPosition<BsonTimestamp
    *         database.
    */
   public static MongoDbCdcTargetPosition targetPosition(final MongoClient mongoClient) {
-    final BsonDocument resumeToken = MongoDbResumeTokenHelper.getResumeToken(mongoClient);
+    final BsonDocument resumeToken = MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient);
     return new MongoDbCdcTargetPosition(resumeToken);
   }
 

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbCdcTargetPosition.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbCdcTargetPosition.java
@@ -6,7 +6,6 @@ package io.airbyte.integrations.debezium.internals.mongodb;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
-import com.mongodb.client.MongoClient;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.debezium.CdcTargetPosition;
 import io.airbyte.integrations.debezium.internals.ChangeEventWithMetadata;
@@ -35,19 +34,6 @@ public class MongoDbCdcTargetPosition implements CdcTargetPosition<BsonTimestamp
 
   public MongoDbCdcTargetPosition(final BsonDocument resumeToken) {
     this.resumeTokenTimestamp = ResumeTokens.getTimestamp(resumeToken);
-  }
-
-  /**
-   * Constructs a new {@link MongoDbCdcTargetPosition} by fetching the most recent resume token from
-   * the MongoDB database.
-   *
-   * @param mongoClient A {@link MongoClient} used to retrieve the resume token.
-   * @return The {@link MongoDbCdcTargetPosition} set to the most recent resume token present in the
-   *         database.
-   */
-  public static MongoDbCdcTargetPosition targetPosition(final MongoClient mongoClient) {
-    final BsonDocument resumeToken = MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient);
-    return new MongoDbCdcTargetPosition(resumeToken);
   }
 
   @VisibleForTesting

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbDebeziumStateUtil.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbDebeziumStateUtil.java
@@ -58,9 +58,8 @@ public class MongoDbDebeziumStateUtil {
    * @return The initial Debezium offset state storage document as a {@link JsonNode}.
    * @throws IllegalStateException if unable to determine the replica set.
    */
-  public JsonNode constructInitialDebeziumState(final MongoClient mongoClient, final String serverId) {
+  public JsonNode constructInitialDebeziumState(final BsonDocument resumeToken, final MongoClient mongoClient, final String serverId) {
     final String replicaSet = getReplicaSetName(mongoClient);
-    final BsonDocument resumeToken = MongoDbResumeTokenHelper.getResumeToken(mongoClient);
     final JsonNode state = formatState(serverId, replicaSet, ((BsonString) ResumeTokens.getData(resumeToken)).getValue());
     LOGGER.info("Initial Debezium state constructed: {}", state);
     return state;
@@ -116,7 +115,7 @@ public class MongoDbDebeziumStateUtil {
 
     final ChangeStreamIterable<BsonDocument> stream = mongoClient.watch(BsonDocument.class);
     stream.resumeAfter(savedOffset);
-    try (var ignored = stream.cursor()) {
+    try (final var ignored = stream.cursor()) {
       LOGGER.info("Valid resume token '{}' present.  Incremental sync will be performed for up-to-date streams.",
           ResumeTokens.getData(savedOffset).asString().getValue());
       return true;

--- a/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbResumeTokenHelper.java
+++ b/airbyte-integrations/bases/debezium/src/main/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbResumeTokenHelper.java
@@ -29,7 +29,7 @@ public class MongoDbResumeTokenHelper {
    * @param mongoClient The {@link MongoClient} used to query the MongoDB server.
    * @return The most recent resume token value.
    */
-  public static BsonDocument getResumeToken(final MongoClient mongoClient) {
+  public static BsonDocument getMostRecentResumeToken(final MongoClient mongoClient) {
     final ChangeStreamIterable<BsonDocument> eventStream = mongoClient.watch(BsonDocument.class);
     try (final MongoChangeStreamCursor<ChangeStreamDocument<BsonDocument>> eventStreamCursor = eventStream.cursor()) {
       /*

--- a/airbyte-integrations/bases/debezium/src/test/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbCdcTargetPositionTest.java
+++ b/airbyte-integrations/bases/debezium/src/test/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbCdcTargetPositionTest.java
@@ -48,7 +48,7 @@ class MongoDbCdcTargetPositionTest {
     when(changeStreamIterable.cursor()).thenReturn(mongoChangeStreamCursor);
     when(mongoClient.watch(BsonDocument.class)).thenReturn(changeStreamIterable);
 
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
     assertNotNull(targetPosition);
     assertEquals(ResumeTokens.getTimestamp(resumeTokenDocument), targetPosition.getResumeTokenTimestamp());
   }
@@ -70,7 +70,7 @@ class MongoDbCdcTargetPositionTest {
     when(mongoClient.watch(BsonDocument.class)).thenReturn(changeStreamIterable);
 
     final ChangeEventWithMetadata changeEventWithMetadata = new ChangeEventWithMetadata(changeEvent);
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
     assertTrue(targetPosition.reachedTargetPosition(changeEventWithMetadata));
 
     when(changeEvent.value()).thenReturn(changeEventJson.replaceAll("\"ts_ms\": \\d+,", "\"ts_ms\": 1590221043000,"));
@@ -95,7 +95,7 @@ class MongoDbCdcTargetPositionTest {
     when(mongoClient.watch(BsonDocument.class)).thenReturn(changeStreamIterable);
 
     final ChangeEventWithMetadata changeEventWithMetadata = new ChangeEventWithMetadata(changeEvent);
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
     assertFalse(targetPosition.reachedTargetPosition(changeEventWithMetadata));
   }
 
@@ -116,7 +116,7 @@ class MongoDbCdcTargetPositionTest {
     when(mongoClient.watch(BsonDocument.class)).thenReturn(changeStreamIterable);
 
     final ChangeEventWithMetadata changeEventWithMetadata = new ChangeEventWithMetadata(changeEvent);
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
     assertTrue(targetPosition.reachedTargetPosition(changeEventWithMetadata));
   }
 
@@ -132,7 +132,7 @@ class MongoDbCdcTargetPositionTest {
     when(changeStreamIterable.cursor()).thenReturn(mongoChangeStreamCursor);
     when(mongoClient.watch(BsonDocument.class)).thenReturn(changeStreamIterable);
 
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
     final BsonTimestamp heartbeatTimestamp = new BsonTimestamp(
         Long.valueOf(ResumeTokens.getTimestamp(resumeTokenDocument).getTime() + TimeUnit.HOURS.toSeconds(1)).intValue(),
         0);
@@ -153,7 +153,7 @@ class MongoDbCdcTargetPositionTest {
     when(changeStreamIterable.cursor()).thenReturn(mongoChangeStreamCursor);
     when(mongoClient.watch(BsonDocument.class)).thenReturn(changeStreamIterable);
 
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
 
     assertTrue(targetPosition.isHeartbeatSupported());
   }
@@ -171,7 +171,7 @@ class MongoDbCdcTargetPositionTest {
     when(changeStreamIterable.cursor()).thenReturn(mongoChangeStreamCursor);
     when(mongoClient.watch(BsonDocument.class)).thenReturn(changeStreamIterable);
 
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
 
     final Map<String, ?> sourceOffset = Map.of(MongoDbDebeziumConstants.ChangeEvent.SOURCE_SECONDS, resumeTokenTimestamp.getTime(),
         MongoDbDebeziumConstants.ChangeEvent.SOURCE_ORDER, resumeTokenTimestamp.getInc(),
@@ -201,7 +201,7 @@ class MongoDbCdcTargetPositionTest {
     final Map<String, String> offset =
         Jsons.object(MongoDbDebeziumStateUtil.formatState(null, null, RESUME_TOKEN), new TypeReference<>() {});
 
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
     final boolean result = targetPosition.isEventAheadOffset(offset, changeEventWithMetadata);
     assertTrue(result);
   }
@@ -225,7 +225,7 @@ class MongoDbCdcTargetPositionTest {
     final Map<String, String> offsetC =
         Jsons.object(MongoDbDebeziumStateUtil.formatState(null, null, OTHER_RESUME_TOKEN), new TypeReference<>() {});
 
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
 
     assertTrue(targetPosition.isSameOffset(offsetA, offsetA));
     assertTrue(targetPosition.isSameOffset(offsetA, offsetB));

--- a/airbyte-integrations/bases/debezium/src/test/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbDebeziumStateUtilTest.java
+++ b/airbyte-integrations/bases/debezium/src/test/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbDebeziumStateUtilTest.java
@@ -65,12 +65,8 @@ class MongoDbDebeziumStateUtilTest {
   @Test
   void testConstructInitialDebeziumState() {
     final String database = DATABASE;
-    final String replicaSet = REPLICA_SET;
     final String resumeToken = RESUME_TOKEN;
     final BsonDocument resumeTokenDocument = ResumeTokens.fromData(resumeToken);
-    final ChangeStreamIterable<BsonDocument> changeStreamIterable = mock(ChangeStreamIterable.class);
-    final MongoChangeStreamCursor<ChangeStreamDocument<BsonDocument>> mongoChangeStreamCursor =
-        mock(MongoChangeStreamCursor.class);
     final ServerDescription serverDescription = mock(ServerDescription.class);
     final ClusterDescription clusterDescription = mock(ClusterDescription.class);
     final MongoClient mongoClient = mock(MongoClient.class);
@@ -80,16 +76,12 @@ class MongoDbDebeziumStateUtilTest {
         MongoDbDebeziumConstants.Configuration.CONNECTION_STRING_CONFIGURATION_KEY, "mongodb://host:12345/",
         MongoDbDebeziumConstants.Configuration.DATABASE_CONFIGURATION_KEY, database));
 
-    when(mongoChangeStreamCursor.getResumeToken()).thenReturn(resumeTokenDocument);
-    when(changeStreamIterable.cursor()).thenReturn(mongoChangeStreamCursor);
     when(serverDescription.getSetName()).thenReturn(REPLICA_SET);
     when(clusterDescription.getServerDescriptions()).thenReturn(List.of(serverDescription));
     when(clusterDescription.getType()).thenReturn(ClusterType.REPLICA_SET);
-    when(mongoClient.watch(BsonDocument.class)).thenReturn(changeStreamIterable);
     when(mongoClient.getClusterDescription()).thenReturn(clusterDescription);
 
-    final JsonNode initialState = mongoDbDebeziumStateUtil.constructInitialDebeziumState(mongoClient,
-        database);
+    final JsonNode initialState = mongoDbDebeziumStateUtil.constructInitialDebeziumState(resumeTokenDocument, mongoClient, database);
 
     assertNotNull(initialState);
     assertEquals(1, initialState.size());
@@ -113,24 +105,16 @@ class MongoDbDebeziumStateUtilTest {
 
   @Test
   void testConstructInitialDebeziumStateMissingReplicaSet() {
-    final String database = DATABASE;
-    final String resumeToken = RESUME_TOKEN;
-    final BsonDocument resumeTokenDocument = ResumeTokens.fromData(resumeToken);
-    final ChangeStreamIterable<BsonDocument> changeStreamIterable = mock(ChangeStreamIterable.class);
-    final MongoChangeStreamCursor<ChangeStreamDocument<BsonDocument>> mongoChangeStreamCursor =
-        mock(MongoChangeStreamCursor.class);
+    final BsonDocument resumeTokenDocument = ResumeTokens.fromData(RESUME_TOKEN);
     final ServerDescription serverDescription = mock(ServerDescription.class);
     final ClusterDescription clusterDescription = mock(ClusterDescription.class);
     final MongoClient mongoClient = mock(MongoClient.class);
 
-    when(mongoChangeStreamCursor.getResumeToken()).thenReturn(resumeTokenDocument);
-    when(changeStreamIterable.cursor()).thenReturn(mongoChangeStreamCursor);
     when(clusterDescription.getServerDescriptions()).thenReturn(List.of(serverDescription));
     when(clusterDescription.getType()).thenReturn(ClusterType.REPLICA_SET);
-    when(mongoClient.watch(BsonDocument.class)).thenReturn(changeStreamIterable);
     when(mongoClient.getClusterDescription()).thenReturn(clusterDescription);
 
-    assertThrows(IllegalStateException.class, () -> mongoDbDebeziumStateUtil.constructInitialDebeziumState(mongoClient, database));
+    assertThrows(IllegalStateException.class, () -> mongoDbDebeziumStateUtil.constructInitialDebeziumState(resumeTokenDocument, mongoClient, DATABASE));
   }
 
   @Test

--- a/airbyte-integrations/bases/debezium/src/test/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbResumeTokenHelperTest.java
+++ b/airbyte-integrations/bases/debezium/src/test/java/io/airbyte/integrations/debezium/internals/mongodb/MongoDbResumeTokenHelperTest.java
@@ -39,7 +39,7 @@ class MongoDbResumeTokenHelperTest {
     when(changeStreamIterable.cursor()).thenReturn(mongoChangeStreamCursor);
     when(mongoClient.watch(BsonDocument.class)).thenReturn(changeStreamIterable);
 
-    final BsonDocument actualResumeToken = MongoDbResumeTokenHelper.getResumeToken(mongoClient);
+    final BsonDocument actualResumeToken = MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient);
     assertEquals(resumeTokenDocument, actualResumeToken);
   }
 

--- a/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test-integration/java/io/airbyte/integrations/source/mongodb/MongoDbSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-internal-poc/src/test-integration/java/io/airbyte/integrations/source/mongodb/MongoDbSourceAcceptanceTest.java
@@ -346,7 +346,7 @@ class MongoDbSourceAcceptanceTest extends SourceAcceptanceTest {
     validateAllStreamsComplete(stateMessages2, List.of(
         new StreamDescriptor().withName(collectionName).withNamespace(databaseName)));
 
-    var idFilter = new Document(DOCUMENT_ID_FIELD, insertedId);
+    final var idFilter = new Document(DOCUMENT_ID_FIELD, insertedId);
     mongoClient.getDatabase(databaseName).getCollection(collectionName).updateOne(idFilter, Updates.combine(Updates.set("newField", "new")));
 
     // Start another sync that finds the update change
@@ -476,7 +476,7 @@ class MongoDbSourceAcceptanceTest extends SourceAcceptanceTest {
   void testReachedTargetPosition() {
     final long eventTimestamp = Long.MAX_VALUE;
     final Integer order = 0;
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
     final ChangeEventWithMetadata changeEventWithMetadata = mock(ChangeEventWithMetadata.class);
 
     when(changeEventWithMetadata.isSnapshotEvent()).thenReturn(true);
@@ -503,8 +503,8 @@ class MongoDbSourceAcceptanceTest extends SourceAcceptanceTest {
 
   @Test
   void testIsSameOffset() {
-    final MongoDbCdcTargetPosition targetPosition = MongoDbCdcTargetPosition.targetPosition(mongoClient);
-    final BsonDocument resumeToken = MongoDbResumeTokenHelper.getResumeToken(mongoClient);
+    final MongoDbCdcTargetPosition targetPosition = new MongoDbCdcTargetPosition(MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient));
+    final BsonDocument resumeToken = MongoDbResumeTokenHelper.getMostRecentResumeToken(mongoClient);
     final String resumeTokenString = resumeToken.get("_data").asString().getValue();
     final String replicaSet = MongoDbDebeziumStateUtil.getReplicaSetName(mongoClient);
     final Map<String, String> emptyOffsetA = Map.of();


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
if we fetch the resume token for the target position and the initial state in the wrong order then we could have issues. To try to avoid this, we are now using the exact same resume token for both cases

## How
Get the most recent resume token in the `MongoDbCdcInitializer` and use that one to build the initial state and the target position

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
