### PR TITLE
Vector DB CDK: Fix chunk size for openai embedder

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
@@ -159,7 +159,7 @@ class OpenAICompatibleEmbedder(Embedder):
         super().__init__()
         self.config = config
         # Client is set internally
-        self.embeddings = LocalAIEmbeddings(model=config.model_name, openai_api_key=config.api_key, openai_api_base=config.base_url, chunk_size=8191, max_retries=15)  # type: ignore
+        self.embeddings = LocalAIEmbeddings(model=config.model_name, openai_api_key=config.api_key, openai_api_base=config.base_url, max_retries=15)  # type: ignore
 
     def check(self) -> Optional[str]:
         deployment_mode = os.environ.get("DEPLOYMENT_MODE", "")

--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
@@ -96,7 +96,7 @@ class BaseOpenAIEmbedder(Embedder):
 
 class OpenAIEmbedder(BaseOpenAIEmbedder):
     def __init__(self, config: OpenAIEmbeddingConfigModel, chunk_size: int):
-        super().__init__(OpenAIEmbeddings(openai_api_key=config.openai_key, chunk_size=8191, max_retries=15), chunk_size)  # type: ignore
+        super().__init__(OpenAIEmbeddings(openai_api_key=config.openai_key, max_retries=15), chunk_size)  # type: ignore
 
 
 class AzureOpenAIEmbedder(BaseOpenAIEmbedder):


### PR DESCRIPTION
When creating embeddings, the OpenAI embedding API has three limits (taken from here: https://github.com/openai/openai-python/issues/519)
* The list of texts to embed is lower than 2048 elements.
* The total number of tokens across all list elements of the input parameter cannot exceed 1,000,000. (Because the rate limit is 1,000,000 tokens per minute.)
* Each individual text cannot be more than 8191 tokens

The second limit got fixed by https://github.com/airbytehq/airbyte/pull/30512

The third limit is never hit because of the processing step in the connector.


This PR is fixing the first issue. When originally implementing this, I confused the `chunk_size` parameter in the langchain embeddings wrapper with `embedding_ctx_length` and set it to a number that's too high for the actual API. I'm just reverting to the default of 1000, if necessary we can let the user configure this option manually in a later step.

