### PR TITLE
CDK: URL-encode query parameters and request body

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/interpolated_mapping.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/interpolated_mapping.py
@@ -34,13 +34,14 @@ class InterpolatedMapping:
         :param additional_parameters: Optional parameters used for interpolation
         :return: The interpolated string
         """
-        interpolated_values = {
-            self._interpolation.eval(name, config, parameters=self._parameters, **additional_parameters): self._eval(
-                value, config, **additional_parameters
-            )
+        valid_key_types = additional_parameters.pop("valid_key_types", (str,))
+        valid_value_types = additional_parameters.pop("valid_value_types", None)
+        return {
+            self._interpolation.eval(
+                name, config, valid_types=valid_key_types, parameters=self._parameters, **additional_parameters
+            ): self._eval(value, config, valid_types=valid_value_types, **additional_parameters)
             for name, value in self.mapping.items()
         }
-        return interpolated_values
 
     def _eval(self, value, config, **kwargs):
         # The values in self._mapping can be of Any type

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -96,7 +96,7 @@ class JinjaInterpolation(Interpolation):
             evaluated = ast.literal_eval(result)
         except (ValueError, SyntaxError):
             return result
-        if valid_types and isinstance(evaluated, tuple(valid_types)):
+        if not valid_types or (valid_types and isinstance(evaluated, tuple(valid_types))):
             return evaluated
         elif valid_types and isinstance(evaluated, dict):
             # try to turn the evaluated object into a json-deserializable string

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -101,7 +101,7 @@ class JinjaInterpolation(Interpolation):
         elif valid_types and isinstance(evaluated, dict):
             # try to turn the evaluated object into a json-deserializable string
             try:
-                return json.dumps(evaluated, separators=(",", ":"))
+                return json.dumps(evaluated)
             except TypeError:
                 return result
         return result

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -4,7 +4,7 @@
 
 import ast
 import json
-from typing import Optional, Tuple, Type
+from typing import Any, Optional, Tuple, Type
 
 from airbyte_cdk.sources.declarative.interpolation.filters import filters
 from airbyte_cdk.sources.declarative.interpolation.interpolation import Interpolation
@@ -64,7 +64,7 @@ class JinjaInterpolation(Interpolation):
         input_str: str,
         config: Config,
         default: Optional[str] = None,
-        valid_types: Optional[Tuple[Type]] = None,
+        valid_types: Optional[Tuple[Type[Any]]] = None,
         **additional_parameters,
     ):
         context = {"config": config, **additional_parameters}
@@ -91,12 +91,12 @@ class JinjaInterpolation(Interpolation):
         # If result is empty or resulted in an undefined error, evaluate and return the default string
         return self._literal_eval(self._eval(default, context), valid_types)
 
-    def _literal_eval(self, result, valid_types: Optional[Tuple[Type]]):
+    def _literal_eval(self, result, valid_types: Optional[Tuple[Type[Any]]]):
         try:
             evaluated = ast.literal_eval(result)
         except (ValueError, SyntaxError):
             return result
-        if not valid_types or (valid_types and isinstance(evaluated, tuple(valid_types))):
+        if not valid_types or (valid_types and isinstance(evaluated, valid_types)):
             return evaluated
         elif valid_types and isinstance(evaluated, dict):
             # try to turn the evaluated object into a json-deserializable string

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -3,7 +3,6 @@
 #
 
 import ast
-import json
 from typing import Any, Optional, Tuple, Type
 
 from airbyte_cdk.sources.declarative.interpolation.filters import filters
@@ -98,12 +97,6 @@ class JinjaInterpolation(Interpolation):
             return result
         if not valid_types or (valid_types and isinstance(evaluated, valid_types)):
             return evaluated
-        elif valid_types and isinstance(evaluated, dict):
-            # try to turn the evaluated object into a json-deserializable string
-            try:
-                return json.dumps(evaluated)
-            except TypeError:
-                return result
         return result
 
     def _eval(self, s: str, context):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_requester.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_requester.py
@@ -258,7 +258,13 @@ class HttpRequester(Requester):
         )
         if isinstance(headers, str):
             raise ValueError("Request headers cannot be a string")
-        return {str(k): str(v) for k, v in headers.items()}
+        formatted_headers = {}
+        for k, v in headers.items():
+            if isinstance(v, list):
+                formatted_headers[str(k)] = ",".join([str(_v) for _v in v])
+            else:
+                formatted_headers[str(k)] = str(v)
+        return formatted_headers
 
     def _request_params(
         self,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_requester.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_requester.py
@@ -258,13 +258,7 @@ class HttpRequester(Requester):
         )
         if isinstance(headers, str):
             raise ValueError("Request headers cannot be a string")
-        formatted_headers = {}
-        for k, v in headers.items():
-            if isinstance(v, list):
-                formatted_headers[str(k)] = ",".join([str(_v) for _v in v])
-            else:
-                formatted_headers[str(k)] = str(v)
-        return formatted_headers
+        return {str(k): str(v) for k, v in headers.items()}
 
     def _request_params(
         self,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_input_provider.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_input_provider.py
@@ -3,7 +3,7 @@
 #
 
 from dataclasses import InitVar, dataclass, field
-from typing import Any, Mapping, Optional, Union
+from typing import Any, List, Mapping, Optional, Type, Union
 
 from airbyte_cdk.sources.declarative.interpolation.interpolated_mapping import InterpolatedMapping
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
@@ -31,7 +31,11 @@ class InterpolatedRequestInputProvider:
             self._interpolator = InterpolatedMapping(self._request_inputs, parameters=parameters)
 
     def eval_request_inputs(
-        self, stream_state: StreamState, stream_slice: Optional[StreamSlice] = None, next_page_token: Mapping[str, Any] = None
+        self,
+        stream_state: StreamState,
+        stream_slice: Optional[StreamSlice] = None,
+        next_page_token: Mapping[str, Any] = None,
+        valid_types: List[Type[Any]] = None,
     ) -> Mapping[str, Any]:
         """
         Returns the request inputs to set on an outgoing HTTP request
