### PR TITLE
:rotating_light: :rotating_light: Source Google Analytics: fix stream naming

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
@@ -28,5 +28,5 @@ COPY source_google_analytics_data_api ./source_google_analytics_data_api
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.6.0
+LABEL io.airbyte.version=2.0.0
 LABEL io.airbyte.name=airbyte/source-google-analytics-data-api

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 1.6.0
+  dockerImageTag: 2.0.0
   dockerRepository: airbyte/source-google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api
   icon: google-analytics.svg
@@ -18,6 +18,11 @@ data:
       enabled: true
     oss:
       enabled: true
+  releases:
+    breakingChanges:
+      2.0.0:
+        message: "Version 2.0.0 introduces changes to stream naming. This fixes a defect when the connector config has multiple properties and produces duplicated streams. In order to have the connector working, please re-set up the connector."
+        upgradeDeadline: "TO BE DONE"
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -22,7 +22,7 @@ data:
     breakingChanges:
       2.0.0:
         message: "Version 2.0.0 introduces changes to stream naming. This fixes a defect when the connector config has multiple properties and produces duplicated streams. In order to have the connector working, please re-set up the connector."
-        upgradeDeadline: "TO BE DONE"
+        upgradeDeadline: "2023-10-16"
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -530,10 +530,20 @@ class SourceGoogleAnalyticsDataApi(AbstractSource):
         return [stream for report in reports + config["custom_reports_array"] for stream in self.instantiate_report_streams(report, config)]
 
     def instantiate_report_streams(self, report: dict, config: Mapping[str, Any], **extra_kwargs) -> GoogleAnalyticsDataApiBaseStream:
+        add_name_suffix = False
         for property_id in config["property_ids"]:
-            yield self.instantiate_report_class(report=report, config={**config, "property_id": property_id})
+            yield self.instantiate_report_class(
+                report=report, add_name_suffix=add_name_suffix, config={**config, "property_id": property_id}
+            )
+            # Append property ID to stream name only for the second and subsequent properties.
+            # This will make a release non-breaking for users with a single property.
+            # This is a temporary solution until https://github.com/airbytehq/airbyte/issues/30926 is implemented.
+            add_name_suffix = True
 
-    def instantiate_report_class(self, report: dict, config: Mapping[str, Any], **extra_kwargs) -> GoogleAnalyticsDataApiBaseStream:
+    @staticmethod
+    def instantiate_report_class(
+        report: dict, add_name_suffix: bool, config: Mapping[str, Any], **extra_kwargs
+    ) -> GoogleAnalyticsDataApiBaseStream:
         cohort_spec = report.get("cohortSpec")
         pivots = report.get("pivots")
         stream_config = {
@@ -550,4 +560,7 @@ class SourceGoogleAnalyticsDataApi(AbstractSource):
         if cohort_spec:
             stream_config["cohort_spec"] = cohort_spec
             report_class_tuple = (CohortReportMixin, *report_class_tuple)
-        return type(report["name"], report_class_tuple, {})(config=stream_config, authenticator=config["authenticator"], **extra_kwargs)
+        name = report["name"]
+        if add_name_suffix:
+            name = f"{name}Property{config['property_id']}"
+        return type(name, report_class_tuple, {})(config=stream_config, authenticator=config["authenticator"], **extra_kwargs)

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -516,7 +516,7 @@ class SourceGoogleAnalyticsDataApi(AbstractSource):
                     invalid_metrics = ", ".join(invalid_metrics)
                     return False, WRONG_METRICS.format(fields=invalid_metrics, report_name=report["name"])
 
-                report_stream = self.instantiate_report_class(report, _config, page_size=100)
+                report_stream = self.instantiate_report_class(report, False, _config, page_size=100)
                 # check if custom_report dimensions + metrics can be combined and report generated
                 stream_slice = next(report_stream.stream_slices(sync_mode=SyncMode.full_refresh))
                 next(report_stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice), None)

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
@@ -97,12 +97,10 @@ def test_check(requests_mock, config_gen, config_values, is_successful, message)
         assert e.value.failure_type == FailureType.config_error
 
 
