### PR TITLE
CI: Move autoformat to master

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -60,7 +60,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         # do not commit if master branch
         with:
-          commit_message: Automated Commit - Formatting Changes
+          commit_message: [skip ci] Automated Commit - Formatting Changes
           commit_user_name: Octavia Squidington III
           commit_user_email: octavia-squidington-iii@users.noreply.github.com
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
 jobs:
   format-and-commit:
     runs-on: ubuntu-latest
@@ -19,8 +18,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
-          # Important that this is set so that CI checks are triggered again
-          # Without this we would be be forever waiting on required checks to pass
+          # Important that this is set so that CI has the permission to
+          # commit to a protected branch
           token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
 
       - uses: actions/setup-java@v3
@@ -57,18 +56,13 @@ jobs:
       - name: Remove any files that have been gitignored
         run: git ls-files -i -c --exclude-from=.gitignore | xargs -r git rm --cached
 
-      - name: Commit Formatting Changes (PR)
+      - name: Commit Formatting Changes
         uses: stefanzweifel/git-auto-commit-action@v4
         # do not commit if master branch
-        if: github.ref != 'refs/heads/master'
         with:
           commit_message: Automated Commit - Formatting Changes
           commit_user_name: Octavia Squidington III
           commit_user_email: octavia-squidington-iii@users.noreply.github.com
-
-      - name: "Fail on Formatting Changes (Master)"
-        if: github.ref == 'refs/heads/master'
-        run: git --no-pager diff && test -z "$(git --no-pager diff)"
 
   notify-failure-slack-channel:
     name: "Notify Slack Channel on Build Failures"


### PR DESCRIPTION
## Proposal
Today, Autoformatting occurs at the PR level.

This is difficult for a few reasons
1. Auto commit can interfere with required checks being reported 
2. Auto commit can cause tests to run twice (expensive)
3. A culture that uses `approve-and-merge` leads to unformatted code reaching master, then being formatted in a subsequent PR

We should 
1. Only autoformat + commit on master (This PR)
2. Have ide extensions and/or commit hooks support (Later changes)


Original credit: @postamar @alafanechere 
Document with discussion: https://docs.google.com/document/d/1X8KVmomXT5EwiNuwyvO5oQGMTMrZbt1nyBxWsSpDEo8/edit?usp=drive_web&ouid=100797160259845229564