### PR TITLE
HOTFIX: Remove Path Requirement for airbyte-ci

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -380,6 +380,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                        | Description                                                                                               |
 |---------| --------------------------------------------------------- |-----------------------------------------------------------------------------------------------------------|
+| 1.4.2   | [#30595](https://github.com/airbytehq/airbyte/pull/30595) | Remove directory name requirement                                                                         |
 | 1.4.1   | [#30595](https://github.com/airbytehq/airbyte/pull/30595) | Load base migration guide into QA Test container for strict encrypt variants                              |
 | 1.4.0   | [#30330](https://github.com/airbytehq/airbyte/pull/30330) | Add support for pyproject.toml as the prefered entry point for a connector package                        |
 | 1.3.0   | [#30461](https://github.com/airbytehq/airbyte/pull/30461) | Add `--use-local-cdk` flag to all connectors commands                                                      |

--- a/airbyte-ci/connectors/pipelines/pipelines/commands/groups/connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/commands/groups/connectors.py
@@ -31,8 +31,8 @@ ALL_CONNECTORS = get_all_connectors_in_repo()
 def validate_environment(is_local: bool, use_remote_secrets: bool):
     """Check if the required environment variables exist."""
     if is_local:
-        if not (os.getcwd().endswith("/airbyte") and Path(".git").is_dir()):
-            raise click.UsageError("You need to run this command from the airbyte repository root.")
+        if not Path(".git").is_dir():
+            raise click.UsageError("You need to run this command from the repository root.")
     else:
         required_env_vars_for_ci = [
             "GCP_GSM_CREDENTIALS",

--- a/airbyte-ci/connectors/pipelines/pipelines/commands/groups/tests.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/commands/groups/tests.py
@@ -46,7 +46,7 @@ async def run_test(poetry_package_path: str, test_directory: str) -> bool:
     logger = logging.getLogger(f"{poetry_package_path}.tests")
     logger.info(f"Running tests for {poetry_package_path}")
     # The following directories are always mounted because a lot of tests rely on them
-    directories_to_always_mount = [".git", "airbyte-integrations", "airbyte-ci"]
+    directories_to_always_mount = [".git", "airbyte-integrations", "airbyte-ci", "airbyte-cdk"]
     directories_to_mount = list(set([poetry_package_path, *directories_to_always_mount]))
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as dagger_client:
         try:

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.4.1"
+version = "1.4.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## Overview
Currently if your repo is named anything else airbyte-ci fails this removes that check as a short term measure

This also puts a quick patch on a failing test