### PR TITLE
✨ Source GetLago : Add Customer Current Usage and Wallet streams

### DIFF
--- a/airbyte-integrations/connectors/source-getlago/Dockerfile
+++ b/airbyte-integrations/connectors/source-getlago/Dockerfile
@@ -34,5 +34,5 @@ COPY source_getlago ./source_getlago
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-getlago

--- a/airbyte-integrations/connectors/source-getlago/Dockerfile
+++ b/airbyte-integrations/connectors/source-getlago/Dockerfile
@@ -34,5 +34,5 @@ COPY source_getlago ./source_getlago
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.3.0
 LABEL io.airbyte.name=airbyte/source-getlago

--- a/airbyte-integrations/connectors/source-getlago/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-getlago/acceptance-test-config.yml
@@ -18,7 +18,11 @@ acceptance_tests:
     tests:
       - config_path: "secrets/config.json"
         configured_catalog_path: "integration_tests/configured_catalog.json"
-        empty_streams: []
+        empty_streams:
+          - name: customer_usage
+            bypass_reason: "Sandbox account can't seed this stream"
+          - name: wallets
+            bypass_reason: "Sandbox account can't seed this stream"
   # TODO uncomment this block to specify that the tests should assert the connector outputs the records provided in the input file a file
   #        expect_records:
   #          path: "integration_tests/expected_records.jsonl"

--- a/airbyte-integrations/connectors/source-getlago/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-getlago/integration_tests/configured_catalog.json
@@ -62,6 +62,24 @@
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "wallets",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "customer_usage",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-getlago/metadata.yaml
+++ b/airbyte-integrations/connectors/source-getlago/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e1a3866b-d3b2-43b6-b6d7-8c1ee4d7f53f
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-getlago
   githubIssueLabel: source-getlago
   icon: getlago.svg

--- a/airbyte-integrations/connectors/source-getlago/metadata.yaml
+++ b/airbyte-integrations/connectors/source-getlago/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e1a3866b-d3b2-43b6-b6d7-8c1ee4d7f53f
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.3.0
   dockerRepository: airbyte/source-getlago
   githubIssueLabel: source-getlago
   icon: getlago.svg

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/manifest.yaml
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/manifest.yaml
@@ -90,6 +90,24 @@ definitions:
         $ref: "#/definitions/customer_partition_router"
       record_selector:
         $ref: "#/definitions/selector"
+  wallets_stream:
+    $ref: "#/definitions/base_stream"
+    $parameters:
+      name: "wallets"
+      primary_key: "lago_id"
+      path: "/wallets"
+  customer_usage_stream:
+    name: "customer_usage"
+    primary_key: "lago_invoice_id"
+    retriever:
+      $ref: "#/definitions/retriever"
+      requester:
+        $ref: "#/definitions/requester"
+        path: "/customers/{{stream_slice.customer_external_id}}/current_usage"
+      paginator:
+        type: NoPagination
+      partition_router:
+        $ref: "#/definitions/customer_partition_router"
 
 streams:
   - "#/definitions/billable_metrics_stream"
@@ -99,6 +117,8 @@ streams:
   - "#/definitions/invoices_stream"
   - "#/definitions/customers_stream"
   - "#/definitions/subscriptions_stream"
