### PR TITLE
Source Notion: Avoid KeyError when no `next_cursor` exists

### DIFF
--- a/airbyte-integrations/connectors/source-notion/Dockerfile
+++ b/airbyte-integrations/connectors/source-notion/Dockerfile
@@ -34,5 +34,5 @@ COPY source_notion ./source_notion
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.1.2
+LABEL io.airbyte.version=1.1.3
 LABEL io.airbyte.name=airbyte/source-notion

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6e00b415-b02e-4160-bf02-58176a0ae687
-  dockerImageTag: 1.1.2
+  dockerImageTag: 1.1.3
   dockerRepository: airbyte/source-notion
   githubIssueLabel: source-notion
   icon: notion.svg

--- a/airbyte-integrations/connectors/source-notion/source_notion/streams.py
+++ b/airbyte-integrations/connectors/source-notion/source_notion/streams.py
@@ -32,9 +32,9 @@ class NotionStream(HttpStream, ABC):
         super().__init__(**kwargs)
         self.start_date = config["start_date"]
 
-    @property
-    def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
-        return None
+    # @property
+    # def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
+    #     return None
 
     @staticmethod
     def check_invalid_start_cursor(response: requests.Response):
@@ -70,9 +70,9 @@ class NotionStream(HttpStream, ABC):
             "has_more": true,
             "results": [ ... ]
         }
-        Doc: https://developers.notion.com/reference/pagination
+        Doc: https://developers.notion.com/reference/intro#pagination
         """
-        next_cursor = response.json()["next_cursor"]
+        next_cursor = response.json().get("next_cursor")
         if next_cursor:
             return {"next_cursor": next_cursor}
 

--- a/airbyte-integrations/connectors/source-notion/source_notion/streams.py
+++ b/airbyte-integrations/connectors/source-notion/source_notion/streams.py
@@ -32,9 +32,9 @@ class NotionStream(HttpStream, ABC):
         super().__init__(**kwargs)
         self.start_date = config["start_date"]
 
-    # @property
-    # def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
-    #     return None
+    @property
+    def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
+        return None
 
     @staticmethod
     def check_invalid_start_cursor(response: requests.Response):

--- a/airbyte-integrations/connectors/source-notion/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-notion/unit_tests/test_streams.py
@@ -35,6 +35,20 @@ def test_next_page_token(patch_base_class, requests_mock):
     assert stream.next_page_token(**inputs) == expected_token
 
 
+@pytest.mark.parametrize('response_json, expected_output', [
+    ({'next_cursor': 'some_cursor', 'has_more': True}, {'next_cursor': 'some_cursor'}),
+    ({'has_more': False}, None),
+    ({}, None)
+])
+def test_next_page_token_with_no_cursor(patch_base_class, response_json, expected_output):
+    stream = NotionStream(config=MagicMock())
+    mock_response = MagicMock()
+    mock_response.json.return_value = response_json
+    result = stream.next_page_token(mock_response)
+    print(result)
+    assert result == expected_output
+
+
 def test_parse_response(patch_base_class, requests_mock):
     stream = NotionStream(config=MagicMock())
     requests_mock.get("https://dummy", json={"results": [{"a": 123}, {"b": "xx"}]})

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -107,7 +107,7 @@ The connector is restricted by Notion [request limits](https://developers.notion
 
 | Version | Date       | Pull Request                                             | Subject                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------- |
-| 1.1.3   | 2023-09-20 | []() | Add handling for no `next_cursor`                                     |
+| 1.1.3   | 2023-09-20 | [30641](https://github.com/airbytehq/airbyte/pull/30641) | Add handling for no `next_cursor`                                     |
 | 1.1.2   | 2023-08-30 | [29999](https://github.com/airbytehq/airbyte/pull/29999) | Update error handling during connection check
 | 1.1.1   | 2023-06-14 | [26535](https://github.com/airbytehq/airbyte/pull/26535) | Migrate from deprecated `authSpecification` to `advancedAuth`                |
 | 1.1.0   | 2023-06-08 | [27170](https://github.com/airbytehq/airbyte/pull/27170) | Fix typo in `blocks` schema                                                  |

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -107,6 +107,7 @@ The connector is restricted by Notion [request limits](https://developers.notion
 
 | Version | Date       | Pull Request                                             | Subject                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------- |
+| 1.1.3   | 2023-09-20 | []() | Add handling for no `next_cursor`                                     |
 | 1.1.2   | 2023-08-30 | [29999](https://github.com/airbytehq/airbyte/pull/29999) | Update error handling during connection check
 | 1.1.1   | 2023-06-14 | [26535](https://github.com/airbytehq/airbyte/pull/26535) | Migrate from deprecated `authSpecification` to `advancedAuth`                |
 | 1.1.0   | 2023-06-08 | [27170](https://github.com/airbytehq/airbyte/pull/27170) | Fix typo in `blocks` schema                                                  |


### PR DESCRIPTION
## What
This PR should resolve
[oncall #2712](https://github.com/airbytehq/oncall/issues/2712)

## How
Small change to handle no `next_cursor` existing in response json.

## Notes
This PR will fail acceptance tests until [schema changes have been merged](https://github.com/airbytehq/airbyte/pull/30587). I'm adding it now just to be ready.