### PR TITLE
Source Amplitude: switch to latest cdk

### DIFF
--- a/airbyte-integrations/connectors/source-amplitude/Dockerfile
+++ b/airbyte-integrations/connectors/source-amplitude/Dockerfile
@@ -34,5 +34,5 @@ COPY source_amplitude ./source_amplitude
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.4
+LABEL io.airbyte.version=0.3.0
 LABEL io.airbyte.name=airbyte/source-amplitude

--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fa9f58c6-2d03-4237-aaa4-07d75e0c1396
-  dockerImageTag: 0.2.4
+  dockerImageTag: 0.3.0
   dockerRepository: airbyte/source-amplitude
   githubIssueLabel: source-amplitude
   icon: amplitude.svg

--- a/airbyte-integrations/connectors/source-amplitude/setup.py
+++ b/airbyte-integrations/connectors/source-amplitude/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk==0.33.0",
+    "airbyte-cdk",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-amplitude/source_amplitude/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/source_amplitude/manifest.yaml
@@ -1,4 +1,4 @@
-version: "0.29.0"
+version: "0.51.13"
 
 definitions:
   selector:

--- a/docs/integrations/sources/amplitude.md
+++ b/docs/integrations/sources/amplitude.md
@@ -43,6 +43,7 @@ The Amplitude connector ideally should gracefully handle Amplitude API limitatio
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
+| 0.3.0   | 2023-09-13 | [30378](https://github.com/airbytehq/airbyte/pull/30378) | Switch to latest CDK version                                                                              |
 | 0.2.4   | 2023-05-05 | [25842](https://github.com/airbytehq/airbyte/pull/25842) | added missing attrs in events schema, enabled default availability strategy                               |
 | 0.2.3   | 2023-04-20 | [25317](https://github.com/airbytehq/airbyte/pull/25317) | Refactor Events Stream, use pre-YAML version based on Python CDK                                          |
 | 0.2.2   | 2023-04-19 | [25315](https://github.com/airbytehq/airbyte/pull/25315) | Refactor to only fetch date_time_fields once per request                                                  |


### PR DESCRIPTION
## What
*https://github.com/airbytehq/airbyte/issues/29745*

## How
*Switch to latest cdk version*
