### PR TITLE
✨ source-file: prevent local file usage on cloud deployment mode

### DIFF
--- a/airbyte-integrations/connectors/source-file/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-file/acceptance-test-config.yml
@@ -15,8 +15,6 @@ acceptance_tests:
       - config_path: "integration_tests/invalid_config.json"
         status: "failed"
       - config_path: "integration_tests/local_config.json"
-        status: "succeed"
-      - config_path: "integration_tests/local_config.json"
         deployment_mode: "cloud"
         status: "failed"
   discovery:

--- a/airbyte-integrations/connectors/source-file/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-file/acceptance-test-config.yml
@@ -6,11 +6,18 @@ acceptance_tests:
   spec:
     tests:
       - spec_path: "source_file/spec.json"
+      - spec_path: "integration_tests/cloud_spec.json"
+        deployment_mode: "cloud"
   connection:
     tests:
       - config_path: "integration_tests/config.json"
         status: "succeed"
       - config_path: "integration_tests/invalid_config.json"
+        status: "failed"
+      - config_path: "integration_tests/local_config.json"
+        status: "succeed"
+      - config_path: "integration_tests/local_config.json"
+        deployment_mode: "cloud"
         status: "failed"
   discovery:
     tests:

--- a/airbyte-integrations/connectors/source-file/integration_tests/cloud_spec.json
+++ b/airbyte-integrations/connectors/source-file/integration_tests/cloud_spec.json
@@ -1,0 +1,216 @@
+{
+  "documentationUrl": "https://docs.airbyte.com/integrations/sources/file",
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "File Source Spec",
+    "type": "object",
+    "additionalProperties": true,
+    "required": ["dataset_name", "format", "url", "provider"],
+    "properties": {
+      "dataset_name": {
+        "type": "string",
+        "title": "Dataset Name",
+        "description": "The Name of the final table to replicate this file into (should include letters, numbers dash and underscores only)."
+      },
+      "format": {
+        "type": "string",
+        "enum": [
+          "csv",
+          "json",
+          "jsonl",
+          "excel",
+          "excel_binary",
+          "feather",
+          "parquet",
+          "yaml"
+        ],
+        "default": "csv",
+        "title": "File Format",
+        "description": "The Format of the file which should be replicated (Warning: some formats may be experimental, please refer to the docs)."
+      },
+      "reader_options": {
+        "type": "string",
+        "title": "Reader Options",
+        "description": "This should be a string in JSON format. It depends on the chosen file format to provide additional options and tune its behavior.",
+        "examples": [
+          "{}",
+          "{\"sep\": \" \"}",
+          "{\"sep\": \"\t\", \"header\": 0, \"names\": [\"column1\", \"column2\"] }"
+        ]
+      },
+      "url": {
+        "type": "string",
+        "title": "URL",
+        "description": "The URL path to access the file which should be replicated.",
+        "examples": [
+          "https://storage.googleapis.com/covid19-open-data/v2/latest/epidemiology.csv",
+          "gs://my-google-bucket/data.csv",
+          "s3://gdelt-open-data/events/20190914.export.csv"
+        ]
+      },
+      "provider": {
+        "type": "object",
+        "title": "Storage Provider",
+        "description": "The storage Provider or Location of the file(s) which should be replicated.",
+        "default": "Public Web",
+        "oneOf": [
+          {
+            "title": "HTTPS: Public Web",
+            "required": ["storage"],
+            "properties": {
+              "storage": { "type": "string", "const": "HTTPS" },
+              "user_agent": {
+                "type": "boolean",
+                "title": "User-Agent",
+                "default": false,
+                "description": "Add User-Agent to request"
+              }
+            }
+          },
+          {
+            "title": "GCS: Google Cloud Storage",
+            "required": ["storage"],
+            "properties": {
+              "storage": {
+                "type": "string",
+                "title": "Storage",
+                "const": "GCS"
+              },
+              "service_account_json": {
+                "type": "string",
+                "title": "Service Account JSON",
+                "airbyte_secret": true,
+                "description": "In order to access private Buckets stored on Google Cloud, this connector would need a service account json credentials with the proper permissions as described <a href=\"https://cloud.google.com/iam/docs/service-accounts\" target=\"_blank\">here</a>. Please generate the credentials.json file and copy/paste its content to this field (expecting JSON formats). If accessing publicly available data, this field is not necessary."
+              }
+            }
+          },
+          {
+            "title": "S3: Amazon Web Services",
+            "required": ["storage"],
+            "properties": {
+              "storage": {
+                "type": "string",
+                "title": "Storage",
+                "const": "S3"
+              },
+              "aws_access_key_id": {
+                "type": "string",
+                "title": "AWS Access Key ID",
+                "description": "In order to access private Buckets stored on AWS S3, this connector would need credentials with the proper permissions. If accessing publicly available data, this field is not necessary."
+              },
+              "aws_secret_access_key": {
+                "type": "string",
+                "title": "AWS Secret Access Key",
+                "description": "In order to access private Buckets stored on AWS S3, this connector would need credentials with the proper permissions. If accessing publicly available data, this field is not necessary.",
+                "airbyte_secret": true
+              }
+            }
+          },
+          {
+            "title": "AzBlob: Azure Blob Storage",
+            "required": ["storage", "storage_account"],
+            "properties": {
+              "storage": {
+                "type": "string",
+                "title": "Storage",
+                "const": "AzBlob"
+              },
+              "storage_account": {
+                "type": "string",
+                "title": "Storage Account",
+                "description": "The globally unique name of the storage account that the desired blob sits within. See <a href=\"https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview\" target=\"_blank\">here</a> for more details."
+              },
+              "sas_token": {
+                "type": "string",
+                "title": "SAS Token",
+                "description": "To access Azure Blob Storage, this connector would need credentials with the proper permissions. One option is a SAS (Shared Access Signature) token. If accessing publicly available data, this field is not necessary.",
+                "airbyte_secret": true
+              },
+              "shared_key": {
+                "type": "string",
+                "title": "Shared Key",
+                "description": "To access Azure Blob Storage, this connector would need credentials with the proper permissions. One option is a storage account shared key (aka account key or access key). If accessing publicly available data, this field is not necessary.",
+                "airbyte_secret": true
+              }
+            }
+          },
+          {
+            "title": "SSH: Secure Shell",
+            "required": ["storage", "user", "host"],
+            "properties": {
+              "storage": {
+                "type": "string",
+                "title": "Storage",
+                "const": "SSH"
+              },
+              "user": { "type": "string", "title": "User", "description": "" },
+              "password": {
+                "type": "string",
+                "title": "Password",
+                "description": "",
+                "airbyte_secret": true
+              },
+              "host": { "type": "string", "title": "Host", "description": "" },
+              "port": {
+                "type": "string",
+                "title": "Port",
+                "default": "22",
+                "description": ""
+              }
+            }
+          },
+          {
+            "title": "SCP: Secure copy protocol",
+            "required": ["storage", "user", "host"],
+            "properties": {
+              "storage": {
+                "type": "string",
+                "title": "Storage",
+                "const": "SCP"
+              },
+              "user": { "type": "string", "title": "User", "description": "" },
+              "password": {
+                "type": "string",
+                "title": "Password",
+                "description": "",
+                "airbyte_secret": true
+              },
+              "host": { "type": "string", "title": "Host", "description": "" },
+              "port": {
+                "type": "string",
+                "title": "Port",
+                "default": "22",
+                "description": ""
+              }
+            }
+          },
+          {
+            "title": "SFTP: Secure File Transfer Protocol",
+            "required": ["storage", "user", "host"],
+            "properties": {
+              "storage": {
+                "type": "string",
+                "title": "Storage",
+                "const": "SFTP"
+              },
+              "user": { "type": "string", "title": "User", "description": "" },
+              "password": {
+                "type": "string",
+                "title": "Password",
+                "description": "",
+                "airbyte_secret": true
+              },
+              "host": { "type": "string", "title": "Host", "description": "" },
+              "port": {
+                "type": "string",
+                "title": "Port",
+                "default": "22",
+                "description": ""
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-file/integration_tests/local_config.json
+++ b/airbyte-integrations/connectors/source-file/integration_tests/local_config.json
@@ -1,0 +1,9 @@
+{
+  "dataset_name": "test",
+  "format": "csv",
+  "reader_options": "{\"bla\": \",\", \"nrows\": 20}",
+  "url": "file:///tmp/fake_file.csv",
+  "provider": {
+    "storage": "local"
+  }
+}

--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
-  dockerImageTag: 0.3.13
+  dockerImageTag: 0.3.14
   dockerRepository: airbyte/source-file
   githubIssueLabel: source-file
   icon: file.svg

--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -15,8 +15,6 @@ data:
   name: File (CSV, JSON, Excel, Feather, Parquet)
   registries:
     cloud:
-      dockerRepository: airbyte/source-file-secure
-      dockerImageTag: 0.3.13 # Dont forget to publish source-file-secure as well when updating this.
       enabled: true
     oss:
       enabled: true

--- a/airbyte-integrations/connectors/source-file/setup.py
+++ b/airbyte-integrations/connectors/source-file/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.2",
+    "airbyte-cdk~=0.51.25",
     "gcsfs==2022.7.1",
     "genson==1.2.2",
     "google-cloud-storage==2.5.0",

--- a/airbyte-integrations/connectors/source-file/source_file/client.py
+++ b/airbyte-integrations/connectors/source-file/source_file/client.py
@@ -36,7 +36,7 @@ from paramiko import SSHException
 from urllib3.exceptions import ProtocolError
 from yaml import safe_load
 
-from .utils import backoff_handler, LOCAL_STORAGE_NAME
+from .utils import LOCAL_STORAGE_NAME, backoff_handler
 
 SSH_TIMEOUT = 60
 

--- a/airbyte-integrations/connectors/source-file/source_file/client.py
+++ b/airbyte-integrations/connectors/source-file/source_file/client.py
@@ -24,7 +24,7 @@ import smart_open
 import smart_open.ssh
 from airbyte_cdk.entrypoint import logger
 from airbyte_cdk.models import AirbyteStream, FailureType, SyncMode
-from airbyte_cdk.utils import AirbyteTracedException
+from airbyte_cdk.utils import AirbyteTracedException, is_cloud_environment
 from azure.storage.blob import BlobServiceClient
 from genson import SchemaBuilder
 from google.cloud.storage import Client as GCSClient
@@ -36,7 +36,7 @@ from paramiko import SSHException
 from urllib3.exceptions import ProtocolError
 from yaml import safe_load
 
-from .utils import backoff_handler
+from .utils import backoff_handler, LOCAL_STORAGE_NAME
 
 SSH_TIMEOUT = 60
 
@@ -252,7 +252,6 @@ class Client:
     """Class that manages reading and parsing data from streams"""
 
     CSV_CHUNK_SIZE = 10_000
-    reader_class = URLFile
     binary_formats = {"excel", "excel_binary", "feather", "parquet", "orc", "pickle"}
 
     def __init__(self, dataset_name: str, url: str, provider: dict, format: str = None, reader_options: dict = None):
@@ -263,6 +262,13 @@ class Client:
         self._reader_options = reader_options or {}
         self.binary_source = self._reader_format in self.binary_formats
         self.encoding = self._reader_options.get("encoding")
+
+    @property
+    def reader_class(self):
+        if is_cloud_environment():
+            return URLFileSecure
+
+        return URLFile
 
     @property
     def stream_name(self) -> str:
@@ -497,3 +503,15 @@ class Client:
                 df = pd.DataFrame(data=(next(data) for _ in range(start, min(start + step, end))), columns=cols)
                 yield df
                 start += step
+
+
+class URLFileSecure(URLFile):
+    """Updating of default logic:
+    This connector shouldn't work with local files.
+    """
+
+    def __init__(self, url: str, provider: dict, binary=None, encoding=None):
+        storage_name = provider["storage"].lower()
+        if url.startswith("file://") or storage_name == LOCAL_STORAGE_NAME:
+            raise RuntimeError("the local file storage is not supported by this connector.")
+        super().__init__(url, provider, binary, encoding)

--- a/airbyte-integrations/connectors/source-file/source_file/source.py
+++ b/airbyte-integrations/connectors/source-file/source_file/source.py
@@ -26,7 +26,7 @@ from airbyte_cdk.sources import Source
 from airbyte_cdk.utils import AirbyteTracedException, is_cloud_environment
 
 from .client import Client
-from .utils import dropbox_force_download, LOCAL_STORAGE_NAME
+from .utils import LOCAL_STORAGE_NAME, dropbox_force_download
 
 
 class SourceFile(Source):

--- a/airbyte-integrations/connectors/source-file/source_file/source.py
+++ b/airbyte-integrations/connectors/source-file/source_file/source.py
@@ -17,15 +17,16 @@ from airbyte_cdk.models import (
     AirbyteMessage,
     AirbyteRecordMessage,
     ConfiguredAirbyteCatalog,
+    ConnectorSpecification,
     FailureType,
     Status,
     Type,
 )
 from airbyte_cdk.sources import Source
-from airbyte_cdk.utils import AirbyteTracedException
+from airbyte_cdk.utils import AirbyteTracedException, is_cloud_environment
 
 from .client import Client
-from .utils import dropbox_force_download
+from .utils import dropbox_force_download, LOCAL_STORAGE_NAME
 
 
 class SourceFile(Source):
@@ -104,6 +105,26 @@ class SourceFile(Source):
             message = f'Failed to load {config["url"]}: please use the Official Google Sheets Source connector'
             raise AirbyteTracedException(message=message, internal_message=message, failure_type=FailureType.config_error)
         return config
+
+    def spec(self, logger: AirbyteLogger) -> ConnectorSpecification:
+        """Returns the json schema for the spec"""
+        spec = super().spec(logger)
+
+        # override cloud spec to remove local file support
+        if is_cloud_environment():
+            for provider in spec.connectionSpecification["properties"]["provider"]["oneOf"]:
+                storage = provider["properties"]["storage"]
+
+            if "enum" in storage:
+                storage.pop("enum")
+                storage["const"] = storage.pop("default")
+
+            for i in range(len(spec.connectionSpecification["properties"]["provider"]["oneOf"])):
+                provider = spec.connectionSpecification["properties"]["provider"]["oneOf"][i]
+                if provider["properties"]["storage"]["const"] == LOCAL_STORAGE_NAME:
+                    spec.connectionSpecification["properties"]["provider"]["oneOf"].pop(i)
+
+        return spec
 
     def check(self, logger, config: Mapping) -> AirbyteConnectionStatus:
         """

--- a/airbyte-integrations/connectors/source-file/source_file/source.py
+++ b/airbyte-integrations/connectors/source-file/source_file/source.py
@@ -112,13 +112,6 @@ class SourceFile(Source):
 
         # override cloud spec to remove local file support
         if is_cloud_environment():
-            for provider in spec.connectionSpecification["properties"]["provider"]["oneOf"]:
-                storage = provider["properties"]["storage"]
-
-            if "enum" in storage:
-                storage.pop("enum")
-                storage["const"] = storage.pop("default")
-
             for i in range(len(spec.connectionSpecification["properties"]["provider"]["oneOf"])):
                 provider = spec.connectionSpecification["properties"]["provider"]["oneOf"][i]
                 if provider["properties"]["storage"]["const"] == LOCAL_STORAGE_NAME:

--- a/airbyte-integrations/connectors/source-file/source_file/utils.py
+++ b/airbyte-integrations/connectors/source-file/source_file/utils.py
@@ -10,6 +10,7 @@ logger = logging.getLogger("airbyte")
 
 LOCAL_STORAGE_NAME = "local"
 
+
 def dropbox_force_download(url):
     """
     https://help.dropbox.com/share/force-download

--- a/airbyte-integrations/connectors/source-file/source_file/utils.py
+++ b/airbyte-integrations/connectors/source-file/source_file/utils.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 # default logger
 logger = logging.getLogger("airbyte")
 
+LOCAL_STORAGE_NAME = "local"
 
 def dropbox_force_download(url):
     """

--- a/docs/integrations/sources/file.md
+++ b/docs/integrations/sources/file.md
@@ -214,61 +214,62 @@ In order to read large files from a remote location, this connector uses the [sm
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                                                                                                 |
-|:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------|
-| 0.3.13  | 2023-10-12 | [31341](https://github.com/airbytehq/airbyte/pull/31341) | Build from airbyte/python-connector-base:1.0.0                                                                |
-| 0.3.12  | 2023-09-19 | [30579](https://github.com/airbytehq/airbyte/pull/30579) | Add ParserError handling for `discovery`                                                                |
-| 0.3.11  | 2023-06-08 | [27157](https://github.com/airbytehq/airbyte/pull/27157) | Force smart open log level to ERROR                                                                     |
-| 0.3.10  | 2023-06-07 | [27107](https://github.com/airbytehq/airbyte/pull/27107) | Make source-file testable in our new airbyte-ci pipelines                                               |
-| 0.3.9   | 2023-05-18 | [26275](https://github.com/airbytehq/airbyte/pull/26275) | Add ParserError handling                                                                                |
-| 0.3.8   | 2023-05-17 | [26210](https://github.com/airbytehq/airbyte/pull/26210) | Bugfix for https://github.com/airbytehq/airbyte/pull/26115                                              |
-| 0.3.7   | 2023-05-16 | [26131](https://github.com/airbytehq/airbyte/pull/26131) | Re-release source-file to be in sync with source-file-secure                                            |
-| 0.3.6   | 2023-05-16 | [26115](https://github.com/airbytehq/airbyte/pull/26115) | Add retry on SSHException('Error reading SSH protocol banner')                                          |
-| 0.3.5   | 2023-05-16 | [26117](https://github.com/airbytehq/airbyte/pull/26117) | Check if reader options is a valid JSON object                                                          |
-| 0.3.4   | 2023-05-10 | [25965](https://github.com/airbytehq/airbyte/pull/25965) | fix Pandas date-time parsing to airbyte type                                                            |
-| 0.3.3   | 2023-05-04 | [25819](https://github.com/airbytehq/airbyte/pull/25819) | GCP service_account_json is a secret                                                                    |
-| 0.3.2   | 2023-05-01 | [25641](https://github.com/airbytehq/airbyte/pull/25641) | Handle network errors                                                                                   |
-| 0.3.1   | 2023-04-27 | [25575](https://github.com/airbytehq/airbyte/pull/25575) | Fix OOM; read Excel files in chunks using `openpyxl`                                                    |
-| 0.3.0   | 2023-04-24 | [25445](https://github.com/airbytehq/airbyte/pull/25445) | Add datatime format parsing support for csv files                                                       |
-| 0.2.38  | 2023-04-12 | [23759](https://github.com/airbytehq/airbyte/pull/23759) | Fix column data types for numerical values                                                              |
-| 0.2.37  | 2023-04-06 | [24525](https://github.com/airbytehq/airbyte/pull/24525) | Fix examples in spec                                                                                    |
-| 0.2.36  | 2023-03-27 | [24588](https://github.com/airbytehq/airbyte/pull/24588) | Remove traceback from user messages.                                                                    |
-| 0.2.35  | 2023-03-03 | [24278](https://github.com/airbytehq/airbyte/pull/24278) | Read only file header when checking connectivity; read only a single chunk when discovering the schema. |
-| 0.2.34  | 2023-03-03 | [23723](https://github.com/airbytehq/airbyte/pull/23723) | Update description in spec, make user-friendly error messages and docs.                                 |
-| 0.2.33  | 2023-01-04 | [21012](https://github.com/airbytehq/airbyte/pull/21012) | Fix special characters bug                                                                              |
-| 0.2.32  | 2022-12-21 | [20740](https://github.com/airbytehq/airbyte/pull/20740) | Source File: increase SSH timeout to 60s                                                                |
-| 0.2.31  | 2022-11-17 | [19567](https://github.com/airbytehq/airbyte/pull/19567) | Source File: bump 0.2.31                                                                                |
-| 0.2.30  | 2022-11-10 | [19222](https://github.com/airbytehq/airbyte/pull/19222) | Use AirbyteConnectionStatus for "check" command                                                         |
-| 0.2.29  | 2022-11-08 | [18587](https://github.com/airbytehq/airbyte/pull/18587) | Fix pandas read_csv header none issue.                                                                  |
-| 0.2.28  | 2022-10-27 | [18428](https://github.com/airbytehq/airbyte/pull/18428) | Add retry logic for `Connection reset error - 104`                                                      |
-| 0.2.27  | 2022-10-26 | [18481](https://github.com/airbytehq/airbyte/pull/18481) | Fix check for wrong format                                                                              |
-| 0.2.26  | 2022-10-18 | [18116](https://github.com/airbytehq/airbyte/pull/18116) | Transform Dropbox shared link                                                                           |
-| 0.2.25  | 2022-10-14 | [17994](https://github.com/airbytehq/airbyte/pull/17994) | Handle `UnicodeDecodeError` during discover step.                                                       |
-| 0.2.24  | 2022-10-03 | [17504](https://github.com/airbytehq/airbyte/pull/17504) | Validate data for `HTTPS` while `check_connection`                                                      |
-| 0.2.23  | 2022-09-28 | [17304](https://github.com/airbytehq/airbyte/pull/17304) | Migrate to per-stream state.                                                                            |
-| 0.2.22  | 2022-09-15 | [16772](https://github.com/airbytehq/airbyte/pull/16772) | Fix schema generation for JSON files containing arrays                                                  |
-| 0.2.21  | 2022-08-26 | [15568](https://github.com/airbytehq/airbyte/pull/15568) | Specify `pyxlsb` library for Excel Binary Workbook files                                                |
-| 0.2.20  | 2022-08-23 | [15870](https://github.com/airbytehq/airbyte/pull/15870) | Fix CSV schema discovery                                                                                |
-| 0.2.19  | 2022-08-19 | [15768](https://github.com/airbytehq/airbyte/pull/15768) | Convert 'nan' to 'null'                                                                                 |
-| 0.2.18  | 2022-08-16 | [15698](https://github.com/airbytehq/airbyte/pull/15698) | Cache binary stream to file for discover                                                                |
-| 0.2.17  | 2022-08-11 | [15501](https://github.com/airbytehq/airbyte/pull/15501) | Cache binary stream to file                                                                             |
-| 0.2.16  | 2022-08-10 | [15293](https://github.com/airbytehq/airbyte/pull/15293) | Add support for encoding reader option                                                                  |
-| 0.2.15  | 2022-08-05 | [15269](https://github.com/airbytehq/airbyte/pull/15269) | Bump `smart-open` version to 6.0.0                                                                      |
-| 0.2.12  | 2022-07-12 | [14535](https://github.com/airbytehq/airbyte/pull/14535) | Fix invalid schema generation for JSON files                                                            |
-| 0.2.11  | 2022-07-12 | [9974](https://github.com/airbytehq/airbyte/pull/14588)  | Add support to YAML format                                                                              |
-| 0.2.9   | 2022-02-01 | [9974](https://github.com/airbytehq/airbyte/pull/9974)   | Update airbyte-cdk 0.1.47                                                                               |
-| 0.2.8   | 2021-12-06 | [8524](https://github.com/airbytehq/airbyte/pull/8524)   | Update connector fields title/description                                                               |
-| 0.2.7   | 2021-10-28 | [7387](https://github.com/airbytehq/airbyte/pull/7387)   | Migrate source to CDK structure, add SAT testing.                                                       |
-| 0.2.6   | 2021-08-26 | [5613](https://github.com/airbytehq/airbyte/pull/5613)   | Add support to xlsb format                                                                              |
-| 0.2.5   | 2021-07-26 | [4953](https://github.com/airbytehq/airbyte/pull/4953)   | Allow non-default port for SFTP type                                                                    |
-| 0.2.4   | 2021-06-09 | [3973](https://github.com/airbytehq/airbyte/pull/3973)   | Add AIRBYTE_ENTRYPOINT for Kubernetes support                                                           |
-| 0.2.3   | 2021-06-01 | [3771](https://github.com/airbytehq/airbyte/pull/3771)   | Add Azure Storage Blob Files option                                                                     |
-| 0.2.2   | 2021-04-16 | [2883](https://github.com/airbytehq/airbyte/pull/2883)   | Fix CSV discovery memory consumption                                                                    |
-| 0.2.1   | 2021-04-03 | [2726](https://github.com/airbytehq/airbyte/pull/2726)   | Fix base connector versioning                                                                           |
-| 0.2.0   | 2021-03-09 | [2238](https://github.com/airbytehq/airbyte/pull/2238)   | Protocol allows future/unknown properties                                                               |
-| 0.1.10  | 2021-02-18 | [2118](https://github.com/airbytehq/airbyte/pull/2118)   | Support JSONL format                                                                                    |
-| 0.1.9   | 2021-02-02 | [1768](https://github.com/airbytehq/airbyte/pull/1768)   | Add test cases for all formats                                                                          |
-| 0.1.8   | 2021-01-27 | [1738](https://github.com/airbytehq/airbyte/pull/1738)   | Adopt connector best practices                                                                          |
-| 0.1.7   | 2020-12-16 | [1331](https://github.com/airbytehq/airbyte/pull/1331)   | Refactor Python base connector                                                                          |
-| 0.1.6   | 2020-12-08 | [1249](https://github.com/airbytehq/airbyte/pull/1249)   | Handle NaN values                                                                                       |
-| 0.1.5   | 2020-11-30 | [1046](https://github.com/airbytehq/airbyte/pull/1046)   | Add connectors using an index YAML file                                                                 |
+| Version | Date       | Pull Request                                             | Subject                                                                                                    |
+|:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------|
+| 0.3.14  | 2023-10-13 | [30984](https://github.com/airbytehq/airbyte/pull/30984) | Prevent local file usage on cloud                                                                          |
+| 0.3.13  | 2023-10-12 | [31341](https://github.com/airbytehq/airbyte/pull/31341) | Build from airbyte/python-connector-base:1.0.0                                                             |
+| 0.3.12  | 2023-09-19 | [30579](https://github.com/airbytehq/airbyte/pull/30579) | Add ParserError handling for `discovery`                                                                   |
+| 0.3.11  | 2023-06-08 | [27157](https://github.com/airbytehq/airbyte/pull/27157) | Force smart open log level to ERROR                                                                        |
+| 0.3.10  | 2023-06-07 | [27107](https://github.com/airbytehq/airbyte/pull/27107) | Make source-file testable in our new airbyte-ci pipelines                                                  |
+| 0.3.9   | 2023-05-18 | [26275](https://github.com/airbytehq/airbyte/pull/26275) | Add ParserError handling                                                                                   |
+| 0.3.8   | 2023-05-17 | [26210](https://github.com/airbytehq/airbyte/pull/26210) | Bugfix for https://github.com/airbytehq/airbyte/pull/26115                                                 |
+| 0.3.7   | 2023-05-16 | [26131](https://github.com/airbytehq/airbyte/pull/26131) | Re-release source-file to be in sync with source-file-secure                                               |
+| 0.3.6   | 2023-05-16 | [26115](https://github.com/airbytehq/airbyte/pull/26115) | Add retry on SSHException('Error reading SSH protocol banner')                                             |
+| 0.3.5   | 2023-05-16 | [26117](https://github.com/airbytehq/airbyte/pull/26117) | Check if reader options is a valid JSON object                                                             |
+| 0.3.4   | 2023-05-10 | [25965](https://github.com/airbytehq/airbyte/pull/25965) | fix Pandas date-time parsing to airbyte type                                                               |
+| 0.3.3   | 2023-05-04 | [25819](https://github.com/airbytehq/airbyte/pull/25819) | GCP service_account_json is a secret                                                                       |
+| 0.3.2   | 2023-05-01 | [25641](https://github.com/airbytehq/airbyte/pull/25641) | Handle network errors                                                                                      |
+| 0.3.1   | 2023-04-27 | [25575](https://github.com/airbytehq/airbyte/pull/25575) | Fix OOM; read Excel files in chunks using `openpyxl`                                                       |
+| 0.3.0   | 2023-04-24 | [25445](https://github.com/airbytehq/airbyte/pull/25445) | Add datatime format parsing support for csv files                                                          |
+| 0.2.38  | 2023-04-12 | [23759](https://github.com/airbytehq/airbyte/pull/23759) | Fix column data types for numerical values                                                                 |
+| 0.2.37  | 2023-04-06 | [24525](https://github.com/airbytehq/airbyte/pull/24525) | Fix examples in spec                                                                                       |
+| 0.2.36  | 2023-03-27 | [24588](https://github.com/airbytehq/airbyte/pull/24588) | Remove traceback from user messages.                                                                       |
+| 0.2.35  | 2023-03-03 | [24278](https://github.com/airbytehq/airbyte/pull/24278) | Read only file header when checking connectivity; read only a single chunk when discovering the schema.    |
+| 0.2.34  | 2023-03-03 | [23723](https://github.com/airbytehq/airbyte/pull/23723) | Update description in spec, make user-friendly error messages and docs.                                    |
+| 0.2.33  | 2023-01-04 | [21012](https://github.com/airbytehq/airbyte/pull/21012) | Fix special characters bug                                                                                 |
+| 0.2.32  | 2022-12-21 | [20740](https://github.com/airbytehq/airbyte/pull/20740) | Source File: increase SSH timeout to 60s                                                                   |
+| 0.2.31  | 2022-11-17 | [19567](https://github.com/airbytehq/airbyte/pull/19567) | Source File: bump 0.2.31                                                                                   |
+| 0.2.30  | 2022-11-10 | [19222](https://github.com/airbytehq/airbyte/pull/19222) | Use AirbyteConnectionStatus for "check" command                                                            |
+| 0.2.29  | 2022-11-08 | [18587](https://github.com/airbytehq/airbyte/pull/18587) | Fix pandas read_csv header none issue.                                                                     |
+| 0.2.28  | 2022-10-27 | [18428](https://github.com/airbytehq/airbyte/pull/18428) | Add retry logic for `Connection reset error - 104`                                                         |
+| 0.2.27  | 2022-10-26 | [18481](https://github.com/airbytehq/airbyte/pull/18481) | Fix check for wrong format                                                                                 |
+| 0.2.26  | 2022-10-18 | [18116](https://github.com/airbytehq/airbyte/pull/18116) | Transform Dropbox shared link                                                                              |
+| 0.2.25  | 2022-10-14 | [17994](https://github.com/airbytehq/airbyte/pull/17994) | Handle `UnicodeDecodeError` during discover step.                                                          |
+| 0.2.24  | 2022-10-03 | [17504](https://github.com/airbytehq/airbyte/pull/17504) | Validate data for `HTTPS` while `check_connection`                                                         |
+| 0.2.23  | 2022-09-28 | [17304](https://github.com/airbytehq/airbyte/pull/17304) | Migrate to per-stream state.                                                                               |
+| 0.2.22  | 2022-09-15 | [16772](https://github.com/airbytehq/airbyte/pull/16772) | Fix schema generation for JSON files containing arrays                                                     |
+| 0.2.21  | 2022-08-26 | [15568](https://github.com/airbytehq/airbyte/pull/15568) | Specify `pyxlsb` library for Excel Binary Workbook files                                                   |
+| 0.2.20  | 2022-08-23 | [15870](https://github.com/airbytehq/airbyte/pull/15870) | Fix CSV schema discovery                                                                                   |
+| 0.2.19  | 2022-08-19 | [15768](https://github.com/airbytehq/airbyte/pull/15768) | Convert 'nan' to 'null'                                                                                    |
+| 0.2.18  | 2022-08-16 | [15698](https://github.com/airbytehq/airbyte/pull/15698) | Cache binary stream to file for discover                                                                   |
+| 0.2.17  | 2022-08-11 | [15501](https://github.com/airbytehq/airbyte/pull/15501) | Cache binary stream to file                                                                                |
+| 0.2.16  | 2022-08-10 | [15293](https://github.com/airbytehq/airbyte/pull/15293) | Add support for encoding reader option                                                                     |
+| 0.2.15  | 2022-08-05 | [15269](https://github.com/airbytehq/airbyte/pull/15269) | Bump `smart-open` version to 6.0.0                                                                         |
+| 0.2.12  | 2022-07-12 | [14535](https://github.com/airbytehq/airbyte/pull/14535) | Fix invalid schema generation for JSON files                                                               |
+| 0.2.11  | 2022-07-12 | [9974](https://github.com/airbytehq/airbyte/pull/14588)  | Add support to YAML format                                                                                 |
+| 0.2.9   | 2022-02-01 | [9974](https://github.com/airbytehq/airbyte/pull/9974)   | Update airbyte-cdk 0.1.47                                                                                  |
+| 0.2.8   | 2021-12-06 | [8524](https://github.com/airbytehq/airbyte/pull/8524)   | Update connector fields title/description                                                                  |
+| 0.2.7   | 2021-10-28 | [7387](https://github.com/airbytehq/airbyte/pull/7387)   | Migrate source to CDK structure, add SAT testing.                                                          |
+| 0.2.6   | 2021-08-26 | [5613](https://github.com/airbytehq/airbyte/pull/5613)   | Add support to xlsb format                                                                                 |
+| 0.2.5   | 2021-07-26 | [4953](https://github.com/airbytehq/airbyte/pull/4953)   | Allow non-default port for SFTP type                                                                       |
+| 0.2.4   | 2021-06-09 | [3973](https://github.com/airbytehq/airbyte/pull/3973)   | Add AIRBYTE_ENTRYPOINT for Kubernetes support                                                              |
+| 0.2.3   | 2021-06-01 | [3771](https://github.com/airbytehq/airbyte/pull/3771)   | Add Azure Storage Blob Files option                                                                        |
+| 0.2.2   | 2021-04-16 | [2883](https://github.com/airbytehq/airbyte/pull/2883)   | Fix CSV discovery memory consumption                                                                       |
+| 0.2.1   | 2021-04-03 | [2726](https://github.com/airbytehq/airbyte/pull/2726)   | Fix base connector versioning                                                                              |
+| 0.2.0   | 2021-03-09 | [2238](https://github.com/airbytehq/airbyte/pull/2238)   | Protocol allows future/unknown properties                                                                  |
+| 0.1.10  | 2021-02-18 | [2118](https://github.com/airbytehq/airbyte/pull/2118)   | Support JSONL format                                                                                       |
+| 0.1.9   | 2021-02-02 | [1768](https://github.com/airbytehq/airbyte/pull/1768)   | Add test cases for all formats                                                                             |
+| 0.1.8   | 2021-01-27 | [1738](https://github.com/airbytehq/airbyte/pull/1738)   | Adopt connector best practices                                                                             |
+| 0.1.7   | 2020-12-16 | [1331](https://github.com/airbytehq/airbyte/pull/1331)   | Refactor Python base connector                                                                             |
+| 0.1.6   | 2020-12-08 | [1249](https://github.com/airbytehq/airbyte/pull/1249)   | Handle NaN values                                                                                          |
+| 0.1.5   | 2020-11-30 | [1046](https://github.com/airbytehq/airbyte/pull/1046)   | Add connectors using an index YAML file                                                                    |


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

In order to remove `source-file-secure`, we need to integrate its funcionality to `source-file`. It uses the cdk helper introduced in https://github.com/airbytehq/airbyte/pull/30980 to adapt the connector's behavior depending on the deployment mode.

close #30625 

## How

Integrate source-file-secure:
- change spec behavior to remove local files on cloud deployment mode (logic from source-file-secure)
- update runtime behavior to error based on deployment mode if local files are used (logic from source-file-secure)
- add CAT tests based on deployment mode
