### PR TITLE
Orchestrator: Use spec.cloud.json is exists

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/spec_cache.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/spec_cache.py
@@ -13,9 +13,18 @@ PROD_SPEC_CACHE_BUCKET_NAME = "io-airbyte-cloud-spec-cache"
 CACHE_FOLDER = "specs"
 
 
-class Registries(Enum):
+class Registries(str, Enum):
     OSS = "oss"
     CLOUD = "cloud"
+
+    @classmethod
+    def _missing_(cls, value):
+        """Returns the registry from the string value. (case insensitive)"""
+        value = value.lower()
+        for member in cls:
+            if member.lower() == value:
+                return member
+        return None
 
 
 SPEC_FILE_NAMES = {Registries.OSS: "spec.json", Registries.CLOUD: "spec.cloud.json"}

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/spec_cache.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/spec_cache.py
@@ -5,32 +5,53 @@
 import json
 from dataclasses import dataclass
 from typing import List
+from enum import Enum
 
 from google.cloud import storage
 
-SPEC_CACHE_BUCKET_NAME = "io-airbyte-cloud-spec-cache"
+PROD_SPEC_CACHE_BUCKET_NAME = "io-airbyte-cloud-spec-cache"
 CACHE_FOLDER = "specs"
-SPEC_FILE_NAME = "spec.json"
 
+class Registries(Enum):
+    OSS = "oss"
+    CLOUD = "cloud"
+
+
+SPEC_FILE_NAMES = {
+    Registries.OSS: "spec.json",
+    Registries.CLOUD: "spec.cloud.json"
+}
 
 @dataclass
 class CachedSpec:
     docker_repository: str
     docker_image_tag: str
     spec_cache_path: str
+    registry: Registries
 
 
-def get_spec_cache_path(docker_repository: str, docker_image_tag: str) -> str:
-    """Returns the path to the spec.json file in the spec cache bucket."""
-    return f"{CACHE_FOLDER}/{docker_repository}/{docker_image_tag}/{SPEC_FILE_NAME}"
+def get_spec_file_name(registry: Registries) -> str:
+    return SPEC_FILE_NAMES[registry]
+
+
+def get_registry_from_spec_cache_path(spec_cache_path: str) -> Registries:
+    """Returns the registry from the spec cache path."""
+    for registry in Registries:
+        if registry.value in spec_cache_path:
+            return registry
+
+    raise Exception(f"Could not find registry in spec cache path: {spec_cache_path}")
 
 
 def get_docker_info_from_spec_cache_path(spec_cache_path: str) -> CachedSpec:
     """Returns the docker repository and tag from the spec cache path."""
 
+    registry = get_registry_from_spec_cache_path(spec_cache_path)
+    registry_file_name = get_spec_file_name(registry)
+
     # remove the leading "specs/" from the path using CACHE_FOLDER
     without_folder = spec_cache_path.replace(f"{CACHE_FOLDER}/", "")
-    without_file = without_folder.replace(f"/{SPEC_FILE_NAME}", "")
+    without_file = without_folder.replace(f"/{registry_file_name}", "")
 
     # split on only the last "/" to get the docker repository and tag
     # this is because the docker repository can have "/" in it
@@ -41,30 +62,48 @@ def get_docker_info_from_spec_cache_path(spec_cache_path: str) -> CachedSpec:
         docker_repository=docker_repository,
         docker_image_tag=docker_image_tag,
         spec_cache_path=spec_cache_path,
+        registry=registry
     )
 
+class SpecCache:
+    def __init__(self, bucket_name: str = PROD_SPEC_CACHE_BUCKET_NAME):
+        self.client = storage.Client.create_anonymous_client()
+        self.bucket = self.client.bucket(bucket_name)
+        self.cached_specs = self.get_all_cached_specs()
 
-def is_spec_cached(docker_repository: str, docker_image_tag: str) -> bool:
-    """Returns True if the spec.json file exists in the spec cache bucket."""
-    spec_path = get_spec_cache_path(docker_repository, docker_image_tag)
+    def get_all_cached_specs(self) -> List[CachedSpec]:
+        """Returns a list of all the specs in the spec cache bucket."""
 
-    client = storage.Client.create_anonymous_client()
-    bucket = client.bucket(SPEC_CACHE_BUCKET_NAME)
-    blob = bucket.blob(spec_path)
+        blobs = self.bucket.list_blobs(prefix=CACHE_FOLDER)
 
