### PR TITLE
Clarify username/pass only working in docker compose

### DIFF
--- a/docs/operator-guides/security.md
+++ b/docs/operator-guides/security.md
@@ -56,7 +56,7 @@ You can secure access to Airbyte using the following methods:
     }
   }
   ```
-- Change the default username and password in your environment's `.env` file:
+- *Only for docker compose deployments:* Change the default username and password in your environment's `.env` file:
   ```
   	# Proxy Configuration
   	# Set to empty values, e.g. "" to disable basic auth


### PR DESCRIPTION
Make clear that the airbyte-proxy is only running in docker compose setups.