### PR TITLE
Remove `source-google-analytics-v4` from Airbyte Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -16,7 +16,7 @@ data:
   name: Google Analytics (Universal Analytics)
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
This PR removes source-google-analytics-v4 from Airbyte Cloud.  This connector is slated for retirement, and the API it uses it getting retired by Google. See #p0-google-analytics-quota-usage-spike (slack) for more information.

From our docs:

```
CAUTION
The Google Analytics (Universal Analytics) connector will be deprecated soon.

Google is phasing out Universal Analytics in favor of Google Analytics 4 (GA4). In consequence, we are deprecating the Google Analytics (Universal Analytics) connector and recommend that you migrate to the [Google Analytics 4 (GA4) connector](https://docs.airbyte.com/integrations/sources/google-analytics-data-api) as soon as possible to ensure your syncs are not affected.

Due to this deprecation, we will not be accepting new contributions for this source.

For more information, see ["Universal Analytics is going away"](https://support.google.com/analytics/answer/11583528).
```

When this PR is merged, no new connectors can be made with the source.  Existing connectors/syncs will continue to work.