### PR TITLE
airbyte-ci: fix escaping bugs in with_integration_base_java_and_normalization

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -398,6 +398,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                        | Description                                                                                               |
 |---------| --------------------------------------------------------- |-----------------------------------------------------------------------------------------------------------|
+| 1.4.5   | [#31133](https://github.com/airbytehq/airbyte/pull/31133) | Fix bug when building containers using `with_integration_base_java_and_normalization`.                    |
 | 1.4.4   | [#30743](https://github.com/airbytehq/airbyte/pull/30743) | Add `--disable-report-auto-open` and `--use-host-gradle-dist-tar` to allow gradle integration.            |
 | 1.4.3   | [#30595](https://github.com/airbytehq/airbyte/pull/30595) | Add --version and version check                                                                           |
 | 1.4.2   | [#30595](https://github.com/airbytehq/airbyte/pull/30595) | Remove directory name requirement                                                                         |

--- a/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
@@ -840,10 +840,10 @@ def with_integration_base_java_and_normalization(context: PipelineContext, build
                 [
                     "python -m ensurepip --upgrade",
                     # Workaround for https://github.com/yaml/pyyaml/issues/601
-                    "pip3 install Cython<3.0 pyyaml~=5.4 --no-build-isolation",
+                    "pip3 install 'Cython<3.0' 'pyyaml~=5.4' --no-build-isolation",
                     f"pip3 install {dbt_adapter_package}",
                     # amazon linux 2 isn't compatible with urllib3 2.x, so force 1.x
-                    "pip3 install urllib3<2",
+                    "pip3 install 'urllib3<2'",
                 ]
             )
         )

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.4.4"
+version = "1.4.5"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
Recently we noticed something wrong when building destination-redshift; in the dagger logs:
```
1603: [2.60s] + pip3 install Cython pyyaml~=5.4 --no-build-isolation
1603: [2.60s] sh: line 1: 3.0: No such file or directory
1603: exec sh -c set -o xtrace && python -m ensurepip --upgrade && pip3 install Cython<3.0 pyyaml~=5.4 --no-build-isolation && pip3 install dbt-redshift==1.0.0 && pip3 install urllib3<2 ERROR: process "sh -c set -o xtrace && python -m ensurepip --upgrade && pip3 install Cython<3.0 pyyaml~=5.4 --no-build-isolation && pip3 install dbt-redshift==1.0.0 && pip3 install urllib3<2" did not complete successfully: exit code: 1
```

As it turns out, the `sh_dash_c` function doesn't escape characters properly. This wasn't known to cause any issues, until now. I've since added the missing `'` because it turns out that alternative solutions like escaping using `shlex` have their own issues.