### PR TITLE
java-cdk: fix broken test due to merge skew

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -76,7 +76,7 @@ jobs:
           # TODO: be able to remove the skipSlowTests property
           # TODO: remove the format task ASAP
           # TODO: roll the CDK tasks into check
-          arguments: --scan --no-daemon --no-watch-fs format check :airbyte-cdk:java:airbyte-cdk:build :airbyte-cdk:java:airbyte-cdk:integrationTest -DskipSlowTests=true
+          arguments: --scan --no-daemon --no-watch-fs format check -DskipSlowTests=true
 
   # In case of self-hosted EC2 errors, remove this block.
   stop-check-runner:

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/integrations/destination_async/GlobalMemoryManagerTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/integrations/destination_async/GlobalMemoryManagerTest.java
@@ -10,23 +10,20 @@ import org.junit.jupiter.api.Test;
 
 public class GlobalMemoryManagerTest {
 
-  private static final long BYTES_10_MB = 10 * 1024 * 1024;
-  private static final long BYTES_35_MB = 35 * 1024 * 1024;
-  private static final long BYTES_5_MB = 5 * 1024 * 1024;
+  private static final long BYTES_MB = 1024 * 1024;
 
   @Test
   void test() {
-    final GlobalMemoryManager mgr = new GlobalMemoryManager(BYTES_35_MB);
+    final GlobalMemoryManager mgr = new GlobalMemoryManager(35 * BYTES_MB);
 
-    assertEquals(BYTES_10_MB, mgr.requestMemory());
-    assertEquals(BYTES_10_MB, mgr.requestMemory());
-    assertEquals(BYTES_10_MB, mgr.requestMemory());
-    assertEquals(BYTES_5_MB, mgr.requestMemory());
+    assertEquals(30 * BYTES_MB, mgr.requestMemory());
+    assertEquals(5 * BYTES_MB, mgr.requestMemory());
     assertEquals(0, mgr.requestMemory());
 
-    mgr.free(BYTES_10_MB);
-
-    assertEquals(BYTES_10_MB, mgr.requestMemory());
+    mgr.free(10 * BYTES_MB);
+    assertEquals(10 * BYTES_MB, mgr.requestMemory());
+    mgr.free(31 * BYTES_MB);
+    assertEquals(30 * BYTES_MB, mgr.requestMemory());
   }
 
 }


### PR DESCRIPTION
This PR fixes another merge skew issue from the java CDK which causes the checks to fail on master.