### PR TITLE
Show postgres destination in sidebar again

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -11,7 +11,7 @@ function getFilenamesInDir(prefix, dir, excludes) {
     .readdirSync(dir)
     .filter(
       (fileName) =>
-        !(fileName.endsWith(".inapp.md") || fileName.endsWith("postgres.md") || fileName.endsWith("-migrations.md"))
+        !(fileName.endsWith(".inapp.md") || fileName.endsWith("-migrations.md"))
     )
     .map((fileName) => fileName.replace(".md", ""))
     .filter((fileName) => excludes.indexOf(fileName.toLowerCase()) === -1)
@@ -40,7 +40,7 @@ function getFilenamesInDir(prefix, dir, excludes) {
 }
 
 function getSourceConnectors() {
-  return getFilenamesInDir("integrations/sources/", sourcesDocs, ["readme"]);
+  return getFilenamesInDir("integrations/sources/", sourcesDocs, ["readme", "postgres"]);
 }
 
 function getDestinationConnectors() {


### PR DESCRIPTION
Shows Postgres again in the sidebar. It was inadvertently hidden in [this PR](https://github.com/airbytehq/airbyte/pull/29295), which moved postgres to the top of the sources list.