### PR TITLE
airbyte-ci: fix integration test log buffering

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -406,6 +406,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                        | Description                                                                                               |
 |---------| --------------------------------------------------------- |-----------------------------------------------------------------------------------------------------------|
+| 1.2.2   | [#30438](https://github.com/airbytehq/airbyte/pull/30438) | Add workaround to always stream logs properly with --is-local.                                            |
 | 1.2.1   | [#30384](https://github.com/airbytehq/airbyte/pull/30384) | Java connector test performance fixes.                                                                    |
 | 1.2.0   | [#30330](https://github.com/airbytehq/airbyte/pull/30330) | Add `--metadata-query` option to connectors command                                                       |
 | 1.1.3   | [#30314](https://github.com/airbytehq/airbyte/pull/30314) | Stop patching gradle files to make them work with airbyte-ci.                                             |

--- a/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
@@ -1009,11 +1009,47 @@ def with_crane(
     return base_container
 
 
-def mounted_connector_secrets(context: PipelineContext, secret_directory_path="secrets") -> Callable:
-    def mounted_connector_secrets_inner(container: Container):
+async def mounted_connector_secrets(context: PipelineContext, secret_directory_path: str) -> Callable[[Container], Container]:
+    # By default, mount the secrets properly as dagger secret files.
+    #
+    # This will cause the contents of these files to be scrubbed from the logs. This scrubbing comes at the cost of
+    # unavoidable latency in the log output, see next paragraph for details as to why. This is fine in a CI environment
+    # however this becomes a nuisance locally: the developer wants the logs to be displayed to them in an as timely
+    # manner as possible. Since the secrets aren't really secret in that case anyway, we mount them in the container as
+    # regular files instead.
+    #
+    # The buffering behavior that comes into play when logs are scrubbed is both unavoidable and not configurable.
+    # It's fundamentally unavoidable because dagger needs to match a bunch of regexes (one per secret) and therefore
+    # needs to buffer at least as many bytes as the longest of all possible matches. Still, this isn't that long in
+    # practice in our case. The real problem is that the buffering is not configurable: dagger relies on a golang
+    # library called transform [1] to perform the regexp matching on a stream and this library hard-codes a buffer
+    # size of 4096 bytes for each regex [2].
+    #
+    # Remove the special local case whenever dagger implements scrubbing differently [3].
+    #
+    # [1] https://golang.org/x/text/transform
+    # [2] https://cs.opensource.google/go/x/text/+/refs/tags/v0.13.0:transform/transform.go;l=130
+    # [3] https://github.com/dagger/dagger/blob/v0.6.4/cmd/shim/main.go#L294
+    #
+    if context.is_local:
+        # Special case for local development.
+
+        contents = {}
+        for secret_file_name, secret in context.connector_secrets.items():
+            contents[secret_file_name] = await secret.plaintext()
+
+        def with_secrets_mounted_as_regular_files(container: Container) -> Container:
+            container = container.with_exec(["mkdir", secret_directory_path], skip_entrypoint=True)
+            for secret_file_name, secret in contents.items():
+                container = container.with_new_file(f"{secret_directory_path}/{secret_file_name}", secret, permissions=0o600)
+            return container
+
+        return with_secrets_mounted_as_regular_files
+
+    def with_secrets_mounted_as_dagger_secrets(container: Container) -> Container:
         container = container.with_exec(["mkdir", secret_directory_path], skip_entrypoint=True)
         for secret_file_name, secret in context.connector_secrets.items():
             container = container.with_mounted_secret(f"{secret_directory_path}/{secret_file_name}", secret)
         return container
 
-    return mounted_connector_secrets_inner
+    return with_secrets_mounted_as_dagger_secrets

--- a/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
@@ -1034,15 +1034,15 @@ async def mounted_connector_secrets(context: PipelineContext, secret_directory_p
     #
     if context.is_local:
         # Special case for local development.
-
+        # Query dagger for the contents of the secrets and mount these strings as files in the container.
         contents = {}
         for secret_file_name, secret in context.connector_secrets.items():
             contents[secret_file_name] = await secret.plaintext()
 
         def with_secrets_mounted_as_regular_files(container: Container) -> Container:
             container = container.with_exec(["mkdir", secret_directory_path], skip_entrypoint=True)
-            for secret_file_name, secret in contents.items():
-                container = container.with_new_file(f"{secret_directory_path}/{secret_file_name}", secret, permissions=0o600)
+            for secret_file_name, secret_content_str in contents.items():
+                container = container.with_new_file(f"{secret_directory_path}/{secret_file_name}", secret_content_str, permissions=0o600)
             return container
 
         return with_secrets_mounted_as_regular_files

--- a/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
@@ -1025,11 +1025,12 @@ async def mounted_connector_secrets(context: PipelineContext, secret_directory_p
     # library called transform [1] to perform the regexp matching on a stream and this library hard-codes a buffer
     # size of 4096 bytes for each regex [2].
     #
-    # Remove the special local case whenever dagger implements scrubbing differently [3].
+    # Remove the special local case whenever dagger implements scrubbing differently [3,4].
     #
     # [1] https://golang.org/x/text/transform
     # [2] https://cs.opensource.google/go/x/text/+/refs/tags/v0.13.0:transform/transform.go;l=130
     # [3] https://github.com/dagger/dagger/blob/v0.6.4/cmd/shim/main.go#L294
+    # [4] https://github.com/airbytehq/airbyte/issues/30394
     #
     if context.is_local:
         # Special case for local development.

--- a/airbyte-ci/connectors/pipelines/pipelines/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/gradle.py
@@ -144,7 +144,7 @@ class GradleTask(Step, ABC):
         # From this point on, we add layers which are task-dependent.
         if self.mount_connector_secrets:
             gradle_container = gradle_container.with_(
-                environments.mounted_connector_secrets(self.context, f"{self.context.connector.code_directory}/secrets")
+                await environments.mounted_connector_secrets(self.context, f"{self.context.connector.code_directory}/secrets")
             )
         if self.bind_to_docker_host:
             # If this GradleTask subclass needs docker, then install it and bind it to the existing global docker host container.

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/common.py
@@ -270,7 +270,7 @@ class AcceptanceTests(PytestStep):
             .with_env_variable("CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH", "/dagger_share/connector_under_test_image.tar")
             .with_workdir("/test_input")
             .with_mounted_directory("/test_input", test_input)
-            .with_(environments.mounted_connector_secrets(self.context, secret_directory_path="/test_input/secrets"))
+            .with_(await environments.mounted_connector_secrets(self.context, "/test_input/secrets"))
         )
         if "_EXPERIMENTAL_DAGGER_RUNNER_HOST" in os.environ:
             self.context.logger.info("Using experimental dagger runner host to run CAT with dagger-in-dagger")

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/python_connectors.py
@@ -86,7 +86,9 @@ class UnitTests(PytestStep):
         Returns:
             StepResult: Failure or success of the unit tests with stdout and stdout.
         """
-        connector_under_test_with_secrets = connector_under_test.with_(environments.mounted_connector_secrets(self.context))
+        connector_under_test_with_secrets = connector_under_test.with_(
+            await environments.mounted_connector_secrets(self.context, "secrets")
+        )
         return await self._run_tests_in_directory(connector_under_test_with_secrets, "unit_tests")
 
 
@@ -106,7 +108,7 @@ class IntegrationTests(PytestStep):
         """
 
         connector_under_test = connector_under_test.with_(environments.bound_docker_host(self.context)).with_(
-            environments.mounted_connector_secrets(self.context)
+            await environments.mounted_connector_secrets(self.context, "secrets")
         )
         return await self._run_tests_in_directory(connector_under_test, "integration_tests")
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.2.1"
+version = "1.2.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -24,6 +24,11 @@ application {
 
 }
 
+integrationTestJava {
+    // This is needed to make the destination-snowflake tests succeed - https://github.com/snowflakedb/snowflake-jdbc/issues/589#issuecomment-983944767
+    jvmArgs = ["--add-opens=java.base/java.nio=ALL-UNNAMED"]
+}
+
 dependencies {
     implementation 'com.google.cloud:google-cloud-storage:1.113.16'
     implementation 'com.google.auth:google-auth-library-oauth2-http:0.25.5'

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -41,14 +41,20 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
 
             outputs.upToDateWhen { false }
 
-            //This allows to set up a `gradle.properties` file inside the connector folder to reduce number of threads and reduce parallelization.
-            //Specially useful for connectors that shares resources (like Redshift or Snowflake).
-            ext.numberThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') as int : Runtime.runtime.availableProcessors() ?: 1
+            maxParallelForks = Runtime.runtime.availableProcessors()
+            // This allows to set up a `gradle.properties` file inside the connector folder to reduce parallelization.
+            // This is especially useful for connectors that shares resources (like Redshift or Snowflake).
+            if (project.hasProperty('numberThreads')) {
+                int numberThreads = 0
+                String numberThreadsString = project.property('numberThreads').toString()
+                if (numberThreadsString.isInteger()) {
+                    numberThreads = numberThreadsString as int
+                }
+                 if (numberThreads > 0 && numberThreads < maxParallelForks) {
+                    maxParallelForks = numberThreads
+                }
+            }
             maxHeapSize = '3g'
-            maxParallelForks = numberThreads
-
-            // This is needed to make the destination-snowflake tests succeed - https://github.com/snowflakedb/snowflake-jdbc/issues/589#issuecomment-983944767
-            jvmArgs = ["--add-opens=java.base/java.nio=ALL-UNNAMED"]
 
             systemProperties = [
                 // Allow tests to set @Execution(ExecutionMode.CONCURRENT)


### PR DESCRIPTION
This PR fixes the log buffering issue in airbyte-ci that has plagued our recent source-mysql integration tests debugging efforts. What would happen is that we'd never see the `./gradlew ...:integrationTest` output in a timely manner, unlike all other pipeline steps.

As it turns out, the trigger for this buffering is that this container has secrets that were mounted to it. These secrets are the credentials downloaded from GSM so they are legit secrets. There's no way around this buffering, see commentary I added in the PR.

In any case, this PR adds a workaround when developing locally: we don't mount those files as secrets, just regular files. This is fine locally because those secrets are readily available on a development machine anyway. When airbyte-ci is not running locally, it's running in a github action or something and the buffering is something we can put up with in that case. In fact, so far, this hasn't been an issue at all in that context.

This PR includes another commit which has a trivial gradle fix. Its main purpose is to exercise this change on the snowflake connector. I'll do a couple of manual runs on python connectors just to make sure I didn't break anything there.