### PR TITLE
Airbyte CDK: fix none type binary error in parquet parser

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
@@ -95,7 +95,10 @@ class ParquetParser(FileTypeParser):
 
         # Decode binary strings to utf-8
         if ParquetParser._is_binary(parquet_value.type):
-            return parquet_value.as_py().decode("utf-8")
+            py_value = parquet_value.as_py()
+            if py_value is None:
+                return py_value
+            return py_value.decode("utf-8")
         if pa.types.is_decimal(parquet_value.type):
             if parquet_format.decimal_as_float:
                 return parquet_value.as_py()

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_parquet_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_parquet_parser.py
@@ -191,6 +191,14 @@ def test_value_dictionary() -> None:
     assert py_value == {"indices": [0, 1, 2, 0, 1], "values": ["apple", "banana", "cherry"]}
 
 
+def test_value_none_binary() -> None:
+    none_binary_scalar = pa.scalar(None, type=pa.binary())
+    try:
+        ParquetParser._to_output_value(none_binary_scalar, _default_parquet_format)
+    except AttributeError:
+        assert False, "`None` type binary should be handled properly"
+
+
 @pytest.mark.parametrize(
     "file_format",
     [


### PR DESCRIPTION
## What
*Issue: https://github.com/airbytehq/oncall/issues/3102. During `check_connection` it tries to read column which value is `None` and then decode it to utf-8 by making `None.decode("utf-8")`. It raises AttributeError as None type doesn't have `decode` attribute*

## How
*Fix parquet parser to handle case when column value is None*
