### PR TITLE
🐛 Source Stripe: handle PermissionError as non breaking during check_connection

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -13,5 +13,5 @@ ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
 
-LABEL io.airbyte.version=4.3.0
+LABEL io.airbyte.version=4.3.1
 LABEL io.airbyte.name=airbyte/source-stripe

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e094cb9a-26de-4645-8761-65c0c425d1de
-  dockerImageTag: 4.3.0
+  dockerImageTag: 4.3.1
   dockerRepository: airbyte/source-stripe
   githubIssueLabel: source-stripe
   icon: stripe.svg

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -76,7 +76,7 @@ class SourceStripe(AbstractSource):
         stripe.api_key = config["client_secret"]
         try:
             stripe.Account.retrieve(config["account_id"])
-        except stripe.error.AuthenticationError as e:
+        except (stripe.error.AuthenticationError, stripe.error.PermissionError) as e:
             return False, str(e)
         return True, None
 

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py
@@ -8,10 +8,15 @@ from unittest.mock import patch
 
 import pytest
 import source_stripe
+import stripe
 from airbyte_cdk.utils import AirbyteTracedException
 from source_stripe import SourceStripe
 
 logger = logging.getLogger("airbyte")
+
+
+def _a_valid_config():
+    return {"account_id": 1, "client_secret": "secret"}
 
 
 @patch.object(source_stripe.source, "stripe")
@@ -25,16 +30,30 @@ def test_streams_are_unique(config):
 
 
 @pytest.mark.parametrize(
-    "input_config, is_success, expected_error_msg",
+    "input_config, expected_error_msg",
     (
-        ({"lookback_window_days": "month"}, False, "Invalid lookback window month. Please use only positive integer values or 0."),
-        ({"start_date": "January First, 2022"}, False, "Invalid start date January First, 2022. Please use YYYY-MM-DDTHH:MM:SSZ format."),
-        ({"slice_range": -10}, False, "Invalid slice range value -10. Please use positive integer values only."),
-        ({"account_id": 1, "client_secret": "secret"}, True, None)
+        ({"lookback_window_days": "month"}, "Invalid lookback window month. Please use only positive integer values or 0."),
+        ({"start_date": "January First, 2022"}, "Invalid start date January First, 2022. Please use YYYY-MM-DDTHH:MM:SSZ format."),
+        ({"slice_range": -10}, "Invalid slice range value -10. Please use positive integer values only."),
+        (_a_valid_config(), None)
     )
 )
-@patch.object(source_stripe.source, "stripe")
-def test_config_validation(mocked_client, input_config, is_success, expected_error_msg):
+@patch.object(source_stripe.source.stripe, "Account")
+def test_config_validation(mocked_client, input_config, expected_error_msg):
     context = pytest.raises(AirbyteTracedException, match=expected_error_msg) if expected_error_msg else does_not_raise()
     with context:
         SourceStripe().check_connection(logger, config=input_config)
+
+
+@pytest.mark.parametrize(
+    "exception",
+    (
+        stripe.error.AuthenticationError,
+        stripe.error.PermissionError,
+    )
+)
+@patch.object(source_stripe.source.stripe, "Account")
+def test_given_stripe_error_when_check_connection_then_connection_not_available(mocked_client, exception):
+    mocked_client.retrieve.side_effect = exception
+    is_available, _ = SourceStripe().check_connection(logger, config=_a_valid_config())
+    assert not is_available

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -192,6 +192,7 @@ The Stripe connector should not run into Stripe API limitations under normal usa
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.3.1   | 2023-09-27 | [30800](https://github.com/airbytehq/airbyte/pull/30800) | Handle permission issues a non breaking                                                                                                              |
 | 4.3.0   | 2023-09-26 | [30752](https://github.com/airbytehq/airbyte/pull/30752) | Do not sync upcoming invoices, extend stream schemas                                                                                                 |
 | 4.2.0   | 2023-09-21 | [30660](https://github.com/airbytehq/airbyte/pull/30660) | Fix updated state for the incremental syncs                                                                                                          |
 | 4.1.1   | 2023-09-15 | [30494](https://github.com/airbytehq/airbyte/pull/30494) | Fix datatype of invoices.lines property                                                                                                              |


### PR DESCRIPTION
## What
A permission issue generated a page. https://airbytehq.sentry.io/issues/4478433518

## How
Also handle PermissionError as connection unavailable
