### PR TITLE
gradle docker: skip if not dev image

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-docker.gradle
+++ b/buildSrc/src/main/groovy/airbyte-docker.gradle
@@ -158,6 +158,10 @@ class AirbyteDockerTaskFactory {
             // Special case: this image is not built by this repo.
             return false
         }
+        if (!taggedImage.endsWith(":dev")) {
+            // Special case: this image is owned by this repo but built separate. e.g. source-file-secure
+            return false
+        }
         // Otherwise, assume the image is built by this repo.
         return true
     }


### PR DESCRIPTION
## Problem
Running gradle was broken as the airbyte docker plugin failed loudly when an airbyte dockerfile had a versioned base dependency

## Solution
Do not mark a project as a build dependency unless it starts with airbyte AND ends with dev