### PR TITLE
`#connector-publish-updates` is a clearer channel name for when connectors are published

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -44,5 +44,5 @@ jobs:
             > :warning: The publish slash command is now deprecated.<br>
             The connector publication happens on merge to the master branch.<br>
             Please use /legacy-publish if you need to publish normalization images.<br>
-            Please join the #publish-on-merge-updates slack channel to track ongoing publish pipelines.<br>
+            Please join the #connector-publish-updates slack channel to track ongoing publish pipelines.<br>
             Please reach out to the @dev-connector-ops team if you need support in publishing a connector.

--- a/airbyte-ci/connectors/pipelines/pipelines/commands/groups/connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/commands/groups/connectors.py
@@ -406,7 +406,7 @@ def build(ctx: click.Context, use_host_gradle_dist_tar: bool) -> bool:
     help="The Slack webhook URL to send notifications to.",
     type=click.STRING,
     envvar="SLACK_CHANNEL",
-    default="#publish-on-merge-updates",
+    default="#connector-publish-updates",
 )
 @click.pass_context
 def publish(


### PR DESCRIPTION
When this is merged, also rename the slack channel