+  - "#/definitions/wallets_stream"
+  - "#/definitions/customer_usage_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/add_ons.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/add_ons.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": true,
   "properties": {
     "lago_id": {
       "type": ["null", "string"]
@@ -9,6 +10,9 @@
       "type": ["null", "string"]
     },
     "created_at": {
+      "type": ["null", "string"]
+    },
+    "invoice_display_name": {
       "type": ["null", "string"]
     },
     "code": {

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/billable_metrics.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/billable_metrics.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": true,
   "properties": {
     "lago_id": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/coupons.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/coupons.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": true,
   "properties": {
     "lago_id": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/customer_usage.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/customer_usage.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "from_datetime": {
+      "type": ["null", "string"]
+    },
+    "to_datetime": {
+      "type": ["null", "string"]
+    },
+    "issuing_date": {
+      "type": ["null", "string"]
+    },
+    "lago_invoice_id": {
+      "type": ["null", "string"]
+    },
+    "currency": {
+      "type": ["null", "string"]
+    },
+    "amount_cents": {
+      "type": ["null", "integer"]
+    },
+    "taxes_amount_cents": {
+      "type": ["null", "integer"]
+    },
+    "total_amount_cents": {
+      "type": ["null", "integer"]
+    },
+    "charges_usage": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null","object"],
+        "properties": {
+          "units": {
+            "type": ["null", "string"]
+          },
+          "events_count": {
+            "type": ["null", "integer"]
+          },
+          "amount_cents": {
+            "type": ["null", "integer"]
+          },
+          "amount_currency": {
+            "type": ["null", "string"]
+          },
+          "charge": {
+            "type": ["null","object"],
+            "properties": {
+              "lago_id": {
+                "type": ["null", "string"]
+              },
+              "charge_model": {
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "billable_metric": {
+            "type": ["null","object"],
+            "properties": {
+              "lago_id": {
+                "type": ["null", "string"]
+              },
+              "name": {
+                "type": ["null", "string"]
+              },
+              "code": {
+                "type": ["null", "string"]
+              },
+              "aggregation_type": {
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "groups": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null","object"],
+              "properties": {
+                "lago_id": {
+                  "type": ["null", "string"]
+                },
+                "key": {
+                  "type": ["null", "string"]
+                },
+                "value": {
+                  "type": ["null", "string"]
+                },
+                "units": {
+                  "type": ["null", "string"]
+                },
+                "events_count": {
+                  "type": ["null", "integer"]
+                },
+                "amount_cents": {
+                  "type": ["null", "integer"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/customer_usage.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/customer_usage.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": true,
   "properties": {
     "from_datetime": {
       "type": ["null", "string"]
@@ -29,7 +30,7 @@
     "charges_usage": {
       "type": ["null", "array"],
       "items": {
-        "type": ["null","object"],
+        "type": ["null", "object"],
         "properties": {
           "units": {
             "type": ["null", "string"]
@@ -44,7 +45,7 @@
             "type": ["null", "string"]
           },
           "charge": {
-            "type": ["null","object"],
+            "type": ["null", "object"],
             "properties": {
               "lago_id": {
                 "type": ["null", "string"]
@@ -55,7 +56,7 @@
             }
           },
           "billable_metric": {
-            "type": ["null","object"],
+            "type": ["null", "object"],
             "properties": {
               "lago_id": {
                 "type": ["null", "string"]
@@ -74,7 +75,7 @@
           "groups": {
             "type": ["null", "array"],
             "items": {
-              "type": ["null","object"],
+              "type": ["null", "object"],
               "properties": {
                 "lago_id": {
                   "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/customers.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/customers.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": true,
   "properties": {
     "lago_id": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/invoices.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/invoices.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": true,
   "properties": {
     "lago_id": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/plans.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/plans.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": true,
   "properties": {
     "lago_id": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/subscriptions.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/subscriptions.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": true,
   "properties": {
     "lago_id": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/wallets.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/wallets.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": true,
   "properties": {
     "lago_id": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/wallets.json
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/schemas/wallets.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "lago_id": {
+      "type": ["null", "string"]
+    },
+    "lago_customer_id": {
+      "type": ["null", "string"]
+    },
+    "external_customer_id": {
+      "type": ["null", "string"]
+    },
+    "status": {
+      "type": ["null", "string"]
+    },
+    "currency": {
+      "type": ["null", "string"]
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "rate_amount": {
+      "type": ["null", "string"]
+    },
+    "credits_balance": {
+      "type": ["null", "string"]
+    },
+    "balance_cents": {
+      "type": ["null", "integer"]
+    },
+    "consumed_credits": {
+      "type": ["null", "string"]
+    },
+    "created_at": {
+      "type": ["null", "string"]
+    },
+    "expiration_at": {
+      "type": ["null", "string"]
+    },
+    "last_balance_sync_at": {
+      "type": ["null", "string"]
+    },
+    "last_consumed_credit_at": {
+      "type": ["null", "string"]
+    },
+    "terminated_at": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/docs/integrations/sources/getlago.md
+++ b/docs/integrations/sources/getlago.md
@@ -32,6 +32,6 @@ This source can sync data from the [Lago API](https://doc.getlago.com/docs/guide
 
 | Version | Date       | Pull Request                                              | Subject                                    |
 | :------ | :--------- | :-------------------------------------------------------- | :----------------------------------------- |
-| 0.2.1   | 2023-10-05 | [#31099](https://github.com/airbytehq/airbyte/pull/31099) | Added customer_usage and wallet stream           |
+| 0.3.0   | 2023-10-05 | [#31099](https://github.com/airbytehq/airbyte/pull/31099) | Added customer_usage and wallet stream           |
 | 0.2.0   | 2023-09-19 | [#30572](https://github.com/airbytehq/airbyte/pull/30572) | Source GetLago: Support API URL           |
 | 0.1.0   | 2022-10-26 | [#18727](https://github.com/airbytehq/airbyte/pull/18727) | 🎉 New Source: getLago API [low-code CDK] |

--- a/docs/integrations/sources/getlago.md
+++ b/docs/integrations/sources/getlago.md
@@ -32,5 +32,6 @@ This source can sync data from the [Lago API](https://doc.getlago.com/docs/guide
 
 | Version | Date       | Pull Request                                              | Subject                                    |
 | :------ | :--------- | :-------------------------------------------------------- | :----------------------------------------- |
+| 0.2.0   | 2023-10-05 | [#31099](https://github.com/airbytehq/airbyte/pull/31099) | Added customer_usage and wallet stream           |
 | 0.2.0   | 2023-09-19 | [#30572](https://github.com/airbytehq/airbyte/pull/30572) | Source GetLago: Support API URL           |
 | 0.1.0   | 2022-10-26 | [#18727](https://github.com/airbytehq/airbyte/pull/18727) | 🎉 New Source: getLago API [low-code CDK] |

--- a/docs/integrations/sources/getlago.md
+++ b/docs/integrations/sources/getlago.md
@@ -32,6 +32,6 @@ This source can sync data from the [Lago API](https://doc.getlago.com/docs/guide
 
 | Version | Date       | Pull Request                                              | Subject                                    |
 | :------ | :--------- | :-------------------------------------------------------- | :----------------------------------------- |
-| 0.2.0   | 2023-10-05 | [#31099](https://github.com/airbytehq/airbyte/pull/31099) | Added customer_usage and wallet stream           |
+| 0.2.1   | 2023-10-05 | [#31099](https://github.com/airbytehq/airbyte/pull/31099) | Added customer_usage and wallet stream           |
 | 0.2.0   | 2023-09-19 | [#30572](https://github.com/airbytehq/airbyte/pull/30572) | Source GetLago: Support API URL           |
 | 0.1.0   | 2022-10-26 | [#18727](https://github.com/airbytehq/airbyte/pull/18727) | 🎉 New Source: getLago API [low-code CDK] |


### PR DESCRIPTION

Closes #20822 

Added stream are [customer current usage](https://doc.getlago.com/api-reference/customer-usage/get-current) and [list wallet](https://doc.getlago.com/api-reference/wallets/get-all)