### PR TITLE
bump testcontainers version to latest

### DIFF
--- a/airbyte-connector-test-harnesses/acceptance-test-harness/build.gradle
+++ b/airbyte-connector-test-harnesses/acceptance-test-harness/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     testImplementation 'com.jayway.jsonpath:json-path:2.7.0'
     testImplementation 'org.mockito:mockito-inline:4.7.0'
     testImplementation libs.postgresql
-    testImplementation libs.platform.testcontainers
-    testImplementation libs.platform.testcontainers.postgresql
+    testImplementation libs.testcontainers
+    testImplementation libs.testcontainers.postgresql
     testImplementation libs.jmh.core
     testImplementation libs.jmh.annotations
     testImplementation 'com.github.docker-java:docker-java:3.2.8'

--- a/airbyte-db/db-lib/build.gradle
+++ b/airbyte-db/db-lib/build.gradle
@@ -2,11 +2,6 @@ plugins {
     id 'java-library'
 }
 
-// Add a configuration for our migrations tasks defined below to encapsulate their dependencies
-configurations {
-    migrations.extendsFrom implementation
-}
-
 configurations.all {
     exclude group: 'io.micronaut.flyway'
 }
@@ -22,12 +17,9 @@ dependencies {
     implementation project(':airbyte-config-oss:config-models-oss')
     implementation libs.flyway.core
 
-    migrations libs.platform.testcontainers.postgresql
-    migrations sourceSets.main.output
-
     // Mark as compile only to avoid leaking transitively to connectors
-    compileOnly libs.platform.testcontainers.postgresql
-    compileOnly libs.connectors.testcontainers.mysql
+    compileOnly libs.testcontainers.postgresql
+    compileOnly libs.testcontainers.mysql
 
     // These are required because gradle might be using lower version of Jna from other
     // library transitive dependency. Can be removed if we can figure out which library is the cause.
@@ -37,8 +29,8 @@ dependencies {
 
     testImplementation project(':airbyte-test-utils')
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation libs.platform.testcontainers.postgresql
-    testImplementation libs.connectors.testcontainers.mysql
+    testImplementation libs.testcontainers.postgresql
+    testImplementation libs.testcontainers.mysql
 
     // Big Query
     implementation('com.google.cloud:google-cloud-bigquery:1.133.1')

--- a/airbyte-integrations/bases/base-java/build.gradle
+++ b/airbyte-integrations/bases/base-java/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     implementation 'org.bouncycastle:bctls-jdk15on:1.66'
 
     implementation libs.jackson.annotations
-    implementation libs.connectors.testcontainers
-    implementation libs.connectors.testcontainers.jdbc
+    implementation libs.testcontainers
+    implementation libs.testcontainers.jdbc
     implementation libs.bundles.datadog
 
     testImplementation 'commons-lang:commons-lang:2.6'

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshBastionContainer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshBastionContainer.java
@@ -12,6 +12,7 @@ import static io.airbyte.integrations.base.ssh.SshTunnel.TunnelMethod.SSH_PASSWO
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.util.HostPortResolver;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -63,12 +64,10 @@ public class SshBastionContainer {
 
   public ImmutableMap.Builder<Object, Object> getBasicDbConfigBuider(final JdbcDatabaseContainer<?> db, final String schemaName) {
     return ImmutableMap.builder()
-        .put("host", Objects.requireNonNull(db.getContainerInfo().getNetworkSettings()
-            .getNetworks()
-            .entrySet().stream().findFirst().get().getValue().getIpAddress()))
+        .put("host", Objects.requireNonNull(HostPortResolver.resolveHost(db)))
         .put("username", db.getUsername())
         .put("password", db.getPassword())
-        .put("port", db.getExposedPorts().get(0))
+        .put("port", HostPortResolver.resolvePort(db))
         .put("database", schemaName)
         .put("ssl", false);
   }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshHelpers.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshHelpers.java
@@ -61,7 +61,8 @@ public class SshHelpers {
    * @return a pair of host and port
    */
   public static ImmutablePair<String, Integer> getOuterContainerAddress(final Container container) {
-    return ImmutablePair.of(container.getHost(),
+    return ImmutablePair.of(
+        container.getHost(),
         container.getFirstMappedPort());
   }
 

--- a/airbyte-integrations/bases/bases-destination-jdbc/build.gradle
+++ b/airbyte-integrations/bases/bases-destination-jdbc/build.gradle
@@ -24,9 +24,9 @@ dependencies {
 //     https://github.com/aesy/datasize
     implementation "io.aesy:datasize:1.0.0"
 
-    testImplementation libs.connectors.testcontainers.postgresql
+    testImplementation libs.testcontainers.postgresql
     testImplementation "org.mockito:mockito-inline:4.1.0"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
-    integrationTestJavaImplementation libs.connectors.testcontainers.postgresql
+    integrationTestJavaImplementation libs.testcontainers.postgresql
 }

--- a/airbyte-integrations/bases/debezium/build.gradle
+++ b/airbyte-integrations/bases/debezium/build.gradle
@@ -16,9 +16,9 @@ dependencies {
     testFixturesImplementation project(':airbyte-integrations:bases:base-java')
 
     testImplementation project(':airbyte-test-utils')
-    testImplementation libs.connectors.testcontainers.jdbc
-    testImplementation libs.connectors.testcontainers.mysql
-    testImplementation libs.connectors.testcontainers.postgresql
+    testImplementation libs.testcontainers.jdbc
+    testImplementation libs.testcontainers.mysql
+    testImplementation libs.testcontainers.postgresql
 
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'

--- a/airbyte-integrations/connectors/destination-cassandra/build.gradle
+++ b/airbyte-integrations/connectors/destination-cassandra/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     // https://mvnrepository.com/artifact/org.assertj/assertj-core
     testImplementation "org.assertj:assertj-core:${assertVersion}"
-    testImplementation libs.connectors.testcontainers.cassandra
+    testImplementation libs.testcontainers.cassandra
     testImplementation project(':airbyte-integrations:bases:standard-destination-test')
 
 

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/build.gradle
@@ -19,10 +19,10 @@ dependencies {
     implementation 'com.clickhouse:clickhouse-jdbc:0.3.2-patch10:all'
 
     // https://mvnrepository.com/artifact/org.testcontainers/clickhouse
-    testImplementation libs.connectors.destination.testcontainers.clickhouse
+    testImplementation libs.testcontainers.clickhouse
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-clickhouse')
     // https://mvnrepository.com/artifact/org.testcontainers/clickhouse
-    integrationTestJavaImplementation libs.connectors.destination.testcontainers.clickhouse
+    integrationTestJavaImplementation libs.testcontainers.clickhouse
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse/build.gradle
@@ -19,14 +19,14 @@ dependencies {
     implementation 'com.clickhouse:clickhouse-jdbc:0.3.2-patch10:all'
 
     // https://mvnrepository.com/artifact/org.testcontainers/clickhouse
-    testImplementation libs.connectors.destination.testcontainers.clickhouse
+    testImplementation libs.testcontainers.clickhouse
     testImplementation project(":airbyte-json-validation")
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-clickhouse')
     integrationTestJavaImplementation project(':airbyte-connector-test-harnesses:acceptance-test-harness')
     // https://mvnrepository.com/artifact/org.testcontainers/clickhouse
-    integrationTestJavaImplementation libs.connectors.destination.testcontainers.clickhouse
+    integrationTestJavaImplementation libs.testcontainers.clickhouse
 }
 
 tasks.named("airbyteDocker").configure {

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 
     // MIT
     // https://www.testcontainers.org/
-    testImplementation libs.connectors.testcontainers.elasticsearch
-    integrationTestJavaImplementation libs.connectors.testcontainers.elasticsearch
+    testImplementation libs.testcontainers.elasticsearch
+    integrationTestJavaImplementation libs.testcontainers.elasticsearch
 
     integrationTestJavaImplementation project(':airbyte-connector-test-harnesses:acceptance-test-harness')
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')

--- a/airbyte-integrations/connectors/destination-elasticsearch/build.gradle
+++ b/airbyte-integrations/connectors/destination-elasticsearch/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 
     // MIT
     // https://www.testcontainers.org/
-    testImplementation libs.connectors.testcontainers.elasticsearch
-    integrationTestJavaImplementation libs.connectors.testcontainers.elasticsearch
+    testImplementation libs.testcontainers.elasticsearch
+    integrationTestJavaImplementation libs.testcontainers.elasticsearch
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-elasticsearch')

--- a/airbyte-integrations/connectors/destination-iceberg/build.gradle
+++ b/airbyte-integrations/connectors/destination-iceberg/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     implementation "org.postgresql:postgresql:42.5.0"
     implementation "commons-collections:commons-collections:3.2.2"
 
-    testImplementation libs.connectors.testcontainers.postgresql
-    integrationTestJavaImplementation libs.connectors.testcontainers.postgresql
+    testImplementation libs.testcontainers.postgresql
+    integrationTestJavaImplementation libs.testcontainers.postgresql
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-iceberg')

--- a/airbyte-integrations/connectors/destination-kafka/build.gradle
+++ b/airbyte-integrations/connectors/destination-kafka/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-kafka')
-    integrationTestJavaImplementation libs.connectors.testcontainers.kafka
+    integrationTestJavaImplementation libs.testcontainers.kafka
 
 }

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/build.gradle
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/build.gradle
@@ -23,5 +23,5 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-mariadb-columnstore')
-    integrationTestJavaImplementation libs.connectors.testcontainers.mariadb
+    integrationTestJavaImplementation libs.testcontainers.mariadb
 }

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(':airbyte-integrations:connectors:destination-mongodb')
     implementation 'org.mongodb:mongodb-driver-sync:4.3.0'
 
-    testImplementation libs.connectors.testcontainers.mongodb
+    testImplementation libs.testcontainers.mongodb
 
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-mongodb-strict-encrypt')
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')

--- a/airbyte-integrations/connectors/destination-mongodb/build.gradle
+++ b/airbyte-integrations/connectors/destination-mongodb/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     implementation 'org.mongodb:mongodb-driver-sync:4.3.0'
 
-    testImplementation libs.connectors.testcontainers.mongodb
+    testImplementation libs.testcontainers.mongodb
     testImplementation project(':airbyte-integrations:bases:standard-destination-test')
 
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-mongodb')

--- a/airbyte-integrations/connectors/destination-mssql-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-mssql-strict-encrypt/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'com.microsoft.sqlserver:mssql-jdbc:8.4.1.jre14'
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation libs.connectors.testcontainers.mssqlserver
+    testImplementation libs.testcontainers.mssqlserver
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-mssql-strict-encrypt')

--- a/airbyte-integrations/connectors/destination-mssql/build.gradle
+++ b/airbyte-integrations/connectors/destination-mssql/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'com.microsoft.sqlserver:mssql-jdbc:8.4.1.jre14'
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation libs.connectors.testcontainers.mssqlserver
+    testImplementation libs.testcontainers.mssqlserver
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-mssql')

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/build.gradle
@@ -20,6 +20,6 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-mysql')
-    integrationTestJavaImplementation libs.connectors.testcontainers.mysql
+    integrationTestJavaImplementation libs.testcontainers.mysql
 
 }

--- a/airbyte-integrations/connectors/destination-mysql/build.gradle
+++ b/airbyte-integrations/connectors/destination-mysql/build.gradle
@@ -19,6 +19,6 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-mysql')
-    integrationTestJavaImplementation libs.connectors.testcontainers.mysql
+    integrationTestJavaImplementation libs.testcontainers.mysql
 
 }

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation libs.connectors.destination.testcontainers.oracle.xe
+    testImplementation libs.testcontainers.oracle.xe
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-oracle')

--- a/airbyte-integrations/connectors/destination-oracle/build.gradle
+++ b/airbyte-integrations/connectors/destination-oracle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation "com.oracle.database.jdbc:ojdbc8-production:19.7.0.0"
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation libs.connectors.destination.testcontainers.oracle.xe
+    testImplementation libs.testcontainers.oracle.xe
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-oracle')

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
 
-    integrationTestJavaImplementation libs.connectors.testcontainers.postgresql
+    integrationTestJavaImplementation libs.testcontainers.postgresql
 
     integrationTestJavaImplementation project(':airbyte-config-oss:config-models-oss')
     integrationTestJavaImplementation project(':airbyte-connector-test-harnesses:acceptance-test-harness')

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 
     testImplementation project(':airbyte-test-utils')
 
-    testImplementation libs.connectors.testcontainers.postgresql
+    testImplementation libs.testcontainers.postgresql
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-postgres')
 
-    integrationTestJavaImplementation libs.connectors.testcontainers.postgresql
+    integrationTestJavaImplementation libs.testcontainers.postgresql
 
 }

--- a/airbyte-integrations/connectors/destination-pulsar/build.gradle
+++ b/airbyte-integrations/connectors/destination-pulsar/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     implementation 'org.apache.pulsar:pulsar-client:2.8.1'
 
-    testImplementation libs.connectors.testcontainers.pulsar
+    testImplementation libs.testcontainers.pulsar
     testImplementation project(':airbyte-integrations:bases:standard-destination-test')
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')

--- a/airbyte-integrations/connectors/destination-redis/build.gradle
+++ b/airbyte-integrations/connectors/destination-redis/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.assertj/assertj-core
     testImplementation "org.assertj:assertj-core:${assertVersion}"
     // https://mvnrepository.com/artifact/org.testcontainers/testcontainers
-    testImplementation libs.connectors.testcontainers
+    testImplementation libs.testcontainers
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-redis')

--- a/airbyte-integrations/connectors/destination-scylla/build.gradle
+++ b/airbyte-integrations/connectors/destination-scylla/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.assertj/assertj-core
     testImplementation "org.assertj:assertj-core:${assertVersion}"
     // https://mvnrepository.com/artifact/org.testcontainers/testcontainers
-    testImplementation libs.connectors.testcontainers.scylla
+    testImplementation libs.testcontainers.scylla
 
 
 

--- a/airbyte-integrations/connectors/destination-tidb/build.gradle
+++ b/airbyte-integrations/connectors/destination-tidb/build.gradle
@@ -15,10 +15,10 @@ dependencies {
     implementation project(':airbyte-integrations:bases:bases-destination-jdbc')
 
     implementation 'mysql:mysql-connector-java:8.0.30'
-    implementation libs.connectors.testcontainers.tidb
+    testImplementation libs.testcontainers.tidb
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-tidb')
 
-    integrationTestJavaImplementation libs.connectors.testcontainers.tidb
+    integrationTestJavaImplementation libs.testcontainers.tidb
 }

--- a/airbyte-integrations/connectors/source-alloydb-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-alloydb-strict-encrypt/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
     testImplementation project(':airbyte-test-utils')
 
-    testImplementation libs.connectors.testcontainers.postgresql
+    testImplementation libs.testcontainers.postgresql
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 

--- a/airbyte-integrations/connectors/source-alloydb/build.gradle
+++ b/airbyte-integrations/connectors/source-alloydb/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
     testImplementation project(':airbyte-test-utils')
 
-    testImplementation libs.connectors.testcontainers.postgresql
+    testImplementation libs.testcontainers.postgresql
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/build.gradle
@@ -23,5 +23,5 @@ dependencies {
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-clickhouse')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-clickhouse-strict-encrypt')
     integrationTestJavaImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
-    integrationTestJavaImplementation libs.connectors.source.testcontainers.clickhouse
+    integrationTestJavaImplementation libs.testcontainers.clickhouse
 }

--- a/airbyte-integrations/connectors/source-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse/build.gradle
@@ -22,5 +22,5 @@ dependencies {
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-clickhouse')
     integrationTestJavaImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
-    integrationTestJavaImplementation libs.connectors.source.testcontainers.clickhouse
+    integrationTestJavaImplementation libs.testcontainers.clickhouse
 }

--- a/airbyte-integrations/connectors/source-cockroachdb-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-cockroachdb-strict-encrypt/build.gradle
@@ -16,12 +16,15 @@ dependencies {
     implementation project(':airbyte-integrations:connectors:source-jdbc')
     implementation project(':airbyte-integrations:connectors:source-relational-db')
     implementation project(':airbyte-integrations:connectors:source-cockroachdb')
-
-    implementation libs.connectors.testcontainers
-    implementation libs.connectors.testcontainers.jdbc
-    implementation libs.connectors.testcontainers.cockroachdb
     implementation libs.postgresql
 
+    testImplementation libs.testcontainers
+    testImplementation libs.testcontainers.jdbc
+    testImplementation libs.testcontainers.cockroachdb
+
+    integrationTestJavaImplementation libs.testcontainers
+    integrationTestJavaImplementation libs.testcontainers.jdbc
+    integrationTestJavaImplementation libs.testcontainers.cockroachdb
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-cockroachdb')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-cockroachdb-strict-encrypt')
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')

--- a/airbyte-integrations/connectors/source-cockroachdb/build.gradle
+++ b/airbyte-integrations/connectors/source-cockroachdb/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
 
-    testImplementation libs.connectors.testcontainers.cockroachdb
+    testImplementation libs.testcontainers.cockroachdb
     testImplementation 'org.apache.commons:commons-lang3:3.11'
 
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-cockroachdb')

--- a/airbyte-integrations/connectors/source-db2-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-db2-strict-encrypt/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
     testImplementation project(':airbyte-test-utils')
-    testImplementation libs.connectors.testcontainers.db2
+    testImplementation libs.testcontainers.db2
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-db2')

--- a/airbyte-integrations/connectors/source-db2/build.gradle
+++ b/airbyte-integrations/connectors/source-db2/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
     testImplementation project(':airbyte-test-utils')
-    testImplementation libs.connectors.testcontainers.db2
+    testImplementation libs.testcontainers.db2
     testImplementation project(":airbyte-json-validation")
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')

--- a/airbyte-integrations/connectors/source-elasticsearch/build.gradle
+++ b/airbyte-integrations/connectors/source-elasticsearch/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 
     //  MIT
     //  https://www.testcontainers.org/
-    testImplementation libs.connectors.testcontainers.elasticsearch
-    integrationTestJavaImplementation libs.connectors.testcontainers.elasticsearch
+    testImplementation libs.testcontainers.elasticsearch
+    integrationTestJavaImplementation libs.testcontainers.elasticsearch
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-elasticsearch')

--- a/airbyte-integrations/connectors/source-jdbc/build.gradle
+++ b/airbyte-integrations/connectors/source-jdbc/build.gradle
@@ -30,12 +30,12 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
 
     testImplementation libs.postgresql
-    testImplementation libs.connectors.testcontainers.postgresql
+    testImplementation libs.testcontainers.postgresql
 
     testImplementation libs.junit.jupiter.system.stubs
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
-    integrationTestJavaImplementation libs.connectors.testcontainers.postgresql
+    integrationTestJavaImplementation libs.testcontainers.postgresql
 
     testFixturesImplementation "org.hamcrest:hamcrest-all:1.3"
     testFixturesImplementation libs.airbyte.protocol

--- a/airbyte-integrations/connectors/source-kafka/build.gradle
+++ b/airbyte-integrations/connectors/source-kafka/build.gradle
@@ -23,14 +23,15 @@ dependencies {
     implementation project(':airbyte-config-oss:config-models-oss')
     implementation libs.airbyte.protocol
     implementation project(':airbyte-integrations:bases:base-java')
-    implementation libs.connectors.testcontainers.kafka
 
     implementation 'org.apache.kafka:kafka-clients:3.2.1'
     implementation 'org.apache.kafka:connect-json:3.2.1'
     implementation 'io.confluent:kafka-avro-serializer:7.2.1'
 
+    testImplementation libs.testcontainers.kafka
+
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-kafka')
-    integrationTestJavaImplementation libs.connectors.testcontainers.kafka
+    integrationTestJavaImplementation libs.testcontainers.kafka
 
 }

--- a/airbyte-integrations/connectors/source-mongodb-v2/build.gradle
+++ b/airbyte-integrations/connectors/source-mongodb-v2/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     implementation 'org.mongodb:mongodb-driver-sync:4.4.0'
 
-    testImplementation libs.connectors.testcontainers.mongodb
+    testImplementation libs.testcontainers.mongodb
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-mongodb-v2')

--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation libs.connectors.testcontainers.mssqlserver
+    testImplementation libs.testcontainers.mssqlserver
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-mssql-strict-encrypt')

--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation libs.connectors.testcontainers.mssqlserver
+    testImplementation libs.testcontainers.mssqlserver
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     performanceTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
     testImplementation libs.junit.jupiter.system.stubs
 
-    testImplementation libs.connectors.testcontainers.mysql
+    testImplementation libs.testcontainers.mysql
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mysql_strict_encrypt/MySqlStrictEncryptSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mysql_strict_encrypt/MySqlStrictEncryptSourceAcceptanceTest.java
@@ -18,6 +18,7 @@ import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.base.ssh.SshHelpers;
 import io.airbyte.integrations.standardtest.source.SourceAcceptanceTest;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.protocol.models.v0.CatalogHelpers;
@@ -51,8 +52,8 @@ public class MySqlStrictEncryptSourceAcceptanceTest extends SourceAcceptanceTest
         .put("method", "STANDARD")
         .build());
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())
@@ -65,8 +66,8 @@ public class MySqlStrictEncryptSourceAcceptanceTest extends SourceAcceptanceTest
         config.get(JdbcUtils.PASSWORD_KEY).asText(),
         DatabaseDriver.MYSQL.getDriverClassName(),
         String.format("jdbc:mysql://%s:%s/%s?%s",
-            config.get(JdbcUtils.HOST_KEY).asText(),
-            config.get(JdbcUtils.PORT_KEY).asText(),
+            container.getHost(),
+            container.getFirstMappedPort(),
             config.get(JdbcUtils.DATABASE_KEY).asText(),
             String.join("&", SSL_PARAMETERS)),
         SQLDialect.MYSQL)) {

--- a/airbyte-integrations/connectors/source-mysql/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     testImplementation 'org.apache.commons:commons-lang3:3.11'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation libs.junit.jupiter.system.stubs
-    testImplementation libs.connectors.testcontainers.mysql
+    testImplementation libs.testcontainers.mysql
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-mysql')

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractMySqlSslCertificateSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractMySqlSslCertificateSourceAcceptanceTest.java
@@ -13,6 +13,7 @@ import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.DatabaseDriver;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import java.io.IOException;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
@@ -36,8 +37,8 @@ public abstract class AbstractMySqlSslCertificateSourceAcceptanceTest extends My
         .put("method", "STANDARD")
         .build());
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CDCMySqlDatatypeAccuracyTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CDCMySqlDatatypeAccuracyTest.java
@@ -14,6 +14,7 @@ import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.DatabaseDriver;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.testcontainers.containers.MySQLContainer;
@@ -37,8 +38,8 @@ public class CDCMySqlDatatypeAccuracyTest extends MySqlDatatypeAccuracyTest {
         .put("initial_waiting_seconds", INITIAL_CDC_WAITING_SECONDS)
         .build());
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())
@@ -52,8 +53,8 @@ public class CDCMySqlDatatypeAccuracyTest extends MySqlDatatypeAccuracyTest {
         config.get(JdbcUtils.PASSWORD_KEY).asText(),
         DatabaseDriver.MYSQL.getDriverClassName(),
         String.format(DatabaseDriver.MYSQL.getUrlFormatString(),
-            config.get(JdbcUtils.HOST_KEY).asText(),
-            config.get(JdbcUtils.PORT_KEY).asInt(),
+            container.getHost(),
+            container.getFirstMappedPort(),
             config.get(JdbcUtils.DATABASE_KEY).asText()),
         SQLDialect.MYSQL);
     final Database database = new Database(dslContext);

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcBinlogsMySqlSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcBinlogsMySqlSourceDatatypeTest.java
@@ -17,6 +17,7 @@ import io.airbyte.db.factory.DatabaseDriver;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.standardtest.source.TestDataHolder;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteStateMessage;
@@ -93,8 +94,8 @@ public class CdcBinlogsMySqlSourceDatatypeTest extends AbstractMySqlSourceDataty
         .put("initial_waiting_seconds", INITIAL_CDC_WAITING_SECONDS)
         .build());
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())
@@ -107,8 +108,8 @@ public class CdcBinlogsMySqlSourceDatatypeTest extends AbstractMySqlSourceDataty
         config.get(JdbcUtils.PASSWORD_KEY).asText(),
         DatabaseDriver.MYSQL.getDriverClassName(),
         String.format(DatabaseDriver.MYSQL.getUrlFormatString(),
-            config.get(JdbcUtils.HOST_KEY).asText(),
-            config.get(JdbcUtils.PORT_KEY).asInt(),
+            container.getHost(),
+            container.getFirstMappedPort(),
             config.get(JdbcUtils.DATABASE_KEY).asText()),
         SQLDialect.MYSQL);
     final Database database = new Database(dslContext);

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcInitialSnapshotMySqlSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcInitialSnapshotMySqlSourceDatatypeTest.java
@@ -15,6 +15,7 @@ import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.DatabaseDriver;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,8 +48,8 @@ public class CdcInitialSnapshotMySqlSourceDatatypeTest extends AbstractMySqlSour
         .put("initial_waiting_seconds", INITIAL_CDC_WAITING_SECONDS)
         .build());
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())
@@ -62,8 +63,8 @@ public class CdcInitialSnapshotMySqlSourceDatatypeTest extends AbstractMySqlSour
         config.get(JdbcUtils.PASSWORD_KEY).asText(),
         DatabaseDriver.MYSQL.getDriverClassName(),
         String.format(DatabaseDriver.MYSQL.getUrlFormatString(),
-            config.get(JdbcUtils.HOST_KEY).asText(),
-            config.get(JdbcUtils.PORT_KEY).asInt(),
+            container.getHost(),
+            container.getFirstMappedPort(),
             config.get(JdbcUtils.DATABASE_KEY).asText()),
         SQLDialect.MYSQL);
     final Database database = new Database(dslContext);

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcMySqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcMySqlSourceAcceptanceTest.java
@@ -23,6 +23,7 @@ import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.base.ssh.SshHelpers;
 import io.airbyte.integrations.standardtest.source.SourceAcceptanceTest;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
