### PR TITLE
[ISSUE #30353] remove file_type from stream config

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -11,12 +11,12 @@ from typing_extensions import Literal
 
 
 class AddedFieldDefinition(BaseModel):
-    type: Literal['AddedFieldDefinition']
+    type: Literal["AddedFieldDefinition"]
     path: List[str] = Field(
         ...,
-        description='List of strings defining the path where to add the value on the record.',
-        examples=[['segment_id'], ['metadata', 'segment_id']],
-        title='Path',
+        description="List of strings defining the path where to add the value on the record.",
+        examples=[["segment_id"], ["metadata", "segment_id"]],
+        title="Path",
     )
     value: str = Field(
         ...,
@@ -26,607 +26,601 @@ class AddedFieldDefinition(BaseModel):
             "{{ record['MetaData']['LastUpdatedTime'] }}",
             "{{ stream_partition['segment_id'] }}",
         ],
-        title='Value',
+        title="Value",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class AddFields(BaseModel):
-    type: Literal['AddFields']
+    type: Literal["AddFields"]
     fields: List[AddedFieldDefinition] = Field(
         ...,
-        description='List of transformations (path and corresponding value) that will be added to the record.',
-        title='Fields',
+        description="List of transformations (path and corresponding value) that will be added to the record.",
+        title="Fields",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class AuthFlowType(Enum):
-    oauth2_0 = 'oauth2.0'
-    oauth1_0 = 'oauth1.0'
+    oauth2_0 = "oauth2.0"
+    oauth1_0 = "oauth1.0"
 
 
 class BasicHttpAuthenticator(BaseModel):
-    type: Literal['BasicHttpAuthenticator']
+    type: Literal["BasicHttpAuthenticator"]
     username: str = Field(
         ...,
-        description='The username that will be combined with the password, base64 encoded and used to make requests. Fill it in the user inputs.',
+        description="The username that will be combined with the password, base64 encoded and used to make requests. Fill it in the user inputs.",
         examples=["{{ config['username'] }}", "{{ config['api_key'] }}"],
-        title='Username',
+        title="Username",
     )
     password: Optional[str] = Field(
-        '',
-        description='The password that will be combined with the username, base64 encoded and used to make requests. Fill it in the user inputs.',
-        examples=["{{ config['password'] }}", ''],
-        title='Password',
+        "",
+        description="The password that will be combined with the username, base64 encoded and used to make requests. Fill it in the user inputs.",
+        examples=["{{ config['password'] }}", ""],
+        title="Password",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class BearerAuthenticator(BaseModel):
-    type: Literal['BearerAuthenticator']
+    type: Literal["BearerAuthenticator"]
     api_token: str = Field(
         ...,
-        description='Token to inject as request header for authenticating with the API.',
+        description="Token to inject as request header for authenticating with the API.",
         examples=["{{ config['api_key'] }}", "{{ config['token'] }}"],
-        title='Bearer Token',
+        title="Bearer Token",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CheckStream(BaseModel):
-    type: Literal['CheckStream']
+    type: Literal["CheckStream"]
     stream_names: List[str] = Field(
         ...,
-        description='Names of the streams to try reading from when running a check operation.',
-        examples=[['users'], ['users', 'contacts']],
-        title='Stream Names',
+        description="Names of the streams to try reading from when running a check operation.",
+        examples=[["users"], ["users", "contacts"]],
+        title="Stream Names",
     )
 
 
 class ConstantBackoffStrategy(BaseModel):
-    type: Literal['ConstantBackoffStrategy']
+    type: Literal["ConstantBackoffStrategy"]
     backoff_time_in_seconds: Union[float, str] = Field(
         ...,
-        description='Backoff time in seconds.',
+        description="Backoff time in seconds.",
         examples=[30, 30.5, "{{ config['backoff_time'] }}"],
-        title='Backoff Time',
+        title="Backoff Time",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CustomAuthenticator(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['CustomAuthenticator']
+    type: Literal["CustomAuthenticator"]
     class_name: str = Field(
         ...,
-        description='Fully-qualified name of the class that will be implementing the custom authentication strategy. Has to be a sub class of DeclarativeAuthenticator. The format is `source_<name>.<package>.<class_name>`.',
-        examples=['source_railz.components.ShortLivedTokenAuthenticator'],
-        title='Class Name',
+        description="Fully-qualified name of the class that will be implementing the custom authentication strategy. Has to be a sub class of DeclarativeAuthenticator. The format is `source_<name>.<package>.<class_name>`.",
+        examples=["source_railz.components.ShortLivedTokenAuthenticator"],
+        title="Class Name",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CustomBackoffStrategy(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['CustomBackoffStrategy']
+    type: Literal["CustomBackoffStrategy"]
     class_name: str = Field(
         ...,
-        description='Fully-qualified name of the class that will be implementing the custom backoff strategy. The format is `source_<name>.<package>.<class_name>`.',
-        examples=['source_railz.components.MyCustomBackoffStrategy'],
-        title='Class Name',
+        description="Fully-qualified name of the class that will be implementing the custom backoff strategy. The format is `source_<name>.<package>.<class_name>`.",
+        examples=["source_railz.components.MyCustomBackoffStrategy"],
+        title="Class Name",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CustomErrorHandler(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['CustomErrorHandler']
+    type: Literal["CustomErrorHandler"]
     class_name: str = Field(
         ...,
-        description='Fully-qualified name of the class that will be implementing the custom error handler. The format is `source_<name>.<package>.<class_name>`.',
-        examples=['source_railz.components.MyCustomErrorHandler'],
-        title='Class Name',
+        description="Fully-qualified name of the class that will be implementing the custom error handler. The format is `source_<name>.<package>.<class_name>`.",
+        examples=["source_railz.components.MyCustomErrorHandler"],
+        title="Class Name",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CustomIncrementalSync(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['CustomIncrementalSync']
+    type: Literal["CustomIncrementalSync"]
     class_name: str = Field(
         ...,
-        description='Fully-qualified name of the class that will be implementing the custom incremental sync. The format is `source_<name>.<package>.<class_name>`.',
-        examples=['source_railz.components.MyCustomIncrementalSync'],
-        title='Class Name',
+        description="Fully-qualified name of the class that will be implementing the custom incremental sync. The format is `source_<name>.<package>.<class_name>`.",
+        examples=["source_railz.components.MyCustomIncrementalSync"],
+        title="Class Name",
     )
     cursor_field: str = Field(
         ...,
-        description='The location of the value on a record that will be used as a bookmark during sync.',
+        description="The location of the value on a record that will be used as a bookmark during sync.",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CustomPaginationStrategy(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['CustomPaginationStrategy']
+    type: Literal["CustomPaginationStrategy"]
     class_name: str = Field(
         ...,
-        description='Fully-qualified name of the class that will be implementing the custom pagination strategy. The format is `source_<name>.<package>.<class_name>`.',
-        examples=['source_railz.components.MyCustomPaginationStrategy'],
-        title='Class Name',
+        description="Fully-qualified name of the class that will be implementing the custom pagination strategy. The format is `source_<name>.<package>.<class_name>`.",
+        examples=["source_railz.components.MyCustomPaginationStrategy"],
+        title="Class Name",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CustomRecordExtractor(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['CustomRecordExtractor']
+    type: Literal["CustomRecordExtractor"]
     class_name: str = Field(
         ...,
-        description='Fully-qualified name of the class that will be implementing the custom record extraction strategy. The format is `source_<name>.<package>.<class_name>`.',
-        examples=['source_railz.components.MyCustomRecordExtractor'],
-        title='Class Name',
+        description="Fully-qualified name of the class that will be implementing the custom record extraction strategy. The format is `source_<name>.<package>.<class_name>`.",
+        examples=["source_railz.components.MyCustomRecordExtractor"],
+        title="Class Name",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CustomRequester(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['CustomRequester']
+    type: Literal["CustomRequester"]
     class_name: str = Field(
         ...,
-        description='Fully-qualified name of the class that will be implementing the custom requester strategy. The format is `source_<name>.<package>.<class_name>`.',
-        examples=['source_railz.components.MyCustomRecordExtractor'],
-        title='Class Name',
+        description="Fully-qualified name of the class that will be implementing the custom requester strategy. The format is `source_<name>.<package>.<class_name>`.",
+        examples=["source_railz.components.MyCustomRecordExtractor"],
+        title="Class Name",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CustomRetriever(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['CustomRetriever']
+    type: Literal["CustomRetriever"]
     class_name: str = Field(
         ...,
-        description='Fully-qualified name of the class that will be implementing the custom retriever strategy. The format is `source_<name>.<package>.<class_name>`.',
-        examples=['source_railz.components.MyCustomRetriever'],
-        title='Class Name',
+        description="Fully-qualified name of the class that will be implementing the custom retriever strategy. The format is `source_<name>.<package>.<class_name>`.",
+        examples=["source_railz.components.MyCustomRetriever"],
+        title="Class Name",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CustomPartitionRouter(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['CustomPartitionRouter']
+    type: Literal["CustomPartitionRouter"]
     class_name: str = Field(
         ...,
-        description='Fully-qualified name of the class that will be implementing the custom partition router. The format is `source_<name>.<package>.<class_name>`.',
-        examples=['source_railz.components.MyCustomPartitionRouter'],
-        title='Class Name',
+        description="Fully-qualified name of the class that will be implementing the custom partition router. The format is `source_<name>.<package>.<class_name>`.",
+        examples=["source_railz.components.MyCustomPartitionRouter"],
+        title="Class Name",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class CustomTransformation(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['CustomTransformation']
+    type: Literal["CustomTransformation"]
     class_name: str = Field(
         ...,
-        description='Fully-qualified name of the class that will be implementing the custom transformation. The format is `source_<name>.<package>.<class_name>`.',
-        examples=['source_railz.components.MyCustomTransformation'],
-        title='Class Name',
+        description="Fully-qualified name of the class that will be implementing the custom transformation. The format is `source_<name>.<package>.<class_name>`.",
+        examples=["source_railz.components.MyCustomTransformation"],
+        title="Class Name",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class RefreshTokenUpdater(BaseModel):
     refresh_token_name: Optional[str] = Field(
-        'refresh_token',
-        description='The name of the property which contains the updated refresh token in the response from the token refresh endpoint.',
-        examples=['refresh_token'],
-        title='Refresh Token Property Name',
+        "refresh_token",
+        description="The name of the property which contains the updated refresh token in the response from the token refresh endpoint.",
+        examples=["refresh_token"],
+        title="Refresh Token Property Name",
     )
     access_token_config_path: Optional[List[str]] = Field(
-        ['credentials', 'access_token'],
-        description='Config path to the access token. Make sure the field actually exists in the config.',
-        examples=[['credentials', 'access_token'], ['access_token']],
-        title='Config Path To Access Token',
+        ["credentials", "access_token"],
+        description="Config path to the access token. Make sure the field actually exists in the config.",
+        examples=[["credentials", "access_token"], ["access_token"]],
+        title="Config Path To Access Token",
     )
     refresh_token_config_path: Optional[List[str]] = Field(
-        ['credentials', 'refresh_token'],
-        description='Config path to the access token. Make sure the field actually exists in the config.',
-        examples=[['credentials', 'refresh_token'], ['refresh_token']],
-        title='Config Path To Refresh Token',
+        ["credentials", "refresh_token"],
+        description="Config path to the access token. Make sure the field actually exists in the config.",
+        examples=[["credentials", "refresh_token"], ["refresh_token"]],
+        title="Config Path To Refresh Token",
     )
     token_expiry_date_config_path: Optional[List[str]] = Field(
-        ['credentials', 'token_expiry_date'],
-        description='Config path to the expiry date. Make sure actually exists in the config.',
-        examples=[['credentials', 'token_expiry_date']],
-        title='Config Path To Expiry Date',
+        ["credentials", "token_expiry_date"],
+        description="Config path to the expiry date. Make sure actually exists in the config.",
+        examples=[["credentials", "token_expiry_date"]],
+        title="Config Path To Expiry Date",
     )
 
 
 class OAuthAuthenticator(BaseModel):
-    type: Literal['OAuthAuthenticator']
+    type: Literal["OAuthAuthenticator"]
     client_id: str = Field(
         ...,
-        description='The OAuth client ID. Fill it in the user inputs.',
+        description="The OAuth client ID. Fill it in the user inputs.",
         examples=["{{ config['client_id }}", "{{ config['credentials']['client_id }}"],
-        title='Client ID',
+        title="Client ID",
     )
     client_secret: str = Field(
         ...,
-        description='The OAuth client secret. Fill it in the user inputs.',
+        description="The OAuth client secret. Fill it in the user inputs.",
         examples=[
             "{{ config['client_secret }}",
             "{{ config['credentials']['client_secret }}",
         ],
-        title='Client Secret',
+        title="Client Secret",
     )
     refresh_token: Optional[str] = Field(
         None,
-        description='Credential artifact used to get a new access token.',
+        description="Credential artifact used to get a new access token.",
         examples=[
             "{{ config['refresh_token'] }}",
             "{{ config['credentials]['refresh_token'] }}",
         ],
-        title='Refresh Token',
+        title="Refresh Token",
     )
     token_refresh_endpoint: str = Field(
         ...,
-        description='The full URL to call to obtain a new access token.',
-        examples=['https://connect.squareup.com/oauth2/token'],
-        title='Token Refresh Endpoint',
+        description="The full URL to call to obtain a new access token.",
+        examples=["https://connect.squareup.com/oauth2/token"],
+        title="Token Refresh Endpoint",
     )
     access_token_name: Optional[str] = Field(
-        'access_token',
-        description='The name of the property which contains the access token in the response from the token refresh endpoint.',
-        examples=['access_token'],
-        title='Access Token Property Name',
+        "access_token",
+        description="The name of the property which contains the access token in the response from the token refresh endpoint.",
+        examples=["access_token"],
+        title="Access Token Property Name",
     )
     expires_in_name: Optional[str] = Field(
-        'expires_in',
-        description='The name of the property which contains the expiry date in the response from the token refresh endpoint.',
-        examples=['expires_in'],
-        title='Token Expiry Property Name',
+        "expires_in",
+        description="The name of the property which contains the expiry date in the response from the token refresh endpoint.",
+        examples=["expires_in"],
+        title="Token Expiry Property Name",
     )
     grant_type: Optional[str] = Field(
-        'refresh_token',
-        description='Specifies the OAuth2 grant type. If set to refresh_token, the refresh_token needs to be provided as well. For client_credentials, only client id and secret are required. Other grant types are not officially supported.',
-        examples=['refresh_token', 'client_credentials'],
-        title='Grant Type',
+        "refresh_token",
+        description="Specifies the OAuth2 grant type. If set to refresh_token, the refresh_token needs to be provided as well. For client_credentials, only client id and secret are required. Other grant types are not officially supported.",
+        examples=["refresh_token", "client_credentials"],
+        title="Grant Type",
     )
     refresh_request_body: Optional[Dict[str, Any]] = Field(
         None,
-        description='Body of the request sent to get a new access token.',
+        description="Body of the request sent to get a new access token.",
         examples=[
             {
-                'applicationId': "{{ config['application_id'] }}",
-                'applicationSecret': "{{ config['application_secret'] }}",
-                'token': "{{ config['token'] }}",
+                "applicationId": "{{ config['application_id'] }}",
+                "applicationSecret": "{{ config['application_secret'] }}",
+                "token": "{{ config['token'] }}",
             }
         ],
-        title='Refresh Request Body',
+        title="Refresh Request Body",
     )
     scopes: Optional[List[str]] = Field(
         None,
-        description='List of scopes that should be granted to the access token.',
-        examples=[
-            ['crm.list.read', 'crm.objects.contacts.read', 'crm.schema.contacts.read']
-        ],
-        title='Scopes',
+        description="List of scopes that should be granted to the access token.",
+        examples=[["crm.list.read", "crm.objects.contacts.read", "crm.schema.contacts.read"]],
+        title="Scopes",
     )
     token_expiry_date: Optional[str] = Field(
         None,
-        description='The access token expiry date.',
-        examples=['2023-04-06T07:12:10.421833+00:00', 1680842386],
-        title='Token Expiry Date',
+        description="The access token expiry date.",
+        examples=["2023-04-06T07:12:10.421833+00:00", 1680842386],
+        title="Token Expiry Date",
     )
     token_expiry_date_format: Optional[str] = Field(
         None,
-        description='The format of the time to expiration datetime. Provide it if the time is returned as a date-time string instead of seconds.',
-        examples=['%Y-%m-%d %H:%M:%S.%f+00:00'],
-        title='Token Expiry Date Format',
+        description="The format of the time to expiration datetime. Provide it if the time is returned as a date-time string instead of seconds.",
+        examples=["%Y-%m-%d %H:%M:%S.%f+00:00"],
+        title="Token Expiry Date Format",
     )
     refresh_token_updater: Optional[RefreshTokenUpdater] = Field(
         None,
-        description='When the token updater is defined, new refresh tokens, access tokens and the access token expiry date are written back from the authentication response to the config object. This is important if the refresh token can only used once.',
-        title='Token Updater',
+        description="When the token updater is defined, new refresh tokens, access tokens and the access token expiry date are written back from the authentication response to the config object. This is important if the refresh token can only used once.",
+        title="Token Updater",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class ExponentialBackoffStrategy(BaseModel):
-    type: Literal['ExponentialBackoffStrategy']
+    type: Literal["ExponentialBackoffStrategy"]
     factor: Optional[Union[float, str]] = Field(
         5,
-        description='Multiplicative constant applied on each retry.',
-        examples=[5, 5.5, '10'],
-        title='Factor',
+        description="Multiplicative constant applied on each retry.",
+        examples=[5, 5.5, "10"],
+        title="Factor",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class SessionTokenRequestBearerAuthenticator(BaseModel):
-    type: Literal['Bearer']
+    type: Literal["Bearer"]
 
 
 class HttpMethodEnum(Enum):
-    GET = 'GET'
-    POST = 'POST'
+    GET = "GET"
+    POST = "POST"
 
 
 class Action(Enum):
-    SUCCESS = 'SUCCESS'
-    FAIL = 'FAIL'
-    RETRY = 'RETRY'
-    IGNORE = 'IGNORE'
+    SUCCESS = "SUCCESS"
+    FAIL = "FAIL"
+    RETRY = "RETRY"
+    IGNORE = "IGNORE"
 
 
 class HttpResponseFilter(BaseModel):
-    type: Literal['HttpResponseFilter']
+    type: Literal["HttpResponseFilter"]
     action: Action = Field(
         ...,
-        description='Action to execute if a response matches the filter.',
-        examples=['SUCCESS', 'FAIL', 'RETRY', 'IGNORE'],
-        title='Action',
+        description="Action to execute if a response matches the filter.",
+        examples=["SUCCESS", "FAIL", "RETRY", "IGNORE"],
+        title="Action",
     )
     error_message: Optional[str] = Field(
         None,
-        description='Error Message to display if the response matches the filter.',
-        title='Error Message',
+        description="Error Message to display if the response matches the filter.",
+        title="Error Message",
     )
     error_message_contains: Optional[str] = Field(
         None,
-        description='Match the response if its error message contains the substring.',
-        example=['This API operation is not enabled for this site'],
-        title='Error Message Substring',
+        description="Match the response if its error message contains the substring.",
+        example=["This API operation is not enabled for this site"],
+        title="Error Message Substring",
     )
     http_codes: Optional[List[int]] = Field(
         None,
-        description='Match the response if its HTTP code is included in this list.',
+        description="Match the response if its HTTP code is included in this list.",
         examples=[[420, 429], [500]],
-        title='HTTP Codes',
+        title="HTTP Codes",
     )
     predicate: Optional[str] = Field(
         None,
-        description='Match the response if the predicate evaluates to true.',
+        description="Match the response if the predicate evaluates to true.",
         examples=[
             "{{ 'Too much requests' in response }}",
             "{{ 'error_code' in response and response['error_code'] == 'ComplexityException' }}",
         ],
-        title='Predicate',
+        title="Predicate",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class InlineSchemaLoader(BaseModel):
-    type: Literal['InlineSchemaLoader']
+    type: Literal["InlineSchemaLoader"]
     schema_: Optional[Dict[str, Any]] = Field(
         None,
-        alias='schema',
+        alias="schema",
         description='Describes a streams\' schema. Refer to the <a href="https://docs.airbyte.com/understanding-airbyte/supported-data-types/">Data Types documentation</a> for more details on which types are valid.',
-        title='Schema',
+        title="Schema",
     )
 
 
 class JsonFileSchemaLoader(BaseModel):
-    type: Literal['JsonFileSchemaLoader']
+    type: Literal["JsonFileSchemaLoader"]
     file_path: Optional[str] = Field(
         None,
         description="Path to the JSON file defining the schema. The path is relative to the connector module's root.",
-        example=['./schemas/users.json'],
-        title='File Path',
+        example=["./schemas/users.json"],
+        title="File Path",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class JsonDecoder(BaseModel):
-    type: Literal['JsonDecoder']
+    type: Literal["JsonDecoder"]
 
 
 class MinMaxDatetime(BaseModel):
-    type: Literal['MinMaxDatetime']
+    type: Literal["MinMaxDatetime"]
     datetime: str = Field(
         ...,
-        description='Datetime value.',
-        examples=['2021-01-01', '2021-01-01T00:00:00Z', "{{ config['start_time'] }}"],
-        title='Datetime',
+        description="Datetime value.",
+        examples=["2021-01-01", "2021-01-01T00:00:00Z", "{{ config['start_time'] }}"],
+        title="Datetime",
     )
     datetime_format: Optional[str] = Field(
-        '',
+        "",
         description='Format of the datetime value. Defaults to "%Y-%m-%dT%H:%M:%S.%f%z" if left empty. Use placeholders starting with "%" to describe the format the API is using. The following placeholders are available:\n  * **%s**: Epoch unix timestamp - `1686218963`\n  * **%ms**: Epoch unix timestamp - `1686218963123`\n  * **%a**: Weekday (abbreviated) - `Sun`\n  * **%A**: Weekday (full) - `Sunday`\n  * **%w**: Weekday (decimal) - `0` (Sunday), `6` (Saturday)\n  * **%d**: Day of the month (zero-padded) - `01`, `02`, ..., `31`\n  * **%b**: Month (abbreviated) - `Jan`\n  * **%B**: Month (full) - `January`\n  * **%m**: Month (zero-padded) - `01`, `02`, ..., `12`\n  * **%y**: Year (without century, zero-padded) - `00`, `01`, ..., `99`\n  * **%Y**: Year (with century) - `0001`, `0002`, ..., `9999`\n  * **%H**: Hour (24-hour, zero-padded) - `00`, `01`, ..., `23`\n  * **%I**: Hour (12-hour, zero-padded) - `01`, `02`, ..., `12`\n  * **%p**: AM/PM indicator\n  * **%M**: Minute (zero-padded) - `00`, `01`, ..., `59`\n  * **%S**: Second (zero-padded) - `00`, `01`, ..., `59`\n  * **%f**: Microsecond (zero-padded to 6 digits) - `000000`, `000001`, ..., `999999`\n  * **%z**: UTC offset - `(empty)`, `+0000`, `-04:00`\n  * **%Z**: Time zone name - `(empty)`, `UTC`, `GMT`\n  * **%j**: Day of the year (zero-padded) - `001`, `002`, ..., `366`\n  * **%U**: Week number of the year (Sunday as first day) - `00`, `01`, ..., `53`\n  * **%W**: Week number of the year (Monday as first day) - `00`, `01`, ..., `53`\n  * **%c**: Date and time representation - `Tue Aug 16 21:30:00 1988`\n  * **%x**: Date representation - `08/16/1988`\n  * **%X**: Time representation - `21:30:00`\n  * **%%**: Literal \'%\' character\n\n  Some placeholders depend on the locale of the underlying system - in most cases this locale is configured as en/US. For more information see the [Python documentation](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).\n',
-        examples=['%Y-%m-%dT%H:%M:%S.%f%z', '%Y-%m-%d', '%s'],
-        title='Datetime Format',
+        examples=["%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%d", "%s"],
+        title="Datetime Format",
     )
     max_datetime: Optional[str] = Field(
         None,
-        description='Ceiling applied on the datetime value. Must be formatted with the datetime_format field.',
-        examples=['2021-01-01T00:00:00Z', '2021-01-01'],
-        title='Max Datetime',
+        description="Ceiling applied on the datetime value. Must be formatted with the datetime_format field.",
+        examples=["2021-01-01T00:00:00Z", "2021-01-01"],
+        title="Max Datetime",
     )
     min_datetime: Optional[str] = Field(
         None,
-        description='Floor applied on the datetime value. Must be formatted with the datetime_format field.',
-        examples=['2010-01-01T00:00:00Z', '2010-01-01'],
-        title='Min Datetime',
+        description="Floor applied on the datetime value. Must be formatted with the datetime_format field.",
+        examples=["2010-01-01T00:00:00Z", "2010-01-01"],
+        title="Min Datetime",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class NoAuth(BaseModel):
-    type: Literal['NoAuth']
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    type: Literal["NoAuth"]
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class NoPagination(BaseModel):
-    type: Literal['NoPagination']
+    type: Literal["NoPagination"]
 
 
 class OAuthConfigSpecification(BaseModel):
     class Config:
         extra = Extra.allow
 
-    oauth_user_input_from_connector_config_specification: Optional[
-        Dict[str, Any]
-    ] = Field(
+    oauth_user_input_from_connector_config_specification: Optional[Dict[str, Any]] = Field(
         None,
         description="OAuth specific blob. This is a Json Schema used to validate Json configurations used as input to OAuth.\nMust be a valid non-nested JSON that refers to properties from ConnectorSpecification.connectionSpecification\nusing special annotation 'path_in_connector_config'.\nThese are input values the user is entering through the UI to authenticate to the connector, that might also shared\nas inputs for syncing data via the connector.\nExamples:\nif no connector values is shared during oauth flow, oauth_user_input_from_connector_config_specification=[]\nif connector values such as 'app_id' inside the top level are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['app_id']\n    }\n  }\nif connector values such as 'info.app_id' nested inside another object are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['info', 'app_id']\n    }\n  }",
         examples=[
-            {'app_id': {'type': 'string', 'path_in_connector_config': ['app_id']}},
+            {"app_id": {"type": "string", "path_in_connector_config": ["app_id"]}},
             {
-                'app_id': {
-                    'type': 'string',
-                    'path_in_connector_config': ['info', 'app_id'],
+                "app_id": {
+                    "type": "string",
+                    "path_in_connector_config": ["info", "app_id"],
                 }
             },
         ],
-        title='OAuth user input',
+        title="OAuth user input",
     )
     complete_oauth_output_specification: Optional[Dict[str, Any]] = Field(
         None,
         description="OAuth specific blob. This is a Json Schema used to validate Json configurations produced by the OAuth flows as they are\nreturned by the distant OAuth APIs.\nMust be a valid JSON describing the fields to merge back to `ConnectorSpecification.connectionSpecification`.\nFor each field, a special annotation `path_in_connector_config` can be specified to determine where to merge it,\nExamples:\n    complete_oauth_output_specification={\n      refresh_token: {\n        type: string,\n        path_in_connector_config: ['credentials', 'refresh_token']\n      }\n    }",
         examples=[
             {
-                'refresh_token': {
-                    'type': 'string,',
-                    'path_in_connector_config': ['credentials', 'refresh_token'],
+                "refresh_token": {
+                    "type": "string,",
+                    "path_in_connector_config": ["credentials", "refresh_token"],
                 }
             }
         ],
-        title='OAuth output specification',
+        title="OAuth output specification",
     )
     complete_oauth_server_input_specification: Optional[Dict[str, Any]] = Field(
         None,
-        description='OAuth specific blob. This is a Json Schema used to validate Json configurations persisted as Airbyte Server configurations.\nMust be a valid non-nested JSON describing additional fields configured by the Airbyte Instance or Workspace Admins to be used by the\nserver when completing an OAuth flow (typically exchanging an auth code for refresh token).\nExamples:\n    complete_oauth_server_input_specification={\n      client_id: {\n        type: string\n      },\n      client_secret: {\n        type: string\n      }\n    }',
-        examples=[
-            {'client_id': {'type': 'string'}, 'client_secret': {'type': 'string'}}
-        ],
-        title='OAuth input specification',
+        description="OAuth specific blob. This is a Json Schema used to validate Json configurations persisted as Airbyte Server configurations.\nMust be a valid non-nested JSON describing additional fields configured by the Airbyte Instance or Workspace Admins to be used by the\nserver when completing an OAuth flow (typically exchanging an auth code for refresh token).\nExamples:\n    complete_oauth_server_input_specification={\n      client_id: {\n        type: string\n      },\n      client_secret: {\n        type: string\n      }\n    }",
+        examples=[{"client_id": {"type": "string"}, "client_secret": {"type": "string"}}],
+        title="OAuth input specification",
     )
     complete_oauth_server_output_specification: Optional[Dict[str, Any]] = Field(
         None,
         description="OAuth specific blob. This is a Json Schema used to validate Json configurations persisted as Airbyte Server configurations that\nalso need to be merged back into the connector configuration at runtime.\nThis is a subset configuration of `complete_oauth_server_input_specification` that filters fields out to retain only the ones that\nare necessary for the connector to function with OAuth. (some fields could be used during oauth flows but not needed afterwards, therefore\nthey would be listed in the `complete_oauth_server_input_specification` but not `complete_oauth_server_output_specification`)\nMust be a valid non-nested JSON describing additional fields configured by the Airbyte Instance or Workspace Admins to be used by the\nconnector when using OAuth flow APIs.\nThese fields are to be merged back to `ConnectorSpecification.connectionSpecification`.\nFor each field, a special annotation `path_in_connector_config` can be specified to determine where to merge it,\nExamples:\n      complete_oauth_server_output_specification={\n        client_id: {\n          type: string,\n          path_in_connector_config: ['credentials', 'client_id']\n        },\n        client_secret: {\n          type: string,\n          path_in_connector_config: ['credentials', 'client_secret']\n        }\n      }",
         examples=[
             {
-                'client_id': {
-                    'type': 'string,',
-                    'path_in_connector_config': ['credentials', 'client_id'],
+                "client_id": {
+                    "type": "string,",
+                    "path_in_connector_config": ["credentials", "client_id"],
                 },
-                'client_secret': {
-                    'type': 'string,',
-                    'path_in_connector_config': ['credentials', 'client_secret'],
+                "client_secret": {
+                    "type": "string,",
+                    "path_in_connector_config": ["credentials", "client_secret"],
                 },
             }
         ],
-        title='OAuth server output specification',
+        title="OAuth server output specification",
     )
 
 
 class OffsetIncrement(BaseModel):
-    type: Literal['OffsetIncrement']
+    type: Literal["OffsetIncrement"]
     page_size: Optional[Union[int, str]] = Field(
         None,
-        description='The number of records to include in each pages.',
+        description="The number of records to include in each pages.",
         examples=[100, "{{ config['page_size'] }}"],
-        title='Limit',
+        title="Limit",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class PageIncrement(BaseModel):
-    type: Literal['PageIncrement']
+    type: Literal["PageIncrement"]
     page_size: Optional[int] = Field(
         None,
-        description='The number of records to include in each pages.',
-        examples=[100, '100'],
-        title='Page Size',
+        description="The number of records to include in each pages.",
+        examples=[100, "100"],
+        title="Page Size",
     )
     start_from_page: Optional[int] = Field(
         0,
-        description='Index of the first page to request.',
+        description="Index of the first page to request.",
         examples=[0, 1],
-        title='Start From Page',
+        title="Start From Page",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class PrimaryKey(BaseModel):
     __root__: Union[str, List[str], List[List[str]]] = Field(
         ...,
-        description='The stream field to be used to distinguish unique records. Can either be a single field, an array of fields representing a composite key, or an array of arrays representing a composite key where the fields are nested fields.',
-        examples=['id', ['code', 'type']],
-        title='Primary Key',
+        description="The stream field to be used to distinguish unique records. Can either be a single field, an array of fields representing a composite key, or an array of arrays representing a composite key where the fields are nested fields.",
+        examples=["id", ["code", "type"]],
+        title="Primary Key",
     )
 
 
 class RecordFilter(BaseModel):
-    type: Literal['RecordFilter']
+    type: Literal["RecordFilter"]
     condition: Optional[str] = Field(
-        '',
-        description='The predicate to filter a record. Records will be removed if evaluated to False.',
+        "",
+        description="The predicate to filter a record. Records will be removed if evaluated to False.",
         examples=[
             "{{ record['created_at'] >= stream_interval['start_time'] }}",
             "{{ record.status in ['active', 'expired'] }}",
         ],
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class RemoveFields(BaseModel):
-    type: Literal['RemoveFields']
+    type: Literal["RemoveFields"]
     field_pointers: List[List[str]] = Field(
         ...,
-        description='Array of paths defining the field to remove. Each item is an array whose field describe the path of a field to remove.',
-        examples=[['tags'], [['content', 'html'], ['content', 'plain_text']]],
-        title='Field Paths',
+        description="Array of paths defining the field to remove. Each item is an array whose field describe the path of a field to remove.",
+        examples=[["tags"], [["content", "html"], ["content", "plain_text"]]],
+        title="Field Paths",
     )
 
 
 class RequestPath(BaseModel):
-    type: Literal['RequestPath']
+    type: Literal["RequestPath"]
 
 
 class InjectInto(Enum):
-    request_parameter = 'request_parameter'
-    header = 'header'
-    body_data = 'body_data'
-    body_json = 'body_json'
+    request_parameter = "request_parameter"
+    header = "header"
+    body_data = "body_data"
+    body_json = "body_json"
 
 
 class RequestOption(BaseModel):
-    type: Literal['RequestOption']
+    type: Literal["RequestOption"]
     field_name: str = Field(
         ...,
-        description='Configures which key should be used in the location that the descriptor is being injected into',
-        examples=['segment_id'],
-        title='Request Option',
+        description="Configures which key should be used in the location that the descriptor is being injected into",
+        examples=["segment_id"],
+        title="Request Option",
     )
     inject_into: InjectInto = Field(
         ...,
-        description='Configures where the descriptor should be set on the HTTP requests. Note that request parameters that are already encoded in the URL path will not be duplicated.',
-        examples=['request_parameter', 'header', 'body_data', 'body_json'],
-        title='Inject Into',
+        description="Configures where the descriptor should be set on the HTTP requests. Note that request parameters that are already encoded in the URL path will not be duplicated.",
+        examples=["request_parameter", "header", "body_data", "body_json"],
+        title="Inject Into",
     )
 
 
@@ -638,253 +632,251 @@ class Schemas(BaseModel):
 
 
 class LegacySessionTokenAuthenticator(BaseModel):
-    type: Literal['LegacySessionTokenAuthenticator']
+    type: Literal["LegacySessionTokenAuthenticator"]
     header: str = Field(
         ...,
-        description='The name of the session token header that will be injected in the request',
-        examples=['X-Session'],
-        title='Session Request Header',
+        description="The name of the session token header that will be injected in the request",
+        examples=["X-Session"],
+        title="Session Request Header",
     )
     login_url: str = Field(
         ...,
-        description='Path of the login URL (do not include the base URL)',
-        examples=['session'],
-        title='Login Path',
+        description="Path of the login URL (do not include the base URL)",
+        examples=["session"],
+        title="Login Path",
     )
     session_token: Optional[str] = Field(
         None,
-        description='Session token to use if using a pre-defined token. Not needed if authenticating with username + password pair',
+        description="Session token to use if using a pre-defined token. Not needed if authenticating with username + password pair",
         example=["{{ config['session_token'] }}"],
-        title='Session Token',
+        title="Session Token",
     )
     session_token_response_key: str = Field(
         ...,
-        description='Name of the key of the session token to be extracted from the response',
-        examples=['id'],
-        title='Response Token Response Key',
+        description="Name of the key of the session token to be extracted from the response",
+        examples=["id"],
+        title="Response Token Response Key",
     )
     username: Optional[str] = Field(
         None,
-        description='Username used to authenticate and obtain a session token',
+        description="Username used to authenticate and obtain a session token",
         examples=[" {{ config['username'] }}"],
-        title='Username',
+        title="Username",
     )
     password: Optional[str] = Field(
-        '',
-        description='Password used to authenticate and obtain a session token',
-        examples=["{{ config['password'] }}", ''],
-        title='Password',
+        "",
+        description="Password used to authenticate and obtain a session token",
+        examples=["{{ config['password'] }}", ""],
+        title="Password",
     )
     validate_session_url: str = Field(
         ...,
-        description='Path of the URL to use to validate that the session token is valid (do not include the base URL)',
-        examples=['user/current'],
-        title='Validate Session Path',
+        description="Path of the URL to use to validate that the session token is valid (do not include the base URL)",
+        examples=["user/current"],
+        title="Validate Session Path",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class WaitTimeFromHeader(BaseModel):
-    type: Literal['WaitTimeFromHeader']
+    type: Literal["WaitTimeFromHeader"]
     header: str = Field(
         ...,
-        description='The name of the response header defining how long to wait before retrying.',
-        examples=['Retry-After'],
-        title='Response Header Name',
+        description="The name of the response header defining how long to wait before retrying.",
+        examples=["Retry-After"],
+        title="Response Header Name",
     )
     regex: Optional[str] = Field(
         None,
-        description='Optional regex to apply on the header to extract its value. The regex should define a capture group defining the wait time.',
-        examples=['([-+]?\\d+)'],
-        title='Extraction Regex',
+        description="Optional regex to apply on the header to extract its value. The regex should define a capture group defining the wait time.",
+        examples=["([-+]?\\d+)"],
+        title="Extraction Regex",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class WaitUntilTimeFromHeader(BaseModel):
-    type: Literal['WaitUntilTimeFromHeader']
+    type: Literal["WaitUntilTimeFromHeader"]
     header: str = Field(
         ...,
-        description='The name of the response header defining how long to wait before retrying.',
-        examples=['wait_time'],
-        title='Response Header',
+        description="The name of the response header defining how long to wait before retrying.",
+        examples=["wait_time"],
+        title="Response Header",
     )
     min_wait: Optional[Union[float, str]] = Field(
         None,
-        description='Minimum time to wait before retrying.',
-        examples=[10, '60'],
-        title='Minimum Wait Time',
+        description="Minimum time to wait before retrying.",
+        examples=[10, "60"],
+        title="Minimum Wait Time",
     )
     regex: Optional[str] = Field(
         None,
-        description='Optional regex to apply on the header to extract its value. The regex should define a capture group defining the wait time.',
-        examples=['([-+]?\\d+)'],
-        title='Extraction Regex',
+        description="Optional regex to apply on the header to extract its value. The regex should define a capture group defining the wait time.",
+        examples=["([-+]?\\d+)"],
+        title="Extraction Regex",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class ApiKeyAuthenticator(BaseModel):
-    type: Literal['ApiKeyAuthenticator']
+    type: Literal["ApiKeyAuthenticator"]
     api_token: Optional[str] = Field(
         None,
-        description='The API key to inject in the request. Fill it in the user inputs.',
+        description="The API key to inject in the request. Fill it in the user inputs.",
         examples=["{{ config['api_key'] }}", "Token token={{ config['api_key'] }}"],
-        title='API Key',
+        title="API Key",
     )
     header: Optional[str] = Field(
         None,
-        description='The name of the HTTP header that will be set to the API key. This setting is deprecated, use inject_into instead. Header and inject_into can not be defined at the same time.',
-        examples=['Authorization', 'Api-Token', 'X-Auth-Token'],
-        title='Header Name',
+        description="The name of the HTTP header that will be set to the API key. This setting is deprecated, use inject_into instead. Header and inject_into can not be defined at the same time.",
+        examples=["Authorization", "Api-Token", "X-Auth-Token"],
+        title="Header Name",
     )
     inject_into: Optional[RequestOption] = Field(
         None,
-        description='Configure how the API Key will be sent in requests to the source API. Either inject_into or header has to be defined.',
+        description="Configure how the API Key will be sent in requests to the source API. Either inject_into or header has to be defined.",
         examples=[
-            {'inject_into': 'header', 'field_name': 'Authorization'},
-            {'inject_into': 'request_parameter', 'field_name': 'authKey'},
+            {"inject_into": "header", "field_name": "Authorization"},
+            {"inject_into": "request_parameter", "field_name": "authKey"},
         ],
-        title='Inject API Key Into Outgoing HTTP Request',
+        title="Inject API Key Into Outgoing HTTP Request",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class AuthFlow(BaseModel):
-    auth_flow_type: Optional[AuthFlowType] = Field(
-        None, description='The type of auth to use', title='Auth flow type'
-    )
+    auth_flow_type: Optional[AuthFlowType] = Field(None, description="The type of auth to use", title="Auth flow type")
     predicate_key: Optional[List[str]] = Field(
         None,
-        description='JSON path to a field in the connectorSpecification that should exist for the advanced auth to be applicable.',
-        examples=[['credentials', 'auth_type']],
-        title='Predicate key',
+        description="JSON path to a field in the connectorSpecification that should exist for the advanced auth to be applicable.",
+        examples=[["credentials", "auth_type"]],
+        title="Predicate key",
     )
     predicate_value: Optional[str] = Field(
         None,
-        description='Value of the predicate_key fields for the advanced auth to be applicable.',
-        examples=['Oauth'],
-        title='Predicate value',
+        description="Value of the predicate_key fields for the advanced auth to be applicable.",
+        examples=["Oauth"],
+        title="Predicate value",
     )
     oauth_config_specification: Optional[OAuthConfigSpecification] = None
 
 
 class CursorPagination(BaseModel):
-    type: Literal['CursorPagination']
+    type: Literal["CursorPagination"]
     cursor_value: str = Field(
         ...,
-        description='Value of the cursor defining the next page to fetch.',
+        description="Value of the cursor defining the next page to fetch.",
         examples=[
-            '{{ headers.link.next.cursor }}',
+            "{{ headers.link.next.cursor }}",
             "{{ last_records[-1]['key'] }}",
             "{{ response['nextPage'] }}",
         ],
-        title='Cursor Value',
+        title="Cursor Value",
     )
     page_size: Optional[int] = Field(
         None,
-        description='The number of records to include in each pages.',
+        description="The number of records to include in each pages.",
         examples=[100],
-        title='Page Size',
+        title="Page Size",
     )
     stop_condition: Optional[str] = Field(
         None,
-        description='Template string evaluating when to stop paginating.',
+        description="Template string evaluating when to stop paginating.",
         examples=[
-            '{{ response.data.has_more is false }}',
+            "{{ response.data.has_more is false }}",
             "{{ 'next' not in headers['link'] }}",
         ],
-        title='Stop Condition',
+        title="Stop Condition",
     )
     decoder: Optional[JsonDecoder] = Field(
         None,
-        description='Component decoding the response so records can be extracted.',
-        title='Decoder',
+        description="Component decoding the response so records can be extracted.",
+        title="Decoder",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class DatetimeBasedCursor(BaseModel):
-    type: Literal['DatetimeBasedCursor']
+    type: Literal["DatetimeBasedCursor"]
     cursor_field: str = Field(
         ...,
-        description='The location of the value on a record that will be used as a bookmark during sync. To ensure no data loss, the API must return records in ascending order based on the cursor field. Nested fields are not supported, so the field must be at the top level of the record. You can use a combination of Add Field and Remove Field transformations to move the nested field to the top.',
-        examples=['created_at', "{{ config['record_cursor'] }}"],
-        title='Cursor Field',
+        description="The location of the value on a record that will be used as a bookmark during sync. To ensure no data loss, the API must return records in ascending order based on the cursor field. Nested fields are not supported, so the field must be at the top level of the record. You can use a combination of Add Field and Remove Field transformations to move the nested field to the top.",
+        examples=["created_at", "{{ config['record_cursor'] }}"],
+        title="Cursor Field",
     )
     datetime_format: str = Field(
         ...,
-        description='The datetime format used to format the datetime values that are sent in outgoing requests to the API. Use placeholders starting with "%" to describe the format the API is using. The following placeholders are available:\n  * **%s**: Epoch unix timestamp - `1686218963`\n  * **%ms**: Epoch unix timestamp (milliseconds) - `1686218963123`\n  * **%a**: Weekday (abbreviated) - `Sun`\n  * **%A**: Weekday (full) - `Sunday`\n  * **%w**: Weekday (decimal) - `0` (Sunday), `6` (Saturday)\n  * **%d**: Day of the month (zero-padded) - `01`, `02`, ..., `31`\n  * **%b**: Month (abbreviated) - `Jan`\n  * **%B**: Month (full) - `January`\n  * **%m**: Month (zero-padded) - `01`, `02`, ..., `12`\n  * **%y**: Year (without century, zero-padded) - `00`, `01`, ..., `99`\n  * **%Y**: Year (with century) - `0001`, `0002`, ..., `9999`\n  * **%H**: Hour (24-hour, zero-padded) - `00`, `01`, ..., `23`\n  * **%I**: Hour (12-hour, zero-padded) - `01`, `02`, ..., `12`\n  * **%p**: AM/PM indicator\n  * **%M**: Minute (zero-padded) - `00`, `01`, ..., `59`\n  * **%S**: Second (zero-padded) - `00`, `01`, ..., `59`\n  * **%f**: Microsecond (zero-padded to 6 digits) - `000000`\n  * **%z**: UTC offset - `(empty)`, `+0000`, `-04:00`\n  * **%Z**: Time zone name - `(empty)`, `UTC`, `GMT`\n  * **%j**: Day of the year (zero-padded) - `001`, `002`, ..., `366`\n  * **%U**: Week number of the year (starting Sunday) - `00`, ..., `53`\n  * **%W**: Week number of the year (starting Monday) - `00`, ..., `53`\n  * **%c**: Date and time - `Tue Aug 16 21:30:00 1988`\n  * **%x**: Date standard format - `08/16/1988`\n  * **%X**: Time standard format - `21:30:00`\n  * **%%**: Literal \'%\' character\n\n  Some placeholders depend on the locale of the underlying system - in most cases this locale is configured as en/US. For more information see the [Python documentation](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).\n',
-        examples=['%Y-%m-%dT%H:%M:%S.%f%z', '%Y-%m-%d', '%s', '%ms'],
-        title='Outgoing Datetime Format',
+        description="The datetime format used to format the datetime values that are sent in outgoing requests to the API. Use placeholders starting with \"%\" to describe the format the API is using. The following placeholders are available:\n  * **%s**: Epoch unix timestamp - `1686218963`\n  * **%ms**: Epoch unix timestamp (milliseconds) - `1686218963123`\n  * **%a**: Weekday (abbreviated) - `Sun`\n  * **%A**: Weekday (full) - `Sunday`\n  * **%w**: Weekday (decimal) - `0` (Sunday), `6` (Saturday)\n  * **%d**: Day of the month (zero-padded) - `01`, `02`, ..., `31`\n  * **%b**: Month (abbreviated) - `Jan`\n  * **%B**: Month (full) - `January`\n  * **%m**: Month (zero-padded) - `01`, `02`, ..., `12`\n  * **%y**: Year (without century, zero-padded) - `00`, `01`, ..., `99`\n  * **%Y**: Year (with century) - `0001`, `0002`, ..., `9999`\n  * **%H**: Hour (24-hour, zero-padded) - `00`, `01`, ..., `23`\n  * **%I**: Hour (12-hour, zero-padded) - `01`, `02`, ..., `12`\n  * **%p**: AM/PM indicator\n  * **%M**: Minute (zero-padded) - `00`, `01`, ..., `59`\n  * **%S**: Second (zero-padded) - `00`, `01`, ..., `59`\n  * **%f**: Microsecond (zero-padded to 6 digits) - `000000`\n  * **%z**: UTC offset - `(empty)`, `+0000`, `-04:00`\n  * **%Z**: Time zone name - `(empty)`, `UTC`, `GMT`\n  * **%j**: Day of the year (zero-padded) - `001`, `002`, ..., `366`\n  * **%U**: Week number of the year (starting Sunday) - `00`, ..., `53`\n  * **%W**: Week number of the year (starting Monday) - `00`, ..., `53`\n  * **%c**: Date and time - `Tue Aug 16 21:30:00 1988`\n  * **%x**: Date standard format - `08/16/1988`\n  * **%X**: Time standard format - `21:30:00`\n  * **%%**: Literal '%' character\n\n  Some placeholders depend on the locale of the underlying system - in most cases this locale is configured as en/US. For more information see the [Python documentation](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).\n",
+        examples=["%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%d", "%s", "%ms"],
+        title="Outgoing Datetime Format",
     )
     start_datetime: Union[str, MinMaxDatetime] = Field(
         ...,
-        description='The datetime that determines the earliest record that should be synced.',
-        examples=['2020-01-1T00:00:00Z', "{{ config['start_time'] }}"],
-        title='Start Datetime',
+        description="The datetime that determines the earliest record that should be synced.",
+        examples=["2020-01-1T00:00:00Z", "{{ config['start_time'] }}"],
+        title="Start Datetime",
     )
     cursor_datetime_formats: Optional[List[str]] = Field(
         None,
-        description='The possible formats for the cursor field, in order of preference. The first format that matches the cursor field value will be used to parse it. If not provided, the `datetime_format` will be used.',
-        title='Cursor Datetime Formats',
+        description="The possible formats for the cursor field, in order of preference. The first format that matches the cursor field value will be used to parse it. If not provided, the `datetime_format` will be used.",
+        title="Cursor Datetime Formats",
     )
     cursor_granularity: Optional[str] = Field(
         None,
-        description='Smallest increment the datetime_format has (ISO 8601 duration) that is used to ensure the start of a slice does not overlap with the end of the previous one, e.g. for %Y-%m-%d the granularity should be P1D, for %Y-%m-%dT%H:%M:%SZ the granularity should be PT1S. Given this field is provided, `step` needs to be provided as well.',
-        examples=['PT1S'],
-        title='Cursor Granularity',
+        description="Smallest increment the datetime_format has (ISO 8601 duration) that is used to ensure the start of a slice does not overlap with the end of the previous one, e.g. for %Y-%m-%d the granularity should be P1D, for %Y-%m-%dT%H:%M:%SZ the granularity should be PT1S. Given this field is provided, `step` needs to be provided as well.",
+        examples=["PT1S"],
+        title="Cursor Granularity",
     )
     end_datetime: Optional[Union[str, MinMaxDatetime]] = Field(
         None,
-        description='The datetime that determines the last record that should be synced. If not provided, `{{ now_utc() }}` will be used.',
-        examples=['2021-01-1T00:00:00Z', '{{ now_utc() }}', '{{ day_delta(-1) }}'],
-        title='End Datetime',
+        description="The datetime that determines the last record that should be synced. If not provided, `{{ now_utc() }}` will be used.",
+        examples=["2021-01-1T00:00:00Z", "{{ now_utc() }}", "{{ day_delta(-1) }}"],
+        title="End Datetime",
     )
     end_time_option: Optional[RequestOption] = Field(
         None,
-        description='Optionally configures how the end datetime will be sent in requests to the source API.',
-        title='Inject End Time Into Outgoing HTTP Request',
+        description="Optionally configures how the end datetime will be sent in requests to the source API.",
+        title="Inject End Time Into Outgoing HTTP Request",
     )
     is_data_feed: Optional[bool] = Field(
         None,
-        description='A data feed API is an API that does not allow filtering and paginates the content from the most recent to the least recent. Given this, the CDK needs to know when to stop paginating and this field will generate a stop condition for pagination.',
-        title='Whether the target API is formatted as a data feed',
+        description="A data feed API is an API that does not allow filtering and paginates the content from the most recent to the least recent. Given this, the CDK needs to know when to stop paginating and this field will generate a stop condition for pagination.",
+        title="Whether the target API is formatted as a data feed",
     )
     lookback_window: Optional[str] = Field(
         None,
-        description='Time interval before the start_datetime to read data for, e.g. P1M for looking back one month.',
-        examples=['P1D', "P{{ config['lookback_days'] }}D"],
-        title='Lookback Window',
+        description="Time interval before the start_datetime to read data for, e.g. P1M for looking back one month.",
+        examples=["P1D", "P{{ config['lookback_days'] }}D"],
+        title="Lookback Window",
     )
     partition_field_end: Optional[str] = Field(
         None,
-        description='Name of the partition start time field.',
-        examples=['ending_time'],
-        title='Partition Field End',
+        description="Name of the partition start time field.",
+        examples=["ending_time"],
+        title="Partition Field End",
     )
     partition_field_start: Optional[str] = Field(
         None,
-        description='Name of the partition end time field.',
-        examples=['starting_time'],
-        title='Partition Field Start',
+        description="Name of the partition end time field.",
+        examples=["starting_time"],
+        title="Partition Field Start",
     )
     start_time_option: Optional[RequestOption] = Field(
         None,
-        description='Optionally configures how the start datetime will be sent in requests to the source API.',
-        title='Inject Start Time Into Outgoing HTTP Request',
+        description="Optionally configures how the start datetime will be sent in requests to the source API.",
+        title="Inject Start Time Into Outgoing HTTP Request",
     )
     step: Optional[str] = Field(
         None,
-        description='The size of the time window (ISO8601 duration). Given this field is provided, `cursor_granularity` needs to be provided as well.',
-        examples=['P1W', "{{ config['step_increment'] }}"],
-        title='Step',
+        description="The size of the time window (ISO8601 duration). Given this field is provided, `cursor_granularity` needs to be provided as well.",
+        examples=["P1W", "{{ config['step_increment'] }}"],
+        title="Step",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class DefaultErrorHandler(BaseModel):
-    type: Literal['DefaultErrorHandler']
+    type: Literal["DefaultErrorHandler"]
     backoff_strategies: Optional[
         List[
             Union[
@@ -897,144 +889,142 @@ class DefaultErrorHandler(BaseModel):
         ]
     ] = Field(
         None,
-        description='List of backoff strategies to use to determine how long to wait before retrying a retryable request.',
-        title='Backoff Strategies',
+        description="List of backoff strategies to use to determine how long to wait before retrying a retryable request.",
+        title="Backoff Strategies",
     )
     max_retries: Optional[int] = Field(
         5,
-        description='The maximum number of time to retry a retryable request before giving up and failing.',
+        description="The maximum number of time to retry a retryable request before giving up and failing.",
         examples=[5, 0, 10],
-        title='Max Retry Count',
+        title="Max Retry Count",
     )
     response_filters: Optional[List[HttpResponseFilter]] = Field(
         None,
         description="List of response filters to iterate on when deciding how to handle an error. When using an array of multiple filters, the filters will be applied sequentially and the response will be selected if it matches any of the filter's predicate.",
-        title='Response Filters',
+        title="Response Filters",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class DefaultPaginator(BaseModel):
-    type: Literal['DefaultPaginator']
-    pagination_strategy: Union[
-        CursorPagination, CustomPaginationStrategy, OffsetIncrement, PageIncrement
-    ] = Field(
+    type: Literal["DefaultPaginator"]
+    pagination_strategy: Union[CursorPagination, CustomPaginationStrategy, OffsetIncrement, PageIncrement] = Field(
         ...,
-        description='Strategy defining how records are paginated.',
-        title='Pagination Strategy',
+        description="Strategy defining how records are paginated.",
+        title="Pagination Strategy",
     )
     decoder: Optional[JsonDecoder] = Field(
         None,
-        description='Component decoding the response so records can be extracted.',
-        title='Decoder',
+        description="Component decoding the response so records can be extracted.",
+        title="Decoder",
     )
     page_size_option: Optional[RequestOption] = None
     page_token_option: Optional[Union[RequestOption, RequestPath]] = None
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class DpathExtractor(BaseModel):
-    type: Literal['DpathExtractor']
+    type: Literal["DpathExtractor"]
     field_path: List[str] = Field(
         ...,
         description='List of potentially nested fields describing the full path of the field to extract. Use "*" to extract all values from an array. See more info in the [docs](https://docs.airbyte.com/connector-development/config-based/understanding-the-yaml-file/record-selector).',
         examples=[
-            ['data'],
-            ['data', 'records'],
-            ['data', '{{ parameters.name }}'],
-            ['data', '*', 'record'],
+            ["data"],
+            ["data", "records"],
+            ["data", "{{ parameters.name }}"],
+            ["data", "*", "record"],
         ],
-        title='Field Path',
+        title="Field Path",
     )
     decoder: Optional[JsonDecoder] = Field(
         None,
-        description='Component decoding the response so records can be extracted.',
-        title='Decoder',
+        description="Component decoding the response so records can be extracted.",
+        title="Decoder",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class SessionTokenRequestApiKeyAuthenticator(BaseModel):
-    type: Literal['ApiKey']
+    type: Literal["ApiKey"]
     inject_into: RequestOption = Field(
         ...,
-        description='Configure how the API Key will be sent in requests to the source API.',
+        description="Configure how the API Key will be sent in requests to the source API.",
         examples=[
-            {'inject_into': 'header', 'field_name': 'Authorization'},
-            {'inject_into': 'request_parameter', 'field_name': 'authKey'},
+            {"inject_into": "header", "field_name": "Authorization"},
+            {"inject_into": "request_parameter", "field_name": "authKey"},
         ],
-        title='Inject API Key Into Outgoing HTTP Request',
+        title="Inject API Key Into Outgoing HTTP Request",
     )
 
 
 class ListPartitionRouter(BaseModel):
-    type: Literal['ListPartitionRouter']
+    type: Literal["ListPartitionRouter"]
     cursor_field: str = Field(
         ...,
         description='While iterating over list values, the name of field used to reference a list value. The partition value can be accessed with string interpolation. e.g. "{{ stream_partition[\'my_key\'] }}" where "my_key" is the value of the cursor_field.',
-        examples=['section', "{{ config['section_key'] }}"],
-        title='Current Partition Value Identifier',
+        examples=["section", "{{ config['section_key'] }}"],
+        title="Current Partition Value Identifier",
     )
     values: Union[str, List[str]] = Field(
         ...,
-        description='The list of attributes being iterated over and used as input for the requests made to the source API.',
-        examples=[['section_a', 'section_b', 'section_c'], "{{ config['sections'] }}"],
-        title='Partition Values',
+        description="The list of attributes being iterated over and used as input for the requests made to the source API.",
+        examples=[["section_a", "section_b", "section_c"], "{{ config['sections'] }}"],
+        title="Partition Values",
     )
     request_option: Optional[RequestOption] = Field(
         None,
-        description='A request option describing where the list value should be injected into and under what field name if applicable.',
-        title='Inject Partition Value Into Outgoing HTTP Request',
+        description="A request option describing where the list value should be injected into and under what field name if applicable.",
+        title="Inject Partition Value Into Outgoing HTTP Request",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class RecordSelector(BaseModel):
-    type: Literal['RecordSelector']
+    type: Literal["RecordSelector"]
     extractor: Union[CustomRecordExtractor, DpathExtractor]
     record_filter: Optional[RecordFilter] = Field(
         None,
-        description='Responsible for filtering records to be emitted by the Source.',
-        title='Record Filter',
+        description="Responsible for filtering records to be emitted by the Source.",
+        title="Record Filter",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class Spec(BaseModel):
-    type: Literal['Spec']
+    type: Literal["Spec"]
     connection_specification: Dict[str, Any] = Field(
         ...,
-        description='A connection specification describing how a the connector can be configured.',
-        title='Connection Specification',
+        description="A connection specification describing how a the connector can be configured.",
+        title="Connection Specification",
     )
     documentation_url: Optional[str] = Field(
         None,
         description="URL of the connector's documentation page.",
-        examples=['https://docs.airbyte.com/integrations/sources/dremio'],
-        title='Documentation URL',
+        examples=["https://docs.airbyte.com/integrations/sources/dremio"],
+        title="Documentation URL",
     )
     advanced_auth: Optional[AuthFlow] = Field(
         None,
-        description='Advanced specification for configuring the authentication flow.',
-        title='Advanced Auth',
+        description="Advanced specification for configuring the authentication flow.",
+        title="Advanced Auth",
     )
 
 
 class CompositeErrorHandler(BaseModel):
-    type: Literal['CompositeErrorHandler']
+    type: Literal["CompositeErrorHandler"]
     error_handlers: List[Union[CompositeErrorHandler, DefaultErrorHandler]] = Field(
         ...,
-        description='List of error handlers to iterate on to determine how to handle a failed response.',
-        title='Error Handlers',
+        description="List of error handlers to iterate on to determine how to handle a failed response.",
+        title="Error Handlers",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class DeclarativeSource(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    type: Literal['DeclarativeSource']
+    type: Literal["DeclarativeSource"]
     check: CheckStream
     streams: List[DeclarativeStream]
     version: str
@@ -1043,7 +1033,7 @@ class DeclarativeSource(BaseModel):
     spec: Optional[Spec] = None
     metadata: Optional[Dict[str, Any]] = Field(
         None,
-        description='For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.',
+        description="For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.",
     )
 
 
@@ -1051,101 +1041,91 @@ class DeclarativeStream(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Literal['DeclarativeStream']
+    type: Literal["DeclarativeStream"]
     retriever: Union[CustomRetriever, SimpleRetriever] = Field(
         ...,
-        description='Component used to coordinate how records are extracted across stream slices and request pages.',
-        title='Retriever',
+        description="Component used to coordinate how records are extracted across stream slices and request pages.",
+        title="Retriever",
     )
-    incremental_sync: Optional[
-        Union[CustomIncrementalSync, DatetimeBasedCursor]
-    ] = Field(
+    incremental_sync: Optional[Union[CustomIncrementalSync, DatetimeBasedCursor]] = Field(
         None,
-        description='Component used to fetch data incrementally based on a time field in the data.',
-        title='Incremental Sync',
+        description="Component used to fetch data incrementally based on a time field in the data.",
+        title="Incremental Sync",
     )
-    name: Optional[str] = Field(
-        '', description='The stream name.', example=['Users'], title='Name'
-    )
-    primary_key: Optional[PrimaryKey] = Field(
-        '', description='The primary key of the stream.', title='Primary Key'
-    )
+    name: Optional[str] = Field("", description="The stream name.", example=["Users"], title="Name")
+    primary_key: Optional[PrimaryKey] = Field("", description="The primary key of the stream.", title="Primary Key")
     schema_loader: Optional[Union[InlineSchemaLoader, JsonFileSchemaLoader]] = Field(
         None,
-        description='Component used to retrieve the schema for the current stream.',
-        title='Schema Loader',
+        description="Component used to retrieve the schema for the current stream.",
+        title="Schema Loader",
     )
-    transformations: Optional[
-        List[Union[AddFields, CustomTransformation, RemoveFields]]
-    ] = Field(
+    transformations: Optional[List[Union[AddFields, CustomTransformation, RemoveFields]]] = Field(
         None,
-        description='A list of transformations to be applied to each output record.',
-        title='Transformations',
+        description="A list of transformations to be applied to each output record.",
+        title="Transformations",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class SessionTokenAuthenticator(BaseModel):
-    type: Literal['SessionTokenAuthenticator']
+    type: Literal["SessionTokenAuthenticator"]
     login_requester: HttpRequester = Field(
         ...,
-        description='Description of the request to perform to obtain a session token to perform data requests. The response body is expected to be a JSON object with a session token property.',
+        description="Description of the request to perform to obtain a session token to perform data requests. The response body is expected to be a JSON object with a session token property.",
         examples=[
             {
-                'type': 'HttpRequester',
-                'url_base': 'https://my_api.com',
-                'path': '/login',
-                'authenticator': {
-                    'type': 'BasicHttpAuthenticator',
-                    'username': '{{ config.username }}',
-                    'password': '{{ config.password }}',
+                "type": "HttpRequester",
+                "url_base": "https://my_api.com",
+                "path": "/login",
+                "authenticator": {
+                    "type": "BasicHttpAuthenticator",
+                    "username": "{{ config.username }}",
+                    "password": "{{ config.password }}",
                 },
             }
         ],
-        title='Login Requester',
+        title="Login Requester",
     )
     session_token_path: List[str] = Field(
         ...,
-        description='The path in the response body returned from the login requester to the session token.',
-        examples=[['access_token'], ['result', 'token']],
-        title='Session Token Path',
+        description="The path in the response body returned from the login requester to the session token.",
+        examples=[["access_token"], ["result", "token"]],
+        title="Session Token Path",
     )
     expiration_duration: Optional[str] = Field(
         None,
-        description='The duration in ISO 8601 duration notation after which the session token expires, starting from the time it was obtained. Omitting it will result in the session token being refreshed for every request.',
-        examples=['PT1H', 'P1D'],
-        title='Expiration Duration',
+        description="The duration in ISO 8601 duration notation after which the session token expires, starting from the time it was obtained. Omitting it will result in the session token being refreshed for every request.",
+        examples=["PT1H", "P1D"],
+        title="Expiration Duration",
     )
-    request_authentication: Union[
-        SessionTokenRequestApiKeyAuthenticator, SessionTokenRequestBearerAuthenticator
-    ] = Field(
+    request_authentication: Union[SessionTokenRequestApiKeyAuthenticator, SessionTokenRequestBearerAuthenticator] = Field(
         ...,
-        description='Authentication method to use for requests sent to the API, specifying how to inject the session token.',
-        title='Data Request Authentication',
+        description="Authentication method to use for requests sent to the API, specifying how to inject the session token.",
+        title="Data Request Authentication",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class HttpRequester(BaseModel):
-    type: Literal['HttpRequester']
+    type: Literal["HttpRequester"]
     url_base: str = Field(
         ...,
-        description='Base URL of the API source. Do not put sensitive information (e.g. API tokens) into this field - Use the Authentication component for this.',
+        description="Base URL of the API source. Do not put sensitive information (e.g. API tokens) into this field - Use the Authentication component for this.",
         examples=[
-            'https://connect.squareup.com/v2',
+            "https://connect.squareup.com/v2",
             "{{ config['base_url'] or 'https://app.posthog.com'}}/api/",
         ],
-        title='API Base URL',
+        title="API Base URL",
     )
     path: str = Field(
         ...,
-        description='Path the specific API endpoint that this stream represents. Do not put sensitive information (e.g. API tokens) into this field - Use the Authentication component for this.',
+        description="Path the specific API endpoint that this stream represents. Do not put sensitive information (e.g. API tokens) into this field - Use the Authentication component for this.",
         examples=[
-            '/products',
+            "/products",
             "/quotes/{{ stream_partition['id'] }}/quote_line_groups",
             "/trades/{{ config['symbol_id'] }}/history",
         ],
-        title='URL Path',
+        title="URL Path",
     )
     authenticator: Optional[
         Union[
@@ -1160,96 +1140,92 @@ class HttpRequester(BaseModel):
         ]
     ] = Field(
         None,
-        description='Authentication method to use for requests sent to the API.',
-        title='Authenticator',
+        description="Authentication method to use for requests sent to the API.",
+        title="Authenticator",
     )
-    error_handler: Optional[
-        Union[DefaultErrorHandler, CustomErrorHandler, CompositeErrorHandler]
-    ] = Field(
+    error_handler: Optional[Union[DefaultErrorHandler, CustomErrorHandler, CompositeErrorHandler]] = Field(
         None,
-        description='Error handler component that defines how to handle errors.',
-        title='Error Handler',
+        description="Error handler component that defines how to handle errors.",
+        title="Error Handler",
     )
     http_method: Optional[Union[str, HttpMethodEnum]] = Field(
-        'GET',
-        description='The HTTP method used to fetch data from the source (can be GET or POST).',
-        examples=['GET', 'POST'],
-        title='HTTP Method',
+        "GET",
+        description="The HTTP method used to fetch data from the source (can be GET or POST).",
+        examples=["GET", "POST"],
+        title="HTTP Method",
     )
     request_body_data: Optional[Union[str, Dict[str, str]]] = Field(
         None,
-        description='Specifies how to populate the body of the request with a non-JSON payload. Plain text will be sent as is, whereas objects will be converted to a urlencoded form.',
+        description="Specifies how to populate the body of the request with a non-JSON payload. Plain text will be sent as is, whereas objects will be converted to a urlencoded form.",
         examples=[
             '[{"clause": {"type": "timestamp", "operator": 10, "parameters":\n    [{"value": {{ stream_interval[\'start_time\'] | int * 1000 }} }]\n  }, "orderBy": 1, "columnName": "Timestamp"}]/\n'
         ],
-        title='Request Body Payload (Non-JSON)',
+        title="Request Body Payload (Non-JSON)",
     )
     request_body_json: Optional[Union[str, Dict[str, Any]]] = Field(
         None,
-        description='Specifies how to populate the body of the request with a JSON payload. Can contain nested objects.',
+        description="Specifies how to populate the body of the request with a JSON payload. Can contain nested objects.",
         examples=[
-            {'sort_order': 'ASC', 'sort_field': 'CREATED_AT'},
-            {'key': "{{ config['value'] }}"},
-            {'sort': {'field': 'updated_at', 'order': 'ascending'}},
+            {"sort_order": "ASC", "sort_field": "CREATED_AT"},
+            {"key": "{{ config['value'] }}"},
+            {"sort": {"field": "updated_at", "order": "ascending"}},
         ],
-        title='Request Body JSON Payload',
+        title="Request Body JSON Payload",
     )
     request_headers: Optional[Union[str, Dict[str, str]]] = Field(
         None,
-        description='Return any non-auth headers. Authentication headers will overwrite any overlapping headers returned from this method.',
-        examples=[{'Output-Format': 'JSON'}, {'Version': "{{ config['version'] }}"}],
-        title='Request Headers',
+        description="Return any non-auth headers. Authentication headers will overwrite any overlapping headers returned from this method.",
+        examples=[{"Output-Format": "JSON"}, {"Version": "{{ config['version'] }}"}],
+        title="Request Headers",
     )
     request_parameters: Optional[Union[str, Dict[str, str]]] = Field(
         None,
-        description='Specifies the query parameters that should be set on an outgoing HTTP request given the inputs.',
+        description="Specifies the query parameters that should be set on an outgoing HTTP request given the inputs.",
         examples=[
-            {'unit': 'day'},
+            {"unit": "day"},
             {
-                'query': 'last_event_time BETWEEN TIMESTAMP "{{ stream_interval.start_time }}" AND TIMESTAMP "{{ stream_interval.end_time }}"'
+                "query": 'last_event_time BETWEEN TIMESTAMP "{{ stream_interval.start_time }}" AND TIMESTAMP "{{ stream_interval.end_time }}"'
             },
-            {'searchIn': "{{ ','.join(config.get('search_in', [])) }}"},
-            {'sort_by[asc]': 'updated_at'},
+            {"searchIn": "{{ ','.join(config.get('search_in', [])) }}"},
+            {"sort_by[asc]": "updated_at"},
         ],
-        title='Query Parameters',
+        title="Query Parameters",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class ParentStreamConfig(BaseModel):
-    type: Literal['ParentStreamConfig']
+    type: Literal["ParentStreamConfig"]
     parent_key: str = Field(
         ...,
-        description='The primary key of records from the parent stream that will be used during the retrieval of records for the current substream. This parent identifier field is typically a characteristic of the child records being extracted from the source API.',
-        examples=['id', "{{ config['parent_record_id'] }}"],
-        title='Parent Key',
+        description="The primary key of records from the parent stream that will be used during the retrieval of records for the current substream. This parent identifier field is typically a characteristic of the child records being extracted from the source API.",
+        examples=["id", "{{ config['parent_record_id'] }}"],
+        title="Parent Key",
     )
-    stream: DeclarativeStream = Field(
-        ..., description='Reference to the parent stream.', title='Parent Stream'
-    )
+    stream: DeclarativeStream = Field(..., description="Reference to the parent stream.", title="Parent Stream")
     partition_field: str = Field(
         ...,
-        description='While iterating over parent records during a sync, the parent_key value can be referenced by using this field.',
-        examples=['parent_id', "{{ config['parent_partition_field'] }}"],
-        title='Current Parent Key Value Identifier',
+        description="While iterating over parent records during a sync, the parent_key value can be referenced by using this field.",
+        examples=["parent_id", "{{ config['parent_partition_field'] }}"],
+        title="Current Parent Key Value Identifier",
     )
     request_option: Optional[RequestOption] = Field(
         None,
-        description='A request option describing where the parent key value should be injected into and under what field name if applicable.',
-        title='Request Option',
+        description="A request option describing where the parent key value should be injected into and under what field name if applicable.",
+        title="Request Option",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class SimpleRetriever(BaseModel):
-    type: Literal['SimpleRetriever']
+    type: Literal["SimpleRetriever"]
     record_selector: RecordSelector = Field(
         ...,
-        description='Component that describes how to extract records from a HTTP response.',
+        description="Component that describes how to extract records from a HTTP response.",
     )
     requester: Union[CustomRequester, HttpRequester] = Field(
         ...,
-        description='Requester component that describes how to prepare HTTP requests to send to the source API.',
+        description="Requester component that describes how to prepare HTTP requests to send to the source API.",
     )
     paginator: Optional[Union[DefaultPaginator, NoPagination]] = Field(
         None,
@@ -1260,28 +1236,24 @@ class SimpleRetriever(BaseModel):
             CustomPartitionRouter,
             ListPartitionRouter,
             SubstreamPartitionRouter,
-            List[
-                Union[
-                    CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter
-                ]
-            ],
+            List[Union[CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter]],
         ]
     ] = Field(
         [],
-        description='PartitionRouter component that describes how to partition the stream, enabling incremental syncs and checkpointing.',
-        title='Partition Router',
+        description="PartitionRouter component that describes how to partition the stream, enabling incremental syncs and checkpointing.",
+        title="Partition Router",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 class SubstreamPartitionRouter(BaseModel):
-    type: Literal['SubstreamPartitionRouter']
+    type: Literal["SubstreamPartitionRouter"]
     parent_stream_configs: List[ParentStreamConfig] = Field(
         ...,
-        description='Specifies which parent streams are being iterated over and how parent records should be used to partition the child stream data set.',
-        title='Parent Stream Configs',
+        description="Specifies which parent streams are being iterated over and how parent records should be used to partition the child stream data set.",
+        title="Parent Stream Configs",
     )
-    parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
+    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
 CompositeErrorHandler.update_forward_refs()

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py
@@ -73,7 +73,7 @@ class DefaultFileBasedAvailabilityStrategy(AbstractFileBasedAvailabilityStrategy
         return files
 
     def _check_parse_record(self, stream: "AbstractFileBasedStream", file: RemoteFile, logger: logging.Logger) -> None:
-        parser = stream.get_parser(stream.config.file_type)
+        parser = stream.get_parser()
 
         try:
             record = next(iter(parser.parse_records(stream.config, file, self.stream_reader, logger, discovered_schema=None)))

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
@@ -3,7 +3,7 @@
 #
 
 from enum import Enum
-from typing import Any, List, Mapping, Optional, Type, Union
+from typing import Any, List, Mapping, Optional, Union
 
 from airbyte_cdk.sources.file_based.config.avro_format import AvroFormat
 from airbyte_cdk.sources.file_based.config.csv_format import CsvFormat

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
@@ -16,9 +16,6 @@ from pydantic import BaseModel, Field, validator
 PrimaryKeyType = Optional[Union[str, List[str]]]
 
 
-VALID_FILE_TYPES: Mapping[str, Type[BaseModel]] = {"avro": AvroFormat, "csv": CsvFormat, "jsonl": JsonlFormat, "parquet": ParquetFormat}
-
-
 class ValidationPolicy(Enum):
     emit_record = "Emit Record"
     skip_record = "Skip Record"
@@ -27,7 +24,6 @@ class ValidationPolicy(Enum):
 
 class FileBasedStreamConfig(BaseModel):
     name: str = Field(title="Name", description="The name of the stream.")
-    file_type: str = Field(title="File Type", description="The data file type that is being extracted for a stream.")
     globs: Optional[List[str]] = Field(
         title="Globs",
         description='The pattern used to specify which files should be selected from the file system. For more information on glob pattern matching look <a href="https://en.wikipedia.org/wiki/Glob_(programming)">here</a>.',
@@ -54,7 +50,7 @@ class FileBasedStreamConfig(BaseModel):
         description="When the state history of the file store is full, syncs will only read files that were last modified in the provided day range.",
         default=3,
     )
-    format: Optional[Union[AvroFormat, CsvFormat, JsonlFormat, ParquetFormat]] = Field(
+    format: Union[AvroFormat, CsvFormat, JsonlFormat, ParquetFormat] = Field(
         title="Format",
         description="The configuration options that are used to alter how to read incoming files that deviate from the standard formatting.",
     )
@@ -63,37 +59,6 @@ class FileBasedStreamConfig(BaseModel):
         description="When enabled, syncs will not validate or structure records against the stream's schema.",
         default=False,
     )
-
-    @validator("file_type", pre=True)
-    def validate_file_type(cls, v: str) -> str:
-        if v not in VALID_FILE_TYPES:
-            raise ValueError(f"Format filetype {v} is not a supported file type")
-        return v
-
-    @classmethod
-    def _transform_legacy_config(cls, legacy_config: Mapping[str, Any], file_type: str) -> Mapping[str, Any]:
-        if file_type.casefold() not in VALID_FILE_TYPES:
-            raise ValueError(f"Format filetype {file_type} is not a supported file type")
-        if file_type.casefold() == "parquet" or file_type.casefold() == "avro":
-            legacy_config = cls._transform_legacy_parquet_or_avro_config(legacy_config)
-        return {file_type: VALID_FILE_TYPES[file_type.casefold()].parse_obj({key: val for key, val in legacy_config.items()})}
-
-    @classmethod
-    def _transform_legacy_parquet_or_avro_config(cls, config: Mapping[str, Any]) -> Mapping[str, Any]:
-        """
-        The legacy parquet parser converts decimal fields to numbers. This isn't desirable because it can lead to precision loss.
-        To avoid introducing a breaking change with the new default, we will set decimal_as_float to True in the legacy configs.
-        """
-        filetype = config.get("filetype")
-        if filetype != "parquet" and filetype != "avro":
-            raise ValueError(
-                f"Expected {filetype} format, got {config}. This is probably due to a CDK bug. Please reach out to the Airbyte team for support."
-            )
-        if config.get("decimal_as_float"):
-            raise ValueError(
-                f"Received legacy {filetype} file form with 'decimal_as_float' set. This is unexpected. Please reach out to the Airbyte team for support."
-            )
-        return {**config, **{"decimal_as_float": True}}
 
     @validator("input_schema", pre=True)
     def validate_input_schema(cls, v: Optional[str]) -> Optional[str]:

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_source.py
@@ -33,7 +33,7 @@ class FileBasedSource(AbstractSource, ABC):
         catalog_path: Optional[str] = None,
         availability_strategy: Optional[AbstractFileBasedAvailabilityStrategy] = None,
         discovery_policy: AbstractDiscoveryPolicy = DefaultDiscoveryPolicy(),
-        parsers: Mapping[str, FileTypeParser] = default_parsers,
+        parsers: Mapping[Type[Any], FileTypeParser] = default_parsers,
         validation_policies: Mapping[ValidationPolicy, AbstractSchemaValidationPolicy] = DEFAULT_SCHEMA_VALIDATION_POLICIES,
         cursor_cls: Type[AbstractFileBasedCursor] = DefaultFileBasedCursor,
     ):

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/__init__.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from typing import Any, Mapping, Type
 
 from .avro_parser import AvroParser
 from .csv_parser import CsvParser
@@ -6,11 +6,17 @@ from .file_type_parser import FileTypeParser
 from .jsonl_parser import JsonlParser
 from .parquet_parser import ParquetParser
 
-default_parsers: Mapping[str, FileTypeParser] = {
-    "avro": AvroParser(),
-    "csv": CsvParser(),
-    "jsonl": JsonlParser(),
-    "parquet": ParquetParser(),
+from airbyte_cdk.sources.file_based.config.avro_format import AvroFormat
+from airbyte_cdk.sources.file_based.config.csv_format import CsvFormat
+from airbyte_cdk.sources.file_based.config.jsonl_format import JsonlFormat
+from airbyte_cdk.sources.file_based.config.parquet_format import ParquetFormat
+
+
+default_parsers: Mapping[Type[Any], FileTypeParser] = {
+    AvroFormat: AvroParser(),
+    CsvFormat: CsvParser(),
+    JsonlFormat: JsonlParser(),
+    ParquetFormat: ParquetParser(),
 }
 
 __all__ = ["AvroParser", "CsvParser", "JsonlParser", "ParquetParser", "default_parsers"]

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/__init__.py
@@ -1,16 +1,15 @@
 from typing import Any, Mapping, Type
 
-from .avro_parser import AvroParser
-from .csv_parser import CsvParser
-from .file_type_parser import FileTypeParser
-from .jsonl_parser import JsonlParser
-from .parquet_parser import ParquetParser
-
 from airbyte_cdk.sources.file_based.config.avro_format import AvroFormat
 from airbyte_cdk.sources.file_based.config.csv_format import CsvFormat
 from airbyte_cdk.sources.file_based.config.jsonl_format import JsonlFormat
 from airbyte_cdk.sources.file_based.config.parquet_format import ParquetFormat
 
+from .avro_parser import AvroParser
+from .csv_parser import CsvParser
+from .file_type_parser import FileTypeParser
+from .jsonl_parser import JsonlParser
+from .parquet_parser import ParquetParser
 
 default_parsers: Mapping[Type[Any], FileTypeParser] = {
     AvroFormat: AvroParser(),

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/avro_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/avro_parser.py
@@ -49,7 +49,7 @@ class AvroParser(FileTypeParser):
         stream_reader: AbstractFileBasedStreamReader,
         logger: logging.Logger,
     ) -> SchemaType:
-        avro_format = config.format or AvroFormat()
+        avro_format = config.format
         if not isinstance(avro_format, AvroFormat):
             raise ValueError(f"Expected ParquetFormat, got {avro_format}")
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
@@ -422,7 +422,7 @@ def _no_cast(row: Mapping[str, str]) -> Mapping[str, str]:
 
 
 def _extract_format(config: FileBasedStreamConfig) -> CsvFormat:
-    config_format = config.format or CsvFormat()
+    config_format = config.format
     if not isinstance(config_format, CsvFormat):
         raise ValueError(f"Invalid format config: {config_format}")
     return config_format

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
@@ -30,7 +30,7 @@ class ParquetParser(FileTypeParser):
         stream_reader: AbstractFileBasedStreamReader,
         logger: logging.Logger,
     ) -> SchemaType:
-        parquet_format = config.format or ParquetFormat()
+        parquet_format = config.format
         if not isinstance(parquet_format, ParquetFormat):
             raise ValueError(f"Expected ParquetFormat, got {parquet_format}")
 
@@ -54,7 +54,7 @@ class ParquetParser(FileTypeParser):
         logger: logging.Logger,
         discovered_schema: Optional[Mapping[str, SchemaType]],
     ) -> Iterable[Dict[str, Any]]:
-        parquet_format = config.format or ParquetFormat()
+        parquet_format = config.format
         if not isinstance(parquet_format, ParquetFormat):
             logger.info(f"Expected ParquetFormat, got {parquet_format}")
             raise ConfigValidationError(FileBasedSourceError.CONFIG_VALIDATION_ERROR)

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/abstract_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/abstract_file_based_stream.py
@@ -4,7 +4,7 @@
 
 from abc import abstractmethod
 from functools import cached_property, lru_cache
-from typing import Any, Dict, Iterable, List, Mapping, Optional
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Type
 
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.file_based.availability_strategy import AbstractFileBasedAvailabilityStrategy
@@ -42,7 +42,7 @@ class AbstractFileBasedStream(Stream):
         stream_reader: AbstractFileBasedStreamReader,
         availability_strategy: AbstractFileBasedAvailabilityStrategy,
         discovery_policy: AbstractDiscoveryPolicy,
-        parsers: Dict[str, FileTypeParser],
+        parsers: Dict[Type[Any], FileTypeParser],
         validation_policy: AbstractSchemaValidationPolicy,
     ):
         super().__init__()
@@ -121,11 +121,11 @@ class AbstractFileBasedStream(Stream):
         """
         ...
 
-    def get_parser(self, file_type: str) -> FileTypeParser:
+    def get_parser(self) -> FileTypeParser:
         try:
-            return self._parsers[file_type]
+            return self._parsers[type(self.config.format)]
         except KeyError:
-            raise UndefinedParserError(FileBasedSourceError.UNDEFINED_PARSER, stream=self.name, file_type=file_type)
+            raise UndefinedParserError(FileBasedSourceError.UNDEFINED_PARSER, stream=self.name, format=type(self.config.format))
 
     def record_passes_validation_policy(self, record: Mapping[str, Any]) -> bool:
         if self.validation_policy:

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -5,6 +5,7 @@
 import asyncio
 import itertools
 import traceback
+from copy import deepcopy
 from functools import cache
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Set, Union
 
@@ -79,7 +80,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
             # On read requests we should always have the catalog available
             raise MissingSchemaError(FileBasedSourceError.MISSING_SCHEMA, stream=self.name)
         # The stream only supports a single file type, so we can use the same parser for all files
-        parser = self.get_parser(self.config.file_type)
+        parser = self.get_parser()
         for file in stream_slice["files"]:
             # only serialize the datetime once
             file_datetime_string = file.last_modified.strftime(self.DATE_TIME_FORMAT)
@@ -190,7 +191,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
             if not inferred_schema:
                 raise InvalidSchemaError(
                     FileBasedSourceError.INVALID_SCHEMA_ERROR,
-                    details=f"Empty schema. Please check that the files are valid {self.config.file_type}",
+                    details=f"Empty schema. Please check that the files are valid for format {self.config.format}",
                     stream=self.name,
                 )
 
@@ -210,7 +211,8 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
     def infer_schema(self, files: List[RemoteFile]) -> Mapping[str, Any]:
         loop = asyncio.get_event_loop()
         schema = loop.run_until_complete(self._infer_schema(files))
-        return self._fill_nulls(schema)
+        # as infer schema returns a Mapping that is assumed to be immutable, we need to create a deepcopy to avoid modifying the reference
+        return self._fill_nulls(deepcopy(schema))
 
     @staticmethod
     def _fill_nulls(schema: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -258,11 +260,11 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
 
     async def _infer_file_schema(self, file: RemoteFile) -> SchemaType:
         try:
-            return await self.get_parser(self.config.file_type).infer_schema(self.config, file, self._stream_reader, self.logger)
+            return await self.get_parser().infer_schema(self.config, file, self._stream_reader, self.logger)
         except Exception as exc:
             raise SchemaInferenceError(
                 FileBasedSourceError.SCHEMA_INFERENCE_ERROR,
                 file=file.uri,
-                stream_file_type=self.config.file_type,
+                format=str(self.config.format),
                 stream=self.name,
             ) from exc

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py
@@ -142,17 +142,17 @@ _double_as_string_avro_format = AvroFormat(double_as_string=True)
                      id="test_decimal_missing_precision"),
         pytest.param(_default_avro_format, {"type": "bytes", "logicalType": "decimal", "precision": 9}, None, ValueError,
                      id="test_decimal_missing_scale"),
-        pytest.param(_default_avro_format, {"type": "bytes", "logicalType": "uuid"}, {"type": ["null", "string"]}, None, id="test_uuid"),
-        pytest.param(_default_avro_format, {"type": "int", "logicalType": "date"}, {"type": ["null", "string"], "format": "date"}, None,
+        pytest.param(_default_avro_format, {"type": "bytes", "logicalType": "uuid"}, {"type": "string"}, None, id="test_uuid"),
+        pytest.param(_default_avro_format, {"type": "int", "logicalType": "date"}, {"type": "string", "format": "date"}, None,
                      id="test_date"),
-        pytest.param(_default_avro_format, {"type": "int", "logicalType": "time-millis"}, {"type": ["null", "integer"]}, None, id="test_time_millis"),
-        pytest.param(_default_avro_format, {"type": "long", "logicalType": "time-micros"}, {"type": ["null", "integer"]}, None,
+        pytest.param(_default_avro_format, {"type": "int", "logicalType": "time-millis"}, {"type": "integer"}, None, id="test_time_millis"),
+        pytest.param(_default_avro_format, {"type": "long", "logicalType": "time-micros"}, {"type": "integer"}, None,
                      id="test_time_micros"),
         pytest.param(
             _default_avro_format,
-            {"type": "long", "logicalType": "timestamp-millis"}, {"type": ["null", "string"], "format": "date-time"}, None, id="test_timestamp_millis"
+            {"type": "long", "logicalType": "timestamp-millis"}, {"type": "string", "format": "date-time"}, None, id="test_timestamp_millis"
         ),
-        pytest.param(_default_avro_format, {"type": "long", "logicalType": "timestamp-micros"}, {"type": ["null", "string"]}, None,
+        pytest.param(_default_avro_format, {"type": "long", "logicalType": "timestamp-micros"}, {"type": "string"}, None,
                      id="test_timestamp_micros"),
         pytest.param(
             _default_avro_format,

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py
@@ -629,7 +629,6 @@ avro_file_with_double_as_number_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "format": {"filetype": "avro"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py
@@ -203,7 +203,7 @@ single_avro_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "avro",
+                    "format": {"filetype": "avro"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -266,7 +266,7 @@ multiple_avro_combine_schema_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "avro",
+                    "format": {"filetype": "avro"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -362,7 +362,7 @@ avro_all_types_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "avro",
+                    "format": {"filetype": "avro"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -463,13 +463,13 @@ multiple_streams_avro_scenario = (
             "streams": [
                 {
                     "name": "songs_stream",
-                    "file_type": "avro",
+                    "format": {"filetype": "avro"},
                     "globs": ["*_songs.avro"],
                     "validation_policy": "Emit Record",
                 },
                 {
                     "name": "festivals_stream",
-                    "file_type": "avro",
+                    "format": {"filetype": "avro"},
                     "globs": ["*_festivals.avro"],
                     "validation_policy": "Emit Record",
                 },
@@ -629,7 +629,7 @@ avro_file_with_double_as_number_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "avro",
+                    "format": {"filetype": "avro"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/check_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/check_scenarios.py
@@ -17,7 +17,7 @@ _base_success_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -55,13 +55,13 @@ success_multi_stream_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv", "*.gz"],
                     "validation_policy": "Emit Record",
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv", "*.gz"],
                     "validation_policy": "Emit Record",
                 }
@@ -79,7 +79,7 @@ success_extensionless_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -109,7 +109,7 @@ success_user_provided_schema_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "string", "col2": "string"}',
@@ -158,7 +158,7 @@ error_record_validation_user_provided_schema_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "always_fail",
                     "input_schema": '{"col1": "number", "col2": "string"}',
@@ -179,13 +179,13 @@ error_multi_stream_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 },
                 {
                     "name": "stream2",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+from airbyte_cdk.sources.file_based.config.csv_format import CsvFormat
 from airbyte_cdk.sources.file_based.exceptions import ConfigValidationError, FileBasedSourceError
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 from unit_tests.sources.file_based.helpers import EmptySchemaParser, LowInferenceLimitDiscoveryPolicy
@@ -15,7 +16,7 @@ single_csv_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -64,11 +65,6 @@ single_csv_scenario = (
                             "type": "object",
                             "properties": {
                                 "name": {"title": "Name", "description": "The name of the stream.", "type": "string"},
-                                "file_type": {
-                                    "title": "File Type",
-                                    "description": "The data file type that is being extracted for a stream.",
-                                    "type": "string",
-                                },
                                 "globs": {
                                     "title": "Globs",
                                     "description": 'The pattern used to specify which files should be selected from the file system. For more information on glob pattern matching look <a href="https://en.wikipedia.org/wiki/Glob_(programming)">here</a>.',
@@ -278,7 +274,7 @@ single_csv_scenario = (
                                     "type": "boolean",
                                 },
                             },
-                            "required": ["name", "file_type"],
+                            "required": ["name", "format"],
                         },
                     },
                 },
@@ -339,7 +335,7 @@ multi_csv_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -441,7 +437,7 @@ multi_csv_stream_n_file_exceeds_limit_for_inference = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -535,13 +531,13 @@ multi_csv_stream_n_file_exceeds_limit_for_inference = (
 
 invalid_csv_scenario = (
     TestScenarioBuilder()
-    .set_name("invalid_csv_scenario")
+    .set_name("invalid_csv_scenario")  # too many values for the number of headers
     .set_config(
         {
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -604,7 +600,7 @@ csv_single_stream_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -684,13 +680,13 @@ csv_multi_stream_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["b.csv"],
                     "validation_policy": "Emit Record",
                 },
@@ -802,7 +798,6 @@ csv_custom_format_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -908,14 +903,12 @@ multi_stream_custom_format = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                     "format": {"filetype": "csv", "delimiter": "#", "escape_char": "!", "double_quote": True, "newlines_in_values": False},
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
                     "globs": ["b.csv"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -1055,7 +1048,7 @@ empty_schema_inference_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -1096,7 +1089,7 @@ empty_schema_inference_scenario = (
             ]
         }
     )
-    .set_parsers({"csv": EmptySchemaParser()})
+    .set_parsers({CsvFormat: EmptySchemaParser()})
     .set_expected_discover_error(AirbyteTracedException, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
     .set_expected_records(
         [
@@ -1130,7 +1123,7 @@ schemaless_csv_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Skip Record",
                     "schemaless": True,
@@ -1225,14 +1218,14 @@ schemaless_csv_multi_stream_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["a.csv"],
                     "validation_policy": "Skip Record",
                     "schemaless": True,
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["b.csv"],
                     "validation_policy": "Skip Record",
                 },
@@ -1332,7 +1325,7 @@ schemaless_with_user_input_schema_fails_connection_check_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Skip Record",
                     "input_schema": '{"col1": "string", "col2": "string", "col3": "string"}',
@@ -1396,7 +1389,7 @@ schemaless_with_user_input_schema_fails_connection_check_multi_stream_scenario =
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["a.csv"],
                     "validation_policy": "Skip Record",
                     "schemaless": True,
@@ -1404,7 +1397,7 @@ schemaless_with_user_input_schema_fails_connection_check_multi_stream_scenario =
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["b.csv"],
                     "validation_policy": "Skip Record",
                 },
@@ -1480,7 +1473,6 @@ csv_string_can_be_null_with_input_schemas_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "string", "col2": "string"}',
@@ -1549,7 +1541,6 @@ csv_string_are_not_null_if_strings_can_be_null_is_false_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "string", "col2": "string"}',
@@ -1619,7 +1610,6 @@ csv_string_not_null_if_no_null_values_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -1686,7 +1676,6 @@ csv_strings_can_be_null_not_quoted_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {"filetype": "csv", "null_values": ["null"]},
@@ -1751,7 +1740,6 @@ csv_newline_in_values_quoted_value_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -1818,7 +1806,6 @@ csv_newline_in_values_not_quoted_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -1897,7 +1884,6 @@ csv_escape_char_is_set_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -1969,7 +1955,6 @@ csv_double_quote_is_set_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -2040,7 +2025,6 @@ csv_custom_delimiter_with_escape_char_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {"filetype": "csv", "double_quotes": True, "quote_char": "@", "delimiter": "|", "escape_char": "+"},
@@ -2106,7 +2090,6 @@ csv_custom_delimiter_in_double_quotes_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -2176,7 +2159,6 @@ csv_skip_before_header_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {"filetype": "csv", "skip_rows_before_header": 2},
@@ -2243,7 +2225,6 @@ csv_skip_after_header_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {"filetype": "csv", "skip_rows_after_header": 2},
@@ -2310,7 +2291,6 @@ csv_skip_before_and_after_header_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -2381,7 +2361,6 @@ csv_autogenerate_column_names_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -2448,7 +2427,6 @@ csv_custom_bool_values_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "boolean", "col2": "boolean"}',
@@ -2518,7 +2496,6 @@ csv_custom_null_values_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "boolean", "col2": "string"}',
@@ -2587,7 +2564,7 @@ earlier_csv_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/incremental_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/incremental_scenarios.py
@@ -13,7 +13,7 @@ single_csv_input_state_is_earlier_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -100,7 +100,7 @@ single_csv_file_is_skipped_if_same_modified_at_as_in_history = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -184,7 +184,7 @@ single_csv_file_is_synced_if_modified_at_is_more_recent_than_in_history = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -270,7 +270,7 @@ single_csv_no_input_state_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -344,7 +344,7 @@ multi_csv_same_timestamp_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -435,7 +435,7 @@ single_csv_input_state_is_later_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -521,7 +521,7 @@ multi_csv_different_timestamps_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -620,7 +620,7 @@ multi_csv_per_timestamp_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -733,7 +733,7 @@ multi_csv_skip_file_if_already_in_history = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -855,7 +855,7 @@ multi_csv_include_missing_files_within_history_range = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -969,7 +969,7 @@ multi_csv_remove_old_files_if_history_is_full_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -1107,7 +1107,7 @@ multi_csv_same_timestamp_more_files_than_history_size_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                     "days_to_sync_if_history_is_full": 3,
@@ -1225,7 +1225,7 @@ multi_csv_sync_recent_files_if_history_is_incomplete_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                     "days_to_sync_if_history_is_full": 3,
@@ -1342,7 +1342,7 @@ multi_csv_sync_files_within_time_window_if_history_is_incomplete__different_time
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                     "days_to_sync_if_history_is_full": 3,
@@ -1465,7 +1465,7 @@ multi_csv_sync_files_within_history_time_window_if_history_is_incomplete_differe
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                     "days_to_sync_if_history_is_full": 3,

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/jsonl_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/jsonl_scenarios.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+from airbyte_cdk.sources.file_based.config.jsonl_format import JsonlFormat
 from airbyte_cdk.sources.file_based.exceptions import FileBasedSourceError
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 from unit_tests.sources.file_based.helpers import LowInferenceBytesJsonlParser, LowInferenceLimitDiscoveryPolicy
@@ -15,7 +16,7 @@ single_jsonl_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -82,7 +83,7 @@ multi_jsonl_with_different_keys_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -163,7 +164,7 @@ multi_jsonl_stream_n_file_exceeds_limit_for_inference = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -241,7 +242,7 @@ multi_jsonl_stream_n_bytes_exceeds_limit_for_inference = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -307,7 +308,7 @@ multi_jsonl_stream_n_bytes_exceeds_limit_for_inference = (
                       "_ab_source_file_url": "b.jsonl"}, "stream": "stream1"},
         ]
     )
-    .set_parsers({"jsonl": LowInferenceBytesJsonlParser()})
+    .set_parsers({JsonlFormat: LowInferenceBytesJsonlParser()})
 ).build()
 
 
@@ -319,7 +320,7 @@ invalid_jsonl_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -390,13 +391,13 @@ jsonl_multi_stream_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["*.jsonl"],
                     "validation_policy": "Emit Record",
                 },
                 {
                     "name": "stream2",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["b.jsonl"],
                     "validation_policy": "Emit Record",
                 }
@@ -501,7 +502,7 @@ schemaless_jsonl_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["*"],
                     "validation_policy": "Skip Record",
                     "schemaless": True,
@@ -577,14 +578,14 @@ schemaless_jsonl_multi_stream_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["a.jsonl"],
                     "validation_policy": "Skip Record",
                     "schemaless": True,
                 },
                 {
                     "name": "stream2",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["b.jsonl"],
                     "validation_policy": "Skip Record",
                 }
@@ -678,7 +679,7 @@ jsonl_user_input_schema_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "jsonl",
+                    "format": {"filetype": "jsonl"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "integer", "col2": "string"}'

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/parquet_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/parquet_scenarios.py
@@ -544,7 +544,6 @@ parquet_file_with_decimal_as_string_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "format": {"filetype": "parquet"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -599,7 +598,6 @@ parquet_file_with_decimal_as_float_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "format": {"filetype": "parquet"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -654,7 +652,6 @@ parquet_file_with_decimal_legacy_config_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "format": {"filetype": "parquet"},
                     "format": {
                         "filetype": "parquet",
                     },
@@ -708,7 +705,6 @@ parquet_with_invalid_config_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "format": {"filetype": "parquet"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/parquet_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/parquet_scenarios.py
@@ -171,7 +171,7 @@ single_parquet_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "parquet",
+                    "format": {"filetype": "parquet"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -227,7 +227,7 @@ single_partitioned_parquet_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "parquet",
+                    "format": {"filetype": "parquet"},
                     "globs": ["path_prefix/**/*"],
                     "validation_policy": "Emit Record",
                 }
@@ -289,7 +289,7 @@ multi_parquet_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "parquet",
+                    "format": {"filetype": "parquet"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -352,7 +352,7 @@ parquet_various_types_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "parquet",
+                    "format": {"filetype": "parquet"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -493,7 +493,7 @@ parquet_file_with_decimal_no_config_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "parquet",
+                    "format": {"filetype": "parquet"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                 }
@@ -544,7 +544,7 @@ parquet_file_with_decimal_as_string_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "parquet",
+                    "format": {"filetype": "parquet"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -599,7 +599,7 @@ parquet_file_with_decimal_as_float_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "parquet",
+                    "format": {"filetype": "parquet"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {
@@ -654,7 +654,7 @@ parquet_file_with_decimal_legacy_config_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "parquet",
+                    "format": {"filetype": "parquet"},
                     "format": {
                         "filetype": "parquet",
                     },
@@ -708,7 +708,7 @@ parquet_with_invalid_config_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "parquet",
+                    "format": {"filetype": "parquet"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "format": {

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/scenario_builder.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/scenario_builder.py
@@ -163,7 +163,7 @@ class TestScenarioBuilder:
         self._expected_records = expected_records
         return self
 
-    def set_parsers(self, parsers: Mapping[str, FileTypeParser]) -> "TestScenarioBuilder":
+    def set_parsers(self, parsers: Mapping[Type[Any], FileTypeParser]) -> "TestScenarioBuilder":
         self._parsers = parsers
         return self
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/user_input_schema_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/user_input_schema_scenarios.py
@@ -78,7 +78,7 @@ valid_single_stream_user_input_schema_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "string", "col2": "string"}',
@@ -98,7 +98,7 @@ single_stream_user_input_schema_scenario_schema_is_invalid = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "x", "col2": "string"}',
@@ -121,7 +121,7 @@ single_stream_user_input_schema_scenario_emit_nonconforming_records = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "integer", "col2": "string"}',
@@ -171,7 +171,7 @@ single_stream_user_input_schema_scenario_skip_nonconforming_records = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*"],
                     "validation_policy": "Skip Record",
                     "input_schema": '{"col1": "integer", "col2": "string"}',
@@ -364,21 +364,21 @@ valid_multi_stream_user_input_schema_scenario = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["a.csv"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "string", "col2": "integer"}',
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["b.csv"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "string", "col2": "string", "col3": "string"}',
                 },
                 {
                     "name": "stream3",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["c.csv"],
                     "validation_policy": "Emit Record",
                 },
@@ -398,21 +398,21 @@ multi_stream_user_input_schema_scenario_schema_is_invalid = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["a.csv"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "string", "col2": "integer"}',
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["b.csv"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "x", "col2": "string", "col3": "string"}',  # this stream's schema is invalid
                 },
                 {
                     "name": "stream3",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["c.csv"],
                     "validation_policy": "Emit Record",
                 },
@@ -435,21 +435,21 @@ multi_stream_user_input_schema_scenario_emit_nonconforming_records = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["a.csv"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "string", "col2": "integer"}',
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["b.csv"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "string", "col2": "integer", "col3": "string"}',  # this stream's records do not conform to the schema
                 },
                 {
                     "name": "stream3",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["c.csv"],
                     "validation_policy": "Emit Record",
                 },
@@ -574,21 +574,21 @@ multi_stream_user_input_schema_scenario_skip_nonconforming_records = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["a.csv"],
                     "validation_policy": "Emit Record",
                     "input_schema": '{"col1": "string", "col2": "integer"}',
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["b.csv"],
                     "validation_policy": "Skip Record",
                     "input_schema": '{"col1": "string", "col2": "integer", "col3": "string"}',  # this stream's records do not conform to the schema
                 },
                 {
                     "name": "stream3",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["c.csv"],
                     "validation_policy": "Emit Record",
                 },

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/validation_policy_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/validation_policy_scenarios.py
@@ -204,7 +204,7 @@ skip_record_scenario_single_stream = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Skip Record",
                 }
@@ -250,13 +250,13 @@ skip_record_scenario_multi_stream = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["a/*.csv"],
                     "validation_policy": "Skip Record",
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["b/*.csv"],
                     "validation_policy": "Skip Record",
                 }
@@ -317,7 +317,7 @@ emit_record_scenario_single_stream = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -359,13 +359,13 @@ emit_record_scenario_multi_stream = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["a/*.csv"],
                     "validation_policy": "Emit Record",
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["b/*.csv"],
                     "validation_policy": "Emit Record",
                 }
@@ -418,7 +418,7 @@ wait_for_rediscovery_scenario_single_stream = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["*.csv"],
                     "validation_policy": "Wait for Discover",
                 }
@@ -453,13 +453,13 @@ wait_for_rediscovery_scenario_multi_stream = (
             "streams": [
                 {
                     "name": "stream1",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["a/*.csv"],
                     "validation_policy": "Wait for Discover",
                 },
                 {
                     "name": "stream2",
-                    "file_type": "csv",
+                    "format": {"filetype": "csv"},
                     "globs": ["b/*.csv"],
                     "validation_policy": "Wait for Discover",
                 }

--- a/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_cursor.py
@@ -7,6 +7,7 @@ from typing import Any, List, Mapping
 from unittest.mock import MagicMock
 
 import pytest
+from airbyte_cdk.sources.file_based.config.csv_format import CsvFormat
 from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig, ValidationPolicy
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.stream.cursor.default_file_based_cursor import DefaultFileBasedCursor
@@ -264,5 +265,5 @@ def get_cursor(max_history_size: int, days_to_sync_if_history_is_full: int) -> D
     cursor_cls = DefaultFileBasedCursor
     cursor_cls.DEFAULT_MAX_HISTORY_SIZE = max_history_size
     config = FileBasedStreamConfig(
-        file_type="csv", name="test", validation_policy=ValidationPolicy.emit_record, days_to_sync_if_history_is_full=days_to_sync_if_history_is_full)
+        format=CsvFormat(), name="test", validation_policy=ValidationPolicy.emit_record, days_to_sync_if_history_is_full=days_to_sync_if_history_is_full)
     return cursor_cls(config)

--- a/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
@@ -19,6 +19,9 @@ from airbyte_cdk.sources.file_based.stream.cursor import AbstractFileBasedCursor
 from airbyte_cdk.sources.file_based.stream.default_file_based_stream import DefaultFileBasedStream
 
 
+class MockFormat:
+    pass
+
 @pytest.mark.parametrize(
     "input_schema, expected_output",
     [
@@ -60,13 +63,12 @@ def test_fill_nulls(input_schema: Mapping[str, Any], expected_output: Mapping[st
 
 
 class DefaultFileBasedStreamTest(unittest.TestCase):
-    _FILE_TYPE = "file_type"
     _NOW = datetime(2022, 10, 22, tzinfo=timezone.utc)
     _A_RECORD = {"a_record": 1}
 
     def setUp(self) -> None:
         self._stream_config = Mock()
-        self._stream_config.file_type = self._FILE_TYPE
+        self._stream_config.format = MockFormat()
         self._stream_config.name = "a stream name"
         self._catalog_schema = Mock()
         self._stream_reader = Mock(spec=AbstractFileBasedStreamReader)
@@ -83,7 +85,7 @@ class DefaultFileBasedStreamTest(unittest.TestCase):
             stream_reader=self._stream_reader,
             availability_strategy=self._availability_strategy,
             discovery_policy=self._discovery_policy,
-            parsers={self._FILE_TYPE: self._parser},
+            parsers={MockFormat: self._parser},
             validation_policy=self._validation_policy,
             cursor=self._cursor,
         )

--- a/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
@@ -22,6 +22,7 @@ from airbyte_cdk.sources.file_based.stream.default_file_based_stream import Defa
 class MockFormat:
     pass
 
+
 @pytest.mark.parametrize(
     "input_schema, expected_output",
     [


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/30353

## How
Removing the field in the config and fixing the usages. Usages are:
* Parser selection
* Error messaging
* Config in tests

## 🚨 User Impact 🚨
In theory, [this](https://github.com/airbytehq/airbyte/compare/issue-30353/file-based-cdk-remove-file-type?expand=1#diff-d6b23b1ee5e90224c8eb3e7fdd7b84041fbaecea90537be165de79fdf1cc2184R53) is a breaking change. However in practice, it is always defined. That being said, I fear this would cause a breaking change release in source-s3