### PR TITLE
Remove checklist items from the PR description template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -97,7 +97,7 @@ Before merging:
 - Smoke test the change on at least one affected connector
    - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
    - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
-   PR is reviewed and approved
+- PR is reviewed and approved
       
 After merging:
 - [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -91,19 +91,19 @@ If this is a community PR, the Airbyte engineer reviewing this PR is responsible
 ### Airbyter
 
 Before merging:
-- [ ] Pull Request description explains what problem it is solving
-- [ ] Code change is unit tested
-- [ ] Build and my-py check pass
-- [ ] Smoke test the change on at least one affected connector
+- Pull Request description explains what problem it is solving
+- Code change is unit tested
+- Build and my-py check pass
+- Smoke test the change on at least one affected connector
    - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
    - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
-- [ ] PR is reviewed and approved
+   PR is reviewed and approved
       
 After merging:
-- [ ] [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
+- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
    - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
    - Write a thoughtful changelog message so we know what was updated.
-- [ ] Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
+- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
    - This step is optional if the change does not affect the connector builder or declarative connectors.
 
 </details>


### PR DESCRIPTION
Remove checklist items from the PR description because they block the Require Connector Merge Checklist Job