### PR TITLE
Pinecone destination: Add namespace setting

### DIFF
--- a/airbyte-integrations/connectors/destination-pinecone/Dockerfile
+++ b/airbyte-integrations/connectors/destination-pinecone/Dockerfile
@@ -38,6 +38,6 @@ COPY destination_pinecone ./destination_pinecone
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.13
+LABEL io.airbyte.version=0.0.14
 
 LABEL io.airbyte.name=airbyte/destination-pinecone

--- a/airbyte-integrations/connectors/destination-pinecone/destination_pinecone/config.py
+++ b/airbyte-integrations/connectors/destination-pinecone/destination_pinecone/config.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from typing import Union
+from typing import Literal, Optional, Union
 
 import dpath.util
 from airbyte_cdk.destinations.vector_db_based.config import (
@@ -16,6 +16,15 @@ from airbyte_cdk.utils.spec_schema_transformations import resolve_refs
 from pydantic import BaseModel, Field
 
 
+class NamespaceModel(BaseModel):
+    mode: Literal["constant"] = Field("constant", const=True)
+    value: Optional[str] = Field(
+        title="Namespace",
+        default="",
+        description="Namespace to use for all records. This is not supported on starter pods",
+    )
+
+
 class PineconeIndexingModel(BaseModel):
     pinecone_key: str = Field(
         ...,
@@ -27,6 +36,7 @@ class PineconeIndexingModel(BaseModel):
         ..., title="Pinecone Environment", description="Pinecone Cloud environment to use", examples=["us-west1-gcp", "gcp-starter"]
     )
     index: str = Field(..., title="Index", description="Pinecone index in your project to load data into")
+    namespace: Optional[NamespaceModel]
 
     class Config:
         title = "Indexing"

--- a/airbyte-integrations/connectors/destination-pinecone/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/destination-pinecone/integration_tests/spec.json
@@ -24,6 +24,25 @@
             "title": "Index",
             "description": "Pinecone index in your project to load data into",
             "type": "string"
+          },
+          "namespace": {
+            "title": "NamespaceModel",
+            "type": "object",
+            "properties": {
+              "mode": {
+                "title": "Mode",
+                "default": "constant",
+                "const": "constant",
+                "enum": ["constant"],
+                "type": "string"
+              },
+              "value": {
+                "title": "Namespace",
+                "description": "Namespace to use for all records. This is not supported on starter pods",
+                "default": "",
+                "type": "string"
+              }
+            }
           }
         },
         "required": ["pinecone_key", "pinecone_environment", "index"],

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -20,7 +20,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 3d2b6f84-7f0d-4e3f-a5e5-7c7d4b50eabd
-  dockerImageTag: 0.0.13
+  dockerImageTag: 0.0.14
   dockerRepository: airbyte/destination-pinecone
   githubIssueLabel: destination-pinecone
   icon: pinecone.svg

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -74,6 +74,7 @@ OpenAI and Fake embeddings produce vectors with 1536 dimensions, and the Cohere 
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.0.14   | 2023-09-28 | [#30649](https://github.com/airbytehq/airbyte/pull/30649)     | Support namespaces | 
 | 0.0.13   | 2023-09-26 | [#30649](https://github.com/airbytehq/airbyte/pull/30649)     | Allow more text splitting options | 
 | 0.0.12   | 2023-09-25 | [#30649](https://github.com/airbytehq/airbyte/pull/30649)     | Fix bug with stale documents left on starter pods | 
 | 0.0.11   | 2023-09-22 | [#30649](https://github.com/airbytehq/airbyte/pull/30649)     | Set visible certified flag | 

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -74,7 +74,7 @@ OpenAI and Fake embeddings produce vectors with 1536 dimensions, and the Cohere 
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.0.14   | 2023-09-28 | [#30649](https://github.com/airbytehq/airbyte/pull/30649)     | Support namespaces | 
+| 0.0.14   | 2023-09-28 | [#30789](https://github.com/airbytehq/airbyte/pull/30789)     | Support namespaces | 
 | 0.0.13   | 2023-09-26 | [#30649](https://github.com/airbytehq/airbyte/pull/30649)     | Allow more text splitting options | 
 | 0.0.12   | 2023-09-25 | [#30649](https://github.com/airbytehq/airbyte/pull/30649)     | Fix bug with stale documents left on starter pods | 
 | 0.0.11   | 2023-09-22 | [#30649](https://github.com/airbytehq/airbyte/pull/30649)     | Set visible certified flag | 


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/30574

By adding a new optional "namespace" field:

<img width="887" alt="Screenshot 2023-09-27 at 12 48 08" src="https://github.com/airbytehq/airbyte/assets/1508364/ffdfca23-b540-4f66-95f0-7a6ee910b50c">

If set, all records are indexed into this namespace. It is not available on starter pods (check is validating that)

The config is structured via a separate object for the namespace setting to allow extensions of different "namespace modes" later on if required using a oneOf without breaking existing configurations. (e.g. reading the namespace from the stream name or from a field in each record)
