### PR TITLE
🐛Airbyte CDK: fix parsing of UUID fields in avro files

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/avro_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/avro_parser.py
@@ -3,7 +3,6 @@
 #
 
 import logging
-import uuid
 from typing import Any, Dict, Iterable, Mapping, Optional
 
 import fastavro
@@ -159,9 +158,7 @@ class AvroParser(FileTypeParser):
             if record_type == "double" and avro_format.double_as_string:
                 return str(record_value)
             return record_value
-        if record_type.get("logicalType") == "uuid":
-            return uuid.UUID(bytes=record_value)
-        elif record_type.get("logicalType") == "decimal":
+        if record_type.get("logicalType") in ("decimal", "uuid"):
             return str(record_value)
         elif record_type.get("logicalType") == "date":
             return record_value.isoformat()

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py
@@ -11,6 +11,7 @@ from airbyte_cdk.sources.file_based.file_types import AvroParser
 
 _default_avro_format = AvroFormat()
 _double_as_string_avro_format = AvroFormat(double_as_string=True)
+_uuid_value = uuid.uuid4()
 
 
 @pytest.mark.parametrize(
@@ -217,9 +218,7 @@ def test_convert_primitive_avro_type_to_json(avro_format, avro_type, expected_js
         pytest.param(_default_avro_format, "bytes", b"hello world", b"hello world", id="test_bytes"),
         pytest.param(_default_avro_format, "string", "hello world", "hello world", id="test_string"),
         pytest.param(_default_avro_format, {"logicalType": "decimal"}, 3.1415, "3.1415", id="test_decimal"),
-        pytest.param(
-            _default_avro_format, {"logicalType": "uuid"}, b"abcdefghijklmnop", uuid.UUID(bytes=b"abcdefghijklmnop"), id="test_uuid"
-        ),
+        pytest.param(_default_avro_format, {"logicalType": "uuid"}, _uuid_value, str(_uuid_value), id="test_uuid"),
         pytest.param(_default_avro_format, {"logicalType": "date"}, datetime.date(2023, 8, 7), "2023-08-07", id="test_date"),
         pytest.param(_default_avro_format, {"logicalType": "time-millis"}, 70267068, 70267068, id="test_time_millis"),
         pytest.param(_default_avro_format, {"logicalType": "time-micros"}, 70267068, 70267068, id="test_time_micros"),

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py
@@ -4,7 +4,6 @@
 
 import datetime
 import decimal
-import uuid
 
 from unit_tests.sources.file_based.in_memory_files_source import TemporaryAvroFilesStreamReader
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder
@@ -95,7 +94,7 @@ _avro_all_types_file = {
                 {"name": "col_fixed", "type": {"type": "fixed", "name": "MyFixed", "size": 4}},
                 # Logical Types
                 {"name": "col_decimal", "type": {"type": "bytes", "logicalType": "decimal", "precision": 10, "scale": 5}},
-                {"name": "col_uuid", "type": {"type": "bytes", "logicalType": "uuid"}},
+                {"name": "col_uuid", "type": {"type": "string", "logicalType": "uuid"}},
                 {"name": "col_date", "type": {"type": "int", "logicalType": "date"}},
                 {"name": "col_time_millis", "type": {"type": "int", "logicalType": "time-millis"}},
                 {"name": "col_time_micros", "type": {"type": "long", "logicalType": "time-micros"}},
@@ -124,7 +123,7 @@ _avro_all_types_file = {
                 {"lead_singer": "Matty Healy", "lead_guitar": "Adam Hann", "bass_guitar": "Ross MacDonald", "drummer": "George Daniel"},
                 b"\x12\x34\x56\x78",
                 decimal.Decimal("1234.56789"),
-                uuid.UUID("123e4567-e89b-12d3-a456-426655440000").bytes,
+                "123e4567-e89b-12d3-a456-426655440000",
                 datetime.date(2022, 5, 29),
                 datetime.time(6, 0, 0, 456000),
                 datetime.time(12, 0, 0, 456789),


### PR DESCRIPTION
## What
Fix the issue with parsing fields with `logicalType` of `uuid` from `avro` files
https://github.com/airbytehq/airbyte/issues/30651

This copy of PR https://github.com/airbytehq/airbyte/pull/30975 was created since the branch name from the original PR leads to pipeline failures.

## How
Remove the logic of creating an instance of `UUID` from bytes in `_to_output_value` as this instance being passed to this function. Return the string representation instead.

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/avro_parser.py`
2. `airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py`
3. `airbyte-cdk/python/unit_tests/sources/file_based/scenarios/avro_scenarios.py`

## 🚨 User Impact 🚨
No breaking changes


## Pre-merge Actions

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- [ ] Pull Request description explains what problem it is solving
- [ ] Code change is unit tested
- [ ] Build and my-py check pass
- [ ] Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- [ ] PR is reviewed and approved
      
After merging:
- [ ] [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- [ ] Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
