### PR TITLE
:bug: Source Recharge: do not pass any filters with cursor value for new style pagination

### DIFF
--- a/airbyte-integrations/connectors/source-recharge/Dockerfile
+++ b/airbyte-integrations/connectors/source-recharge/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.1.0
+LABEL io.airbyte.version=1.1.1
 LABEL io.airbyte.name=airbyte/source-recharge

--- a/airbyte-integrations/connectors/source-recharge/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recharge/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 45d2e135-2ede-49e1-939f-3e3ec357a65e
-  dockerImageTag: 1.1.0
+  dockerImageTag: 1.1.1
   dockerRepository: airbyte/source-recharge
   githubIssueLabel: source-recharge
   icon: recharge.svg
@@ -13,10 +13,8 @@ data:
   name: Recharge
   registries:
     cloud:
-      dockerImageTag: 1.0.1
       enabled: true
     oss:
-      dockerImageTag: 1.0.1
       enabled: true
   releaseStage: generally_available
   documentationUrl: https://docs.airbyte.com/integrations/sources/recharge

--- a/airbyte-integrations/connectors/source-recharge/unit_tests/test_api.py
+++ b/airbyte-integrations/connectors/source-recharge/unit_tests/test_api.py
@@ -281,12 +281,7 @@ class TestIncrementalStreams:
                 {"cursor": "123"},
                 {"updated_at": "2030-01-01"},
                 {"start_date": "2020-01-01T00:00:00Z", "end_date": "2020-02-01T00:00:00Z"},
-                {
-                    "limit": 250,
-                    "cursor": "123",
-                    "updated_at_min": "2020-01-01T00:00:00Z",
-                    "updated_at_max": "2020-02-01T00:00:00Z"
-                }
+                {"limit": 250, "cursor": "123"}
             ),
             (
                 Customers,
@@ -307,12 +302,7 @@ class TestIncrementalStreams:
                 {"cursor": "123"},
                 {"updated_at": "2030-01-01"},
                 {"start_date": "2020-01-01T00:00:00Z", "end_date": "2020-02-01T00:00:00Z"},
-                {
-                    "limit": 250,
-                    "cursor": "123",
-                    "updated_at_min": "2020-01-01T00:00:00Z",
-                    "updated_at_max": "2020-02-01T00:00:00Z"
-                }
+                {"limit": 250, "cursor": "123"}
             ),
             (
                 Orders,

--- a/docs/integrations/sources/recharge.md
+++ b/docs/integrations/sources/recharge.md
@@ -76,6 +76,7 @@ The Recharge connector should gracefully handle Recharge API limitations under n
 
 | Version | Date       | Pull Request                                             | Subject                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------|
+| 1.1.1   | 2023-09-26 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | For the new style pagination, pass only limit along with cursor                           |
 | 1.1.0   | 2023-09-26 | [30756](https://github.com/airbytehq/airbyte/pull/30756) | Fix pagination and slicing                                                                |
 | 1.0.1   | 2023-08-30 | [29992](https://github.com/airbytehq/airbyte/pull/29992) | Revert for orders stream to use old API version 2021-01                                   |
 | 1.0.0   | 2023-06-22 | [27612](https://github.com/airbytehq/airbyte/pull/27612) | Change data type of the `shopify_variant_id_not_found` field of the `Charges` stream      |

--- a/docs/integrations/sources/recharge.md
+++ b/docs/integrations/sources/recharge.md
@@ -76,7 +76,7 @@ The Recharge connector should gracefully handle Recharge API limitations under n
 
 | Version | Date       | Pull Request                                             | Subject                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------|
-| 1.1.1   | 2023-09-26 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | For the new style pagination, pass only limit along with cursor                           |
+| 1.1.1   | 2023-09-26 | [30782](https://github.com/airbytehq/airbyte/pull/30782) | For the new style pagination, pass only limit along with cursor                           |
 | 1.1.0   | 2023-09-26 | [30756](https://github.com/airbytehq/airbyte/pull/30756) | Fix pagination and slicing                                                                |
 | 1.0.1   | 2023-08-30 | [29992](https://github.com/airbytehq/airbyte/pull/29992) | Revert for orders stream to use old API version 2021-01                                   |
 | 1.0.0   | 2023-06-22 | [27612](https://github.com/airbytehq/airbyte/pull/27612) | Change data type of the `shopify_variant_id_not_found` field of the `Charges` stream      |


### PR DESCRIPTION
## What
https://github.com/airbytehq/oncall/issues/3069
422 error occurres if a filter is passed along with the cursor value for the new style pagination

## How
- Pass only cursor and limit for the new style pagination
- No changes for the old style pagination