@@ -42,7 +46,7 @@ class InterpolatedRequestInputProvider:
         :return: The request inputs to set on an outgoing HTTP request
         """
         kwargs = {"stream_state": stream_state, "stream_slice": stream_slice, "next_page_token": next_page_token}
-        interpolated_value = self._interpolator.eval(self.config, **kwargs)
+        interpolated_value = self._interpolator.eval(self.config, valid_types=valid_types, **kwargs)
 
         if isinstance(interpolated_value, dict):
             non_null_tokens = {k: v for k, v in interpolated_value.items() if v is not None}

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_input_provider.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_input_provider.py
@@ -35,7 +35,8 @@ class InterpolatedRequestInputProvider:
         stream_state: StreamState,
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Mapping[str, Any] = None,
-        valid_types: Tuple[Type[Any]] = None,
+        valid_key_types: Tuple[Type[Any]] = None,
+        valid_value_types: Tuple[Type[Any]] = None,
     ) -> Mapping[str, Any]:
         """
         Returns the request inputs to set on an outgoing HTTP request
@@ -43,11 +44,14 @@ class InterpolatedRequestInputProvider:
         :param stream_state: The stream state
         :param stream_slice: The stream slice
         :param next_page_token: The pagination token
-        :param valid_types: A tuple of types that the interpolator should allow
+        :param valid_key_types: A tuple of types that the interpolator should allow
+        :param valid_value_types: A tuple of types that the interpolator should allow
         :return: The request inputs to set on an outgoing HTTP request
         """
         kwargs = {"stream_state": stream_state, "stream_slice": stream_slice, "next_page_token": next_page_token}
-        interpolated_value = self._interpolator.eval(self.config, valid_types=valid_types, **kwargs)
+        interpolated_value = self._interpolator.eval(
+            self.config, valid_key_types=valid_key_types, valid_value_types=valid_value_types, **kwargs
+        )
 
         if isinstance(interpolated_value, dict):
             non_null_tokens = {k: v for k, v in interpolated_value.items() if v is not None}

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_input_provider.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_input_provider.py
@@ -3,7 +3,7 @@
 #
 
 from dataclasses import InitVar, dataclass, field
-from typing import Any, List, Mapping, Optional, Type, Union
+from typing import Any, Mapping, Optional, Tuple, Type, Union
 
 from airbyte_cdk.sources.declarative.interpolation.interpolated_mapping import InterpolatedMapping
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
@@ -35,7 +35,7 @@ class InterpolatedRequestInputProvider:
         stream_state: StreamState,
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Mapping[str, Any] = None,
-        valid_types: List[Type[Any]] = None,
+        valid_types: Tuple[Type[Any]] = None,
     ) -> Mapping[str, Any]:
         """
         Returns the request inputs to set on an outgoing HTTP request
@@ -43,6 +43,7 @@ class InterpolatedRequestInputProvider:
         :param stream_state: The stream state
         :param stream_slice: The stream slice
         :param next_page_token: The pagination token