-def test_streams(mocker, patch_base_class):
+def test_streams(patch_base_class, config_gen):
+    config = config_gen(property_ids=["Prop1", "PropN"])
     source = SourceGoogleAnalyticsDataApi()
-
-    config_mock = MagicMock()
-    config_mock.__getitem__.side_effect = patch_base_class["config"].__getitem__
-
-    streams = source.streams(patch_base_class["config"])
-    expected_streams_number = 57
+    streams = source.streams(config)
+    expected_streams_number = 57 * 2
+    assert len([stream for stream in streams if "_property_" in stream.name]) == 57
     assert len(set(streams)) == expected_streams_number

--- a/docs/integrations/sources/google-analytics-data-api-migrations.md
+++ b/docs/integrations/sources/google-analytics-data-api-migrations.md
@@ -1,0 +1,6 @@
+# Google Analytics Data API Migration Guide
+
+## Upgrading to 2.0.0
+
+A major update of most streams to avoid having duplicate stream names. This is relevant for the connections having more than one property ID.
+Resetting a connector is needed if you have more than one property ID in your config.

--- a/docs/integrations/sources/google-analytics-data-api-migrations.md
+++ b/docs/integrations/sources/google-analytics-data-api-migrations.md
@@ -1,4 +1,4 @@
-# Google Analytics Data API Migration Guide
+# Google Analytics 4 (GA4) Migration Guide
 
 ## Upgrading to 2.0.0
 

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -273,32 +273,33 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                                                                         |
-|:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------|
-| 1.6.0   | 2023-09-19 | [30460](https://github.com/airbytehq/airbyte/pull/30460) | Migrated custom reports from string to array; add `FilterExpressions` support   |
-| 1.5.1   | 2023-09-20 | [30608](https://github.com/airbytehq/airbyte/pull/30608) | Revert `:` auto replacement name to underscore                                  |
-| 1.5.0   | 2023-09-18 | [30421](https://github.com/airbytehq/airbyte/pull/30421) | Add `yearWeek`, `yearMonth`, `year` dimensions cursor                           |
-| 1.4.1   | 2023-09-17 | [30506](https://github.com/airbytehq/airbyte/pull/30506) | Fix None type error when metrics or dimensions response does not have name      |
-| 1.4.0   | 2023-09-15 | [30417](https://github.com/airbytehq/airbyte/pull/30417) | Change start date to optional; add suggested streams and update errors handling |
-| 1.3.1   | 2023-09-14 | [30424](https://github.com/airbytehq/airbyte/pull/30424) | Fixed duplicated stream issue                                                   |
-| 1.2.0   | 2023-09-11 | [30290](https://github.com/airbytehq/airbyte/pull/30290) | Add new preconfigured reports                                                   |
-| 1.1.3   | 2023-08-04 | [29103](https://github.com/airbytehq/airbyte/pull/29103) | Update input field descriptions                                                 |
-| 1.1.2   | 2023-07-03 | [27909](https://github.com/airbytehq/airbyte/pull/27909) | Limit the page size of custom report streams                                    |
-| 1.1.1   | 2023-06-26 | [27718](https://github.com/airbytehq/airbyte/pull/27718) | Limit the page size when calling `check()`                                      |
-| 1.1.0   | 2023-06-26 | [27738](https://github.com/airbytehq/airbyte/pull/27738) | License Update: Elv2                                                            |
-| 1.0.0   | 2023-06-22 | [26283](https://github.com/airbytehq/airbyte/pull/26283) | Added primary_key and lookback window                                           |
-| 0.2.7   | 2023-06-21 | [27531](https://github.com/airbytehq/airbyte/pull/27531) | Fix formatting                                                                  |
-| 0.2.6   | 2023-06-09 | [27207](https://github.com/airbytehq/airbyte/pull/27207) | Improve api rate limit messages                                                 |
-| 0.2.5   | 2023-06-08 | [27175](https://github.com/airbytehq/airbyte/pull/27175) | Improve Error Messages                                                          |
-| 0.2.4   | 2023-06-01 | [26887](https://github.com/airbytehq/airbyte/pull/26887) | Remove `authSpecification` from connector spec in favour of `advancedAuth`      |
-| 0.2.3   | 2023-05-16 | [26126](https://github.com/airbytehq/airbyte/pull/26126) | Fix pagination                                                                  |
-| 0.2.2   | 2023-05-12 | [25987](https://github.com/airbytehq/airbyte/pull/25987) | Categorized Config Errors Accurately                                            |
-| 0.2.1   | 2023-05-11 | [26008](https://github.com/airbytehq/airbyte/pull/26008) | Added handling for `429 - potentiallyThresholdedRequestsPerHour` error          |
-| 0.2.0   | 2023-04-13 | [25179](https://github.com/airbytehq/airbyte/pull/25179) | Implement support for custom Cohort and Pivot reports                           |
-| 0.1.3   | 2023-03-10 | [23872](https://github.com/airbytehq/airbyte/pull/23872) | Fix parse + cursor for custom reports                                           |
-| 0.1.2   | 2023-03-07 | [23822](https://github.com/airbytehq/airbyte/pull/23822) | Improve `rate limits` customer faced error messages and retry logic for `429`   |
-| 0.1.1   | 2023-01-10 | [21169](https://github.com/airbytehq/airbyte/pull/21169) | Slicer updated, unit tests added                                                |
-| 0.1.0   | 2023-01-08 | [20889](https://github.com/airbytehq/airbyte/pull/20889) | Improved config validation, SAT                                                 |
-| 0.0.3   | 2022-08-15 | [15229](https://github.com/airbytehq/airbyte/pull/15229) | Source Google Analytics Data Api: code refactoring                              |
-| 0.0.2   | 2022-07-27 | [15087](https://github.com/airbytehq/airbyte/pull/15087) | fix documentationUrl                                                            |
-| 0.0.1   | 2022-05-09 | [12701](https://github.com/airbytehq/airbyte/pull/12701) | Introduce Google Analytics Data API source                                      |
+| Version | Date       | Pull Request                                             | Subject                                                                          |
+|:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------|
+| 2.0.0   | 2023-09-29 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Use distinct stream naming in case there are multiple properties in the config.  |
+| 1.6.0   | 2023-09-19 | [30460](https://github.com/airbytehq/airbyte/pull/30460) | Migrated custom reports from string to array; add `FilterExpressions` support    |
+| 1.5.1   | 2023-09-20 | [30608](https://github.com/airbytehq/airbyte/pull/30608) | Revert `:` auto replacement name to underscore                                   |
+| 1.5.0   | 2023-09-18 | [30421](https://github.com/airbytehq/airbyte/pull/30421) | Add `yearWeek`, `yearMonth`, `year` dimensions cursor                            |
+| 1.4.1   | 2023-09-17 | [30506](https://github.com/airbytehq/airbyte/pull/30506) | Fix None type error when metrics or dimensions response does not have name       |
+| 1.4.0   | 2023-09-15 | [30417](https://github.com/airbytehq/airbyte/pull/30417) | Change start date to optional; add suggested streams and update errors handling  |
+| 1.3.1   | 2023-09-14 | [30424](https://github.com/airbytehq/airbyte/pull/30424) | Fixed duplicated stream issue                                                    |
+| 1.2.0   | 2023-09-11 | [30290](https://github.com/airbytehq/airbyte/pull/30290) | Add new preconfigured reports                                                    |
+| 1.1.3   | 2023-08-04 | [29103](https://github.com/airbytehq/airbyte/pull/29103) | Update input field descriptions                                                  |
+| 1.1.2   | 2023-07-03 | [27909](https://github.com/airbytehq/airbyte/pull/27909) | Limit the page size of custom report streams                                     |
+| 1.1.1   | 2023-06-26 | [27718](https://github.com/airbytehq/airbyte/pull/27718) | Limit the page size when calling `check()`                                       |
+| 1.1.0   | 2023-06-26 | [27738](https://github.com/airbytehq/airbyte/pull/27738) | License Update: Elv2                                                             |
+| 1.0.0   | 2023-06-22 | [26283](https://github.com/airbytehq/airbyte/pull/26283) | Added primary_key and lookback window                                            |
+| 0.2.7   | 2023-06-21 | [27531](https://github.com/airbytehq/airbyte/pull/27531) | Fix formatting                                                                   |
+| 0.2.6   | 2023-06-09 | [27207](https://github.com/airbytehq/airbyte/pull/27207) | Improve api rate limit messages                                                  |
+| 0.2.5   | 2023-06-08 | [27175](https://github.com/airbytehq/airbyte/pull/27175) | Improve Error Messages                                                           |
+| 0.2.4   | 2023-06-01 | [26887](https://github.com/airbytehq/airbyte/pull/26887) | Remove `authSpecification` from connector spec in favour of `advancedAuth`       |
+| 0.2.3   | 2023-05-16 | [26126](https://github.com/airbytehq/airbyte/pull/26126) | Fix pagination                                                                   |
+| 0.2.2   | 2023-05-12 | [25987](https://github.com/airbytehq/airbyte/pull/25987) | Categorized Config Errors Accurately                                             |
+| 0.2.1   | 2023-05-11 | [26008](https://github.com/airbytehq/airbyte/pull/26008) | Added handling for `429 - potentiallyThresholdedRequestsPerHour` error           |
+| 0.2.0   | 2023-04-13 | [25179](https://github.com/airbytehq/airbyte/pull/25179) | Implement support for custom Cohort and Pivot reports                            |
+| 0.1.3   | 2023-03-10 | [23872](https://github.com/airbytehq/airbyte/pull/23872) | Fix parse + cursor for custom reports                                            |
+| 0.1.2   | 2023-03-07 | [23822](https://github.com/airbytehq/airbyte/pull/23822) | Improve `rate limits` customer faced error messages and retry logic for `429`    |
+| 0.1.1   | 2023-01-10 | [21169](https://github.com/airbytehq/airbyte/pull/21169) | Slicer updated, unit tests added                                                 |
+| 0.1.0   | 2023-01-08 | [20889](https://github.com/airbytehq/airbyte/pull/20889) | Improved config validation, SAT                                                  |
+| 0.0.3   | 2022-08-15 | [15229](https://github.com/airbytehq/airbyte/pull/15229) | Source Google Analytics Data Api: code refactoring                               |
+| 0.0.2   | 2022-07-27 | [15087](https://github.com/airbytehq/airbyte/pull/15087) | fix documentationUrl                                                             |
+| 0.0.1   | 2022-05-09 | [12701](https://github.com/airbytehq/airbyte/pull/12701) | Introduce Google Analytics Data API source                                       |

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -275,7 +275,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version | Date       | Pull Request                                             | Subject                                                                          |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------|
-| 2.0.0   | 2023-09-29 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Use distinct stream naming in case there are multiple properties in the config.  |
+| 2.0.0   | 2023-09-29 | [30930](https://github.com/airbytehq/airbyte/pull/30930) | Use distinct stream naming in case there are multiple properties in the config.  |
 | 1.6.0   | 2023-09-19 | [30460](https://github.com/airbytehq/airbyte/pull/30460) | Migrated custom reports from string to array; add `FilterExpressions` support    |
 | 1.5.1   | 2023-09-20 | [30608](https://github.com/airbytehq/airbyte/pull/30608) | Revert `:` auto replacement name to underscore                                   |
 | 1.5.0   | 2023-09-18 | [30421](https://github.com/airbytehq/airbyte/pull/30421) | Add `yearWeek`, `yearMonth`, `year` dimensions cursor                            |


### PR DESCRIPTION
## What
Fix duplicate stream names
https://github.com/airbytehq/oncall/issues/3093

## How
- Append "property_<propertyID>" to stream names if there's more than 1 property in the config (so that customers with 1 property would not be affected). This is a temporary solution to fix oncall issue. The long term solution should be implemented in a follow up issue https://github.com/airbytehq/airbyte-internal-issues/issues/2143 (should be planned next quarter)

## 🚨 User Impact 🚨
Users with more than 1 property ID will have to reset the connector. Users with 1 property ID will not be affected.