@@ -115,8 +116,8 @@ public class CdcMySqlSourceAcceptanceTest extends SourceAcceptanceTest {
         .build());
     environmentVariables.set(EnvVariableFeatureFlags.USE_STREAM_CAPABLE_STATE, "true");
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcMySqlSslCaCertificateSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcMySqlSslCaCertificateSourceAcceptanceTest.java
@@ -13,6 +13,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.MySqlUtils;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import org.testcontainers.containers.MySQLContainer;
 
 public class CdcMySqlSslCaCertificateSourceAcceptanceTest extends CdcMySqlSourceAcceptanceTest {
@@ -39,8 +40,8 @@ public class CdcMySqlSslCaCertificateSourceAcceptanceTest extends CdcMySqlSource
         .build());
 
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcMySqlSslRequiredSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcMySqlSslRequiredSourceAcceptanceTest.java
@@ -12,6 +12,7 @@ import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import org.testcontainers.containers.MySQLContainer;
 
 public class CdcMySqlSslRequiredSourceAcceptanceTest extends CdcMySqlSourceAcceptanceTest {
@@ -31,8 +32,8 @@ public class CdcMySqlSslRequiredSourceAcceptanceTest extends CdcMySqlSourceAccep
         .build());
 
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MySqlDatatypeAccuracyTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MySqlDatatypeAccuracyTest.java
@@ -14,6 +14,7 @@ import io.airbyte.db.factory.DatabaseDriver;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.standardtest.source.TestDataHolder;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import io.airbyte.protocol.models.JsonSchemaType;
 import java.util.Arrays;
 import java.util.List;
