### PR TITLE
🐛 [source-google-analytics-data-api] revert back to 1.1.3

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 1.2.0
+  dockerImageTag: 1.1.3
   dockerRepository: airbyte/source-google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api
   icon: google-analytics.svg

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 1.1.3
+  dockerImageTag: 1.2.0
   dockerRepository: airbyte/source-google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api
   icon: google-analytics.svg
@@ -15,6 +15,7 @@ data:
   name: Google Analytics 4 (GA4)
   registries:
     cloud:
+      dockerImageTag: 1.1.3 # pinning back in cloud due to OC issue 2951
       enabled: true
     oss:
       enabled: true


### PR DESCRIPTION
## What

https://github.com/airbytehq/oncall/issues/2951

Due to an OC issue w/ the schema duplicated, we need to revert to previous working version. We can then address root cause. This does appear to be breaking, but due to the schema issues, i'm not sure that proper discovers would run regardless

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`
