### PR TITLE
Connector Build Pipeline: Install pytz for normalization

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
@@ -841,6 +841,8 @@ def with_integration_base_java_and_normalization(context: PipelineContext, build
                     "python -m ensurepip --upgrade",
                     # Workaround for https://github.com/yaml/pyyaml/issues/601
                     "pip3 install 'Cython<3.0' 'pyyaml~=5.4' --no-build-isolation",
+                    # Required for dbt https://github.com/dbt-labs/dbt-core/issues/7075
+                    "pip3 install 'pytz~=2023.3'",
                     f"pip3 install {dbt_adapter_package}",
                     # amazon linux 2 isn't compatible with urllib3 2.x, so force 1.x
                     "pip3 install 'urllib3<2'",


### PR DESCRIPTION
## What

closes: https://github.com/airbytehq/airbyte/issues/31135

> and, in fact, so is any connector relying on with_integration_base_java_and_normalization, and this has been the case for several weeks.

> As of the time of filing this issue there's a problem with pip-installing certain packages which aren't quoted correctly. Having fixed that, there's another problem in that dbt deps fails to run, complaining about pytz not being present.

> I don't know how to fix that.

> FYI these containers are based off of amazoncorretto which only has python 3.9; could this be related?

## How
Installs pyt explicitly

## Notes for reviewer
A more elegant way is needed for defining pip packages to install. But this is broken now.