### PR TITLE
Update slack to return empty iterable instead of a empty list

### DIFF
--- a/airbyte-integrations/connectors/source-slack/Dockerfile
+++ b/airbyte-integrations/connectors/source-slack/Dockerfile
@@ -17,5 +17,5 @@ COPY main.py ./
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.3.3
+LABEL io.airbyte.version=0.3.4
 LABEL io.airbyte.name=airbyte/source-slack

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c2281cee-86f9-4a86-bb48-d23286b4c7bd
-  dockerImageTag: 0.3.3
+  dockerImageTag: 0.3.4
   dockerRepository: airbyte/source-slack
   githubIssueLabel: source-slack
   icon: slack.svg

--- a/airbyte-integrations/connectors/source-slack/source_slack/source.py
+++ b/airbyte-integrations/connectors/source-slack/source_slack/source.py
@@ -209,9 +209,9 @@ class IncrementalMessageStream(ChanneledStream, ABC):
         stream_state: Mapping[str, Any] = None,
     ) -> Iterable[Mapping[str, Any]]:
         if not stream_slice:
-            # return an empty iterable
+            # return an empty iterator
             # this is done to emit at least one state message when no slices are generated
-            return iter([])
+            yield from []
         return super().read_records(sync_mode, cursor_field=cursor_field, stream_slice=stream_slice, stream_state=stream_state)
 
 

--- a/airbyte-integrations/connectors/source-slack/source_slack/source.py
+++ b/airbyte-integrations/connectors/source-slack/source_slack/source.py
@@ -211,7 +211,7 @@ class IncrementalMessageStream(ChanneledStream, ABC):
         if not stream_slice:
             # return an empty iterator
             # this is done to emit at least one state message when no slices are generated
-            yield from []
+            return iter([])
         return super().read_records(sync_mode, cursor_field=cursor_field, stream_slice=stream_slice, stream_state=stream_state)
 
 

--- a/airbyte-integrations/connectors/source-slack/source_slack/source.py
+++ b/airbyte-integrations/connectors/source-slack/source_slack/source.py
@@ -209,8 +209,9 @@ class IncrementalMessageStream(ChanneledStream, ABC):
         stream_state: Mapping[str, Any] = None,
     ) -> Iterable[Mapping[str, Any]]:
         if not stream_slice:
+            # return an empty iterable
             # this is done to emit at least one state message when no slices are generated
-            return []
+            return iter([])
         return super().read_records(sync_mode, cursor_field=cursor_field, stream_slice=stream_slice, stream_state=stream_state)
 
 

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -92,7 +92,7 @@ We recommend creating a restricted, read-only key specifically for Airbyte acces
 3. **Required** Enter your `start_date`.
 4. **Required** Enter your `lookback_window`, which corresponds to amount of days in the past from which you want to sync data.
 5. Toggle `join_channels`, if you want to join all channels or to sync data only from channels the bot is already in. If not set, you'll need to manually add the bot to all the channels from which you'd like to sync messages.
-6. Enter your `channel_filter`, this should be list of channel names (without leading '#' char) that limits the channels from which you'd like to sync. If no channels are specified, Airbyte will replicate all data. 
+6. Enter your `channel_filter`, this should be list of channel names (without leading '#' char) that limits the channels from which you'd like to sync. If no channels are specified, Airbyte will replicate all data.
 7. Enter your `api_token`.
 8. Click **Set up source**.
 <!-- /env:oss -->
@@ -137,7 +137,7 @@ It is recommended to sync required channels only, this can be done by specifying
 
 | Version | Date       | Pull Request                                             | Subject                                                                             |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------|
-| 0.3.3   | 2023-10-06 | [30580](https://github.com/airbytehq/airbyte/pull/30580) | Update CDK and remove non iterable return from records                              |
+| 0.3.4   | 2023-10-06 | [31134](https://github.com/airbytehq/airbyte/pull/31134) | Update CDK and remove non iterable return from records                              |
 | 0.3.3   | 2023-09-28 | [30580](https://github.com/airbytehq/airbyte/pull/30580) | Add `bot_id` field to threads schema                               |
 | 0.3.2   | 2023-09-20 | [30613](https://github.com/airbytehq/airbyte/pull/30613) | Set default value for channel_filters during discover                               |
 | 0.3.1   | 2023-09-19 | [30570](https://github.com/airbytehq/airbyte/pull/30570) | Use default availability strategy                                                   |

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -137,6 +137,7 @@ It is recommended to sync required channels only, this can be done by specifying
 
 | Version | Date       | Pull Request                                             | Subject                                                                             |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------|
+| 0.3.3   | 2023-10-06 | [30580](https://github.com/airbytehq/airbyte/pull/30580) | Update CDK and remove non iterable return from records                              |
 | 0.3.3   | 2023-09-28 | [30580](https://github.com/airbytehq/airbyte/pull/30580) | Add `bot_id` field to threads schema                               |
 | 0.3.2   | 2023-09-20 | [30613](https://github.com/airbytehq/airbyte/pull/30613) | Set default value for channel_filters during discover                               |
 | 0.3.1   | 2023-09-19 | [30570](https://github.com/airbytehq/airbyte/pull/30570) | Use default availability strategy                                                   |


### PR DESCRIPTION
## What

Source Slack is failing with 'list' object is not an iterator
https://airbytehq.sentry.io/issues/4508254133/?alert_rule_id=11478402&alert_type=issue&notification_uuid=1295203e-5b64-45d0-91d9-70b3377988a9&project=6527718

This seems to be related to Slack returning an empty list in one case
https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-slack/source_slack/source.py#L213

Related to: https://github.com/airbytehq/airbyte/pull/31122


## How
Weve already updated the cdk to handle this for all connectors.

This PR
1. Updates the connector to use the new cdk
2. casts the array iterable on the slack side to be safe

