### PR TITLE
Source Amplitude: fix data region keyerror

### DIFF
--- a/airbyte-integrations/connectors/source-amplitude/Dockerfile
+++ b/airbyte-integrations/connectors/source-amplitude/Dockerfile
@@ -34,5 +34,5 @@ COPY source_amplitude ./source_amplitude
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.3.1
+LABEL io.airbyte.version=0.3.2
 LABEL io.airbyte.name=airbyte/source-amplitude

--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fa9f58c6-2d03-4237-aaa4-07d75e0c1396
-  dockerImageTag: 0.3.1
+  dockerImageTag: 0.3.2
   dockerRepository: airbyte/source-amplitude
   githubIssueLabel: source-amplitude
   icon: amplitude.svg

--- a/airbyte-integrations/connectors/source-amplitude/source_amplitude/source.py
+++ b/airbyte-integrations/connectors/source-amplitude/source_amplitude/source.py
@@ -36,7 +36,7 @@ class SourceAmplitude(YamlDeclarativeSource):
             Events(
                 authenticator=auth,
                 start_date=config["start_date"],
-                data_region=config["data_region"],
+                data_region=config.get("data_region", "Standard Server"),
                 event_time_interval={"size_unit": "hours", "size": config.get("request_time_range", 24)},
             )
         )

--- a/airbyte-integrations/connectors/source-amplitude/source_amplitude/streams.py
+++ b/airbyte-integrations/connectors/source-amplitude/source_amplitude/streams.py
@@ -101,6 +101,11 @@ class Events(HttpStream):
         return record
 
     def get_most_recent_cursor(self, stream_state: Mapping[str, Any] = None) -> datetime.datetime:
+        """
+        Use `start_time` instead of `cursor` in the case of more recent.
+        This can happen whenever a user simply finds that they are syncing to much data and would like to change `start_time` to be more recent.
+        See: https://github.com/airbytehq/airbyte/issues/25367 for more details
+        """
         cursor_date = (
             pendulum.parse(stream_state[self.cursor_field])
             if stream_state and self.cursor_field in stream_state

--- a/docs/integrations/sources/amplitude.md
+++ b/docs/integrations/sources/amplitude.md
@@ -43,6 +43,7 @@ The Amplitude connector ideally should gracefully handle Amplitude API limitatio
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
+| 0.3.2   | 2023-09-18 | [30525](https://github.com/airbytehq/airbyte/pull/30525) | Fix `KeyError` while getting `data_region` from config                                                    |
 | 0.3.1   | 2023-09-15 | [30471](https://github.com/airbytehq/airbyte/pull/30471) | Fix `Event` stream: Use `start_time` instead of cursor in the case of more recent                         |
 | 0.3.0   | 2023-09-13 | [30378](https://github.com/airbytehq/airbyte/pull/30378) | Switch to latest CDK version                                                                              |
 | 0.2.4   | 2023-05-05 | [25842](https://github.com/airbytehq/airbyte/pull/25842) | added missing attrs in events schema, enabled default availability strategy                               |


### PR DESCRIPTION
## What
- *The issue: https://github.com/airbytehq/oncall/issues/2525*
- *The problem: As `data_region` is not a requierd field we need to be sure the key exists, so we must use `.get(<key>, "default")` construction instead of `config[key]`*

## How
- *Take value from a dictionary in a safe way*
- *Add some comments*