-    return blob.exists()
+        return [get_docker_info_from_spec_cache_path(blob.name) for blob in blobs]
 
+    def find_spec_cache(self, docker_repository: str, docker_image_tag: str, registry: Registries) -> CachedSpec:
+        """Returns the spec cache path for a given docker repository and tag."""
 
-def list_cached_specs() -> List[CachedSpec]:
-    """Returns a list of all the specs in the spec cache bucket."""
-    client = storage.Client.create_anonymous_client()
-    bucket = client.bucket(SPEC_CACHE_BUCKET_NAME)
-    blobs = bucket.list_blobs(prefix=CACHE_FOLDER)
+        # find the spec cache path for the given docker repository and tag
+        for cached_spec in self.cached_specs:
+            if (
+                    cached_spec.docker_repository == docker_repository
+                    and cached_spec.registry == registry
+                    and cached_spec.docker_image_tag == docker_image_tag
+                ):
+                return cached_spec
 
-    return [get_docker_info_from_spec_cache_path(blob.name) for blob in blobs]
+        return None
 
+    def find_spec_cache_with_fallback(self, docker_repository: str, docker_image_tag: str, registry: Registries = Registries.OSS) -> CachedSpec:
+        """Returns the spec cache path for a given docker repository and tag and fallback to OSS if none found"""
 
-def get_cached_spec(spec_cache_path: str) -> dict:
-    client = storage.Client.create_anonymous_client()
-    bucket = client.bucket(SPEC_CACHE_BUCKET_NAME)
-    return json.loads(bucket.blob(spec_cache_path).download_as_string())
+        # if the registry is cloud try to return the cloud spec first
+        if registry == Registries.CLOUD:
+            spec_cache = self._find_spec_cache(docker_repository, docker_image_tag, registry)
+            if spec_cache:
+                return spec_cache
+
+        # fallback to OSS
+        return self._find_spec_cache(docker_repository, docker_image_tag, Registries.OSS)
+
+    def download_spec(self, spec_cache_path: str) -> dict:
+        """Downloads the spec from the spec cache bucket."""
+        return json.loads(self.bucket.blob(spec_cache_path).download_as_string())

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.1.6"
+version = "0.2.0"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_spec_cache.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_spec_cache.py
@@ -1,0 +1,69 @@
+import pytest
+from unittest.mock import patch
+from metadata_service.spec_cache import SpecCache, CachedSpec, Registries, get_docker_info_from_spec_cache_path
+
+
+@pytest.fixture
+def mock_spec_cache():
+    with patch('google.cloud.storage.Client.create_anonymous_client') as MockClient, \
+         patch('google.cloud.storage.Client.bucket') as MockBucket:
+
+        # Create stub mock client and bucket
+        MockClient.return_value
+        MockBucket.return_value
+
+        # Create a list of 4 test CachedSpecs
+        test_specs = [
+            CachedSpec("image1", "tag-has-override", "path1", Registries.OSS),
+            CachedSpec("image1", "tag-has-override", "path2", Registries.CLOUD),
+            CachedSpec("image2", "tag-no-override", "path3", Registries.OSS),
+            CachedSpec("image3", "tag-no-override", "path4", Registries.CLOUD),
+        ]
+
+        # Mock get_all_cached_specs to return test_specs
+        with patch.object(SpecCache, 'get_all_cached_specs', return_value=test_specs):
+            yield SpecCache()
+
+@pytest.mark.parametrize("image,tag,given_registry,expected_registry", [
+    ("image1", "tag-has-override", "OSS", Registries.OSS),
+    ("image1", "tag-has-override", "CLOUD", Registries.CLOUD),
+    ("image2", "tag-no-override", "OSS", Registries.OSS),
+    ("image2", "tag-no-override", "CLOUD", Registries.OSS),
+    ("image3", "tag-no-override", "OSS", None),
+    ("image3", "tag-no-override", "CLOUD", Registries.CLOUD),
+    ("nonexistent", "tag", "OSS", None),
+    ("nonexistent", "tag", "CLOUD", None),
+])
+def test_find_spec_cache_with_fallback(mock_spec_cache, image, tag, given_registry, expected_registry):
+    spec = mock_spec_cache.find_spec_cache_with_fallback(image, tag, given_registry)
+    if expected_registry == None:
+        assert spec == None
+    else:
+        assert spec.docker_repository == image
+        assert spec.docker_image_tag == tag
+        assert spec.registry == expected_registry
+
+@pytest.mark.parametrize("spec_cache_path,expected_spec", [
+    ("specs/airbyte/destination-azure-blob-storage/0.1.1/spec.json",
+     CachedSpec("airbyte/destination-azure-blob-storage", "0.1.1", "specs/airbyte/destination-azure-blob-storage/0.1.1/spec.json", Registries.OSS)),
+
+    ("specs/airbyte/destination-azure-blob-storage/0.1.1/spec.cloud.json",
+     CachedSpec("airbyte/destination-azure-blob-storage", "0.1.1", "specs/airbyte/destination-azure-blob-storage/0.1.1/spec.cloud.json", Registries.CLOUD)),
+
+    ("specs/airbyte/source-azure-blob-storage/1.1.1/spec.json",
+     CachedSpec("airbyte/source-azure-blob-storage", "1.1.1", "specs/airbyte/source-azure-blob-storage/1.1.1/spec.json", Registries.OSS)),
+
+    ("specs/faros/some-name/1.1.1/spec.json",
+     CachedSpec("faros/some-name", "1.1.1", "specs/faros/some-name/1.1.1/spec.json", Registries.OSS))
+])
+def test_get_docker_info_from_spec_cache_path(spec_cache_path, expected_spec):
+    actual_spec = get_docker_info_from_spec_cache_path(spec_cache_path)
+
+    assert actual_spec.docker_repository == expected_spec.docker_repository
+    assert actual_spec.docker_image_tag == expected_spec.docker_image_tag
+    assert actual_spec.spec_cache_path == expected_spec.spec_cache_path
+    assert actual_spec.registry == expected_spec.registry
+
+def test_get_docker_info_from_spec_cache_path_invalid():
+    with pytest.raises(Exception):
+        get_docker_info_from_spec_cache_path("specs/airbyte/destination-azure-blob-storage/0.1.1/spec")

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_spec_cache.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_spec_cache.py
@@ -1,12 +1,14 @@
-import pytest
 from unittest.mock import patch