@@ -44,8 +45,8 @@ public class MySqlDatatypeAccuracyTest extends AbstractMySqlSourceDatatypeTest {
         .put("method", "STANDARD")
         .build());
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())
@@ -58,8 +59,8 @@ public class MySqlDatatypeAccuracyTest extends AbstractMySqlSourceDatatypeTest {
             config.get(JdbcUtils.PASSWORD_KEY).asText(),
             DatabaseDriver.MYSQL.getDriverClassName(),
             String.format(DatabaseDriver.MYSQL.getUrlFormatString(),
-                config.get(JdbcUtils.HOST_KEY).asText(),
-                config.get(JdbcUtils.PORT_KEY).asInt(),
+                container.getHost(),
+                container.getFirstMappedPort(),
                 config.get(JdbcUtils.DATABASE_KEY).asText()),
             SQLDialect.MYSQL,
             Map.of("zeroDateTimeBehavior", "convertToNull")));

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MySqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MySqlSourceAcceptanceTest.java
@@ -16,6 +16,7 @@ import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.base.ssh.SshHelpers;
 import io.airbyte.integrations.standardtest.source.SourceAcceptanceTest;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.protocol.models.v0.CatalogHelpers;
@@ -54,8 +55,8 @@ public class MySqlSourceAcceptanceTest extends SourceAcceptanceTest {
         .build());
     environmentVariables.set(EnvVariableFeatureFlags.USE_STREAM_CAPABLE_STATE, "true");
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())
@@ -67,8 +68,8 @@ public class MySqlSourceAcceptanceTest extends SourceAcceptanceTest {
         config.get(JdbcUtils.PASSWORD_KEY).asText(),
         DatabaseDriver.MYSQL.getDriverClassName(),
         String.format(DatabaseDriver.MYSQL.getUrlFormatString(),
-            config.get(JdbcUtils.HOST_KEY).asText(),
-            config.get(JdbcUtils.PORT_KEY).asInt(),
+            container.getHost(),
+            container.getFirstMappedPort(),
             config.get(JdbcUtils.DATABASE_KEY).asText()),
         SQLDialect.MYSQL)) {
       final Database database = new Database(dslContext);

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MySqlSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MySqlSourceDatatypeTest.java
@@ -12,6 +12,7 @@ import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.DatabaseDriver;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import java.util.Map;
 import org.jooq.SQLDialect;
 import org.testcontainers.containers.MySQLContainer;
@@ -31,8 +32,8 @@ public class MySqlSourceDatatypeTest extends AbstractMySqlSourceDatatypeTest {
         .put("method", "STANDARD")
         .build());
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())
@@ -45,8 +46,8 @@ public class MySqlSourceDatatypeTest extends AbstractMySqlSourceDatatypeTest {
             config.get(JdbcUtils.PASSWORD_KEY).asText(),
             DatabaseDriver.MYSQL.getDriverClassName(),
             String.format(DatabaseDriver.MYSQL.getUrlFormatString(),
-                config.get(JdbcUtils.HOST_KEY).asText(),
-                config.get(JdbcUtils.PORT_KEY).asInt(),
+                container.getHost(),
+                container.getFirstMappedPort(),
                 config.get(JdbcUtils.DATABASE_KEY).asText()),
             SQLDialect.MYSQL,
             Map.of("zeroDateTimeBehavior", "convertToNull")));

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MySqlSslSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MySqlSslSourceAcceptanceTest.java
@@ -12,6 +12,7 @@ import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.DatabaseDriver;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.integrations.util.HostPortResolver;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.testcontainers.containers.MySQLContainer;
@@ -31,8 +32,8 @@ public class MySqlSslSourceAcceptanceTest extends MySqlSourceAcceptanceTest {
         .build();
 
     config = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, container.getHost())
