### PR TITLE
Vector DB Destinations: Fix OpenAI batch size and Weaviate field name collision

### DIFF
--- a/airbyte-integrations/connectors/destination-chroma/Dockerfile
+++ b/airbyte-integrations/connectors/destination-chroma/Dockerfile
@@ -41,5 +41,5 @@ COPY destination_chroma ./destination_chroma
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.2
+LABEL io.airbyte.version=0.0.3
 LABEL io.airbyte.name=airbyte/destination-chroma

--- a/airbyte-integrations/connectors/destination-chroma/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-chroma/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 0b75218b-f702-4a28-85ac-34d3d84c0fc2
-  dockerImageTag: 0.0.2
+  dockerImageTag: 0.0.3
   dockerRepository: airbyte/destination-chroma
   githubIssueLabel: destination-chroma
   icon: chroma.svg

--- a/airbyte-integrations/connectors/destination-chroma/setup.py
+++ b/airbyte-integrations/connectors/destination-chroma/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk[vector-db-based]==0.51.22",
+    "airbyte-cdk[vector-db-based]==0.51.28",
     "chromadb",
 ]
 

--- a/airbyte-integrations/connectors/destination-milvus/Dockerfile
+++ b/airbyte-integrations/connectors/destination-milvus/Dockerfile
@@ -37,5 +37,5 @@ COPY destination_milvus ./destination_milvus
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.3
+LABEL io.airbyte.version=0.0.4
 LABEL io.airbyte.name=airbyte/destination-milvus

--- a/airbyte-integrations/connectors/destination-milvus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-milvus/metadata.yaml
@@ -20,7 +20,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 65de8962-48c9-11ee-be56-0242ac120002
-  dockerImageTag: 0.0.3
+  dockerImageTag: 0.0.4
   dockerRepository: airbyte/destination-milvus
   githubIssueLabel: destination-milvus
   icon: milvus.svg

--- a/airbyte-integrations/connectors/destination-milvus/setup.py
+++ b/airbyte-integrations/connectors/destination-milvus/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk[vector-db-based]==0.51.22", "pymilvus==2.3.0"]
+MAIN_REQUIREMENTS = ["airbyte-cdk[vector-db-based]==0.51.28", "pymilvus==2.3.0"]
 
 TEST_REQUIREMENTS = ["pytest~=6.2"]
 

--- a/airbyte-integrations/connectors/destination-pinecone/Dockerfile
+++ b/airbyte-integrations/connectors/destination-pinecone/Dockerfile
@@ -38,6 +38,6 @@ COPY destination_pinecone ./destination_pinecone
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.14
+LABEL io.airbyte.version=0.0.15
 
 LABEL io.airbyte.name=airbyte/destination-pinecone

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -20,7 +20,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 3d2b6f84-7f0d-4e3f-a5e5-7c7d4b50eabd
-  dockerImageTag: 0.0.14
+  dockerImageTag: 0.0.15
   dockerRepository: airbyte/destination-pinecone
   githubIssueLabel: destination-pinecone
   icon: pinecone.svg

--- a/airbyte-integrations/connectors/destination-pinecone/setup.py
+++ b/airbyte-integrations/connectors/destination-pinecone/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk[vector-db-based]==0.51.22",
+    "airbyte-cdk[vector-db-based]==0.51.28",
     "pinecone-client[grpc]",
 ]
 

--- a/airbyte-integrations/connectors/destination-qdrant/Dockerfile
+++ b/airbyte-integrations/connectors/destination-qdrant/Dockerfile
@@ -41,5 +41,5 @@ COPY destination_qdrant ./destination_qdrant
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.0.3
+LABEL io.airbyte.version=0.0.4
 LABEL io.airbyte.name=airbyte/destination-qdrant

--- a/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
@@ -20,7 +20,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 6eb1198a-6d38-43e5-aaaa-dccd8f71db2b
-  dockerImageTag: 0.0.3
+  dockerImageTag: 0.0.4
   dockerRepository: airbyte/destination-qdrant
   githubIssueLabel: destination-qdrant
   icon: qdrant.svg

