### PR TITLE
Add dummy component for FieldAnchor

### DIFF
--- a/docusaurus/src/components/FieldAnchor.jsx
+++ b/docusaurus/src/components/FieldAnchor.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+/**
+ * FieldAnchor is a dummy-component in the docusaurus build but is used when the documentation is rendered in the webapp
+ * to be able to highlight the relevant section for a focused field in the form next to the documentation.
+ * 
+ * The "field" property has to be set to the field name in the form the section should be connected to: <FieldAnchor field="replication_method.replication_slot" />
+ * For oneOf fields, the selected mode has to be specified in square brackets:  <FieldAnchor field="replication_method[CDC]" />
+ * It's possible to list multiple fields separated by comma: <FieldAnchor field="replication_method.replication_slot,replication_method.queue_size" />
+ */
+export const FieldAnchor = ({ children }) => {
+  return <div>{children}</div>;
+};

--- a/docusaurus/src/theme/MDXComponents/index.js
+++ b/docusaurus/src/theme/MDXComponents/index.js
@@ -2,9 +2,11 @@ import React from 'react';
 // Import the original mapper
 import MDXComponents from '@theme-original/MDXComponents';
 import { AppliesTo } from '@site/src/components/AppliesTo';
+import { FieldAnchor } from '@site/src/components/FieldAnchor';
 
 export default {
   // Re-use the default mapping
   ...MDXComponents,
   AppliesTo,
+  FieldAnchor
 };


### PR DESCRIPTION
To explicitly handle the special field anchor component used in the webapp (https://github.com/airbytehq/airbyte-platform-internal/pull/9057), this PR is adding a dummy component for it in docusaurus.