-        .put(JdbcUtils.PORT_KEY, container.getFirstMappedPort())
+        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
+        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
         .put(JdbcUtils.DATABASE_KEY, container.getDatabaseName())
         .put(JdbcUtils.USERNAME_KEY, container.getUsername())
         .put(JdbcUtils.PASSWORD_KEY, container.getPassword())
@@ -46,8 +47,8 @@ public class MySqlSslSourceAcceptanceTest extends MySqlSourceAcceptanceTest {
         config.get(JdbcUtils.PASSWORD_KEY).asText(),
         DatabaseDriver.MYSQL.getDriverClassName(),
         String.format("jdbc:mysql://%s:%s/%s",
-            config.get(JdbcUtils.HOST_KEY).asText(),
-            config.get(JdbcUtils.PORT_KEY).asText(),
+            container.getHost(),
+            container.getFirstMappedPort(),
             config.get(JdbcUtils.DATABASE_KEY).asText()),
         SQLDialect.MYSQL)) {
       final Database database = new Database(dslContext);

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation libs.connectors.source.testcontainers.oracle.xe
+    testImplementation libs.testcontainers.oracle.xe
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-oracle-strict-encrypt')

--- a/airbyte-integrations/connectors/source-oracle/build.gradle
+++ b/airbyte-integrations/connectors/source-oracle/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation libs.connectors.source.testcontainers.oracle.xe
+    testImplementation libs.testcontainers.oracle.xe
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-oracle')

--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
     testImplementation libs.junit.jupiter.system.stubs
 
-    testImplementation libs.connectors.testcontainers.jdbc
-    testImplementation libs.connectors.testcontainers.postgresql
+    testImplementation libs.testcontainers.jdbc
+    testImplementation libs.testcontainers.postgresql
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     testImplementation project(":airbyte-json-validation")
     testImplementation project(':airbyte-test-utils')
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation libs.connectors.testcontainers.jdbc
-    testImplementation libs.connectors.testcontainers.postgresql
+    testImplementation libs.testcontainers.jdbc
+    testImplementation libs.testcontainers.postgresql
     testImplementation libs.junit.jupiter.system.stubs
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')

--- a/airbyte-integrations/connectors/source-relational-db/build.gradle
+++ b/airbyte-integrations/connectors/source-relational-db/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
 
     testImplementation libs.postgresql
-    testImplementation libs.connectors.testcontainers.postgresql
+    testImplementation libs.testcontainers.postgresql
 
     testImplementation libs.junit.jupiter.system.stubs
 

--- a/airbyte-integrations/connectors/source-sftp/build.gradle
+++ b/airbyte-integrations/connectors/source-sftp/build.gradle
@@ -18,5 +18,5 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-sftp')
-    testImplementation libs.connectors.testcontainers
+    testImplementation libs.testcontainers
 }

