### PR TITLE
gradle: search for python3.11 binary for AL2023 support

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -395,6 +395,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 1.5.1   | [#31227](https://github.com/airbytehq/airbyte/pull/31227)  | Use python 3.11 in amazoncorretto-bazed gradle containers.                                                |
 | 1.5.0   | [#30456](https://github.com/airbytehq/airbyte/pull/30456)  | Start building Python connectors using our base images.                                                   |
 | 1.4.6   | [ #31087](https://github.com/airbytehq/airbyte/pull/31087) | Throw error if airbyte-ci tools is out of date                                                            |
 | 1.4.5   | [#31133](https://github.com/airbytehq/airbyte/pull/31133)  | Fix bug when building containers using `with_integration_base_java_and_normalization`.                    |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -395,7 +395,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| 1.5.1   | [#31227](https://github.com/airbytehq/airbyte/pull/31227)  | Use python 3.11 in amazoncorretto-bazed gradle containers.                                                |
+| 1.5.1   | [#31227](https://github.com/airbytehq/airbyte/pull/31227)  | Use python 3.11 in amazoncorretto-bazed gradle containers, run 'test' gradle task instead of 'check'.     |
 | 1.5.0   | [#30456](https://github.com/airbytehq/airbyte/pull/30456)  | Start building Python connectors using our base images.                                                   |
 | 1.4.6   | [ #31087](https://github.com/airbytehq/airbyte/pull/31087) | Throw error if airbyte-ci tools is out of date                                                            |
 | 1.4.5   | [#31133](https://github.com/airbytehq/airbyte/pull/31133)  | Fix bug when building containers using `with_integration_base_java_and_normalization`.                    |

--- a/airbyte-ci/connectors/pipelines/pipelines/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/gradle.py
@@ -90,7 +90,7 @@ class GradleTask(Step, ABC):
             "findutils",  # gradle requires xargs, which is shipped in findutils.
             "jq",  # required by :airbyte-connector-test-harnesses:acceptance-test-harness to inspect docker images.
             "npm",  # required by :format.
-            "pip",  # required by :format.
+            "python3.11-pip",  # required by :format.
             "rsync",  # required for gradle cache synchronization.
         ]
 

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/java_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/java_connectors.py
@@ -55,7 +55,7 @@ class UnitTests(GradleTask):
     """A step to run unit tests for Java connectors."""
 
     title = "Java Connector Unit Tests"
-    gradle_task_name = "check"
+    gradle_task_name = "test"
     bind_to_docker_host = True
 
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.5.0"
+version = "1.5.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,9 @@ python {
     minPythonVersion = '3.10' // should be 3.10 for local development
 
     // Amazon Linux support.
+    // The airbyte-ci tool runs gradle tasks in AL2023-based containers.
+    // In AL2023, `python3` is necessarily v3.9, and later pythons need to be installed and named explicitly.
+    // See https://github.com/amazonlinux/amazon-linux-2023/issues/459 for details.
     try {
         if ("python3.11 --version".execute().waitFor() == 0) {
             // python3.11 definitely exists at this point, use it instead of 'python3'.

--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,18 @@ python {
     } catch (IOException _) {
         // Swallow exception if pyenv is not installed.
     }
+    // Amazon Linux support.
+    if (pythonBinary == 'python3') {
+        try {
+            def py311Version = "python3.11 --version".execute()
+            if (py311Version.waitFor() == 0) {
+                // python3.11 definitely exists at this point, use it instead of 'python3'.
+                pythonBinary "python3.11"
+            }
+        } catch (IOException _) {
+            // Swallow exception if python3.11 is not installed.
+        }
+    }
 
     scope = 'VIRTUALENV'
     installVirtualenv = true

--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,15 @@ python {
     envPath = '.venv'
     minPythonVersion = '3.10' // should be 3.10 for local development
 
+    // Amazon Linux support.
+    try {
+        if ("python3.11 --version".execute().waitFor() == 0) {
+            // python3.11 definitely exists at this point, use it instead of 'python3'.
+            pythonBinary "python3.11"
+        }
+    } catch (IOException _) {
+        // Swallow exception if python3.11 is not installed.
+    }
     // Pyenv support.
     try {
         def pyenvRoot = "pyenv root".execute()
@@ -170,18 +179,6 @@ python {
         }
     } catch (IOException _) {
         // Swallow exception if pyenv is not installed.
-    }
-    // Amazon Linux support.
-    if (pythonBinary == 'python3') {
-        try {
-            def py311Version = "python3.11 --version".execute()
-            if (py311Version.waitFor() == 0) {
-                // python3.11 definitely exists at this point, use it instead of 'python3'.
-                pythonBinary "python3.11"
-            }
-        } catch (IOException _) {
-            // Swallow exception if python3.11 is not installed.
-        }
     }
 
     scope = 'VIRTUALENV'

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -80,6 +80,15 @@ class AirbytePythonPlugin implements Plugin<Project> {
             envPath = venvDirectoryName
             minPythonVersion '3.10'
 
+            // Amazon Linux support.
+            try {
+                if ("python3.11 --version".execute().waitFor() == 0) {
+                    // python3.11 definitely exists at this point, use it instead of 'python3'.
+                    pythonBinary "python3.11"
+                }
+            } catch (IOException _) {
+                // Swallow exception if python3.11 is not installed.
+            }
             // Pyenv support.
             try {
                 def pyenvRoot = "pyenv root".execute()
@@ -91,18 +100,6 @@ class AirbytePythonPlugin implements Plugin<Project> {
                 }
             } catch (IOException _) {
                 // Swallow exception if pyenv is not installed.
-            }
-            // Amazon Linux support.
-            if (pythonBinary == 'python3') {
-                try {
-                    def py311Version = "python3.11 --version".execute()
-                    if (py311Version.waitFor() == 0) {
-                        // python3.11 definitely exists at this point, use it instead of 'python3'.
-                        pythonBinary "python3.11"
-                    }
-                } catch (IOException _) {
-                    // Swallow exception if python3.11 is not installed.
-                }
             }
 
             scope 'VIRTUALENV'

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -92,6 +92,18 @@ class AirbytePythonPlugin implements Plugin<Project> {
             } catch (IOException _) {
                 // Swallow exception if pyenv is not installed.
             }
+            // Amazon Linux support.
+            if (pythonBinary == 'python3') {
+                try {
+                    def py311Version = "python3.11 --version".execute()
+                    if (py311Version.waitFor() == 0) {
+                        // python3.11 definitely exists at this point, use it instead of 'python3'.
+                        pythonBinary "python3.11"
+                    }
+                } catch (IOException _) {
+                    // Swallow exception if python3.11 is not installed.
+                }
+            }
 
             scope 'VIRTUALENV'
             installVirtualenv = true

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -81,6 +81,9 @@ class AirbytePythonPlugin implements Plugin<Project> {
             minPythonVersion '3.10'
 
             // Amazon Linux support.
+            // The airbyte-ci tool runs gradle tasks in AL2023-based containers.
+            // In AL2023, `python3` is necessarily v3.9, and later pythons need to be installed and named explicitly.
+            // See https://github.com/amazonlinux/amazon-linux-2023/issues/459 for details.
             try {
                 if ("python3.11 --version".execute().waitFor() == 0) {
                     // python3.11 definitely exists at this point, use it instead of 'python3'.


### PR DESCRIPTION
I broke airbyte-ci last week for all java connectors by making version 3.10+ a requirement for python in gradle. This PR fixes this by installing and using python3.11 in the amazoncorretto-based gradle containers. Under the hood, it's Amazon Linux 2023, which comes with python 3.9 by default.