### PR TITLE
Source Pendo: add new stream Visitors

### DIFF
--- a/airbyte-integrations/connectors/source-pendo/Dockerfile
+++ b/airbyte-integrations/connectors/source-pendo/Dockerfile
@@ -34,5 +34,5 @@ COPY source_pendo ./source_pendo
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-pendo

--- a/airbyte-integrations/connectors/source-pendo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pendo/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b1ccb590-e84f-46c0-83a0-2048ccfffdae
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/source-pendo
   githubIssueLabel: source-pendo
   icon: pendo.svg

--- a/airbyte-integrations/connectors/source-pendo/source_pendo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pendo/source_pendo/manifest.yaml
@@ -2959,6 +2959,64 @@ streams:
           field_path: []
       paginator:
         type: NoPagination
+  - type: DeclarativeStream
+    name: Visitors
+    primary_key:
+      - visitorId
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          metadata:
+            type: object
+            properties:
+              auto:
+                type: object
+              agent:
+                type: object
+              custom:
+                type: object
+            additionalProperties: true
+          visitorId:
+            type: string
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://app.pendo.io/api/v1/
+        path: aggregation
+        http_method: POST
+        request_parameters: {}
+        request_headers: {}
+        request_body_json:
+          request:
+            name: all-visitors
+            sort:
+              - visitorId
+            pipeline:
+              - source:
+                  visitors:
+                    identified: "{{ config.identified_visitors_only }}"
+            requestId: all-visitors
+          response:
+            mimeType: application/json
+        authenticator:
+          type: ApiKeyAuthenticator
+          header: x-pendo-integration-key
+          api_token: "{{ config['api_key'] }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - results
+      paginator:
+        type: NoPagination
+metadata:
+  autoImportSchema:
+    Visitors: true
 spec:
   connection_specification:
     $schema: http://json-schema.org/draft-07/schema#
@@ -2968,8 +3026,15 @@ spec:
     properties:
       api_key:
         type: string
+        order: 0
         title: API Key
         airbyte_secret: true
+      identified_visitors_only:
+        type: boolean
+        order: 1
+        title: Identified Visitors Only
+        default: true
+        description: Do you want to only sync identified visitors?
     additionalProperties: true
   documentation_url: https://docs.airbyte.com/integrations/sources/pendo
   type: Spec

--- a/airbyte-integrations/connectors/source-pendo/source_pendo/spec.yaml
+++ b/airbyte-integrations/connectors/source-pendo/source_pendo/spec.yaml
@@ -7,6 +7,13 @@ connectionSpecification:
   properties:
     api_key:
       type: string
+      order: 0
       title: API Key
       airbyte_secret: true
+    identified_visitors_only:
+      type: boolean
+      order: 1
+      title: Identified Visitors Only
+      default: true
+      description: Do you want to only sync identified visitors?
   additionalProperties: true

--- a/docs/integrations/sources/pendo.md
+++ b/docs/integrations/sources/pendo.md
@@ -60,4 +60,5 @@ The Pendo source connector supports the following [sync modes](https://docs.airb
 
 | Version | Date       | Pull Request                                             | Subject                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 0.1.1   | 2023-09-21 | [TBD](https://github.com/airbytehq/airbyte/pull)   | Add Visitors Stream
 | 0.1.0   | 2023-03-14 | [3563](https://github.com/airbytehq/airbyte/pull/3563)   | Initial Release                                                                |

--- a/docs/integrations/sources/pendo.md
+++ b/docs/integrations/sources/pendo.md
@@ -60,5 +60,5 @@ The Pendo source connector supports the following [sync modes](https://docs.airb
 
 | Version | Date       | Pull Request                                             | Subject                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 0.1.1   | 2023-09-21 | [TBD](https://github.com/airbytehq/airbyte/pull)   | Add Visitors Stream
+| 0.1.1   | 2023-09-21 | [30700](https://github.com/airbytehq/airbyte/pull/30700) | Add Visitors Stream
 | 0.1.0   | 2023-03-14 | [3563](https://github.com/airbytehq/airbyte/pull/3563)   | Initial Release                                                                |


### PR DESCRIPTION
## What
Adding missing support for Visitors data to the Pendo Connector Source

Implements [30667](https://github.com/airbytehq/airbyte/issues/30667)

*It helps to add screenshots if it affects the frontend.*

New optional field:
<img width="700" alt="image" src="https://github.com/shayan-nathan/airbyte/assets/95660002/83b2fc88-dbed-4972-a484-9e5b11302211">

<img width="956" alt="image" src="https://github.com/shayan-nathan/airbyte/assets/95660002/9344a11a-9390-41d3-875b-501eeb437c3e">

Sync was successful:
<img width="768" alt="image" src="https://github.com/shayan-nathan/airbyte/assets/95660002/c7b642b1-95d9-49f7-88e4-ed58257e849b">

## How
It uses Pendo's `aggregation` API endpoint to retrieve Visitors data https://engageapi.pendo.io/#7c8479b8-3843-403c-94a9-04cbdf542db9

And is inspired by the Pendo singer tap
https://github.dev/singer-io/tap-pendo/blob/master/tap_pendo/streams.py
https://github.com/singer-io/tap-pendo/blob/4b10c85c5541b9faf8bd12c3c6fd39fe04e48759/tap_pendo/streams.py#L1261-L1262

## Recommended reading order
1. `manifest.yaml`
2. `spec.yaml`

## 🚨 User Impact 🚨

Based on the guidelines, this will require a **minor change** version bump because it adds a new stream and an optional parameter to the connector spec but does not impact anything pre-existing.

## Pre-merge Actions
<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>