--- a/airbyte-integrations/connectors/source-tidb/build.gradle
+++ b/airbyte-integrations/connectors/source-tidb/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.22'
 
     // Add testcontainers and use GenericContainer for TiDB
-    implementation libs.connectors.testcontainers.tidb
+    testImplementation libs.testcontainers.tidb
 
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
 
@@ -30,7 +30,7 @@ dependencies {
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-tidb')
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 
-    integrationTestJavaImplementation libs.connectors.testcontainers.tidb
+    integrationTestJavaImplementation libs.testcontainers.tidb
 
 }
 

--- a/airbyte-test-utils/build.gradle
+++ b/airbyte-test-utils/build.gradle
@@ -19,11 +19,11 @@ dependencies {
     api libs.junit.jupiter.api
 
     // Mark as compile only to avoid leaking transitively to connectors
-    compileOnly libs.platform.testcontainers.jdbc
-    compileOnly libs.platform.testcontainers.postgresql
-    compileOnly libs.platform.testcontainers.cockroachdb
+    compileOnly libs.testcontainers.jdbc
+    compileOnly libs.testcontainers.postgresql
+    compileOnly libs.testcontainers.cockroachdb
 
-    testImplementation libs.platform.testcontainers.jdbc
-    testImplementation libs.platform.testcontainers.postgresql
-    testImplementation libs.platform.testcontainers.cockroachdb
+    testImplementation libs.testcontainers.jdbc
+    testImplementation libs.testcontainers.postgresql
+    testImplementation libs.testcontainers.cockroachdb
 }

