### PR TITLE
[airbyte-ci] test connectors inside their built container

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
@@ -492,6 +492,10 @@ class Connector:
         if self.supports_normalization:
             return f"{self.metadata['normalizationConfig']['normalizationTag']}"
 
+    @property
+    def is_using_poetry(self) -> bool:
+        return Path(self.code_directory / "pyproject.toml").exists()
+
     def get_secret_manager(self, gsm_credentials: str):
         return SecretsManager(connector_name=self.technical_name, gsm_credentials=gsm_credentials)
 

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -395,6 +395,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 1.6.0   | [#30474](https://github.com/airbytehq/airbyte/pull/30474)  | Test connector inside their containers.                                                                  |
 | 1.5.1   | [#31227](https://github.com/airbytehq/airbyte/pull/31227)  | Use python 3.11 in amazoncorretto-bazed gradle containers, run 'test' gradle task instead of 'check'.     |
 | 1.5.0   | [#30456](https://github.com/airbytehq/airbyte/pull/30456)  | Start building Python connectors using our base images.                                                   |
 | 1.4.6   | [ #31087](https://github.com/airbytehq/airbyte/pull/31087) | Throw error if airbyte-ci tools is out of date                                                            |

--- a/airbyte-ci/connectors/pipelines/pipelines/bases.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/bases.py
@@ -23,8 +23,8 @@ from dagger import Container, DaggerError
 from jinja2 import Environment, PackageLoader, select_autoescape
 from pipelines import sentry_utils
 from pipelines.actions import remote_storage
-from pipelines.consts import GCS_PUBLIC_DOMAIN, LOCAL_REPORTS_PATH_ROOT, PYPROJECT_TOML_FILE_PATH
-from pipelines.utils import METADATA_FILE_NAME, check_path_in_workdir, format_duration, get_exec_result
+from pipelines.consts import GCS_PUBLIC_DOMAIN, LOCAL_REPORTS_PATH_ROOT
+from pipelines.utils import METADATA_FILE_NAME, format_duration, get_exec_result
 from rich.console import Group
 from rich.panel import Panel
 from rich.style import Style
@@ -274,42 +274,6 @@ class Step(ABC):
             StepStatus.FAILURE,
             stdout=f"Timed out after the max duration of {format_duration(self.max_duration)}. Please checkout the Dagger logs to see what happened.",
         )
-
-
-class PytestStep(Step, ABC):
-    """An abstract class to run pytest tests and evaluate success or failure according to pytest logs."""
-
-    skipped_exit_code = 5
-
-    async def _run_tests_in_directory(self, connector_under_test: Container, test_directory: str) -> StepResult:
-        """Run the pytest tests in the test_directory that was passed.
-
-        A StepStatus.SKIPPED is returned if no tests were discovered.
-
-        Args:
-            connector_under_test (Container): The connector under test container.
-            test_directory (str): The directory in which the python test modules are declared
-
-        Returns:
-            Tuple[StepStatus, Optional[str], Optional[str]]: Tuple of StepStatus, stderr and stdout.
-        """
-        test_config = "pytest.ini" if await check_path_in_workdir(connector_under_test, "pytest.ini") else "/" + PYPROJECT_TOML_FILE_PATH
-        if await check_path_in_workdir(connector_under_test, test_directory):
-            tester = connector_under_test.with_exec(
-                [
-                    "python",
-                    "-m",
-                    "pytest",
-                    "-s",
-                    test_directory,
-                    "-c",
-                    test_config,
-                ]
-            )
-            return await self.get_step_result(tester)
-
-        else:
-            return StepResult(self, StepStatus.SKIPPED)
 
 
 class NoOpStep(Step):

--- a/airbyte-ci/connectors/pipelines/pipelines/builds/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/builds/python_connectors.py
@@ -91,7 +91,7 @@ class BuildConnectorImages(BuildConnectorImagesBase):
             Container: The connector container built from its Dockerfile.
         """
         self.logger.warn(
-            "This connector is built from its Dockerfile. This is now deprecated. Please set connectorBuildOptions.baseImage metadata field to use or new build process."
+            "This connector is built from its Dockerfile. This is now deprecated. Please set connectorBuildOptions.baseImage metadata field to use our new build process."
         )
         container = self.dagger_client.container(platform=platform).build(await self.context.get_connector_dir())
         container = await apply_python_development_overrides(self.context, container)

--- a/airbyte-ci/connectors/pipelines/pipelines/commands/groups/tests.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/commands/groups/tests.py
@@ -46,7 +46,7 @@ async def run_test(poetry_package_path: str, test_directory: str) -> bool:
     logger = logging.getLogger(f"{poetry_package_path}.tests")
     logger.info(f"Running tests for {poetry_package_path}")
     # The following directories are always mounted because a lot of tests rely on them
-    directories_to_always_mount = [".git", "airbyte-integrations", "airbyte-ci", "airbyte-cdk"]
+    directories_to_always_mount = [".git", "airbyte-integrations", "airbyte-ci", "airbyte-cdk", "pyproject.toml"]
     directories_to_mount = list(set([poetry_package_path, *directories_to_always_mount]))
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as dagger_client:
         try:

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/common.py
@@ -17,7 +17,7 @@ from connector_ops.utils import Connector
 from dagger import Container, Directory, File
 from pipelines import hacks
 from pipelines.actions import environments
-from pipelines.bases import CIContext, PytestStep, Step, StepResult, StepStatus
+from pipelines.bases import CIContext, Step, StepResult, StepStatus
 from pipelines.utils import METADATA_FILE_NAME
 
 
@@ -175,12 +175,13 @@ class QaChecks(Step):
         return await self.get_step_result(qa_checks)
 
 
-class AcceptanceTests(PytestStep):
+class AcceptanceTests(Step):
     """A step to run acceptance tests for a connector if it has an acceptance test config file."""
 
     title = "Acceptance tests"
     CONTAINER_TEST_INPUT_DIRECTORY = "/test_input"
     CONTAINER_SECRETS_DIRECTORY = "/test_input/secrets"
+    skipped_exit_code = 5
 
     @property
     def base_cat_command(self) -> List[str]:

--- a/airbyte-ci/connectors/pipelines/pipelines/utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/utils.py
@@ -54,7 +54,7 @@ async def check_path_in_workdir(container: Container, path: str) -> bool:
     Returns:
         bool: Whether the path exists in the container working directory.
     """
-    workdir = (await container.with_exec(["pwd"]).stdout()).strip()
+    workdir = (await container.with_exec(["pwd"], skip_entrypoint=True).stdout()).strip()
     mounts = await container.mounts()
     if workdir in mounts:
         expected_file_path = Path(workdir[1:]) / path

--- a/airbyte-ci/connectors/pipelines/poetry.lock
+++ b/airbyte-ci/connectors/pipelines/poetry.lock
@@ -1733,13 +1733,13 @@ files = [
 
 [[package]]
 name = "sentry-sdk"
-version = "1.31.0"
+version = "1.32.0"
 description = "Python client for Sentry (https://sentry.io)"
 optional = false
 python-versions = "*"
 files = [
-    {file = "sentry-sdk-1.31.0.tar.gz", hash = "sha256:6de2e88304873484207fed836388e422aeff000609b104c802749fd89d56ba5b"},
-    {file = "sentry_sdk-1.31.0-py2.py3-none-any.whl", hash = "sha256:64a7141005fb775b9db298a30de93e3b83e0ddd1232dc6f36eb38aebc1553291"},
+    {file = "sentry-sdk-1.32.0.tar.gz", hash = "sha256:935e8fbd7787a3702457393b74b13d89a5afb67185bc0af85c00cb27cbd42e7c"},
+    {file = "sentry_sdk-1.32.0-py2.py3-none-any.whl", hash = "sha256:eeb0b3550536f3bbc05bb1c7e0feb3a78d74acb43b607159a606ed2ec0a33a4d"},
 ]
 
 [package.dependencies]

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.5.1"
+version = "1.6.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+import pytest
+from connector_ops.utils import Connector
+from pipelines.bases import StepResult
+from pipelines.builds.python_connectors import BuildConnectorImages
+from pipelines.contexts import ConnectorContext
+from pipelines.tests.python_connectors import UnitTests
+
+pytestmark = [
+    pytest.mark.anyio,
+]
+
+
+class TestUnitTests:
+    @pytest.fixture
+    def connector_with_setup(self):
+        return Connector("source-faker")
+
+    @pytest.fixture
+    def connector_with_poetry(self):
+        return Connector("destination-duckdb")
+
+    @pytest.fixture
+    def context_for_connector_with_setup(self, connector_with_setup, dagger_client):
+        context = ConnectorContext(
+            pipeline_name="test unit tests",
+            connector=connector_with_setup,
+            git_branch="test",
+            git_revision="test",
+            report_output_prefix="test",
+            is_local=True,
+            use_remote_secrets=True,
+        )
+        context.dagger_client = dagger_client
+        context.connector_secrets = {}
+        return context
+
+    @pytest.fixture
+    async def container_with_setup(self, context_for_connector_with_setup, current_platform):
+        result = await BuildConnectorImages(context_for_connector_with_setup, current_platform).run()
+        return result.output_artifact[current_platform]
+
+    @pytest.fixture
+    def context_for_connector_with_poetry(self, connector_with_poetry, dagger_client):
+        context = ConnectorContext(
+            pipeline_name="test unit tests",
+            connector=connector_with_poetry,
+            git_branch="test",
+            git_revision="test",
+            report_output_prefix="test",
+            is_local=True,
+            use_remote_secrets=True,
+        )
+        context.dagger_client = dagger_client
+        context.connector_secrets = {}
+        return context
+
+    @pytest.fixture
+    async def container_with_poetry(self, context_for_connector_with_poetry, current_platform):
+        result = await BuildConnectorImages(context_for_connector_with_poetry, current_platform).run()
+        return result.output_artifact[current_platform]
+
+    async def test__run_for_setup_py(self, context_for_connector_with_setup, container_with_setup):
+        # Assume that the tests directory is available
+        result = await UnitTests(context_for_connector_with_setup)._run(container_with_setup)
+        assert isinstance(result, StepResult)
+        assert "test session starts" in result.stdout or "test session starts" in result.stderr
+        pip_freeze_output = await result.output_artifact.with_exec(["pip", "freeze"], skip_entrypoint=True).stdout()
+        assert (
+            context_for_connector_with_setup.connector.technical_name in pip_freeze_output
+        ), "The connector should be installed in the test environment."
+        assert "pytest" in pip_freeze_output, "The pytest package should be installed in the test environment."
+
+    async def test__run_for_poetry(self, context_for_connector_with_poetry, container_with_poetry):
+        # Assume that the tests directory is available
+        result = await UnitTests(context_for_connector_with_poetry).run(container_with_poetry)
+        assert isinstance(result, StepResult)
+        # We only check for the presence of "test session starts" because we have no guarantee that the tests will pass
+        assert "test session starts" in result.stdout or "test session starts" in result.stderr, "The pytest tests should have started."
+        pip_freeze_output = await result.output_artifact.with_exec(["poetry", "run", "pip", "freeze"], skip_entrypoint=True).stdout()
+
+        assert (
+            context_for_connector_with_poetry.connector.technical_name in pip_freeze_output
+        ), "The connector should be installed in the test environment."
+        assert "pytest" in pip_freeze_output, "The pytest package should be installed in the test environment."


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Our original implementation of python connector testing was the following:
* Create a python container
* Mount the connector code to it
* Install some testing dependencies
* Run pytest

The problem with this approach is that we're running connector tests inside their real environment: their docker image.
So far  our  test environment had to keep up with the system dependencies of the connectors. 
These test environment could also install python dependencies that are not declare in the original connector python package.

## How
* Remove the ConnectorPackageInstall step
* Make the built connector container the input of the test step
* Install dev/test dependencies on top of the original built image
* Mount to the container the whole connector directory, to a /test_environment directory (the connector directory is not fully available on the built image).

The state of this "prepared" container is not kept for other steps like CAT or publish. It's just used in the python Unit / integration test step (subclasses of the PytestStep). 

