### PR TITLE
CDK: Add helper for cloud env

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -22,6 +22,7 @@ from airbyte_cdk.models import AirbyteMessage, Status, Type
 from airbyte_cdk.models.airbyte_protocol import ConnectorSpecification  # type: ignore [attr-defined]
 from airbyte_cdk.sources import Source
 from airbyte_cdk.sources.utils.schema_helpers import check_config_against_spec_or_exit, split_config
+from airbyte_cdk.utils import is_cloud_environment
 from airbyte_cdk.utils.airbyte_secrets_utils import get_secrets, update_secrets
 from airbyte_cdk.utils.constants import ENV_REQUEST_CACHE_PATH
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
@@ -37,10 +38,8 @@ class AirbyteEntrypoint(object):
     def __init__(self, source: Source):
         init_uncaught_exception_handler(logger)
 
-        # DEPLOYMENT_MODE is read when instantiating the entrypoint because it is the common path shared by syncs and connector
-        # builder test requests
-        deployment_mode = os.environ.get("DEPLOYMENT_MODE", "")
-        if deployment_mode.casefold() == CLOUD_DEPLOYMENT_MODE:
+        # deployment mode is read when instantiating the entrypoint because it is the common path shared by syncs and connector builder test requests
+        if is_cloud_environment():
             _init_internal_request_filter()
 
         self.source = source

--- a/airbyte-cdk/python/airbyte_cdk/utils/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/__init__.py
@@ -4,5 +4,6 @@
 
 from .schema_inferrer import SchemaInferrer
 from .traced_exception import AirbyteTracedException
+from .is_cloud_environment import is_cloud_environment
 
-__all__ = ["AirbyteTracedException", "SchemaInferrer"]
+__all__ = ["AirbyteTracedException", "SchemaInferrer", "is_cloud_environment"]

--- a/airbyte-cdk/python/airbyte_cdk/utils/is_cloud_environment.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/is_cloud_environment.py
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import os
+
+CLOUD_DEPLOYMENT_MODE = "cloud"
+
+
+def is_cloud_environment():
+    """
+    Returns True if the connector is running in a cloud environment, False otherwise.
+
+    The function checks the value of the DEPLOYMENT_MODE environment variable which is set by the platform.
+    This function can be used to determine whether stricter security measures should be applied.
+    """
+    deployment_mode = os.environ.get("DEPLOYMENT_MODE", "")
+    return deployment_mode.casefold() == CLOUD_DEPLOYMENT_MODE


### PR DESCRIPTION
As it's used in various places by now, this PR adds a common helper to determine whether a connector is running in a cloud environment or not.

The main use case for that is to decide whether some additional security measures have to be applied or not.