--- a/airbyte-integrations/connectors/destination-qdrant/setup.py
+++ b/airbyte-integrations/connectors/destination-qdrant/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk[vector-db-based]==0.51.22", "qdrant-client", "fastembed"]
+MAIN_REQUIREMENTS = ["airbyte-cdk[vector-db-based]==0.51.28", "qdrant-client", "fastembed"]
 
 TEST_REQUIREMENTS = ["pytest~=6.2"]
 

--- a/airbyte-integrations/connectors/destination-weaviate/Dockerfile
+++ b/airbyte-integrations/connectors/destination-weaviate/Dockerfile
@@ -37,5 +37,5 @@ COPY destination_weaviate ./destination_weaviate
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/destination-weaviate

--- a/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
+++ b/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
@@ -146,7 +146,7 @@ class WeaviateIndexer(Indexer):
             normalized_key = key[0].lower() + key[1:]
             # "id" and "additional" are reserved properties in Weaviate, prefix to disambiguate
             if key == "id" or key == "_id" or key == "_additional":
-                normalized_key = f"__{key}"
+                normalized_key = f"raw_{key}"
             if isinstance(value, list) and len(value) == 0:
                 # Handling of empty list that's not part of defined schema otherwise Weaviate throws invalid string property
                 continue

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 7b7d7a0d-954c-45a0-bcfc-39a634b97736
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/destination-weaviate
   githubIssueLabel: destination-weaviate
   icon: weaviate.svg

--- a/airbyte-integrations/connectors/destination-weaviate/setup.py
+++ b/airbyte-integrations/connectors/destination-weaviate/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk[vector-db-based]==0.51.22", "weaviate-client==3.23.2"]
+MAIN_REQUIREMENTS = ["airbyte-cdk[vector-db-based]==0.51.28", "weaviate-client==3.23.2"]
 
 TEST_REQUIREMENTS = ["pytest~=6.2", "docker", "pytest-docker"]
 

--- a/docs/integrations/destinations/chroma.md
+++ b/docs/integrations/destinations/chroma.md
@@ -75,5 +75,6 @@ You should now have all the requirements needed to configure Chroma as a destina
 
 | Version | Date       | Pull Request                                               | Subject                                    |
 | :------ | :--------- | :--------------------------------------------------------- | :----------------------------------------- |
