### PR TITLE
Fix stretched airbyte logo in docs

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -1,14 +1,16 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const yaml = require('js-yaml');
+const yaml = require("js-yaml");
 const fs = require("node:fs");
 const path = require("node:path");
 
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 
-const redirects = yaml.load(fs.readFileSync(path.join(__dirname, "redirects.yml"), "utf-8"));
+const redirects = yaml.load(
+  fs.readFileSync(path.join(__dirname, "redirects.yml"), "utf-8")
+);
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -41,18 +43,16 @@ const config = {
             rules: [
               {
                 test: /\.ya?ml$/,
-                use: 'yaml-loader'
-              }
-            ]
+                use: "yaml-loader",
+              },
+            ],
           },
         };
       },
     }),
   ],
 
-  clientModules: [
-    require.resolve("./src/scripts/cloudStatus.js"),
-  ],
+  clientModules: [require.resolve("./src/scripts/cloudStatus.js")],
 
   presets: [
     [
@@ -91,9 +91,9 @@ const config = {
         },
       },
       algolia: {
-          appId: 'OYKDBC51MU',
-          apiKey: '15c487fd9f7722282efd8fcb76746fce', // Public API key: it is safe to commit it
-          indexName: 'airbyte',
+        appId: "OYKDBC51MU",
+        apiKey: "15c487fd9f7722282efd8fcb76746fce", // Public API key: it is safe to commit it
+        indexName: "airbyte",
       },
       navbar: {
         title: "",
@@ -101,7 +101,6 @@ const config = {
           alt: "Simple, secure and extensible data integration",
           src: "img/logo-dark.png",
           srcDark: "img/logo-light.png",
-          width: 140,
           height: 40,
         },
         items: [
@@ -138,7 +137,7 @@ const config = {
             position: "right",
             "aria-label": "Airbyte on GitHub",
             className: "header-github-link",
-          }
+          },
         ],
       },
       prism: {


### PR DESCRIPTION
Fixes a bug added in https://github.com/airbytehq/airbyte/pull/29908.  Fixes a stretched logo

Before:
<img width="493" alt="Screenshot 2023-09-19 at 5 06 45 PM" src="https://github.com/airbytehq/airbyte/assets/303226/8766c231-0a5c-497c-b5c6-7a2f146ed095">

After:
<img width="460" alt="Screenshot 2023-09-19 at 5 06 37 PM" src="https://github.com/airbytehq/airbyte/assets/303226/c1b3e09f-5ae5-4414-bb5c-ea8f71362106">
