### PR TITLE
Snowflake Native Apps: update Linkedin Ads instructions; add permissions needed for running the app with tasks

### DIFF
--- a/docs/snowflake-native-apps/linkedin-ads.md
+++ b/docs/snowflake-native-apps/linkedin-ads.md
@@ -96,6 +96,12 @@ GRANT USAGE ON SCHEMA <your_schema> TO APPLICATION AIRBYTE_LINKEDIN_ADS;
 GRANT READ ON SECRET integration_linkedin_ads_oauth TO APPLICATION AIRBYTE_LINKEDIN_ADS;
 ```
 
+8. Grant permissions for the app to create a warehouse on which to execute sync tasks, and to execute tasks.
+```
+GRANT CREATE WAREHOUSE ON ACCOUNT TO APPLICATION AIRBYTE_LINKEDIN_ADS;
+GRANT EXECUTE TASK ON ACCOUNT TO APPLICATION AIRBYTE_LINKEDIN_ADS;
+```
+
 
 ## Configure a connection
 Once this is all set up, you can now configure a connection. To do so, use the Streamlit app by going in the `Apps` section and selecting `AIRBYTE_LINKEDIN_ADS`. You will have to accept the Anaconda terms in order to use Streamlit. 


### PR DESCRIPTION
Documentation update associated with https://github.com/airbytehq/snowflake-native-apps/pull/105; this shouldn't be merged until the the snowflake-native-apps PR is merged.

Adds instructions for setting permissions to create a warehouse and execute tasks.