+| 0.0.3   | 2023-10-04 | [#31075](https://github.com/airbytehq/airbyte/pull/31075) | Fix OpenAI embedder batch size |
 | 0.0.2   | 2023-09-29 | [#30820](https://github.com/airbytehq/airbyte/pull/30820)     | Update CDK | 
 | 0.0.1   | 2023-09-08 | [#30023](https://github.com/airbytehq/airbyte/pull/30023) | 🎉 New Destination: Chroma (Vector Database)    |

--- a/docs/integrations/destinations/milvus.md
+++ b/docs/integrations/destinations/milvus.md
@@ -105,6 +105,7 @@ vector_store.similarity_search("test")
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.0.4   | 2023-10-04 | [#31075](https://github.com/airbytehq/airbyte/pull/31075) | Fix OpenAI embedder batch size |
 | 0.0.3   | 2023-09-29 | [#30820](https://github.com/airbytehq/airbyte/pull/30820)     | Update CDK | 
 | 0.0.2   | 2023-08-25 | [#30689](https://github.com/airbytehq/airbyte/pull/30689)     | Update CDK to support azure OpenAI embeddings and text splitting options, make sure primary key field is not accidentally set, promote to certified | 
 | 0.0.1   | 2023-08-12 | [#29442](https://github.com/airbytehq/airbyte/pull/29442)     | Milvus connector with some embedders  | 

--- a/docs/integrations/destinations/pinecone.md
+++ b/docs/integrations/destinations/pinecone.md
@@ -74,6 +74,7 @@ OpenAI and Fake embeddings produce vectors with 1536 dimensions, and the Cohere 
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.0.15   | 2023-10-04 | [#31075](https://github.com/airbytehq/airbyte/pull/31075) | Fix OpenAI embedder batch size |
 | 0.0.14   | 2023-09-29 | [#30820](https://github.com/airbytehq/airbyte/pull/30820)     | Update CDK | 
 | 0.0.13   | 2023-09-26 | [#30649](https://github.com/airbytehq/airbyte/pull/30649)     | Allow more text splitting options | 
 | 0.0.12   | 2023-09-25 | [#30649](https://github.com/airbytehq/airbyte/pull/30649)     | Fix bug with stale documents left on starter pods | 

--- a/docs/integrations/destinations/qdrant.md
+++ b/docs/integrations/destinations/qdrant.md
@@ -70,6 +70,7 @@ You should now have all the requirements needed to configure Qdrant as a destina
 
 | Version | Date       | Pull Request                                               | Subject                                    |
 | :------ | :--------- | :--------------------------------------------------------- | :----------------------------------------- |
+| 0.0.4   | 2023-10-04 | [#31075](https://github.com/airbytehq/airbyte/pull/31075) | Fix OpenAI embedder batch size |
 | 0.0.3   | 2023-09-29 | [#30820](https://github.com/airbytehq/airbyte/pull/30820)     | Update CDK | 
 | 0.0.2   | 2023-09-25 | [#30689](https://github.com/airbytehq/airbyte/pull/30689) | Update CDK to support Azure OpenAI embeddings and text splitting options |
 | 0.0.1   | 2023-09-22 | [#30332](https://github.com/airbytehq/airbyte/pull/30332) | 🎉 New Destination: Qdrant (Vector Database)    |

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -83,7 +83,7 @@ As properties have to start will a lowercase letter in Weaviate, field names mig
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
-| 0.2.1   | 2023-10-04 | [#30151](https://github.com/airbytehq/airbyte/pull/30151) | Fix OpenAI embedder batch size and conflict field name handling |
+| 0.2.1   | 2023-10-04 | [#31075](https://github.com/airbytehq/airbyte/pull/31075) | Fix OpenAI embedder batch size and conflict field name handling |
 | 0.2.0   | 2023-09-22 | [#30151](https://github.com/airbytehq/airbyte/pull/30151) | Add embedding capabilities, overwrite and dedup support and API key auth mode, make certified. 🚨 Breaking changes - check migrations guide. |
 | 0.1.1   | 2022-02-08 | [\#22527](https://github.com/airbytehq/airbyte/pull/22527) | Multiple bug fixes: Support String based IDs, arrays of uknown type and additionalProperties of type object and array of objects |
 | 0.1.0   | 2022-12-06 | [\#20094](https://github.com/airbytehq/airbyte/pull/20094) | Add Weaviate destination                                                                                                         |

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -77,12 +77,13 @@ If a class doesn't exist in the schema of the cluster, it will be created using 
 
 You can also create the class in Weaviate in advance if you need more control over the schema in Weaviate. In this case, the text properies `_ab_stream` and `_ab_record_id` need to be created for bookkeeping reasons. In case a sync is run in `Overwrite` mode, the class will be deleted and recreated.
 
-As properties have to start will a lowercase letter in Weaviate, field names might be updated during the loading process.
+As properties have to start will a lowercase letter in Weaviate, field names might be updated during the loading process. The field names `id`, `_id` and `_additional` are reserved keywords in Weaviate, so they will be renamed to `raw_id`, `raw__id` and `raw_additional` respectively.
 
 ## Changelog
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| 0.2.1   | 2023-10-04 | [#30151](https://github.com/airbytehq/airbyte/pull/30151) | Fix OpenAI embedder batch size and conflict field name handling |
 | 0.2.0   | 2023-09-22 | [#30151](https://github.com/airbytehq/airbyte/pull/30151) | Add embedding capabilities, overwrite and dedup support and API key auth mode, make certified. 🚨 Breaking changes - check migrations guide. |
 | 0.1.1   | 2022-02-08 | [\#22527](https://github.com/airbytehq/airbyte/pull/22527) | Multiple bug fixes: Support String based IDs, arrays of uknown type and additionalProperties of type object and array of objects |
 | 0.1.0   | 2022-12-06 | [\#20094](https://github.com/airbytehq/airbyte/pull/20094) | Add Weaviate destination                                                                                                         |


### PR DESCRIPTION
This PR fixes two problems:
* Rolling out https://github.com/airbytehq/airbyte/pull/31067
* Disambiguating fields properly in Weaviate to not cause field names that are incompatible with GraphQL (as it's commonly used in Weaviate)