--- a/deps.toml
+++ b/deps.toml
@@ -1,16 +1,7 @@
 [versions]
 airbyte-protocol = "0.3.6"
 commons_io = "2.7"
-connectors-destination-testcontainers-clickhouse = "1.17.3"
-connectors-destination-testcontainers-elasticsearch = "1.17.3"
-connectors-destination-testcontainers-oracle-xe = "1.17.3"
-connectors-source-testcontainers-clickhouse = "1.17.3"
-connectors-testcontainers = "1.15.3"
-connectors-testcontainers-cassandra = "1.16.0"
-connectors-testcontainers-mariadb = "1.16.2"
-connectors-testcontainers-pulsar = "1.16.2"
-connectors-testcontainers-scylla = "1.16.2"
-connectors-testcontainers-tidb = "1.16.3"
+testcontainers = "1.19.0"
 datadog-version = "0.111.0"
 fasterxml_version = "2.14.0"
 flyway = "7.14.0"
@@ -42,25 +33,23 @@ appender-log4j2 = { module = "com.therealvan:appender-log4j2", version = "3.6.0"
 assertj-core = { module = "org.assertj:assertj-core", version = "3.21.0" }
 aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.6" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons_io" }
-connectors-destination-testcontainers-clickhouse = { module = "org.testcontainers:clickhouse", version.ref = "connectors-destination-testcontainers-clickhouse" }
-connectors-destination-testcontainers-oracle-xe = { module = "org.testcontainers:oracle-xe", version.ref = "connectors-destination-testcontainers-oracle-xe" }
-connectors-source-testcontainers-clickhouse = { module = "org.testcontainers:clickhouse", version.ref = "connectors-source-testcontainers-clickhouse" }
-connectors-source-testcontainers-oracle-xe = { module = "org.testcontainers:oracle-xe", version.ref = "connectors-testcontainers" }
-connectors-testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "connectors-testcontainers" }
-connectors-testcontainers-cassandra = { module = "org.testcontainers:cassandra", version.ref = "connectors-testcontainers-cassandra" }
-connectors-testcontainers-cockroachdb = { module = "org.testcontainers:cockroachdb", version.ref = "connectors-testcontainers" }
-connectors-testcontainers-db2 = { module = "org.testcontainers:db2", version.ref = "connectors-testcontainers" }
-connectors-testcontainers-elasticsearch = { module = "org.testcontainers:elasticsearch", version.ref = "connectors-destination-testcontainers-elasticsearch" }
-connectors-testcontainers-jdbc = { module = "org.testcontainers:jdbc", version.ref = "connectors-testcontainers" }
-connectors-testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "connectors-testcontainers" }
-connectors-testcontainers-mariadb = { module = "org.testcontainers:mariadb", version.ref = "connectors-testcontainers-mariadb" }
-connectors-testcontainers-mongodb = { module = "org.testcontainers:mongodb", version.ref = "connectors-testcontainers" }
-connectors-testcontainers-mssqlserver = { module = "org.testcontainers:mssqlserver", version.ref = "connectors-testcontainers" }
-connectors-testcontainers-mysql = { module = "org.testcontainers:mysql", version.ref = "connectors-testcontainers" }
-connectors-testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "connectors-testcontainers" }
-connectors-testcontainers-pulsar = { module = "org.testcontainers:pulsar", version.ref = "connectors-testcontainers-pulsar" }
-connectors-testcontainers-scylla = { module = "org.testcontainers:testcontainers", version.ref = "connectors-testcontainers-scylla" }
-connectors-testcontainers-tidb = { module = "org.testcontainers:testcontainers", version.ref = "connectors-testcontainers-tidb" }
+testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
+testcontainers-cassandra = { module = "org.testcontainers:cassandra", version.ref = "testcontainers" }
+testcontainers-clickhouse = { module = "org.testcontainers:clickhouse", version.ref = "testcontainers" }
+testcontainers-cockroachdb = { module = "org.testcontainers:cockroachdb", version.ref = "testcontainers" }
+testcontainers-db2 = { module = "org.testcontainers:db2", version.ref = "testcontainers" }
+testcontainers-elasticsearch = { module = "org.testcontainers:elasticsearch", version.ref = "testcontainers" }
+testcontainers-jdbc = { module = "org.testcontainers:jdbc", version.ref = "testcontainers" }
+testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "testcontainers" }
+testcontainers-mariadb = { module = "org.testcontainers:mariadb", version.ref = "testcontainers" }
+testcontainers-mongodb = { module = "org.testcontainers:mongodb", version.ref = "testcontainers" }
+testcontainers-mssqlserver = { module = "org.testcontainers:mssqlserver", version.ref = "testcontainers" }
+testcontainers-mysql = { module = "org.testcontainers:mysql", version.ref = "testcontainers" }
+testcontainers-oracle-xe = { module = "org.testcontainers:oracle-xe", version.ref = "testcontainers" }
+testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
+testcontainers-pulsar = { module = "org.testcontainers:pulsar", version.ref = "testcontainers" }
+testcontainers-scylla = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
+testcontainers-tidb = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 datadog-trace-api = { module = "com.datadoghq:dd-trace-api", version.ref = "datadog-version" }
 datadog-trace-ot = { module = "com.datadoghq:dd-trace-ot", version.ref = "datadog-version" }
 fasterxml = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "fasterxml_version" }
