### PR TITLE
Gradle: Add base dependency to base java

### DIFF
--- a/airbyte-integrations/bases/base-java/build.gradle
+++ b/airbyte-integrations/bases/base-java/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation libs.airbyte.protocol
+    implementation project(':airbyte-integrations:bases:base')
     implementation project(':airbyte-config-oss:config-models-oss')
     implementation project(':airbyte-commons-cli')
     implementation project(':airbyte-json-validation')


### PR DESCRIPTION
## Problem
1. essentially base-java references airbyte/integration-base:dev in its dockerfile
1. but does not list it as a dependency in its gradle file

and This is where a disconnect occurs
1. our custom gradle task knows it should be a dependency (because it looks at the dockerfile)
1. but airbyte-ci does not know (because it looks at the build.settings file)
1. So it does not include the integration-base folder in its build env

## Solution
Add base to base java as a dependency in the gradle file