-from metadata_service.spec_cache import SpecCache, CachedSpec, Registries, get_docker_info_from_spec_cache_path
+
+import pytest
+from metadata_service.spec_cache import CachedSpec, Registries, SpecCache, get_docker_info_from_spec_cache_path
 
 
 @pytest.fixture
 def mock_spec_cache():
-    with patch('google.cloud.storage.Client.create_anonymous_client') as MockClient, \
-         patch('google.cloud.storage.Client.bucket') as MockBucket:
+    with patch("google.cloud.storage.Client.create_anonymous_client") as MockClient, patch(
+        "google.cloud.storage.Client.bucket"
+    ) as MockBucket:
 
         # Create stub mock client and bucket
         MockClient.return_value
@@ -21,19 +23,23 @@ def mock_spec_cache():
         ]
 
         # Mock get_all_cached_specs to return test_specs
-        with patch.object(SpecCache, 'get_all_cached_specs', return_value=test_specs):
+        with patch.object(SpecCache, "get_all_cached_specs", return_value=test_specs):
             yield SpecCache()
 
-@pytest.mark.parametrize("image,tag,given_registry,expected_registry", [
-    ("image1", "tag-has-override", "OSS", Registries.OSS),
-    ("image1", "tag-has-override", "CLOUD", Registries.CLOUD),
-    ("image2", "tag-no-override", "OSS", Registries.OSS),
-    ("image2", "tag-no-override", "CLOUD", Registries.OSS),
-    ("image3", "tag-no-override", "OSS", None),
-    ("image3", "tag-no-override", "CLOUD", Registries.CLOUD),
-    ("nonexistent", "tag", "OSS", None),
-    ("nonexistent", "tag", "CLOUD", None),
-])
+
+@pytest.mark.parametrize(
+    "image,tag,given_registry,expected_registry",
+    [
+        ("image1", "tag-has-override", "OSS", Registries.OSS),
+        ("image1", "tag-has-override", "CLOUD", Registries.CLOUD),
+        ("image2", "tag-no-override", "OSS", Registries.OSS),
+        ("image2", "tag-no-override", "CLOUD", Registries.OSS),
+        ("image3", "tag-no-override", "OSS", None),
+        ("image3", "tag-no-override", "CLOUD", Registries.CLOUD),
+        ("nonexistent", "tag", "OSS", None),
+        ("nonexistent", "tag", "CLOUD", None),
+    ],
+)
 def test_find_spec_cache_with_fallback(mock_spec_cache, image, tag, given_registry, expected_registry):
     spec = mock_spec_cache.find_spec_cache_with_fallback(image, tag, given_registry)
     if expected_registry == None:
