### PR TITLE
make migration docs uppercase

### DIFF
--- a/docs/release_notes/destinations_v2.js
+++ b/docs/release_notes/destinations_v2.js
@@ -84,8 +84,8 @@ export const SnowflakeMigrationGenerator = () => {
     let v2RawTableName = '"' + concatenateRawTableName(new_namespace, name) + '"';
     let v1namespace = snowflakeConvertStreamName(og_namespace);
     let v1name = snowflakeConvertStreamName("_airbyte_raw_" + name);
-    return `CREATE SCHEMA IF NOT EXISTS "${raw_schema}";
-CREATE OR REPLACE TABLE "${raw_schema}".${v2RawTableName} (
+    return `CREATE SCHEMA IF NOT EXISTS "${raw_schema.toUpperCase()}";
+CREATE OR REPLACE TABLE "${raw_schema.toUpperCase()}".${v2RawTableName.toUpperCase()} (
   "_airbyte_raw_id" STRING NOT NULL PRIMARY KEY,
   "_airbyte_extracted_at" TIMESTAMP_TZ DEFAULT CURRENT_TIMESTAMP(),
   "_airbyte_loaded_at" TIMESTAMP_TZ,
@@ -96,7 +96,7 @@ AS (
         _airbyte_emitted_at AS "_airbyte_extracted_at",
         CAST(NULL AS TIMESTAMP_TZ) AS "_airbyte_loaded_at",
         _airbyte_data AS "_airbyte_data"
-    FROM ${v1namespace}.${v1name}
+    FROM ${v1namespace.toUpperCase()}.${v1name.toUpperCase()}
 )`;
   }
   return (


### PR DESCRIPTION
When we moved to make snowflake tables explicitly uppercase we missed the migration docs, here are the migration docs after this change
<img width="863" alt="Screenshot 2023-09-19 at 10 37 18 AM" src="https://github.com/airbytehq/airbyte/assets/4081089/7353c7f9-664d-44df-bc64-cae222bc1b55">
