### PR TITLE
add rolling back oss instructions

### DIFF
--- a/docs/release_notes/upgrading_to_destinations_v2.md
+++ b/docs/release_notes/upgrading_to_destinations_v2.md
@@ -41,7 +41,12 @@ Whenever possible, we've taken this opportunity to use the best data type for st
 
 ## Quick Start to Upgrading
 
-**Self-hosted Airbyte users will need to be on at least version 0.50.24 of the Airbyte Platform.  Update the Airbyte Platform _before_ updating any of the connectors.**
+:::caution
+
+**[Airbyte Open Source Only]** You should upgrade to 0.50.24+ of the Airbyte Platform _before_ updating to Destinations V2. Failure to do so may cause upgraded connections to fail.
+
+:::
+
 
 The quickest path to upgrading is to click upgrade on any out-of-date connection in the UI:
 
@@ -55,11 +60,7 @@ After upgrading the out-of-date destination to a [Destinations V2 compatible ver
 4. The new raw tables will be typed and de-duplicated according to the Destinations V2 format.
 5. Once typing and de-duplication has completed successfully, your previous final table will be replaced with the updated data.
 
-:::caution
-
-Due to the amount of operations to be completed, this first sync after upgrading to Destination V2 **will be longer than normal**. Once your first sync has completed successfully, you may need to make changes to downstream models (dbt, sql, etc.) transforming data. See this [walkthrough of top changes to expect for more details](#updating-downstream-transformations).
-
-:::
+Due to the amount of operations to be completed, the first sync after upgrading to Destination V2 **will be longer than normal**. Once your first sync has completed successfully, you may need to make changes to downstream models (dbt, sql, etc.) transforming data. See this [walkthrough of top changes to expect for more details](#updating-downstream-transformations).
 
 Pre-existing raw tables, SCD tables and "unnested" tables will always be left untouched. You can delete these at your convenience, but these tables will no longer be kept up-to-date by Airbyte syncs.
 Each destination version is managed separately, so if you have multiple destinations, they all need to be upgraded one by one.
@@ -71,10 +72,6 @@ Versions are tied to the destination. When you update the destination, **all con
 - [Upgrading Connections One by One Using CDC](#upgrade-paths-for-connections-using-cdc)
 - [Upgrading as a User of Raw Tables](#upgrading-as-a-user-of-raw-tables)
 - [Rolling back to Legacy Normalization](#oss-only-rolling-back-to-legacy-normalization)
-
-:::info
-If you were a Destinations V2 "Early Access" user, you will still need to opt-into the latest connector version. However, you will not experience the data migration and syncs will continue to work as they have been since the "early access" period began.
-:::
 
 ## Advanced Upgrade Paths
 
@@ -153,9 +150,9 @@ For each [CDC-supported](https://docs.airbyte.com/understanding-airbyte/cdc) sou
 For each destination connector, Destinations V2 is effective as of the following versions:
 
 | Destination Connector | Safe Rollback Version | Destinations V2 Compatible |
-| --------------------- | --------------------- | -------------------------- |
-| BigQuery              | 1.4.4                 | 2.0.0+                     |
-| Snowflake             | 2.0.0                 | 3.0.0+                     |
+| --------------------- | --------------------- |----------------------------|
+| BigQuery              | 1.4.4                 | 2.0.6+                     |
+| Snowflake             | 2.0.0                 | 3.1.0+                     |
 | Redshift              | 0.4.8                 | 2.0.0+                     |
 | MSSQL                 | 0.1.24                | 2.0.0+                     |
 | MySQL                 | 0.1.20                | 2.0.0+                     |
@@ -164,7 +161,19 @@ For each destination connector, Destinations V2 is effective as of the following
 | DuckDB                | 0.1.0                 | 2.0.0+                     |
 | Clickhouse            | 0.2.3                 | 2.0.0+                     |
 
-Note: If you encounter errors while upgrading from a V1 to a V2 destination, please reach out to support. It may be advantagous to only drop probematic V2 tables rather than to do a full reset, depending on tye type of error.
+### [Open Source Only] Rolling Back to Legacy Normalization
+
+If you upgrade to Destinations V2 and start encountering issues, as an Open Source user you can optionally roll back. If you are running an outdated Airbyte Platform version (prior to `v0.50.24`), this may occur more frequently by accidentally upgrading to Destinations V2.  However:
+* Rolling back will require resetting each of your upgraded connections. 
+* If you are hoping to receive support from the Airbyte team, you will need to re-upgrade to Destinations V2 by **November 1, 2023**.
+
+To roll back, follow these steps:
+1. In the Airbyte UI, go to the 'Settings page, then to 'Destinations'.
+2. Manually type in the previous destination version you were running, or one of the versions listed in the table above.
+3. Enter this older version to roll back to the previous connector version.
+4. Reset all connections which synced at least once to a previously upgraded destination. To be safe, you may reset all connections sending data to a previously upgraded destination.
+
+If you are an Airbyte Cloud customer, and encounter errors while upgrading from a V1 to a V2 destination, please reach out to support. We do not always recommend doing a full reset, depending on the type of error.
 
 ## Destinations V2 Implementation Differences
 


### PR DESCRIPTION
* Makes the warning around upgrading platform versions even more explicit
* Adds canned instructions on rolling back for OSS users
* Changes V2 compatible versions for BQ and Snowflake
* Removes instructions specific to early access customers