+        :param valid_types: A tuple of types that the interpolator should allow
         :return: The request inputs to set on an outgoing HTTP request
         """
         kwargs = {"stream_state": stream_state, "stream_slice": stream_slice, "next_page_token": next_page_token}

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_options_provider.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_options_provider.py
@@ -14,6 +14,7 @@ from airbyte_cdk.sources.declarative.requesters.request_options.request_options_
 from airbyte_cdk.sources.declarative.types import Config, StreamSlice, StreamState
 
 RequestInput = Union[str, Mapping[str, str]]
+ValidRequestTypes = [str, list]
 
 
 @dataclass
@@ -69,7 +70,9 @@ class InterpolatedRequestOptionsProvider(RequestOptionsProvider):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> MutableMapping[str, Any]:
-        interpolated_value = self._parameter_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token)
+        interpolated_value = self._parameter_interpolator.eval_request_inputs(
+            stream_state, stream_slice, next_page_token, valid_types=ValidRequestTypes
+        )
         if isinstance(interpolated_value, dict):
             return interpolated_value
         return {}
@@ -81,7 +84,7 @@ class InterpolatedRequestOptionsProvider(RequestOptionsProvider):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
-        return self._headers_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token)
+        return self._headers_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token, valid_types=ValidRequestTypes)
 
     def get_request_body_data(
         self,
@@ -90,7 +93,7 @@ class InterpolatedRequestOptionsProvider(RequestOptionsProvider):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Optional[Union[Mapping, str]]:
-        return self._body_data_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token)
+        return self._body_data_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token, valid_types=ValidRequestTypes)
 
     def get_request_body_json(
         self,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_options_provider.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_options_provider.py
@@ -71,7 +71,7 @@ class InterpolatedRequestOptionsProvider(RequestOptionsProvider):
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> MutableMapping[str, Any]:
         interpolated_value = self._parameter_interpolator.eval_request_inputs(
-            stream_state, stream_slice, next_page_token, valid_types=ValidRequestTypes
+            stream_state, stream_slice, next_page_token, valid_key_types=(str,), valid_value_types=ValidRequestTypes
         )
         if isinstance(interpolated_value, dict):
             return interpolated_value
@@ -84,7 +84,7 @@ class InterpolatedRequestOptionsProvider(RequestOptionsProvider):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
-        return self._headers_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token, valid_types=ValidRequestTypes)
+        return self._headers_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token)
 
     def get_request_body_data(
         self,
@@ -93,7 +93,13 @@ class InterpolatedRequestOptionsProvider(RequestOptionsProvider):
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Optional[Union[Mapping, str]]:
-        return self._body_data_interpolator.eval_request_inputs(stream_state, stream_slice, next_page_token, valid_types=ValidRequestTypes)
+        return self._body_data_interpolator.eval_request_inputs(
+            stream_state,
+            stream_slice,
+            next_page_token,
+            valid_key_types=(str,),
+            valid_value_types=ValidRequestTypes,
+        )
 
     def get_request_body_json(
         self,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_options_provider.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/interpolated_request_options_provider.py
@@ -14,7 +14,7 @@ from airbyte_cdk.sources.declarative.requesters.request_options.request_options_
 from airbyte_cdk.sources.declarative.types import Config, StreamSlice, StreamState
 
 RequestInput = Union[str, Mapping[str, str]]
-ValidRequestTypes = [str, list]
+ValidRequestTypes = (str, list)
 
 
 @dataclass

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/request_options/test_interpolated_request_options_provider.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/request_options/test_interpolated_request_options_provider.py
@@ -19,18 +19,18 @@ config = {"option": "OPTION"}
         ("test_static_param", {"a_static_request_param": "a_static_value"}, {"a_static_request_param": "a_static_value"}),
         ("test_value_depends_on_state", {"read_from_state": "{{ stream_state['date'] }}"}, {"read_from_state": "2021-01-01"}),
         ("test_value_depends_on_stream_slice", {"read_from_slice": "{{ stream_slice['start_date'] }}"}, {"read_from_slice": "2020-01-01"}),
-        ("test_value_depends_on_next_page_token", {"read_from_token": "{{ next_page_token['offset'] }}"}, {"read_from_token": 12345}),
+        ("test_value_depends_on_next_page_token", {"read_from_token": "{{ next_page_token['offset'] }}"}, {"read_from_token": "12345"}),
         ("test_value_depends_on_config", {"read_from_config": "{{ config['option'] }}"}, {"read_from_config": "OPTION"}),
         (
             "test_parameter_is_interpolated",
             {"{{ stream_state['date'] }} - {{stream_slice['start_date']}} - {{next_page_token['offset']}} - {{config['option']}}": "ABC"},
             {"2021-01-01 - 2020-01-01 - 12345 - OPTION": "ABC"},
         ),
-        ("test_boolean_false_value", {"boolean_false": "{{ False }}"}, {"boolean_false": False}),
-        ("test_integer_falsy_value", {"integer_falsy": "{{ 0 }}"}, {"integer_falsy": 0}),
-        ("test_number_falsy_value", {"number_falsy": "{{ 0.0 }}"}, {"number_falsy": 0.0}),
+        ("test_boolean_false_value", {"boolean_false": "{{ False }}"}, {"boolean_false": "False"}),
+        ("test_integer_falsy_value", {"integer_falsy": "{{ 0 }}"}, {"integer_falsy": "0"}),
+        ("test_number_falsy_value", {"number_falsy": "{{ 0.0 }}"}, {"number_falsy": "0.0"}),
         ("test_string_falsy_value", {"string_falsy": "{{ '' }}"}, {}),
-        ("test_none_value", {"none_value": "{{ None }}"}, {}),
+        ("test_none_value", {"none_value": "{{ None }}"}, {"none_value": "None"}),
     ],
 )
 def test_interpolated_request_params(test_name, input_request_params, expected_request_params):

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/test_http_requester.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/test_http_requester.py
@@ -408,55 +408,55 @@ def test_request_param_interpolation(request_parameters, config, expected_query_
             "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
             id="test-request-body-dictionary",
         ),
-        pytest.param(
-            {"k": "1,2"},
-            {},
-            "k=1%2C2",  # k=1,2
-            id="test-request-body-comma-separated-numbers",
-        ),
-        pytest.param(
-            {"k": "a,b"},
-            {},
-            "k=a%2Cb",  # k=a,b
-            id="test-request-body-comma-separated-strings",
-        ),
-        pytest.param(
-            {"k": "[1,2]"},
-            {},
-            "k=1&k=2",
-            id="test-request-body-list-of-numbers",
-        ),
-        pytest.param(
-            {"k": '["a", "b"]'},
-            {},
-            "k=a&k=b",
-            id="test-request-body-list-of-strings",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
-            # k={"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}
-            "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
-            id="test-request-body-from-config-object",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": [1, 2]},
-            "k=1&k=2",
-            id="test-request-body-from-config-list-of-numbers",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": ["a", "b"]},
-            "k=a&k=b",
-            id="test-request-body-from-config-list-of-strings",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": ["a,b"]},
-            "k=a%2Cb",  # k=a,b
-            id="test-request-body-from-config-comma-separated-strings",
-        ),
+        # pytest.param(
+        #     {"k": "1,2"},
+        #     {},
+        #     "k=1%2C2",  # k=1,2
+        #     id="test-request-body-comma-separated-numbers",
+        # ),
+        # pytest.param(
+        #     {"k": "a,b"},
+        #     {},
+        #     "k=a%2Cb",  # k=a,b
+        #     id="test-request-body-comma-separated-strings",
+        # ),
+        # pytest.param(
+        #     {"k": "[1,2]"},
+        #     {},
+        #     "k=1&k=2",
+        #     id="test-request-body-list-of-numbers",
+        # ),
+        # pytest.param(
+        #     {"k": '["a", "b"]'},
+        #     {},
+        #     "k=a&k=b",
+        #     id="test-request-body-list-of-strings",
+        # ),
+        # pytest.param(
+        #     {"k": '{{ config["k"] }}'},
+        #     {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
+        #     # k={"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}
+        #     "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
+        #     id="test-request-body-from-config-object",
+        # ),
+        # pytest.param(
+        #     {"k": '{{ config["k"] }}'},
+        #     {"k": [1, 2]},
+        #     "k=1&k=2",
+        #     id="test-request-body-from-config-list-of-numbers",
+        # ),
+        # pytest.param(
+        #     {"k": '{{ config["k"] }}'},
+        #     {"k": ["a", "b"]},
+        #     "k=a&k=b",
+        #     id="test-request-body-from-config-list-of-strings",
+        # ),
+        # pytest.param(
+        #     {"k": '{{ config["k"] }}'},
+        #     {"k": ["a,b"]},
+        #     "k=a%2Cb",  # k=a,b
+        #     id="test-request-body-from-config-comma-separated-strings",
+        # ),
     ],
 )
 def test_request_body_interpolation(request_body_data, config, expected_request_body_data):
@@ -472,80 +472,6 @@ def test_request_body_interpolation(request_body_data, config, expected_request_
     requester.send_request()
     sent_request: PreparedRequest = requester._session.send.call_args_list[0][0][0]
     assert sent_request.body == expected_request_body_data
-
-
-@pytest.mark.parametrize(
-    "headers, config, expected_headers",
-    [
-        pytest.param(
-            {"k": '{"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}'},
-            {},
-            '{"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}',
-            id="test-header-dictionary",
-        ),
-        pytest.param(
-            {"k": "1,2"},
-            {},
-            "1,2",
-            id="test-header-comma-separated-numbers",
-        ),
-        pytest.param(
-            {"k": "a,b"},
-            {},
-            "a,b",
-            id="test-header-comma-separated-strings",
-        ),
-        pytest.param(
-            {"k": "[1,2]"},
-            {},
-            "1,2",
-            id="test-header-list-of-numbers",
-        ),
-        pytest.param(
-            {"k": '["a", "b"]'},
-            {},
-            "a,b",
-            id="test-header-list-of-strings",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
-            '{"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}',
-            id="test-header-from-config-object",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": [1, 2]},
-            "1,2",
-            id="test-header-from-config-list-of-numbers",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": ["a", "b"]},
-            "a,b",
-            id="test-header-from-config-list-of-strings",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": ["a,b"]},
-            "a,b",
-            id="test-header-from-config-comma-separated-strings",
-        ),
-    ],
-)
-def test_request_header_interpolation(headers, config, expected_headers):
-    options_provider = InterpolatedRequestOptionsProvider(
-        config=config,
-        request_parameters={},
-        request_body_data={},
-        request_headers=headers,
-        parameters={},
-    )
-    requester = create_requester()
-    requester._request_options_provider = options_provider
-    requester.send_request()
-    sent_request: PreparedRequest = requester._session.send.call_args_list[0][0][0]
-    assert sent_request.headers["k"] == expected_headers
 
 
 @pytest.mark.parametrize(

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/test_http_requester.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/test_http_requester.py
@@ -327,8 +327,7 @@ def test_send_request_params(provider_params, param_params, authenticator_params
         pytest.param(
             {"k": '{"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}'},
             {},
-            # k={"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}
-            "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
+            "k=%7B%22updatedDateFrom%22%3A+%222023-08-20T00%3A00%3A00Z%22%2C+%22updatedDateTo%22%3A+%222023-08-20T23%3A59%3A59Z%22%7D",
             id="test-request-parameter-dictionary",
         ),
         pytest.param(
@@ -357,10 +356,8 @@ def test_send_request_params(provider_params, param_params, authenticator_params
         ),
         pytest.param(
             {"k": '{{ config["k"] }}'},
-            {
-                "k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}
-            },  # k={"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}
-            "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
+            {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
+            "k=%7B%22updatedDateFrom%22%3A+%222023-08-20T00%3A00%3A00Z%22%2C+%22updatedDateTo%22%3A+%222023-08-20T23%3A59%3A59Z%22%7D",
             id="test-request-parameter-from-config-object",
         ),
         pytest.param(
@@ -380,6 +377,12 @@ def test_send_request_params(provider_params, param_params, authenticator_params
             {"k": ["a,b"]},
             "k=a%2Cb",  # k=a,b
             id="test-request-parameter-from-config-comma-separated-strings",
+        ),
+        pytest.param(
+            {'["a", "b"]': '{{ config["k"] }}'},
+            {"k": [1, 2]},
+            "%5B%22a%22%2C+%22b%22%5D=1&%5B%22a%22%2C+%22b%22%5D=2",
+            id="test-key-with-list-is-not-interpolated",
         ),
     ],
 )
@@ -402,61 +405,116 @@ def test_request_param_interpolation(request_parameters, config, expected_query_
     "request_body_data, config, expected_request_body_data",
     [
         pytest.param(
-            {"k": '{"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}'},
+            {"k": '{"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}'},
             {},
-            # k={"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}
-            "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
+            # k={"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}
+            "k=%7B%22updatedDateFrom%22%3A+%222023-08-20T00%3A00%3A00Z%22%2C+%22updatedDateTo%22%3A+%222023-08-20T23%3A59%3A59Z%22%7D",
             id="test-request-body-dictionary",
         ),
-        # pytest.param(
-        #     {"k": "1,2"},
-        #     {},
-        #     "k=1%2C2",  # k=1,2
-        #     id="test-request-body-comma-separated-numbers",
-        # ),
-        # pytest.param(
-        #     {"k": "a,b"},
-        #     {},
-        #     "k=a%2Cb",  # k=a,b
-        #     id="test-request-body-comma-separated-strings",
-        # ),
-        # pytest.param(
-        #     {"k": "[1,2]"},
-        #     {},
-        #     "k=1&k=2",
-        #     id="test-request-body-list-of-numbers",
-        # ),
-        # pytest.param(
-        #     {"k": '["a", "b"]'},
-        #     {},
-        #     "k=a&k=b",
-        #     id="test-request-body-list-of-strings",
-        # ),
-        # pytest.param(
-        #     {"k": '{{ config["k"] }}'},
-        #     {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
-        #     # k={"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}
-        #     "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
-        #     id="test-request-body-from-config-object",
-        # ),
-        # pytest.param(
-        #     {"k": '{{ config["k"] }}'},
-        #     {"k": [1, 2]},
-        #     "k=1&k=2",
-        #     id="test-request-body-from-config-list-of-numbers",
-        # ),
-        # pytest.param(
-        #     {"k": '{{ config["k"] }}'},
-        #     {"k": ["a", "b"]},
-        #     "k=a&k=b",
-        #     id="test-request-body-from-config-list-of-strings",
-        # ),
-        # pytest.param(
-        #     {"k": '{{ config["k"] }}'},
-        #     {"k": ["a,b"]},
-        #     "k=a%2Cb",  # k=a,b
-        #     id="test-request-body-from-config-comma-separated-strings",
-        # ),
+        pytest.param(
+            {"k": "1,2"},
+            {},
+            "k=1%2C2",  # k=1,2
+            id="test-request-body-comma-separated-numbers",
+        ),
+        pytest.param(
+            {"k": "a,b"},
+            {},
+            "k=a%2Cb",  # k=a,b
+            id="test-request-body-comma-separated-strings",
+        ),
+        pytest.param(
+            {"k": "[1,2]"},
+            {},
+            "k=1&k=2",
+            id="test-request-body-list-of-numbers",
+        ),
+        pytest.param(
+            {"k": '["a", "b"]'},
+            {},
+            "k=a&k=b",
+            id="test-request-body-list-of-strings",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
+            # k={"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}
+            "k=%7B%22updatedDateFrom%22%3A+%222023-08-20T00%3A00%3A00Z%22%2C+%22updatedDateTo%22%3A+%222023-08-20T23%3A59%3A59Z%22%7D",
+            id="test-request-body-from-config-object",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": [1, 2]},
+            "k=1&k=2",
+            id="test-request-body-from-config-list-of-numbers",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": ["a", "b"]},
+            "k=a&k=b",
+            id="test-request-body-from-config-list-of-strings",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": ["a,b"]},
+            "k=a%2Cb",  # k=a,b
+            id="test-request-body-from-config-comma-separated-strings",
+        ),
+        pytest.param(
+            {"k": "1,2"},
+            {},
+            "k=1%2C2",  # k=1,2
+            id="test-request-body-comma-separated-numbers",
+        ),
+        pytest.param(
+            {"k": "a,b"},
+            {},
+            "k=a%2Cb",  # k=a,b
+            id="test-request-body-comma-separated-strings",
+        ),
+        pytest.param(
+            {"k": "[1,2]"},
+            {},
+            "k=1&k=2",
+            id="test-request-body-list-of-numbers",
+        ),
+        pytest.param(
+            {"k": '["a", "b"]'},
+            {},
+            "k=a&k=b",
+            id="test-request-body-list-of-strings",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
+            # k={"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}
+            "k=%7B%22updatedDateFrom%22%3A+%222023-08-20T00%3A00%3A00Z%22%2C+%22updatedDateTo%22%3A+%222023-08-20T23%3A59%3A59Z%22%7D",
+            id="test-request-body-from-config-object",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": [1, 2]},
+            "k=1&k=2",
+            id="test-request-body-from-config-list-of-numbers",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": ["a", "b"]},
+            "k=a&k=b",
+            id="test-request-body-from-config-list-of-strings",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": ["a,b"]},
+            "k=a%2Cb",  # k=a,b
+            id="test-request-body-from-config-comma-separated-strings",
+        ),
+        pytest.param(
+            {'["a", "b"]': '{{ config["k"] }}'},
+            {"k": [1, 2]},
+            "%5B%22a%22%2C+%22b%22%5D=1&%5B%22a%22%2C+%22b%22%5D=2",
+            id="test-key-with-list-is-not-interpolated",
+        ),
     ],
 )
 def test_request_body_interpolation(request_body_data, config, expected_request_body_data):

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/test_http_requester.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/test_http_requester.py
@@ -17,6 +17,7 @@ from airbyte_cdk.sources.declarative.interpolation.interpolated_string import In
 from airbyte_cdk.sources.declarative.requesters.error_handlers.default_error_handler import DefaultErrorHandler
 from airbyte_cdk.sources.declarative.requesters.error_handlers.error_handler import ErrorHandler
 from airbyte_cdk.sources.declarative.requesters.http_requester import HttpMethod, HttpRequester
+from airbyte_cdk.sources.declarative.requesters.request_options import InterpolatedRequestOptionsProvider
 from airbyte_cdk.sources.declarative.types import Config
 from airbyte_cdk.sources.streams.http.exceptions import DefaultBackoffException, RequestBodyException, UserDefinedBackoffException
 from requests import PreparedRequest
@@ -318,6 +319,233 @@ def test_send_request_params(provider_params, param_params, authenticator_params
         parsed_url = urlparse(sent_request.url)
         query_params = {key: value[0] for key, value in parse_qs(parsed_url.query).items()}
         assert query_params == expected_params
+
+
+@pytest.mark.parametrize(
+    "request_parameters, config, expected_query_params",
+    [
+        pytest.param(
+            {"k": '{"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}'},
+            {},
+            # k={"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}
+            "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
+            id="test-request-parameter-dictionary",
+        ),
+        pytest.param(
+            {"k": "1,2"},
+            {},
+            "k=1%2C2",  # k=1,2
+            id="test-request-parameter-comma-separated-numbers",
+        ),
+        pytest.param(
+            {"k": "a,b"},
+            {},
+            "k=a%2Cb",  # k=a,b
+            id="test-request-parameter-comma-separated-strings",
+        ),
+        pytest.param(
+            {"k": "[1,2]"},
+            {},
+            "k=1&k=2",
+            id="test-request-parameter-list-of-numbers",
+        ),
+        pytest.param(
+            {"k": '["a", "b"]'},
+            {},
+            "k=a&k=b",
+            id="test-request-parameter-list-of-strings",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {
+                "k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}
+            },  # k={"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}
+            "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
+            id="test-request-parameter-from-config-object",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": [1, 2]},
+            "k=1&k=2",
+            id="test-request-parameter-from-config-list-of-numbers",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": ["a", "b"]},
+            "k=a&k=b",
+            id="test-request-parameter-from-config-list-of-strings",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": ["a,b"]},
+            "k=a%2Cb",  # k=a,b
+            id="test-request-parameter-from-config-comma-separated-strings",
+        ),
+    ],
+)
+def test_request_param_interpolation(request_parameters, config, expected_query_params):
+    options_provider = InterpolatedRequestOptionsProvider(
+        config=config,
+        request_parameters=request_parameters,
+        request_body_data={},
+        request_headers={},
+        parameters={},
+    )
+    requester = create_requester()
+    requester._request_options_provider = options_provider
+    requester.send_request()
+    sent_request: PreparedRequest = requester._session.send.call_args_list[0][0][0]
+    assert sent_request.url.split("?", 1)[-1] == expected_query_params
+
+
+@pytest.mark.parametrize(
+    "request_body_data, config, expected_request_body_data",
+    [
+        pytest.param(
+            {"k": '{"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}'},
+            {},
+            # k={"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}
+            "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
+            id="test-request-body-dictionary",
+        ),
+        pytest.param(
+            {"k": "1,2"},
+            {},
+            "k=1%2C2",  # k=1,2
+            id="test-request-body-comma-separated-numbers",
+        ),
+        pytest.param(
+            {"k": "a,b"},
+            {},
+            "k=a%2Cb",  # k=a,b
+            id="test-request-body-comma-separated-strings",
+        ),
+        pytest.param(
+            {"k": "[1,2]"},
+            {},
+            "k=1&k=2",
+            id="test-request-body-list-of-numbers",
+        ),
+        pytest.param(
+            {"k": '["a", "b"]'},
+            {},
+            "k=a&k=b",
+            id="test-request-body-list-of-strings",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
+            # k={"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}
+            "k=%7B%22updatedDateFrom%22%3A%222023-08-20T00%3A00%3A00Z%22%2C%22updatedDateTo%22%3A%222023-08-20T23%3A59%3A59Z%22%7D",
+            id="test-request-body-from-config-object",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": [1, 2]},
+            "k=1&k=2",
+            id="test-request-body-from-config-list-of-numbers",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": ["a", "b"]},
+            "k=a&k=b",
+            id="test-request-body-from-config-list-of-strings",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": ["a,b"]},
+            "k=a%2Cb",  # k=a,b
+            id="test-request-body-from-config-comma-separated-strings",
+        ),
+    ],
+)
+def test_request_body_interpolation(request_body_data, config, expected_request_body_data):
+    options_provider = InterpolatedRequestOptionsProvider(
+        config=config,
+        request_parameters={},
+        request_body_data=request_body_data,
+        request_headers={},
+        parameters={},
+    )
+    requester = create_requester()
+    requester._request_options_provider = options_provider
+    requester.send_request()
+    sent_request: PreparedRequest = requester._session.send.call_args_list[0][0][0]
+    assert sent_request.body == expected_request_body_data
+
+
+@pytest.mark.parametrize(
+    "headers, config, expected_headers",
+    [
+        pytest.param(
+            {"k": '{"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}'},
+            {},
+            '{"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}',
+            id="test-header-dictionary",
+        ),
+        pytest.param(
+            {"k": "1,2"},
+            {},
+            "1,2",
+            id="test-header-comma-separated-numbers",
+        ),
+        pytest.param(
+            {"k": "a,b"},
+            {},
+            "a,b",
+            id="test-header-comma-separated-strings",
+        ),
+        pytest.param(
+            {"k": "[1,2]"},
+            {},
+            "1,2",
+            id="test-header-list-of-numbers",
+        ),
+        pytest.param(
+            {"k": '["a", "b"]'},
+            {},
+            "a,b",
+            id="test-header-list-of-strings",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
+            '{"updatedDateFrom":"2023-08-20T00:00:00Z","updatedDateTo":"2023-08-20T23:59:59Z"}',
+            id="test-header-from-config-object",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": [1, 2]},
+            "1,2",
+            id="test-header-from-config-list-of-numbers",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": ["a", "b"]},
+            "a,b",
+            id="test-header-from-config-list-of-strings",
+        ),
+        pytest.param(
+            {"k": '{{ config["k"] }}'},
+            {"k": ["a,b"]},
+            "a,b",
+            id="test-header-from-config-comma-separated-strings",
+        ),
+    ],
+)
+def test_request_header_interpolation(headers, config, expected_headers):
+    options_provider = InterpolatedRequestOptionsProvider(
+        config=config,
+        request_parameters={},
+        request_body_data={},
+        request_headers=headers,
+        parameters={},
+    )
+    requester = create_requester()
+    requester._request_options_provider = options_provider
+    requester.send_request()
+    sent_request: PreparedRequest = requester._session.send.call_args_list[0][0][0]
+    assert sent_request.headers["k"] == expected_headers
 
 
 @pytest.mark.parametrize(

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/test_http_requester.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/test_http_requester.py
@@ -357,7 +357,8 @@ def test_send_request_params(provider_params, param_params, authenticator_params
         pytest.param(
             {"k": '{{ config["k"] }}'},
             {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
-            "k=%7B%22updatedDateFrom%22%3A+%222023-08-20T00%3A00%3A00Z%22%2C+%22updatedDateTo%22%3A+%222023-08-20T23%3A59%3A59Z%22%7D",
+            # {'updatedDateFrom': '2023-08-20T00:00:00Z', 'updatedDateTo': '2023-08-20T23:59:59Z'}
+            "k=%7B%27updatedDateFrom%27%3A+%272023-08-20T00%3A00%3A00Z%27%2C+%27updatedDateTo%27%3A+%272023-08-20T23%3A59%3A59Z%27%7D",
             id="test-request-parameter-from-config-object",
         ),
         pytest.param(
@@ -438,57 +439,8 @@ def test_request_param_interpolation(request_parameters, config, expected_query_
         pytest.param(
             {"k": '{{ config["k"] }}'},
             {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
-            # k={"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}
-            "k=%7B%22updatedDateFrom%22%3A+%222023-08-20T00%3A00%3A00Z%22%2C+%22updatedDateTo%22%3A+%222023-08-20T23%3A59%3A59Z%22%7D",
-            id="test-request-body-from-config-object",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": [1, 2]},
-            "k=1&k=2",
-            id="test-request-body-from-config-list-of-numbers",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": ["a", "b"]},
-            "k=a&k=b",
-            id="test-request-body-from-config-list-of-strings",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": ["a,b"]},
-            "k=a%2Cb",  # k=a,b
-            id="test-request-body-from-config-comma-separated-strings",
-        ),
-        pytest.param(
-            {"k": "1,2"},
-            {},
-            "k=1%2C2",  # k=1,2
-            id="test-request-body-comma-separated-numbers",
-        ),
-        pytest.param(
-            {"k": "a,b"},
-            {},
-            "k=a%2Cb",  # k=a,b
-            id="test-request-body-comma-separated-strings",
-        ),
-        pytest.param(
-            {"k": "[1,2]"},
-            {},
-            "k=1&k=2",
-            id="test-request-body-list-of-numbers",
-        ),
-        pytest.param(
-            {"k": '["a", "b"]'},
-            {},
-            "k=a&k=b",
-            id="test-request-body-list-of-strings",
-        ),
-        pytest.param(
-            {"k": '{{ config["k"] }}'},
-            {"k": {"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}},
-            # k={"updatedDateFrom": "2023-08-20T00:00:00Z", "updatedDateTo": "2023-08-20T23:59:59Z"}
-            "k=%7B%22updatedDateFrom%22%3A+%222023-08-20T00%3A00%3A00Z%22%2C+%22updatedDateTo%22%3A+%222023-08-20T23%3A59%3A59Z%22%7D",
+            # k={'updatedDateFrom': '2023-08-20T00:00:00Z', 'updatedDateTo': '2023-08-20T23:59:59Z'}
+            "k=%7B%27updatedDateFrom%27%3A+%272023-08-20T00%3A00%3A00Z%27%2C+%27updatedDateTo%27%3A+%272023-08-20T23%3A59%3A59Z%27%7D",
             id="test-request-body-from-config-object",
         ),
         pytest.param(
@@ -512,8 +464,15 @@ def test_request_param_interpolation(request_parameters, config, expected_query_
         pytest.param(
             {'["a", "b"]': '{{ config["k"] }}'},
             {"k": [1, 2]},
-            "%5B%22a%22%2C+%22b%22%5D=1&%5B%22a%22%2C+%22b%22%5D=2",
+            "%5B%22a%22%2C+%22b%22%5D=1&%5B%22a%22%2C+%22b%22%5D=2",  # ["a", "b"]=1&["a", "b"]=2
             id="test-key-with-list-is-not-interpolated",
+        ),
+        pytest.param(
+            {"k": "{'updatedDateFrom': '2023-08-20T00:00:00Z', 'updatedDateTo': '2023-08-20T23:59:59Z'}"},
+            {},
+            # k={'updatedDateFrom': '2023-08-20T00:00:00Z', 'updatedDateTo': '2023-08-20T23:59:59Z'}
+            "k=%7B%27updatedDateFrom%27%3A+%272023-08-20T00%3A00%3A00Z%27%2C+%27updatedDateTo%27%3A+%272023-08-20T23%3A59%3A59Z%27%7D",
+            id="test-single-quotes-are-retained",
         ),
     ],
 )


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/29918.

#### What

Updates the handling of query params and request body data such that:
- If the value of a query param has the structure of a list (i.e. starts with [, ends with ], and the elements are comma-separated), then we treat it as a list and unpack it
- Otherwise, we treat it as a string and url-encode it

Updates the handling of request headers such that if the value has the structure of a list, we set the header key's value to a list, otherwise treat it as a string. 

#### How

Modify the Jinja interpolator's `_literal_eval` method to take in a new argument, `valid_types`, which is a tuple of types that are allowed by the caller. When `_literal_eval` tries to evaluate the value, if the evaluated value is in `valid_types`, we return the evaluated value. Otherwise we return a string. `[interpolated_request_options_provider.py](https://github.com/airbytehq/airbyte/pull/30407/files#diff-d8aec9e480b31092835970bb69bff51f89af53ffb497f38ac536ad44ac728dc7)`'s methods for getting request params, body, and headers, are also modified to send valid types (which all consist of `str` and `list`).