### PR TITLE
Milvus connector: Normalize primary key field

### DIFF
--- a/airbyte-integrations/connectors/destination-milvus/destination_milvus/indexer.py
+++ b/airbyte-integrations/connectors/destination-milvus/destination_milvus/indexer.py
@@ -51,6 +51,7 @@ class MilvusIndexer(Indexer):
 
         self._collection = Collection(self.config.collection)
         self._collection.load()
+        self._primary_key = next((field["name"] for field in self._collection.describe()["fields"] if field["is_primary"]), None)
 
     def check(self) -> Optional[str]:
         deployment_mode = os.environ.get("DEPLOYMENT_MODE", "")
@@ -99,8 +100,8 @@ class MilvusIndexer(Indexer):
 
         for key, value in metadata.items():
             normalized_key = key
-            # "id" is a reserved properties in Milvus, prefix to disambiguate
-            if key == "id":
+            # the primary key can't be set directly with auto_id, so we prefix it with an underscore
+            if key == self._primary_key:
                 normalized_key = f"_{key}"
             result[normalized_key] = value
 

--- a/airbyte-integrations/connectors/destination-milvus/destination_milvus/indexer.py
+++ b/airbyte-integrations/connectors/destination-milvus/destination_milvus/indexer.py
@@ -115,5 +115,7 @@ class MilvusIndexer(Indexer):
         entities = []
         for i in range(len(document_chunks)):
             chunk = document_chunks[i]
-            entities.append({**self._normalize(chunk.metadata), self.config.vector_field: chunk.embedding, self.config.text_field: chunk.page_content})
+            entities.append(
+                {**self._normalize(chunk.metadata), self.config.vector_field: chunk.embedding, self.config.text_field: chunk.page_content}
+            )
         self._collection.insert(entities)

--- a/airbyte-integrations/connectors/destination-milvus/destination_milvus/indexer.py
+++ b/airbyte-integrations/connectors/destination-milvus/destination_milvus/indexer.py
@@ -94,6 +94,18 @@ class MilvusIndexer(Indexer):
             self._collection.delete(expr=f"{id_field} in [{id_list_expr}]")
             page = iterator.next()
 
+    def _normalize(self, metadata: dict) -> dict:
+        result = {}
+
+        for key, value in metadata.items():
+            normalized_key = key
+            # "id" is a reserved properties in Milvus, prefix to disambiguate
+            if key == "id":
+                normalized_key = f"_{key}"
+            result[normalized_key] = value
+
+        return result
+
     def index(self, document_chunks: List[Chunk], delete_ids: List[str]) -> None:
         if len(delete_ids) > 0:
             id_list_expr = ", ".join([f'"{id}"' for id in delete_ids])
@@ -102,5 +114,5 @@ class MilvusIndexer(Indexer):
         entities = []
         for i in range(len(document_chunks)):
             chunk = document_chunks[i]
-            entities.append({**chunk.metadata, self.config.vector_field: chunk.embedding, self.config.text_field: chunk.page_content})
+            entities.append({**self._normalize(chunk.metadata), self.config.vector_field: chunk.embedding, self.config.text_field: chunk.page_content})
         self._collection.insert(entities)

--- a/airbyte-integrations/connectors/destination-milvus/unit_tests/indexer_test.py
+++ b/airbyte-integrations/connectors/destination-milvus/unit_tests/indexer_test.py
@@ -130,6 +130,7 @@ class TestMilvusIndexer(unittest.TestCase):
         self.milvus_indexer._collection.delete.assert_not_called()
 
     def test_index_calls_insert(self):
+        self.milvus_indexer._primary_key = "id"
         self.milvus_indexer.index([Mock(metadata={"key": "value", "id": 5}, page_content="some content", embedding=[1,2,3])], [])
 
         self.milvus_indexer._collection.insert.assert_called_with(

--- a/airbyte-integrations/connectors/destination-milvus/unit_tests/indexer_test.py
+++ b/airbyte-integrations/connectors/destination-milvus/unit_tests/indexer_test.py
@@ -130,10 +130,10 @@ class TestMilvusIndexer(unittest.TestCase):
         self.milvus_indexer._collection.delete.assert_not_called()
 
     def test_index_calls_insert(self):
-        self.milvus_indexer.index([Mock(metadata={"key": "value"}, page_content="some content", embedding=[1,2,3])], [])
+        self.milvus_indexer.index([Mock(metadata={"key": "value", "id": 5}, page_content="some content", embedding=[1,2,3])], [])
 
         self.milvus_indexer._collection.insert.assert_called_with(
-            [{"key": "value", "vector": [1,2,3], "text": "some content"}]
+            [{"key": "value", "vector": [1,2,3], "text": "some content", "_id": 5}]
         )
 
     def test_index_calls_delete(self):

--- a/docs/integrations/destinations/milvus.md
+++ b/docs/integrations/destinations/milvus.md
@@ -61,6 +61,8 @@ To get started, create a new collection in your Milvus instance. Make sure that
 * The primary key field is set to [auto_id](https://milvus.io/docs/create_collection.md)
 * There is a vector field with the correct dimensionality (1536 for OpenAI, 1024 for Cohere) and [a configured index](https://milvus.io/docs/build_index.md)
 
+If the record contains a field with the same name as the primary key, it will be prefixed with an underscore so Milvus can control the value.
+
 ### Setting up a collection
 
 When using the Zilliz cloud, this can be done using the UI - in this case only the colleciton name and the vector dimensionality needs to be configured, the vector field with index will be automatically created under the name `vector`. Using the REST API, the following command will create the index:


### PR DESCRIPTION
## What

The Milvus connector requires auto_id to be set on the collection it loads into. If the record contains a value for the primary key field, this will cause an error. This PR makes sure that the field name is prefixed with an underscore if necessary.
