### PR TITLE
Docs: Source S3 clarify bucket-level permissions

### DIFF
--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -9,12 +9,13 @@ Please note that using cloud storage may incur egress costs. Egress refers to da
 ## Prerequisites
 
 - Access to the S3 bucket containing the files to replicate.
+- For **private buckets**, an AWS account with the ability to grant permissions to read from the bucket.
 
 ## Setup guide
 
 ### Step 1: Set up Amazon S3
 
-**If you are syncing from a private bucket**, you will need to provide your `AWS Access Key ID` and `AWS Secret Access Key` to authenticate the connection, and ensure that the IAM user associated with the credentials has `read` and `list` permissions for the bucket. If you are unfamiliar with configuring AWS permissions, you can follow these steps to obtain the necessary permissions and credentials:
+**If you are syncing from a private bucket**, you will need to provide both an `AWS Access Key ID` and `AWS Secret Access Key` to authenticate the connection. The IAM user associated with the credentials must be granted `read` and `list` permissions for the bucket and its objects. If you are unfamiliar with configuring AWS permissions, you can follow these steps to obtain the necessary permissions and credentials:
 
 1. Log in to your Amazon AWS account and open the [IAM console](https://console.aws.amazon.com/iam/home#home).
 2. In the IAM dashboard, select **Policies**, then click **Create Policy**.
@@ -38,6 +39,10 @@ Please note that using cloud storage may incur egress costs. Egress refers to da
     ]
 }
 ```
+
+:::note
+At this time, object-level permissions alone are not sufficient to successfully authenticate the connection. Please ensure you include the **bucket-level** permissions as provided in the example above.
+:::
 
 4. Give your policy a descriptive name, then click **Create policy**.
 5. In the IAM dashboard, click **Users**. Select an existing IAM user or create a new one by clicking **Add users**.


### PR DESCRIPTION
## What

Added some more emphasis on the need to grant bucket-level permissions during S3 Source setup, as requested in [this issue](https://github.com/airbytehq/airbyte/issues/30415).

## How
- Added prerequisite for private buckets.
- Slight rewording and added note to emphasize importance of granting permissions at the bucket level.
- I can also add some images to the AWS credentials/permissions setup guide for clarity if preferred. However, I believe we generally avoid adding media to the connector guides to reduce maintenance overhead as visual aids inevitably become deprecated. Any preference on this?