### PR TITLE
Remove google plugins from docs

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -67,10 +67,6 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
-        gtag: {
-          trackingID: "UA-156258629-2",
-          anonymizeIP: true,
-        },
       }),
     ],
   ],

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -80,8 +80,6 @@
     "@docusaurus/module-type-aliases": "^2.1.0",
     "@docusaurus/plugin-client-redirects": "^2.1.0",
     "@docusaurus/plugin-debug": "^2.1.0",
-    "@docusaurus/plugin-google-analytics": "^2.1.0",
-    "@docusaurus/plugin-google-gtag": "^2.1.0",
     "@docusaurus/plugin-sitemap": "^2.1.0",
     "@docusaurus/preset-classic": "^2.1.0",
     "@docusaurus/theme-classic": "^2.1.0",

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -1885,7 +1885,7 @@
     react-json-view "^1.21.3"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-google-analytics@2.3.1", "@docusaurus/plugin-google-analytics@^2.1.0":
+"@docusaurus/plugin-google-analytics@2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz#e2e7db4cf6a7063e8ba5e128d4e413f4d6a0c862"
   integrity sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==
@@ -1895,7 +1895,7 @@
     "@docusaurus/utils-validation" "2.3.1"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-google-gtag@2.3.1", "@docusaurus/plugin-google-gtag@^2.1.0":
+"@docusaurus/plugin-google-gtag@2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.3.1.tgz#b8da54a60c0a50aca609c3643faef78cb4f247a0"
   integrity sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==


### PR DESCRIPTION
Removes google plugins from the dos, since we now use the Cloudflare reverse proxy to inject those scripts (to be aligned with how we inject the Fullstory and Osano script already).