@@ -43,19 +49,40 @@ def test_find_spec_cache_with_fallback(mock_spec_cache, image, tag, given_regist
         assert spec.docker_image_tag == tag
         assert spec.registry == expected_registry
 
-@pytest.mark.parametrize("spec_cache_path,expected_spec", [
-    ("specs/airbyte/destination-azure-blob-storage/0.1.1/spec.json",
-     CachedSpec("airbyte/destination-azure-blob-storage", "0.1.1", "specs/airbyte/destination-azure-blob-storage/0.1.1/spec.json", Registries.OSS)),
 
-    ("specs/airbyte/destination-azure-blob-storage/0.1.1/spec.cloud.json",
-     CachedSpec("airbyte/destination-azure-blob-storage", "0.1.1", "specs/airbyte/destination-azure-blob-storage/0.1.1/spec.cloud.json", Registries.CLOUD)),
-
-    ("specs/airbyte/source-azure-blob-storage/1.1.1/spec.json",
-     CachedSpec("airbyte/source-azure-blob-storage", "1.1.1", "specs/airbyte/source-azure-blob-storage/1.1.1/spec.json", Registries.OSS)),
-
-    ("specs/faros/some-name/1.1.1/spec.json",
-     CachedSpec("faros/some-name", "1.1.1", "specs/faros/some-name/1.1.1/spec.json", Registries.OSS))
-])
+@pytest.mark.parametrize(
+    "spec_cache_path,expected_spec",
+    [
+        (
+            "specs/airbyte/destination-azure-blob-storage/0.1.1/spec.json",
+            CachedSpec(
+                "airbyte/destination-azure-blob-storage",
+                "0.1.1",
+                "specs/airbyte/destination-azure-blob-storage/0.1.1/spec.json",
+                Registries.OSS,
+            ),
+        ),
+        (
+            "specs/airbyte/destination-azure-blob-storage/0.1.1/spec.cloud.json",
+            CachedSpec(
+                "airbyte/destination-azure-blob-storage",
+                "0.1.1",
+                "specs/airbyte/destination-azure-blob-storage/0.1.1/spec.cloud.json",
+                Registries.CLOUD,
+            ),
+        ),
+        (
+            "specs/airbyte/source-azure-blob-storage/1.1.1/spec.json",
+            CachedSpec(
+                "airbyte/source-azure-blob-storage", "1.1.1", "specs/airbyte/source-azure-blob-storage/1.1.1/spec.json", Registries.OSS
+            ),
+        ),
+        (
+            "specs/faros/some-name/1.1.1/spec.json",
+            CachedSpec("faros/some-name", "1.1.1", "specs/faros/some-name/1.1.1/spec.json", Registries.OSS),
+        ),
+    ],
+)
 def test_get_docker_info_from_spec_cache_path(spec_cache_path, expected_spec):
     actual_spec = get_docker_info_from_spec_cache_path(spec_cache_path)
 
@@ -63,6 +90,7 @@ def test_get_docker_info_from_spec_cache_path(spec_cache_path, expected_spec):
     assert actual_spec.docker_image_tag == expected_spec.docker_image_tag
     assert actual_spec.spec_cache_path == expected_spec.spec_cache_path
     assert actual_spec.registry == expected_spec.registry
+
 
 def test_get_docker_info_from_spec_cache_path_invalid():
     with pytest.raises(Exception):

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -47,13 +47,10 @@ class MissingCachedSpecError(Exception):
 @sentry_sdk.trace
 def apply_spec_to_registry_entry(registry_entry: dict, spec_cache: SpecCache, registry_name: str) -> dict:
     cached_spec = spec_cache.find_spec_cache_with_fallback(
-        registry_entry["dockerRepository"],
-        registry_entry["dockerImageTag"],
-        registry_name
+        registry_entry["dockerRepository"], registry_entry["dockerImageTag"], registry_name
     )
     if cached_spec is None:
         raise MissingCachedSpecError(f"No cached spec found for {registry_entry['dockerRepository']}:{registry_entry['dockerImageTag']}")
-
 
     entry_with_spec = copy.deepcopy(registry_entry)
     entry_with_spec["spec"] = spec_cache.download_spec(cached_spec)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -17,7 +17,7 @@ from google.cloud import storage
 from metadata_service.constants import ICON_FILE_NAME, METADATA_FILE_NAME
 from metadata_service.models.generated.ConnectorRegistryDestinationDefinition import ConnectorRegistryDestinationDefinition
 from metadata_service.models.generated.ConnectorRegistrySourceDefinition import ConnectorRegistrySourceDefinition
-from metadata_service.spec_cache import get_cached_spec, list_cached_specs
+from metadata_service.spec_cache import SpecCache
 from orchestrator.config import MAX_METADATA_PARTITION_RUN_REQUEST, VALID_REGISTRIES, get_public_url_for_gcs_file
 from orchestrator.logging import sentry
 from orchestrator.logging.publish_connector_lifecycle import PublishConnectorLifecycle, PublishConnectorLifecycleStage, StageStatus
@@ -45,19 +45,19 @@ class MissingCachedSpecError(Exception):
 
 
 @sentry_sdk.trace
-def apply_spec_to_registry_entry(registry_entry: dict, cached_specs: OutputDataFrame) -> dict:
-    cached_connector_version = {
-        (cached_spec["docker_repository"], cached_spec["docker_image_tag"]): cached_spec["spec_cache_path"]
-        for cached_spec in cached_specs.to_dict(orient="records")
-    }
-
-    try:
-        spec_path = cached_connector_version[(registry_entry["dockerRepository"], registry_entry["dockerImageTag"])]
-        entry_with_spec = copy.deepcopy(registry_entry)
-        entry_with_spec["spec"] = get_cached_spec(spec_path)
-        return entry_with_spec
-    except KeyError:
+def apply_spec_to_registry_entry(registry_entry: dict, spec_cache: SpecCache, registry_name: str) -> dict:
+    cached_spec = spec_cache.find_spec_cache_with_fallback(
+        registry_entry["dockerRepository"],
+        registry_entry["dockerImageTag"],
+        registry_name
+    )
+    if cached_spec is None:
         raise MissingCachedSpecError(f"No cached spec found for {registry_entry['dockerRepository']}:{registry_entry['dockerImageTag']}")
+
+
+    entry_with_spec = copy.deepcopy(registry_entry)
+    entry_with_spec["spec"] = spec_cache.download_spec(cached_spec)
+    return entry_with_spec
 
 
 def calculate_migration_documentation_url(releases_or_breaking_change: dict, documentation_url: str, version: Optional[str] = None) -> str:
@@ -254,7 +254,7 @@ def persist_registry_entry_to_json(
 @sentry_sdk.trace
 def generate_and_persist_registry_entry(
     metadata_entry: LatestMetadataEntry,
-    cached_specs: OutputDataFrame,
+    spec_cache: SpecCache,
     metadata_directory_manager: GCSFileManager,
     registry_name: str,
 ) -> str:
@@ -269,7 +269,7 @@ def generate_and_persist_registry_entry(
         Output[ConnectorRegistryV0]: The registry.
     """
     raw_entry_dict = metadata_to_registry_entry(metadata_entry, registry_name)
-    registry_entry_with_spec = apply_spec_to_registry_entry(raw_entry_dict, cached_specs)
+    registry_entry_with_spec = apply_spec_to_registry_entry(raw_entry_dict, spec_cache, registry_name)
 
     _, ConnectorModel = get_connector_type_from_registry_entry(registry_entry_with_spec)
 
@@ -436,13 +436,13 @@ def registry_entry(context: OpExecutionContext, metadata_entry: Optional[LatestM
         f"Generating registry entry for {metadata_entry.file_path}",
     )
 
-    cached_specs = pd.DataFrame(list_cached_specs())
+    spec_cache = SpecCache()
 
     root_metadata_directory_manager = context.resources.root_metadata_directory_manager
     enabled_registries, disabled_registries = get_registry_status_lists(metadata_entry)
 
     persisted_registry_entries = {
-        registry_name: generate_and_persist_registry_entry(metadata_entry, cached_specs, root_metadata_directory_manager, registry_name)
+        registry_name: generate_and_persist_registry_entry(metadata_entry, spec_cache, root_metadata_directory_manager, registry_name)
         for registry_name in enabled_registries
     }
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
@@ -2013,7 +2013,7 @@ files = [
 
 [[package]]
 name = "metadata-service"
-version = "0.1.6"
+version = "0.2.0"
 description = ""
 optional = false
 python-versions = "^3.9"


### PR DESCRIPTION
## Overview
Uses spec.cloud.json for cloud registry entries if it exists

closes: #30624
