### PR TITLE
Fix31015 typo in default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-issue-connector.yaml
+++ b/.github/ISSUE_TEMPLATE/1-issue-connector.yaml
@@ -61,7 +61,7 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Revelant information
+      label: Relevant information
       description: Please give any additional information you have and steps to reproduce the problem.
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/3-issue-cli.yaml
+++ b/.github/ISSUE_TEMPLATE/3-issue-cli.yaml
@@ -29,7 +29,7 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: relevant information
+      label: Relevant information
       description: Please give any additional information you have and steps to reproduce the problem.
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/3-issue-cli.yaml
+++ b/.github/ISSUE_TEMPLATE/3-issue-cli.yaml
@@ -29,7 +29,7 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Revelant information
+      label: relevant information
       description: Please give any additional information you have and steps to reproduce the problem.
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/5-feature-new-connector.yaml
+++ b/.github/ISSUE_TEMPLATE/5-feature-new-connector.yaml
@@ -20,7 +20,7 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Revelant Information
+      label: Relevant Information
       description: >-
         Why do you need this integration? How does your team intend to use the data? This helps us understand the use case.
         How often do you want to run syncs?

--- a/.github/ISSUE_TEMPLATE/6-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/6-feature-request.yaml
@@ -14,7 +14,7 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Revelant Information
+      label: Relevant Information
       description: >-
         What are you trying to do, and why is it hard? A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
         A clear and concise description of what you want to see happen, or the change you would like to see

--- a/.github/ISSUE_TEMPLATE/9-other.yaml
+++ b/.github/ISSUE_TEMPLATE/9-other.yaml
@@ -12,5 +12,5 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Revelant information
+      label: Relevant information
       description: Please give any aditional information.


### PR DESCRIPTION
## What
I noticed a minor typo in one of the default issue templates in this repository. The word "Revelant" is used instead of "Relevant." This typo exists in multiple issue templates. #31015 

## How
I have corrected the typo by changing "Revelant" to "Relevant" in the affected issue template(s).


## Why
This may seem like a minor issue, but maintaining high-quality documentation and templates is crucial for a project's professionalism and user experience.
With over 11k+ stars, it's essential to ensure that even small issues like typos are addressed to maintain the project's reputation.



