### PR TITLE
🐛 Set heartbeat timeout between messages for source linkedin ads to 24 hours

### DIFF
--- a/airbyte-integrations/connectors/source-linkedin-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-linkedin-ads/Dockerfile
@@ -33,5 +33,5 @@ COPY source_linkedin_ads ./source_linkedin_ads
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.6.1
+LABEL io.airbyte.version=0.6.2
 LABEL io.airbyte.name=airbyte/source-linkedin-ads

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
-  maxSecondsBetweenMessages: 21600
+  maxSecondsBetweenMessages: 86400
   dockerImageTag: 0.6.1
   dockerRepository: airbyte/source-linkedin-ads
   githubIssueLabel: source-linkedin-ads

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
   maxSecondsBetweenMessages: 86400
-  dockerImageTag: 0.6.1
+  dockerImageTag: 0.6.2
   dockerRepository: airbyte/source-linkedin-ads
   githubIssueLabel: source-linkedin-ads
   icon: linkedin.svg

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -171,6 +171,7 @@ After 5 unsuccessful attempts - the connector will stop the sync operation. In s
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 0.6.2   | 2023-08-23 | [29600](https://github.com/airbytehq/airbyte/pull/31221) | Increase max time between messages to 24 hours                                                                  |
 | 0.6.1   | 2023-08-23 | [29600](https://github.com/airbytehq/airbyte/pull/29600) | Update field descriptions                                                                                       |
 | 0.6.0   | 2023-08-22 | [29721](https://github.com/airbytehq/airbyte/pull/29721) | Add `Conversions` stream                                                                                        |
 | 0.5.0   | 2023-08-14 | [29175](https://github.com/airbytehq/airbyte/pull/29175) | Add Custom report Constructor                                                                                   |


### PR DESCRIPTION
## What
Source LinkedIn Ads should properly handle the quota back off period. Per [this request](https://airbytehq-team.slack.com/archives/C02U46QK5C3/p1696957352268749)

## How
Set heartbeat timeout between messages for source linkedin ads to 24 hours in accordance with the rate limit cooldown period specified in their docs.

## Recommended reading order
N/A

## 🚨 User Impact 🚨
Should allow customers who hit the daily quota to finish syncs.
