### PR TITLE
CDK: coerce read records to an iterator

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/utils/stream_helper.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/utils/stream_helper.py
@@ -34,5 +34,7 @@ def get_first_record_for_slice(stream: Stream, stream_slice: Optional[Mapping[st
     :raises StopIteration: if there is no first record to return (the read_records generator is empty)
     :return: StreamData containing the first record in the slice
     """
-    records_for_slice = stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice)
+    # We wrap the return output of read_records() because some implementations return types that are iterable,
+    # but not iterators such as lists or tuples
+    records_for_slice = iter(stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice))
     return next(records_for_slice)

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/test_availability_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/test_availability_strategy.py
@@ -63,10 +63,18 @@ class MockHttpStream(HttpStream):
         (False, ["Please visit the connector's documentation to learn more."]),
     ],
 )
+@pytest.mark.parametrize("records_as_list", [True, False])
 def test_default_http_availability_strategy(
-    mocker, status_code, json_contents, expected_is_available, expected_messages, include_source, expected_docs_url_messages
+    mocker, status_code, json_contents, expected_is_available, expected_messages, include_source, expected_docs_url_messages, records_as_list
 ):
-    http_stream = MockHttpStream()
+    class MockListHttpStream(MockHttpStream):
+        def read_records(self, *args, **kvargs):
+            if records_as_list:
+                return list(super().read_records(*args, **kvargs))
+            else:
+                return super().read_records(*args, **kvargs)
+
+    http_stream = MockListHttpStream()
     assert isinstance(http_stream.availability_strategy, HttpAvailabilityStrategy)
 
     class MockResponseWithJsonContents(requests.Response, mocker.MagicMock):
@@ -140,7 +148,8 @@ def test_send_handles_retries_when_checking_availability(mocker, caplog):
         assert message in caplog.text
 
 
-def test_http_availability_strategy_on_empty_stream(mocker):
+@pytest.mark.parametrize("records_as_list", [True, False])
+def test_http_availability_strategy_on_empty_stream(mocker, records_as_list):
     class MockEmptyHttpStream(mocker.MagicMock, MockHttpStream):
         def __init__(self, *args, **kvargs):
             mocker.MagicMock.__init__(self)
@@ -152,7 +161,10 @@ def test_http_availability_strategy_on_empty_stream(mocker):
     assert isinstance(empty_stream.availability_strategy, HttpAvailabilityStrategy)
 
     # Generator should have no values to generate
-    empty_stream.read_records.return_value = iter([])
+    if records_as_list:
+        empty_stream.read_records.return_value = []
+    else:
+        empty_stream.read_records.return_value = iter([])
 
     logger = logging.getLogger("airbyte.test-source")
     stream_is_available, _ = empty_stream.check_availability(logger)

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/test_availability_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/test_availability_strategy.py
@@ -65,7 +65,14 @@ class MockHttpStream(HttpStream):
 )
 @pytest.mark.parametrize("records_as_list", [True, False])
 def test_default_http_availability_strategy(
-    mocker, status_code, json_contents, expected_is_available, expected_messages, include_source, expected_docs_url_messages, records_as_list
+    mocker,
+    status_code,
+    json_contents,
+    expected_is_available,
+    expected_messages,
+    include_source,
+    expected_docs_url_messages,
+    records_as_list,
 ):
     class MockListHttpStream(MockHttpStream):
         def read_records(self, *args, **kvargs):


### PR DESCRIPTION
## What
Source Slack is failing with `'list' object is not an iterator`
https://airbytehq.sentry.io/issues/4508254133/?alert_rule_id=11478402&alert_type=issue&notification_uuid=1295203e-5b64-45d0-91d9-70b3377988a9&project=6527718

This seems to be related to Slack returning an empty list in one case
https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-slack/source_slack/source.py#L213



related to:
https://github.com/airbytehq/oncall/issues/3076

## How
This updates `get_first_record_for_slice` to cast the return of `read_records` to an iterable.

similar to `get_first_stream_slice`

## Notes for reviewer
this is my first foray into this area of the code base. Does this make sense?

Also I plan to update source-slack after this