### PR TITLE
✨ Destination Google Sheets: include socat binary in docker image

### DIFF
--- a/airbyte-integrations/connectors/destination-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/destination-google-sheets/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.9-slim
 
 # Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# Include socat binary in the connector image
+RUN apt-get update && apt-get install -y bash && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 
@@ -13,5 +14,5 @@ COPY main.py ./
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.3
 LABEL io.airbyte.name=airbyte/destination-google-sheets

--- a/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: a4cbd2d1-8dbe-4818-b8bc-b90ad782d12a
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.3
   dockerRepository: airbyte/destination-google-sheets
   githubIssueLabel: destination-google-sheets
   icon: google-sheets.svg

--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -130,6 +130,7 @@ You cannot create more than 200 worksheets within single spreadsheet.
 
 | Version | Date       | Pull Request                                             | Subject                                        |
 |---------|------------|----------------------------------------------------------|------------------------------------------------|
+| 0.2.3   | 2023-09-25 | coming soon | Performance testing - include socat binary in docker image |
 | 0.2.2   | 2023-07-06 | [28035](https://github.com/airbytehq/airbyte/pull/28035) | Migrate from authSpecification to advancedAuth |
 | 0.2.1   | 2023-06-26 | [27782](https://github.com/airbytehq/airbyte/pull/27782) | Only allow HTTPS urls                          |
 | 0.2.0   | 2023-06-26 | [27780](https://github.com/airbytehq/airbyte/pull/27780) | License Update: Elv2                           |

--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -130,7 +130,7 @@ You cannot create more than 200 worksheets within single spreadsheet.
 
 | Version | Date       | Pull Request                                             | Subject                                        |
 |---------|------------|----------------------------------------------------------|------------------------------------------------|
-| 0.2.3   | 2023-09-25 | coming soon | Performance testing - include socat binary in docker image |
+| 0.2.3   | 2023-09-25 | [30748](https://github.com/airbytehq/airbyte/pull/30748) | Performance testing - include socat binary in docker image |
 | 0.2.2   | 2023-07-06 | [28035](https://github.com/airbytehq/airbyte/pull/28035) | Migrate from authSpecification to advancedAuth |
 | 0.2.1   | 2023-06-26 | [27782](https://github.com/airbytehq/airbyte/pull/27782) | Only allow HTTPS urls                          |
 | 0.2.0   | 2023-06-26 | [27780](https://github.com/airbytehq/airbyte/pull/27780) | License Update: Elv2                           |


### PR DESCRIPTION
## What
- Similar to https://github.com/airbytehq/airbyte/pull/30560

This is for
- https://github.com/airbytehq/airbyte-internal-issues/issues/5298
- https://github.com/airbytehq/airbyte-platform-internal/pull/8870

## How
Build and publish destination Google Sheets to include socat in the docker image.
This will then be used in https://github.com/airbytehq/airbyte-platform-internal/pull/8870


## 🚨 User Impact 🚨
None from this PR alone (socat will be added to the image but won't be used until https://github.com/airbytehq/airbyte-platform-internal/pull/8870 is merged.)