@@ -103,10 +92,6 @@ otel-bom = { module = "io.opentelemetry:opentelemetry-bom", version = "1.14.0" }
 otel-sdk = { module = "io.opentelemetry:opentelemetry-sdk-metrics", version = "1.14.0" }
 otel-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-metrics-testing", version = "1.13.0-alpha" }
 otel-semconv = { module = "io.opentelemetry:opentelemetry-semconv", version = "1.14.0-alpha" }
-platform-testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "platform-testcontainers" }
-platform-testcontainers-cockroachdb = { module = "org.testcontainers:cockroachdb", version.ref = "platform-testcontainers" }
-platform-testcontainers-jdbc = { module = "org.testcontainers:jdbc", version.ref = "platform-testcontainers" }
-platform-testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "platform-testcontainers" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 quartz-scheduler = { module = "org.quartz-scheduler:quartz", version = "2.3.2" }
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactor" }


### PR DESCRIPTION
This PR bumps all testcontainers package versions to the latest across the board, following up on work started by @alafanechere. We need to do this to have access to images for the architectures that we use (arm machines on aws, apple silicon locally...). The need for this was especially pressing for source-mysql apparently, airbyte-ci just doesn't work for that connector right now. 

Notice that I tie all testcontainers dependencies to one version number. This is deliberate, any testcontainers package will transitively depend on the testcontainers base package of the same version. To use a specific, different version in a connector for whatever reason, let's import it using a hardcoded string instead of a reference to deps.toml. @aaronsteers perhaps the CDK will formalize things in this respect? It seems sensible that testcontainers version pinning could happen in there.

I made a reasonable effort to test that this doesn't break anything _that I think that we care about_. This change actually breaks many connector's tests, but I haven't worried about those which were already routinely broken according to https://connectors.airbyte.com/files/generated_reports/connector_registry_report.html. The fixes, in any case, are fairly straightforward.

This PR will trigger a bunch of CI runs, which is actually desirable for a change. I'll go over the reports after the week-end, once they've had a chance to run. I did some manual tests before publishing this that verified that this fixes the source-mysql + strict-encrypt builds so this is ready for review. If any other connectors need fixing the changes are along the same lines so that shouldn't block the review. 

Informs https://github.com/airbytehq/airbyte/issues/29463