### PR TITLE
🐛 Source Quickbooks; UnitPrice expecting integer but can be float

### DIFF
--- a/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/schemas/bills.json
+++ b/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/schemas/bills.json
@@ -121,7 +121,7 @@
                 "type": ["null", "string"]
               },
               "UnitPrice": {
-                "type": ["null", "integer"]
+                "type": ["null", "number"]
               }
             },
             "type": ["null", "object"]

--- a/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/schemas/credit_memos.json
+++ b/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/schemas/credit_memos.json
@@ -81,7 +81,7 @@
                 "type": ["null", "object"]
               },
               "UnitPrice": {
-                "type": ["null", "integer"]
+                "type": ["null", "number"]
               },
               "TaxCodeRef": {
                 "properties": {

--- a/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/schemas/items.json
+++ b/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/schemas/items.json
@@ -73,7 +73,7 @@
       "type": ["null", "integer"]
     },
     "UnitPrice": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"]
     },
     "SyncToken": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/schemas/refund_receipts.json
+++ b/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/schemas/refund_receipts.json
@@ -78,7 +78,7 @@
                 "type": ["null", "object"]
               },
               "UnitPrice": {
-                "type": ["null", "integer"]
+                "type": ["null", "number"]
               }
             },
             "type": ["null", "object"]

--- a/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/schemas/sales_receipts.json
+++ b/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/schemas/sales_receipts.json
@@ -166,7 +166,7 @@
                 "type": ["null", "number"]
               },
               "UnitPrice": {
-                "type": ["null", "integer"]
+                "type": ["null", "number"]
               },
               "TaxCodeRef": {
                 "type": ["null", "object"],


### PR DESCRIPTION
## What
- We've been running into issues importing data from Quickbooks where UnitPrices are expected to be integers but are understandably doubles in the API.
- Some of the JSON Schema files for UnitPrice were already using number, I only had to change 5/10 of them.
- Admittedly I noticed a couple of other places in the schema where integer seems to be used incorrectly but I cannot be too sure of whether it is or not since I haven't personally run into an issue and Quickbooks' Docs are hard to follow :sweat_smile: 

## How
- Changed JSON Schema files to expect `number` instead of `integer`.

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
- According to comments #27644 this would be classed as a breaking change due to types changing.
