### PR TITLE
🐛 source-file: fix integration tests

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -396,8 +396,9 @@ This command runs the Python tests for a airbyte-ci poetry package.
 `airbyte-ci tests airbyte-integrations/bases/connector-acceptance-test --test-directory=unit_tests`
 
 ## Changelog
-| Version | PR                                                        | Description                                                                                               |
-|---------| --------------------------------------------------------- |-----------------------------------------------------------------------------------------------------------|
+| Version | PR                                                       | Description                                                                                               |
+|---------| -------------------------------------------------------- |-----------------------------------------------------------------------------------------------------------|
+| 1.5.0    |[#30984](https://github.com/airbytehq/airbyte/pull/30984) | Adds docker to python test containers                                                                     |
 | 1.4.6   |[ #31087](https://github.com/airbytehq/airbyte/pull/31087) | Throw error if airbyte-ci tools is out of date                                                            |
 | 1.4.5   | [#31133](https://github.com/airbytehq/airbyte/pull/31133) | Fix bug when building containers using `with_integration_base_java_and_normalization`.                    |
 | 1.4.4   | [#30743](https://github.com/airbytehq/airbyte/pull/30743) | Add `--disable-report-auto-open` and `--use-host-gradle-dist-tar` to allow gradle integration.            |
@@ -405,8 +406,8 @@ This command runs the Python tests for a airbyte-ci poetry package.
 | 1.4.2   | [#30595](https://github.com/airbytehq/airbyte/pull/30595) | Remove directory name requirement                                                                         |
 | 1.4.1   | [#30595](https://github.com/airbytehq/airbyte/pull/30595) | Load base migration guide into QA Test container for strict encrypt variants                              |
 | 1.4.0   | [#30330](https://github.com/airbytehq/airbyte/pull/30330) | Add support for pyproject.toml as the prefered entry point for a connector package                        |
-| 1.3.0   | [#30461](https://github.com/airbytehq/airbyte/pull/30461) | Add `--use-local-cdk` flag to all connectors commands                                                      |
-| 1.2.3   | [#30477](https://github.com/airbytehq/airbyte/pull/30477) | Fix a test regression introduced the previous version.                                            |
+| 1.3.0   | [#30461](https://github.com/airbytehq/airbyte/pull/30461) | Add `--use-local-cdk` flag to all connectors commands                                                     |
+| 1.2.3   | [#30477](https://github.com/airbytehq/airbyte/pull/30477) | Fix a test regression introduced the previous version.                                                    |
 | 1.2.2   | [#30438](https://github.com/airbytehq/airbyte/pull/30438) | Add workaround to always stream logs properly with --is-local.                                            |
 | 1.2.1   | [#30384](https://github.com/airbytehq/airbyte/pull/30384) | Java connector test performance fixes.                                                                    |
 | 1.2.0   | [#30330](https://github.com/airbytehq/airbyte/pull/30330) | Add `--metadata-query` option to connectors command                                                       |
@@ -432,7 +433,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 | 0.2.1   | [#28767](https://github.com/airbytehq/airbyte/pull/28767) | Improve pytest step result evaluation to prevent false negative/positive.                                 |
 | 0.2.0   | [#28857](https://github.com/airbytehq/airbyte/pull/28857) | Add the `airbyte-ci tests` command to run the test suite on any `airbyte-ci` poetry package.              |
 | 0.1.1   | [#28858](https://github.com/airbytehq/airbyte/pull/28858) | Increase the max duration of Connector Package install to 20mn.                                           |
-| 0.1.0   |                                                           | Alpha version not in production yet. All the commands described in this doc are available.                |
+| 0.1.0   |                                                          | Alpha version not in production yet. All the commands described in this doc are available.                |
 
 ## More info
 This project is owned by the Connectors Operations team.

--- a/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/actions/environments.py
@@ -57,7 +57,7 @@ def with_python_base(context: PipelineContext, python_version: str = "3.10") -> 
             sh_dash_c(
                 [
                     "apt-get update",
-                    "apt-get install -y build-essential cmake g++ libffi-dev libstdc++6 git",
+                    "apt-get install -y build-essential cmake g++ libffi-dev libstdc++6 git curl",
                     "pip install pip==23.1.2",
                 ]
             )
@@ -82,6 +82,7 @@ def with_testing_dependencies(context: PipelineContext) -> Container:
 
     return (
         python_environment.with_exec(["pip", "install"] + CONNECTOR_TESTING_REQUIREMENTS)
+        .with_exec(sh_dash_c(["curl -fsSL https://get.docker.com | sh"]))
         .with_file(f"/{PYPROJECT_TOML_FILE_PATH}", pyproject_toml_file)
         .with_file(f"/{LICENSE_SHORT_FILE_PATH}", license_short_file)
     )

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/python_connectors.py
@@ -59,7 +59,7 @@ class ConnectorPackageInstall(Step):
     """A step to install the Python connector package in a container."""
 
     title = "Connector package install"
-    max_duration = timedelta(minutes=20)
+    # max_duration = timedelta(minutes=20)
     max_retries = 3
 
     async def _run(self) -> StepResult:

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/python_connectors.py
@@ -59,7 +59,7 @@ class ConnectorPackageInstall(Step):
     """A step to install the Python connector package in a container."""
 
     title = "Connector package install"
-    # max_duration = timedelta(minutes=20)
+    max_duration = timedelta(minutes=20)
     max_retries = 3
 
     async def _run(self) -> StepResult:

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.4.6"
+version = "1.5.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-integrations/connectors/source-file/setup.py
+++ b/airbyte-integrations/connectors/source-file/setup.py
@@ -24,7 +24,7 @@ MAIN_REQUIREMENTS = [
     "pyxlsb==1.0.9",
 ]
 
-TEST_REQUIREMENTS = ["requests-mock~=1.9.3", "pytest~=6.2", "pytest-docker~=1.0.0", "pytest-mock~=3.6.1", "docker-compose"]
+TEST_REQUIREMENTS = ["requests-mock~=1.9.3", "pytest~=6.2", "pytest-mock~=3.6.1"]
 
 setup(
     name="source_file",

--- a/airbyte-integrations/connectors/source-file/setup.py
+++ b/airbyte-integrations/connectors/source-file/setup.py
@@ -24,7 +24,7 @@ MAIN_REQUIREMENTS = [
     "pyxlsb==1.0.9",
 ]
 
-TEST_REQUIREMENTS = ["requests-mock~=1.9.3", "pytest~=6.2", "pytest-mock~=3.6.1"]
+TEST_REQUIREMENTS = ["requests-mock~=1.9.3", "pytest~=6.2", "pytest-docker~=2.0", "pytest-mock~=3.6.1"]
 
 setup(
     name="source_file",


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

_split from https://github.com/airbytehq/airbyte/pull/30984_

Integration tests have been broken for source-file for a long time. Installing test dependencies ran indefinitely due to a resolution issue. This PR fixes it.

## How

- airbyte-ci: Include docker as dependency in test containers
- source-file: remove docker-compose python dependency, which is deprecated. bump pytest-docker to v2 to use new docker compose v2.
