### PR TITLE
🐛 Set Azure OpenAI chunk_size to 16.

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
@@ -97,7 +97,8 @@ class OpenAIEmbedder(BaseOpenAIEmbedder):
 
 class AzureOpenAIEmbedder(BaseOpenAIEmbedder):
     def __init__(self, config: AzureOpenAIEmbeddingConfigModel, chunk_size: int):
-        super().__init__(OpenAIEmbeddings(openai_api_key=config.openai_key, chunk_size=8191, max_retries=15, openai_api_type="azure", openai_api_version="2023-05-15", openai_api_base=config.api_base, deployment=config.deployment), chunk_size)  # type: ignore
+        # Azure OpenAI API has — as of 20230927 — a limit of 16 documents per request
+        super().__init__(OpenAIEmbeddings(openai_api_key=config.openai_key, chunk_size=16, max_retries=15, openai_api_type="azure", openai_api_version="2023-05-15", openai_api_base=config.api_base, deployment=config.deployment), chunk_size)  # type: ignore
 
 
 COHERE_VECTOR_SIZE = 1024


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
The Azure OpenAI API will return an error when embedding more than 16 documents.

## How
Set the chunk_size of Azure OpenAI config model to 16 (current max, see: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#embeddings).