### PR TITLE
Source Google Ads: fix breaking change message

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -39,7 +39,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: This release introduces fixes to custom query schema creation. Users should refresh their schemas and data after upgrading.
+        message: This release introduces fixes to custom query schema creation. Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs.
         upgradeDeadline: "2023-10-31"
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   tags:

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -39,7 +39,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: This release introduces fix to custom query schemas creation. User should refresh their schemas and data before update.
+        message: This release introduces fixes to custom query schema creation. Users should refresh their schemas and data after upgrading.
         upgradeDeadline: "2023-10-31"
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   tags:

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_custom_query.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_custom_query.py
@@ -27,29 +27,31 @@ class Obj:
 
 
 def test_get_json_schema():
-    query_object = MagicMock(return_value={
-        'a': Obj(data_type=Obj(name='ENUM'), is_repeated=False, enum_values=['a', 'aa']),
-        'b': Obj(data_type=Obj(name='ENUM'), is_repeated=True,  enum_values=['b', 'bb']),
-        'c': Obj(data_type=Obj(name='MESSAGE'), is_repeated=False),
-        'd': Obj(data_type=Obj(name='MESSAGE'), is_repeated=True),
-        'e': Obj(data_type=Obj(name='STRING'), is_repeated=False),
-        'f': Obj(data_type=Obj(name='DATE'), is_repeated=False),
-    })
-    instance = CustomQueryMixin(config={'query': Obj(fields=['a', 'b', 'c', 'd', 'e', 'f'])})
+    query_object = MagicMock(
+        return_value={
+            "a": Obj(data_type=Obj(name="ENUM"), is_repeated=False, enum_values=["a", "aa"]),
+            "b": Obj(data_type=Obj(name="ENUM"), is_repeated=True, enum_values=["b", "bb"]),
+            "c": Obj(data_type=Obj(name="MESSAGE"), is_repeated=False),
+            "d": Obj(data_type=Obj(name="MESSAGE"), is_repeated=True),
+            "e": Obj(data_type=Obj(name="STRING"), is_repeated=False),
+            "f": Obj(data_type=Obj(name="DATE"), is_repeated=False),
+        }
+    )
+    instance = CustomQueryMixin(config={"query": Obj(fields=["a", "b", "c", "d", "e", "f"])})
     instance.cursor_field = None
     instance.google_ads_client = Obj(get_fields_metadata=query_object)
     schema = instance.get_json_schema()
 
     assert schema == {
-        '$schema': 'http://json-schema.org/draft-07/schema#',
-        'additionalProperties': True,
-        'type': 'object',
-        'properties': {
-            'a': {'type': 'string', 'enum': ['a', 'aa']},
-            'b': {'type': ['null', 'array'], 'items': {'type': 'string', 'enum': ['b', 'bb']}},
-            'c': {'type': ['string', 'null']},
-            'd': {'type': ['null', 'array'], 'items': {'type': ['string', 'null']}},
-            'e': {'type': ['string', 'null']},
-            'f': {'type': ['string', 'null'], 'format': 'date'},
-        }
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": True,
+        "type": "object",
+        "properties": {
+            "a": {"type": "string", "enum": ["a", "aa"]},
+            "b": {"type": ["null", "array"], "items": {"type": "string", "enum": ["b", "bb"]}},
+            "c": {"type": ["string", "null"]},
+            "d": {"type": ["null", "array"], "items": {"type": ["string", "null"]}},
+            "e": {"type": ["string", "null"]},
+            "f": {"type": ["string", "null"], "format": "date"},
+        },
     }

--- a/docs/integrations/sources/google-ads-migrations.md
+++ b/docs/integrations/sources/google-ads-migrations.md
@@ -2,4 +2,4 @@
 
 ## Upgrading to 1.0.0
 
-This release introduced fixes to the creation of custom query schemas. For instance, the field ad_group_ad.ad.final_urls in the custom query has had its type changed from `{"type": "string"}` to `{"type": ["null", "array"], "items": {"type": "string"}}`. Users should refresh their schemas and data before updating.
+This release introduced fixes to the creation of custom query schemas. For instance, the field ad_group_ad.ad.final_urls in the custom query has had its type changed from `{"type": "string"}` to `{"type": ["null", "array"], "items": {"type": "string"}}`. Users should refresh their schemas and data after upgrading.

--- a/docs/integrations/sources/google-ads-migrations.md
+++ b/docs/integrations/sources/google-ads-migrations.md
@@ -2,4 +2,4 @@
 
 ## Upgrading to 1.0.0
 
-This release introduced fixes to the creation of custom query schemas. For instance, the field ad_group_ad.ad.final_urls in the custom query has had its type changed from `{"type": "string"}` to `{"type": ["null", "array"], "items": {"type": "string"}}`. Users should refresh their schemas and data after upgrading.
+This release introduced fixes to the creation of custom query schemas. For instance, the field ad_group_ad.ad.final_urls in the custom query has had its type changed from `{"type": "string"}` to `{"type": ["null", "array"], "items": {"type": "string"}}`. Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs.


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

There was an error in the breaking change message for GAds introduced in #30705, which stated that the resolution step of refreshing schemas should happen before upgrading the connector.

However, this should happen _after_ upgrading the connector. To take the new version into consideration.

## How

Fix messaging.
