### PR TITLE
Trigger chameleon survey on down votes

### DIFF
--- a/docusaurus/src/theme/TOCItems/index.js
+++ b/docusaurus/src/theme/TOCItems/index.js
@@ -5,6 +5,23 @@ import { faThumbsDown, faThumbsUp } from '@fortawesome/free-regular-svg-icons';
 
 import styles from "./TOCItemsWrapper.module.css";
 
+function showDocSurvey() {
+  const showSurvey = () => {
+    chmln.show("6525a7ef3f4f150011627c9f");
+  }
+
+  if (!window.chmln) {
+    // Initialize Chameleon if it's not loaded already
+    !function(d,w){var t="SaG54hxuMI4CDIZa2yBv4lX1NHVB0jQBNTORqyAN2p2tE4-1OtIxC-DS9ywbXXIr2TPyYr",c="chmln",i=d.createElement("script");if(w[c]||(w[c]={}),!w[c].root){w[c].accountToken=t,w[c].location=w.location.href.toString(),w[c].now=new Date,w[c].fastUrl='https://fast.chameleon.io/';var m="identify alias track clear set show on off custom help _data".split(" ");for(var s=0;s<m.length;s++){!function(){var t=w[c][m[s]+"_a"]=[];w[c][m[s]]=function(){t.push(arguments);};}();}i.src=w[c].fastUrl+"messo/"+t+"/messo.min.js",i.async=!0,d.head.appendChild(i);}}(document,window);
+    // As soon as it's loaded show the survey
+    window.chmln.on("load:chmln", showSurvey);
+    // Identify the user reusing the segment id if possible
+    window.chmln.identify(window.analytics?.user().id() ?? window.analytics?.user().anonymousId() ?? "chmln-no-segment-user", {});
+  } else {
+    showSurvey();
+  }
+}
+
 export default function TOCItemsWrapper(props) {
   const [voted, setVoted] = useState(false);
   const onVote = (vote) => {
@@ -15,6 +32,9 @@ export default function TOCItemsWrapper(props) {
       vote,
     });
     setVoted(true);
+    if (vote === "down") {
+      showDocSurvey();
+    }
   };
   return (
     <>


### PR DESCRIPTION
Whenever a user downvotes a doc page, load the Chameleon script (we don't want to have that for all visitors, due to our quota there), and trigger a specific survey to ask for more feedback.