### PR TITLE
Add Schema Generation to e2e testing source

### DIFF
--- a/docs/integrations/sources/e2e-test.js
+++ b/docs/integrations/sources/e2e-test.js
@@ -78,6 +78,7 @@ export const SchemaGenerator = () => {
       <div>
         <label for="schema-generator-column-count">Desired Number of Columns:</label>
         <input type="number" id="schema-generator-column-count" name="schema-generator-column-count" onChange={updateSchema}/>
+        <p>Generated Schema:</p>
         <CodeBlock id={"generated_e2e_test_schema"} language={"javascript"}>
           { generatedSchema['schema'] }
         </CodeBlock>

--- a/docs/integrations/sources/e2e-test.js
+++ b/docs/integrations/sources/e2e-test.js
@@ -1,0 +1,86 @@
+import React, {useState} from 'react';
+import CodeBlock from '@theme/CodeBlock';
+
+function simpleProperty(name, type) {
+  return [name, { type }];
+}
+
+function dateProperty(name, format, airbyteType) {
+  const definition = {
+    type: ['null', 'string'],
+    format,
+  };
+  if (airbyteType !== null) {
+    definition.airbyte_type = airbyteType;
+  }
+  return [name, definition];
+}
+
+const allSupportedColumnTypePropertyGenerators = [
+  (i) => simpleProperty(`string_${i}`, 'string'),
+  (i) => simpleProperty(`boolean_${i}`, 'boolean'),
+  (i) => dateProperty(`date_${i}`, 'date', null),
+  (i) => dateProperty(`timestamp_wo_tz_${i}`, 'date-time', 'timestamp_without_timezone'),
+  (i) => dateProperty(`timestamp_w_tz_${i}`, 'date-time', 'timestamp_with_timezone'),
+  (i) => dateProperty(`time_wo_tz_${i}`, 'time', 'time_without_timezone'),
+  (i) => dateProperty(`time_w_tz_${i}`, 'time', 'time_with_timezone'),
+  (i) => simpleProperty(`integer_${i}`, 'integer'),
+  (i) => simpleProperty(`number_${i}`, 'number'),
+  (i) => simpleProperty(`array_${i}`, 'array'),
+  (i) => simpleProperty(`object_${i}`, 'object'),
+];
+
+function generateWideSchema(columns) {
+
+  const fullSchema = { type: 'object' };
+  const properties = {};
+
+  // Special case id and updated_at column
+  const id = simpleProperty('id', 'integer');
+  properties[id[0]] = id[1];
+  properties['updated_at'] = { type: 'string', format: 'date-time', airbyte_type: 'timestamp_with_timezone' };
+
+  let columnCount = 2;
+  let propertyGeneratorIndex = 0;
+
+  while (columnCount < columns) {
+    const propertyInfo = allSupportedColumnTypePropertyGenerators[propertyGeneratorIndex](columnCount);
+    properties[propertyInfo[0]] = propertyInfo[1];
+
+    propertyGeneratorIndex += 1;
+    if (propertyGeneratorIndex === allSupportedColumnTypePropertyGenerators.length) {
+      propertyGeneratorIndex = 0;
+    }
+
+    columnCount += 1;
+  }
+
+  fullSchema.properties = properties;
+
+  return fullSchema;
+}
+
+
+
+
+export const SchemaGenerator = () => {
+
+  const [generatedSchema, updateGeneratedSchema] = useState({
+    'schema' : JSON.stringify(generateWideSchema(10))
+  })
+  function updateSchema(event) {
+    const columns = parseInt(document.getElementById("schema-generator-column-count").value)
+    const schema = JSON.stringify(generateWideSchema(columns))
+    updateGeneratedSchema({'schema': schema})
+  }
+
+  return (
+      <div>
+        <label for="schema-generator-column-count">Desired Number of Columns:</label>
+        <input type="number" id="schema-generator-column-count" name="schema-generator-column-count" onChange={updateSchema}/>
+        <CodeBlock id={"generated_e2e_test_schema"} language={"javascript"}>
+          { generatedSchema['schema'] }
+        </CodeBlock>
+      </div>
+  )
+}

--- a/docs/integrations/sources/e2e-test.md
+++ b/docs/integrations/sources/e2e-test.md
@@ -31,7 +31,7 @@ Here is its configuration:
 
 #### Example Stream Schemas
 If you need a stream for testing performance simulating a wide table, we have an example [500 column stream](https://gist.github.com/jbfbell/9b7db8fdf0de0187c7da92df2f699502)
-or use this tool to generate your own with an arbitrary width using the form below.
+or use this tool to generate your own with an arbitrary width using the form below, then copy+paste into your configuration. 
 
 <SchemaGenerator />
 

--- a/docs/integrations/sources/e2e-test.md
+++ b/docs/integrations/sources/e2e-test.md
@@ -31,7 +31,7 @@ Here is its configuration:
 
 #### Example Stream Schemas
 If you need a stream for testing performance simulating a wide table, we have an example [500 column stream](https://gist.github.com/jbfbell/9b7db8fdf0de0187c7da92df2f699502)
-or the form below to generate your own with an arbitrary width, then copy+paste the resulting schema into your configuration. 
+or use the form below to generate your own with an arbitrary width, then copy+paste the resulting schema into your configuration. 
 
 <SchemaGenerator />
 

--- a/docs/integrations/sources/e2e-test.md
+++ b/docs/integrations/sources/e2e-test.md
@@ -1,3 +1,5 @@
+import {SchemaGenerator} from './e2e-test.js'
+
 # End-to-End Testing Source
 
 ## Overview
@@ -25,6 +27,13 @@ Here is its configuration:
 | Both              | max records         | integer | yes      | 100                 | The number of record messages to emit from this connector. Min 1. Max 100 billion.                                                                      |
 |                   | random seed         | integer | no       | current time millis | The seed is used in random Json object generation. Min 0. Max 1 million.                                                                                |
 |                   | message interval    | integer | no       | 0                   | The time interval between messages in millisecond. Min 0 ms. Max 60000 ms (1 minute).                                                                   |
+
+
+#### Example Stream Schemas
+If you need a stream for testing performance simulating a wide table, we have an example [500 column stream](https://gist.github.com/jbfbell/9b7db8fdf0de0187c7da92df2f699502)
+or use this tool to generate your own with an arbitrary width using the form below.
+
+<SchemaGenerator />
 
 ### Legacy Infinite Feed
 

--- a/docs/integrations/sources/e2e-test.md
+++ b/docs/integrations/sources/e2e-test.md
@@ -31,7 +31,7 @@ Here is its configuration:
 
 #### Example Stream Schemas
 If you need a stream for testing performance simulating a wide table, we have an example [500 column stream](https://gist.github.com/jbfbell/9b7db8fdf0de0187c7da92df2f699502)
-or use this tool to generate your own with an arbitrary width using the form below, then copy+paste into your configuration. 
+or the form below to generate your own with an arbitrary width, then copy+paste the resulting schema into your configuration. 
 
 <SchemaGenerator />
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -11,7 +11,7 @@ function getFilenamesInDir(prefix, dir, excludes) {
     .readdirSync(dir)
     .filter(
       (fileName) =>
-        !(fileName.endsWith(".inapp.md") || fileName.endsWith("-migrations.md"))
+        !(fileName.endsWith(".inapp.md") || fileName.endsWith("-migrations.md") || fileName.endsWith(".js"))
     )
     .map((fileName) => fileName.replace(".md", ""))
     .filter((fileName) => excludes.indexOf(fileName.toLowerCase()) === -1)


### PR DESCRIPTION
For the e2e source, you can provide your own schema and it will generate random data. This updates the documentation to link to an example 500 column schema and also adds a react component allowing people to generate their own schemas of any width