### PR TITLE
CAT: fix test_read_sequential_slices

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Tuple, Union
-
+import dpath.util
 import pendulum
 import pytest
 from airbyte_protocol.models import AirbyteMessage, AirbyteStateMessage, AirbyteStateType, ConfiguredAirbyteCatalog, SyncMode, Type
@@ -170,7 +170,7 @@ class TestIncremental(BaseTest):
         states_1 = filter_output(output_1, type_=Type.STATE)
 
         # We sometimes have duplicate identical state messages in a stream which we can filter out to speed things up
-        unique_state_messages = [message for index, message in enumerate(states_1) if message not in states_1[:index]]
+        unique_state_messages = [message for index, message in enumerate(states_1) if message not in states_1[:index] and not dpath.util.search(message.state.data, "**", afilter=lambda x: not x)]
 
         # Important!
 


### PR DESCRIPTION
## What

fix `test_read_sequential_slices`

## How

exclude state messages with empty state

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨

no breaking changes


## Pre-merge Actions
<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
