### PR TITLE
airbyte-ci: java unit tests now run check not test

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -395,6 +395,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 1.5.1   | [#31226](https://github.com/airbytehq/airbyte/pull/31226)  | Remove format check from java connectors.                                                                 |
 | 1.5.0   | [#30456](https://github.com/airbytehq/airbyte/pull/30456)  | Start building Python connectors using our base images.                                                   |
 | 1.4.6   | [ #31087](https://github.com/airbytehq/airbyte/pull/31087) | Throw error if airbyte-ci tools is out of date                                                            |
 | 1.4.5   | [#31133](https://github.com/airbytehq/airbyte/pull/31133)  | Fix bug when building containers using `with_integration_base_java_and_normalization`.                    |

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/java_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/java_connectors.py
@@ -55,7 +55,7 @@ class UnitTests(GradleTask):
     """A step to run unit tests for Java connectors."""
 
     title = "Java Connector Unit Tests"
-    gradle_task_name = "check"
+    gradle_task_name = "test"
     bind_to_docker_host = True
 
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.5.0"
+version = "1.5.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION

## What
Fixes an issue where unit tests failed as python3.9 was installed

Related [slack thread](https://airbytehq-team.slack.com/archives/C046KQF5GBT/p1696899333203729)
## How
This was because we were trying to run python formatters.

The solution is to not run these, or any check, but only run unit tests as `gradle check` is run at the top level on any PR already