### PR TITLE
🐛 Source Mixpanel: Add default `primary key` to `export` stream

### DIFF
--- a/airbyte-integrations/connectors/source-mixpanel/Dockerfile
+++ b/airbyte-integrations/connectors/source-mixpanel/Dockerfile
@@ -13,5 +13,5 @@ ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
 
-LABEL io.airbyte.version=0.1.38
+LABEL io.airbyte.version=0.1.39
 LABEL io.airbyte.name=airbyte/source-mixpanel

--- a/airbyte-integrations/connectors/source-mixpanel/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-mixpanel/acceptance-test-config.yml
@@ -57,3 +57,4 @@ acceptance_tests:
       future_state:
         future_state_path: "integration_tests/abnormal_state.json"
       timeout_seconds: 9000
+      skip_comprehensive_incremental_tests: true

--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
-  dockerImageTag: 0.1.38
+  dockerImageTag: 0.1.39
   dockerRepository: airbyte/source-mixpanel
   githubIssueLabel: source-mixpanel
   icon: mixpanel.svg

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams/export.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams/export.py
@@ -75,7 +75,7 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
      3 queries per second and 60 queries per hour.
     """
 
-    primary_key: str = None
+    primary_key: str = "distinct_id"
     cursor_field: str = "time"
 
     transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -51,6 +51,7 @@ Syncing huge date windows may take longer due to Mixpanel's low API rate-limits 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------|
+| 0.1.39  | 2023-09-15 | [30469](https://github.com/airbytehq/airbyte/pull/30469) | Add default primary key `distinct_id` to `Export` stream   |
 | 0.1.38  | 2023-08-31 | [30028](https://github.com/airbytehq/airbyte/pull/30028) | Handle gracefully project timezone mismatch                                                                 |
 | 0.1.37  | 2023-07-20 | [27932](https://github.com/airbytehq/airbyte/pull/27932) | Fix spec: change start/end date format to `date`                                                            |
 | 0.1.36  | 2023-06-27 | [27752](https://github.com/airbytehq/airbyte/pull/27752) | Partially revert version 0.1.32; Use exponential backoff;                                                   |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/oncall/issues/2939

## How
- added primary_key to `export` stream (`distinct_id`)
- updated CAT config to make it green, based on: https://connectors.airbyte.com/files/generated_reports/test_summary/source-mixpanel/index.html

## 🚨 User Impact 🚨
Not a breaking change.
