### PR TITLE
CAT: fix system deps install

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -6,7 +6,7 @@ ENV DOCKER_VERSION = "24.0.2"
 
 RUN apt-get update \
     && pip install --upgrade pip \
-    && apt-get install tzdata bash curl
+    && apt-get -y install tzdata bash curl
 
 # Docker is required for the dagger in docker use case.
 RUN curl -fsSL https://get.docker.com | sh


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
An old typo in CAT Dockerfile makes its build fail.
This was not previously detected because of layer caching.
