### PR TITLE
tools: update schema_generator to use latest version of cdk

### DIFF
--- a/tools/schema_generator/schema_generator/infer_schemas.py
+++ b/tools/schema_generator/schema_generator/infer_schemas.py
@@ -29,6 +29,7 @@ import sys
 from airbyte_cdk.models import AirbyteMessage, Type
 from genson import SchemaBuilder
 from genson.schema.strategies.object import Object
+import genson.schema.strategies as strategies
 
 
 class NoRequiredObj(Object):
@@ -43,12 +44,18 @@ class NoRequiredObj(Object):
         if self._properties:
             schema["properties"] = self._properties_to_schema(self._properties)
         if self._pattern_properties:
-            schema["patternProperties"] = self._properties_to_schema(self._pattern_properties)
+            schema["patternProperties"] = self._properties_to_schema(
+                self._pattern_properties)
+
+        schema["additionalProperties"] = True
         return schema
 
 
 class NoRequiredSchemaBuilder(SchemaBuilder):
     EXTRA_STRATEGIES = (NoRequiredObj,)
+
+    def __init__(self):
+        super().__init__(schema_uri='http://json-schema.org/draft-07/schema#')
 
 
 def infer_schemas():
@@ -58,6 +65,7 @@ def infer_schemas():
 
     builders = {}
     for line in sys.stdin:
+        print(line)
         message = AirbyteMessage.parse_raw(line)
         if message.type == Type.RECORD:
             stream_name = message.record.stream

--- a/tools/schema_generator/schema_generator/infer_schemas.py
+++ b/tools/schema_generator/schema_generator/infer_schemas.py
@@ -29,7 +29,6 @@ import sys
 from airbyte_cdk.models import AirbyteMessage, Type
 from genson import SchemaBuilder
 from genson.schema.strategies.object import Object
-import genson.schema.strategies as strategies
 
 
 class NoRequiredObj(Object):
@@ -65,7 +64,6 @@ def infer_schemas():
 
     builders = {}
     for line in sys.stdin:
-        print(line)
         message = AirbyteMessage.parse_raw(line)
         if message.type == Type.RECORD:
             stream_name = message.record.stream

--- a/tools/schema_generator/setup.py
+++ b/tools/schema_generator/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte_cdk==0.1.60", "genson==1.2.2"]
+MAIN_REQUIREMENTS = ["airbyte_cdk==0.51.18", "genson==1.2.2"]
 
 TEST_REQUIREMENTS = ["pytest"]
 


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

This is a small change that updates the schema_generator to use the latest version of the CDK. The schema_generator currently uses an old version of the protocol and fails when trying to process TRACE AirbyteMessages that are of type of ESTIMATE or STATUS_UPDATE. 

Additionally, this adds a default json-07 url to each of the schema files generated. 

## How
*Describe the solution*
Update the setup.py file to use the latest version of the cdk python module

## Recommended reading order
1. `x.java`
2. `y.python`

