### PR TITLE
Maxi297/fix datetime format inference issue

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/utils/datetime_format_inferrer.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/datetime_format_inferrer.py
@@ -36,14 +36,14 @@ class DatetimeFormatInferrer:
         This is the case if the value is a string or an integer between 1_000_000_000 and 2_000_000_000 for seconds
         or between 1_000_000_000_000 and 2_000_000_000_000 for milliseconds.
         This is separate from the format check for performance reasons"""
-        for timestamp_range in self._timestamp_heuristic_ranges:
-            if isinstance(value, str):
-                try:
-                    if int(value) in timestamp_range:
+        if isinstance(value, (str, int)):
+            try:
+                value_as_int = int(value)
+                for timestamp_range in self._timestamp_heuristic_ranges:
+                    if value_as_int in timestamp_range:
                         return True
-                except ValueError:
-                    return True
-            if isinstance(value, int) and value in timestamp_range:
+            except ValueError:
+                # given that it's not parsable as an int, it can represent a datetime with one of the self._formats
                 return True
         return False
 

--- a/airbyte-cdk/python/airbyte_cdk/utils/datetime_format_inferrer.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/datetime_format_inferrer.py
@@ -37,8 +37,12 @@ class DatetimeFormatInferrer:
         or between 1_000_000_000_000 and 2_000_000_000_000 for milliseconds.
         This is separate from the format check for performance reasons"""
         for timestamp_range in self._timestamp_heuristic_ranges:
-            if isinstance(value, str) and (not value.isdecimal() or int(value) in timestamp_range):
-                return True
+            if isinstance(value, str):
+                try:
+                    if int(value) in timestamp_range:
+                        return True
+                except ValueError:
+                    return True
             if isinstance(value, int) and value in timestamp_range:
                 return True
         return False

--- a/airbyte-cdk/python/unit_tests/utils/test_datetime_format_inferrer.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_datetime_format_inferrer.py
@@ -22,6 +22,7 @@ NOW = 1234567
         ("timestamp_ms_match_string", [{"d": "1686058051000"}], {"d": "%ms"}),
         ("timestamp_no_match_integer", [{"d": 99}], {}),
         ("timestamp_no_match_string", [{"d": "99999999999999999999"}], {}),
+        ("timestamp_overflow", [{"d": f"{10**100}_100"}], {}),  # this case was previously causing OverflowError hence this test
         ("simple_no_match", [{"d": "20220203"}], {}),
         ("multiple_match", [{"d": "2022-02-03", "e": "2022-02-03"}], {"d": "%Y-%m-%d", "e": "%Y-%m-%d"}),
         (


### PR DESCRIPTION
## What
A user as reported an issue where entering a record selector would cause the error `timestamp out of range for platform time_t` without stacktrace and more information. This was caused by some value not being decimal but that could be casted as an int and would cause overflow. Example `f"{10**100_000}"`

## How
Relying on casting to int instead of `isdecimal`
