### PR TITLE
Change status to has issues for down github statuses

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -122,7 +122,7 @@ jobs:
         uses: joelwmale/webhook-action@master
         with:
           url: ${{ secrets.INSTATUS_CONNECTOR_CI_WEBHOOK_URL }}
-          body: '{ "trigger": "down" }'
+          body: '{ "trigger": "down", "status": "HASISSUES" }'
 
   set-instatus-incident-on-success:
     name: Create Instatus Incident on Success

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -70,7 +70,7 @@ jobs:
         uses: joelwmale/webhook-action@master
         with:
           url: ${{ secrets.INSTATUS_CONNECTOR_CI_WEBHOOK_URL }}
-          body: '{ "trigger": "down" }'
+          body: '{ "trigger": "down", "status": "HASISSUES" }'
 
   set-instatus-incident-on-success:
     name: Create Instatus Incident on Success


### PR DESCRIPTION
The instatus incidents for github issues say major outage. Thats scary, lets try and reduce that.