### PR TITLE
🐛 Pinecone destination: Fix delete with many entries on starter pods

### DIFF
--- a/airbyte-integrations/connectors/destination-pinecone/Dockerfile
+++ b/airbyte-integrations/connectors/destination-pinecone/Dockerfile
@@ -38,6 +38,6 @@ COPY destination_pinecone ./destination_pinecone
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.8
+LABEL io.airbyte.version=0.0.9
 
 LABEL io.airbyte.name=airbyte/destination-pinecone

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 3d2b6f84-7f0d-4e3f-a5e5-7c7d4b50eabd
-  dockerImageTag: 0.0.8
+  dockerImageTag: 0.0.9
   dockerRepository: airbyte/destination-pinecone
   githubIssueLabel: destination-pinecone
   icon: pinecone.svg

--- a/airbyte-integrations/connectors/destination-pinecone/unit_tests/pinecone_indexer_test.py
+++ b/airbyte-integrations/connectors/destination-pinecone/unit_tests/pinecone_indexer_test.py
@@ -88,6 +88,7 @@ def test_pinecone_index_upsert_and_delete_starter(mock_describe_index):
         show_progress=False,
     )
 
+
 def test_pinecone_index_delete_1k_limit(mock_describe_index):
     indexer = create_pinecone_indexer()
     indexer._pod_type = "starter"

--- a/airbyte-integrations/connectors/destination-pinecone/unit_tests/pinecone_indexer_test.py
+++ b/airbyte-integrations/connectors/destination-pinecone/unit_tests/pinecone_indexer_test.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 from airbyte_cdk.models import ConfiguredAirbyteCatalog
@@ -87,6 +87,16 @@ def test_pinecone_index_upsert_and_delete_starter(mock_describe_index):
         async_req=True,
         show_progress=False,
     )
+
+def test_pinecone_index_delete_1k_limit(mock_describe_index):
+    indexer = create_pinecone_indexer()
+    indexer._pod_type = "starter"
+    indexer.pinecone_index.query.return_value = MagicMock(matches=[MagicMock(id=f"doc_id_{str(i)}") for i in range(1300)])
+    indexer.index(
+        [],
+        ["delete_id1"],
+    )
+    indexer.pinecone_index.delete.assert_has_calls([call(ids=[f"doc_id_{str(i)}" for i in range(1000)]), call(ids=[f"doc_id_{str(i+1000)}" for i in range(300)])])
 
 
 def test_pinecone_index_empty_batch():

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -74,6 +74,7 @@ OpenAI and Fake embeddings produce vectors with 1536 dimensions, and the Cohere 
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.0.9   | 2023-09-18 | [#30510](https://github.com/airbytehq/airbyte/pull/30510)     | Fix bug with overwrite mode on starter pods | 
 | 0.0.8   | 2023-09-14 | [#30296](https://github.com/airbytehq/airbyte/pull/30296)     | Add Azure embedder | 
 | 0.0.7   | 2023-09-13 | [#30382](https://github.com/airbytehq/airbyte/pull/30382)     | Promote to certified/beta | 
 | 0.0.6   | 2023-09-09 | [#30193](https://github.com/airbytehq/airbyte/pull/30193)     | Improve documentation | 


### PR DESCRIPTION
On starter pods, delete-by-filter is not available so the connector implements it via a search + a subsequent delete by id. However, the limit for the search is 10k while the limit for a delete is 1k, which means the sync fails if the connector has to delete more than 1k vectors at once: https://docs.pinecone.io/docs/limits

This PR fixes the problem by chunking the id list into batches of 1k elements which are processed one after the other.