### PR TITLE
source-google-ads: Fix type of `google_ads_campaign_budget`.`status`

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-ads/Dockerfile
@@ -13,5 +13,5 @@ COPY main.py ./
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.0.0
+LABEL io.airbyte.version=1.0.1
 LABEL io.airbyte.name=airbyte/source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: 1.0.0
+  dockerImageTag: 1.0.1
   dockerRepository: airbyte/source-google-ads
   githubIssueLabel: source-google-ads
   icon: google-adwords.svg

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/campaign_budget.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/campaign_budget.json
@@ -60,10 +60,7 @@
       "type": ["null", "string"]
     },
     "campaign_budget.status": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "string"]
-      }
+      "type": ["null", "string"]
     },
     "campaign_budget.total_amount_micros": {
       "type": ["null", "integer"]

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -48,6 +48,7 @@ A single access token can grant varying degrees of access to multiple APIs. A va
 The scope for the Google Ads API is: https://www.googleapis.com/auth/adwords
 
 Each Google Ads API developer token is assigned an access level and "permissible use". The access level determines whether you can affect production accounts and the number of operations and requests that you can execute daily. Permissible use determines the specific Google Ads API features that the developer token is allowed to use. Read more about it and apply for higher access [here](https://developers.google.com/google-ads/api/docs/access-levels#access_levels_2).
+
 ### Step 3: Set up the Google Ads connector in Airbyte
 
 <!-- /env:oss -->
@@ -103,7 +104,9 @@ The Google Ads source connector supports the following [sync modes](https://docs
 - [Incremental Sync - Append + Deduped](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped)
 
 #### Incremental Events Streams
+
 List of stream:
+
 - [ad_group_criterions](https://developers.google.com/google-ads/api/fields/v14/ad_group_criterion)
 - [ad_listing_group_criterions](https://developers.google.com/google-ads/api/fields/v14/ad_group_criterion)
 - [campaign_criterion](https://developers.google.com/google-ads/api/fields/v14/campaign_criterion)
@@ -115,6 +118,7 @@ The initial sync operates as a full refresh. Subsequent syncs begin by reading u
 :::warning
 It's important to note that the Google Ads API resource ChangeStatus has a limit of 10,000 records per request. That's why you cannot sync stream with more than 10,000 updates in a single microsecond. In such cases, it's recommended to use a full refresh sync to ensure all updates are captured.
 :::
+
 ## Supported Streams
 
 The Google Ads source connector can sync the following tables. It can also sync custom queries using GAQL.
@@ -132,7 +136,6 @@ The Google Ads source connector can sync the following tables. It can also sync 
 - [keyword](https://developers.google.com/google-ads/api/fields/v11/keyword_view)
 
 Note that `ad_groups`, `ad_group_ads`, and `campaigns` contain a `labels` field, which should be joined against their respective `*_labels` streams if you want to view the actual labels. For example, the `ad_groups` stream contains an `ad_group.labels` field, which you would join against the `ad_group_labels` stream's `label.resource_name` field.
-
 
 ### Report Tables
 
@@ -155,14 +158,14 @@ Due to Google Ads API constraints, the `click_view` stream retrieves data one da
 :::
 
 :::warning
-Google Ads doesn't support `PERFORMACE_MAX` campaigns on `ad_group` or `ad` stream level, only on `campaign` level. 
+Google Ads doesn't support `PERFORMACE_MAX` campaigns on `ad_group` or `ad` stream level, only on `campaign` level.
 If you have this type of campaign Google will remove them from the results for the `ads` reports.
 More [info](https://github.com/airbytehq/airbyte/issues/11062) and [Google Discussions](https://groups.google.com/g/adwords-api/c/_mxbgNckaLQ).
 :::
 
 For incremental streams, data is synced up to the previous day using your Google Ads account time zone since Google Ads can filter data only by [date](https://developers.google.com/google-ads/api/fields/v11/ad_group_ad#segments.date) without time. Also, some reports cannot load data real-time due to Google Ads [limitations](https://support.google.com/google-ads/answer/2544985?hl=en).
 
-### Reasoning Behind Primary Key Selection 
+### Reasoning Behind Primary Key Selection
 
 Primary keys are chosen to uniquely identify records within streams. In this selection, we considered the scope of ID uniqueness as detailed in [the Google Ads API structure documentation](https://developers.google.com/google-ads/api/docs/concepts/api-structure#object_ids). This approach guarantees that each record remains unique across various scopes and contexts. Moreover, in the Google Ads API, segmentation is crucial for dissecting performance data. As pointed out in [the Google Ads support documentation](https://developers.google.com/google-ads/api/docs/reporting/segmentation), segments offer a granular insight into data based on specific criteria, like device type or click interactions.
 
@@ -192,14 +195,13 @@ Follow Google's guidance on [Selectability between segments and metrics](https:/
 For an existing Google Ads source, when you are updating or removing Custom GAQL Queries, you should also subsequently refresh your source schema to pull in any changes.
 :::
 
-
 ## Difference between manager and client accounts
 
 A manager account isn't an "upgrade" of your Google Ads account. Instead, it's an entirely new Google Ads account you create. Think of a manager account as an umbrella Google Ads account with several individual Google Ads accounts linked to it. You can link new and existing Google Ads accounts, as well as other manager accounts.
 
 You can then monitor ad performance, update campaigns, and manage other account tasks for those client accounts. Your manager account can also be given ownership of a client account. This allows you to manage user access for the client account.
 
-[Link](https://support.google.com/google-ads/answer/6139186?hl=en#) for more details on how it works and how you can create it. 
+[Link](https://support.google.com/google-ads/answer/6139186?hl=en#) for more details on how it works and how you can create it.
 
 **Manager Accounts (MCC)** primarily focus on account management and oversight. They can access and manage multiple client accounts, view shared resources, and handle invitations to link with client accounts.
 
@@ -229,8 +231,9 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 ## Changelog
 
 | Version  | Date       | Pull Request                                             | Subject                                                                                                                              |
-|:---------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| `1.0.0`  | 2023-09-28  | [30705](https://github.com/airbytehq/airbyte/pull/30705) | Fix schemas for custom queries                                                                                                       |
+| :------- | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| `1.0.1`  | 2023-10-02 | [xxx](https://github.com/airbytehq/airbyte/pull/xxx)     | Fix type of `google_ads_campaign_budget`.`status`                                                                                    |
+| `1.0.0`  | 2023-09-28 | [30705](https://github.com/airbytehq/airbyte/pull/30705) | Fix schemas for custom queries                                                                                                       |
 | `0.11.1` | 2023-09-26 | [30758](https://github.com/airbytehq/airbyte/pull/30758) | Exception should not be raises if a stream is not found                                                                              |
 | `0.11.0` | 2023-09-23 | [30704](https://github.com/airbytehq/airbyte/pull/30704) | Update error handling                                                                                                                |
 | `0.10.0` | 2023-09-19 | [30091](https://github.com/airbytehq/airbyte/pull/30091) | Fix schemas for correct primary and foreign keys                                                                                     |

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -232,7 +232,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version  | Date       | Pull Request                                             | Subject                                                                                                                              |
 | :------- | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| `1.0.1`  | 2023-10-02 | [xxx](https://github.com/airbytehq/airbyte/pull/xxx)     | Fix type of `google_ads_campaign_budget`.`status`                                                                                    |
+| `1.0.1`  | 2023-10-02 | [30997](https://github.com/airbytehq/airbyte/pull/30997) | Fix type of `google_ads_campaign_budget`.`status`                                                                                    |
 | `1.0.0`  | 2023-09-28 | [30705](https://github.com/airbytehq/airbyte/pull/30705) | Fix schemas for custom queries                                                                                                       |
 | `0.11.1` | 2023-09-26 | [30758](https://github.com/airbytehq/airbyte/pull/30758) | Exception should not be raises if a stream is not found                                                                              |
 | `0.11.0` | 2023-09-23 | [30704](https://github.com/airbytehq/airbyte/pull/30704) | Update error handling                                                                                                                |


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/30988
Closes https://github.com/airbytehq/oncall/issues/3103 (source-google-ads)
Closes https://github.com/airbytehq/oncall/issues/3036 (source-google-ads)
Closes https://github.com/airbytehq/oncall/issues/3109 (source-google-ads)

Learn more in [Slack](https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1696273664990779)