### PR TITLE
Remove enterprise note from DD docs

### DIFF
--- a/docs/operator-guides/collecting-metrics.md
+++ b/docs/operator-guides/collecting-metrics.md
@@ -1,19 +1,24 @@
 # Monitoring Airbyte
 
+
 Airbyte offers you various ways to monitor your ELT pipelines. These options range from using open-source tools to integrating with enterprise-grade SaaS platforms.
 
 Here's a quick overview:
 * Connection Logging: All Airbyte instances provide extensive logs for each connector, giving detailed reports on the data synchronization process. This is available across all Airbyte offerings.
-* [Airbyte Datadog Integration](#airbyte-datadog-integration): Airbyte Enterprise customers can leverage our integration with Datadog. This lets you monitor and analyze your data pipelines right within your Datadog dashboards at no additional cost.
+* [Airbyte Datadog Integration](#airbyte-datadog-integration): Airbyte customers can leverage our integration with Datadog. This lets you monitor and analyze your data pipelines right within your Datadog dashboards at no additional cost.
 * Airbyte OpenTelemetry (OTEL) Integration: Coming soon, this will allow you to push metrics to your self-hosted monitoring solution using OpenTelemetry.
 
 Please browse the sections below for more details on each option and how to set it up.
 
 ## Airbyte Datadog Integration
 
-![Datadog's Airbyte Integration Dashboard](assets/DatadogAirbyteIntegration_OutOfTheBox_Dashboard.png)
 
-<AppliesTo selfManagedEnterprise />
+:::info
+Monitoring your Airbyte instance using Datadog is an early preview feature and still in development.
+Expect changes to this feature and the configuration to happen in the future.
+:::
+
+![Datadog's Airbyte Integration Dashboard](assets/DatadogAirbyteIntegration_OutOfTheBox_Dashboard.png)
 
 Airbyte's new integration with Datadog brings the convenience of monitoring and analyzing your Airbyte data pipelines directly within your Datadog dashboards. 
 This integration brings forth new `airbyte.*` metrics along with new dashboards. The list of metrics is found [here](https://docs.datadoghq.com/integrations/airbyte/#data-collected).

--- a/docs/operator-guides/collecting-metrics.md
+++ b/docs/operator-guides/collecting-metrics.md
@@ -15,7 +15,8 @@ Please browse the sections below for more details on each option and how to set 
 
 :::info
 Monitoring your Airbyte instance using Datadog is an early preview feature and still in development.
-Expect changes to this feature and the configuration to happen in the future.
+Expect changes to this feature and the configuration to happen in the future. This feature will be
+only for Airbyte Enterprise customers in the future.
 :::
 
 ![Datadog's Airbyte Integration Dashboard](assets/DatadogAirbyteIntegration_OutOfTheBox_Dashboard.png)


### PR DESCRIPTION
Remove the Airbyte Enterprise notes from the Datadog integration doc, since you literally can't run this at the moment with Airbyte Enterprise (due to it only working with docker compose).