### PR TITLE
File CDK: Allow configuration of parsed records during check and discover from parser

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py
@@ -53,10 +53,15 @@ class DefaultFileBasedAvailabilityStrategy(AbstractFileBasedAvailabilityStrategy
         - If the user provided a schema in the config, check that a subset of records in
           one file conform to the schema via a call to stream.conforms_to_schema(schema).
         """
+        parser = stream.get_parser()
         try:
             files = self._check_list_files(stream)
-            if not stream.get_parser().override_max_n_files_for_parsability == 0:
+            if not parser.override_max_n_files_for_parsability == 0:
                 self._check_parse_record(stream, files[0], logger)
+            else:
+                # If the parser is set to not check parsability, we still want to check that we can open the file.
+                handle = stream.stream_reader.open_file(files[0], parser.file_read_mode, None, logger)
+                handle.close()
         except CheckAvailabilityError:
             return False, "".join(traceback.format_exc())
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py
@@ -44,7 +44,7 @@ class DefaultFileBasedAvailabilityStrategy(AbstractFileBasedAvailabilityStrategy
 
         For the stream:
         - Verify that we can list files from the stream using the configured globs.
-        - Verify that we can read one file from the stream as long as the stream parser is not setting override_max_n_files_for_parsability to 0.
+        - Verify that we can read one file from the stream as long as the stream parser is not setting parser_max_n_files_for_parsability to 0.
 
         This method will also check that the files and their contents are consistent
         with the configured options, as follows:
@@ -56,7 +56,7 @@ class DefaultFileBasedAvailabilityStrategy(AbstractFileBasedAvailabilityStrategy
         parser = stream.get_parser()
         try:
             files = self._check_list_files(stream)
-            if not parser.override_max_n_files_for_parsability == 0:
+            if not parser.parser_max_n_files_for_parsability == 0:
                 self._check_parse_record(stream, files[0], logger)
             else:
                 # If the parser is set to not check parsability, we still want to check that we can open the file.

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py
@@ -44,7 +44,7 @@ class DefaultFileBasedAvailabilityStrategy(AbstractFileBasedAvailabilityStrategy
 
         For the stream:
         - Verify that we can list files from the stream using the configured globs.
-        - Verify that we can read one file from the stream.
+        - Verify that we can read one file from the stream as long as the stream parser is not setting override_max_n_files_for_parsability to 0.
 
         This method will also check that the files and their contents are consistent
         with the configured options, as follows:
@@ -55,7 +55,8 @@ class DefaultFileBasedAvailabilityStrategy(AbstractFileBasedAvailabilityStrategy
         """
         try:
             files = self._check_list_files(stream)
-            self._check_parse_record(stream, files[0], logger)
+            if not stream.get_parser().override_max_n_files_for_parsability == 0:
+                self._check_parse_record(stream, files[0], logger)
         except CheckAvailabilityError:
             return False, "".join(traceback.format_exc())
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/discovery_policy/abstract_discovery_policy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/discovery_policy/abstract_discovery_policy.py
@@ -4,6 +4,7 @@
 
 from abc import ABC, abstractmethod
 
+from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 
 class AbstractDiscoveryPolicy(ABC):
     """
@@ -16,7 +17,6 @@ class AbstractDiscoveryPolicy(ABC):
     def n_concurrent_requests(self) -> int:
         ...
 
-    @property
     @abstractmethod
-    def max_n_files_for_schema_inference(self) -> int:
+    def get_max_n_files_for_schema_inference(self, parser: FileTypeParser) -> int:
         ...

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/discovery_policy/abstract_discovery_policy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/discovery_policy/abstract_discovery_policy.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 
 from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 
+
 class AbstractDiscoveryPolicy(ABC):
     """
     Used during discovery; allows the developer to configure the number of concurrent

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/discovery_policy/default_discovery_policy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/discovery_policy/default_discovery_policy.py
@@ -21,8 +21,8 @@ class DefaultDiscoveryPolicy(AbstractDiscoveryPolicy):
 
     def get_max_n_files_for_schema_inference(self, parser: FileTypeParser) -> int:
         return min(
-                filter(
-                    None,
-                    (DEFAULT_MAX_N_FILES_FOR_STREAM_SCHEMA_INFERENCE, parser.parser_max_n_files_for_schema_inference),
-                )
+            filter(
+                None,
+                (DEFAULT_MAX_N_FILES_FOR_STREAM_SCHEMA_INFERENCE, parser.parser_max_n_files_for_schema_inference),
             )
+        )

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/discovery_policy/default_discovery_policy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/discovery_policy/default_discovery_policy.py
@@ -3,6 +3,7 @@
 #
 
 from airbyte_cdk.sources.file_based.discovery_policy.abstract_discovery_policy import AbstractDiscoveryPolicy
+from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 
 DEFAULT_N_CONCURRENT_REQUESTS = 10
 DEFAULT_MAX_N_FILES_FOR_STREAM_SCHEMA_INFERENCE = 10
@@ -18,6 +19,10 @@ class DefaultDiscoveryPolicy(AbstractDiscoveryPolicy):
     def n_concurrent_requests(self) -> int:
         return DEFAULT_N_CONCURRENT_REQUESTS
 
-    @property
-    def max_n_files_for_schema_inference(self) -> int:
-        return DEFAULT_MAX_N_FILES_FOR_STREAM_SCHEMA_INFERENCE
+    def get_max_n_files_for_schema_inference(self, parser: FileTypeParser) -> int:
+        return min(
+                filter(
+                    None,
+                    (DEFAULT_MAX_N_FILES_FOR_STREAM_SCHEMA_INFERENCE, parser.parser_max_n_files_for_schema_inference),
+                )
+            )

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/file_type_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/file_type_parser.py
@@ -20,6 +20,20 @@ class FileTypeParser(ABC):
     supported file type.
     """
 
+    @property
+    def override_max_n_files_for_schema_inference(self) -> Optional[int]:
+        """
+        The discovery policy decides how many files are loaded for schema inference. This method can provide a parser-specific override. If it's defined, the smaller of the two values will be used.
+        """
+        return None
+
+    @property
+    def override_max_n_files_for_parsability(self) -> Optional[int]:
+        """
+        The availability policy decides how many files are loaded for checking whether parsing works correctly. This method can provide a parser-specific override. If it's defined, the smaller of the two values will be used.
+        """
+        return None
+
     @abstractmethod
     async def infer_schema(
         self,

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/file_type_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/file_type_parser.py
@@ -28,7 +28,7 @@ class FileTypeParser(ABC):
         return None
 
     @property
-    def override_max_n_files_for_parsability(self) -> Optional[int]:
+    def parser_max_n_files_for_parsability(self) -> Optional[int]:
         """
         The availability policy decides how many files are loaded for checking whether parsing works correctly. This method can provide a parser-specific override. If it's defined, the smaller of the two values will be used.
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/file_type_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/file_type_parser.py
@@ -21,7 +21,7 @@ class FileTypeParser(ABC):
     """
 
     @property
-    def override_max_n_files_for_schema_inference(self) -> Optional[int]:
+    def parser_max_n_files_for_schema_inference(self) -> Optional[int]:
         """
         The discovery policy decides how many files are loaded for schema inference. This method can provide a parser-specific override. If it's defined, the smaller of the two values will be used.
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/abstract_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/abstract_file_based_stream.py
@@ -49,7 +49,7 @@ class AbstractFileBasedStream(Stream):
         self.config = config
         self.catalog_schema = catalog_schema
         self.validation_policy = validation_policy
-        self._stream_reader = stream_reader
+        self.stream_reader = stream_reader
         self._discovery_policy = discovery_policy
         self._availability_strategy = availability_strategy
         self._parsers = parsers

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -87,7 +87,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
             n_skipped = line_no = 0
 
             try:
-                for record in parser.parse_records(self.config, file, self._stream_reader, self.logger, schema):
+                for record in parser.parse_records(self.config, file, self.stream_reader, self.logger, schema):
                     line_no += 1
                     if self.config.schemaless:
                         record = {"data": record}
@@ -178,12 +178,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
             if total_n_files == 0:
                 raise NoFilesMatchingError(FileBasedSourceError.EMPTY_STREAM, stream=self.name)
 
-            max_n_files_for_schema_inference = min(
-                filter(
-                    None,
-                    (self._discovery_policy.max_n_files_for_schema_inference, self.get_parser().override_max_n_files_for_schema_inference),
-                )
-            )
+            max_n_files_for_schema_inference = self._discovery_policy.get_max_n_files_for_schema_inference(self.get_parser())
             if total_n_files > max_n_files_for_schema_inference:
                 # Use the most recent files for schema inference, so we pick up schema changes during discovery.
                 files = sorted(files, key=lambda x: x.last_modified, reverse=True)[:max_n_files_for_schema_inference]
@@ -211,7 +206,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
         The output of this method is cached so we don't need to list the files more than once.
         This means we won't pick up changes to the files during a sync.
         """
-        return list(self._stream_reader.get_matching_files(self.config.globs or [], self.config.legacy_prefix, self.logger))
+        return list(self.stream_reader.get_matching_files(self.config.globs or [], self.config.legacy_prefix, self.logger))
 
     def infer_schema(self, files: List[RemoteFile]) -> Mapping[str, Any]:
         loop = asyncio.get_event_loop()
@@ -265,7 +260,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
 
     async def _infer_file_schema(self, file: RemoteFile) -> SchemaType:
         try:
-            return await self.get_parser().infer_schema(self.config, file, self._stream_reader, self.logger)
+            return await self.get_parser().infer_schema(self.config, file, self.stream_reader, self.logger)
         except Exception as exc:
             raise SchemaInferenceError(
                 FileBasedSourceError.SCHEMA_INFERENCE_ERROR,

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -178,7 +178,12 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
             if total_n_files == 0:
                 raise NoFilesMatchingError(FileBasedSourceError.EMPTY_STREAM, stream=self.name)
 
-            max_n_files_for_schema_inference = self._discovery_policy.max_n_files_for_schema_inference
+            max_n_files_for_schema_inference = min(
+                filter(
+                    None,
+                    (self._discovery_policy.max_n_files_for_schema_inference, self.get_parser().override_max_n_files_for_schema_inference),
+                )
+            )
             if total_n_files > max_n_files_for_schema_inference:
                 # Use the most recent files for schema inference, so we pick up schema changes during discovery.
                 files = sorted(files, key=lambda x: x.last_modified, reverse=True)[:max_n_files_for_schema_inference]

--- a/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py
@@ -49,3 +49,15 @@ class DefaultFileBasedAvailabilityStrategyTest(unittest.TestCase):
         is_available, reason = self._strategy.check_availability_and_parsability(self._stream, Mock(), Mock())
 
         assert is_available
+
+    def test_parse_records_is_not_called_with_override_max_n_files_for_parsability_set(self) -> None:
+        """
+        If the stream parser sets override_max_n_files_for_parsability to 0, then we should not call parse_records on it
+        """
+        self._parser.override_max_n_files_for_parsability = 0
+        self._stream.list_files.return_value = [_FILE_WITH_UNKNOWN_EXTENSION]
+
+        is_available, reason = self._strategy.check_availability_and_parsability(self._stream, Mock(), Mock())
+
+        assert is_available
+        assert not self._parser.parse_records.called

--- a/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py
@@ -36,6 +36,7 @@ class DefaultFileBasedAvailabilityStrategyTest(unittest.TestCase):
         self._stream.catalog_schema = _ANY_SCHEMA
         self._stream.config = _ANY_CONFIG
         self._stream.validation_policy = PropertyMock(validate_schema_before_sync=False)
+        self._stream.stream_reader = self._stream_reader
 
     def test_given_file_extension_does_not_match_when_check_availability_and_parsability_then_stream_is_still_available(self) -> None:
         """
@@ -61,3 +62,4 @@ class DefaultFileBasedAvailabilityStrategyTest(unittest.TestCase):
 
         assert is_available
         assert not self._parser.parse_records.called
+        assert self._stream_reader.open_file.called

--- a/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py
@@ -51,11 +51,11 @@ class DefaultFileBasedAvailabilityStrategyTest(unittest.TestCase):
 
         assert is_available
 
-    def test_parse_records_is_not_called_with_override_max_n_files_for_parsability_set(self) -> None:
+    def test_parse_records_is_not_called_with_parser_max_n_files_for_parsability_set(self) -> None:
         """
-        If the stream parser sets override_max_n_files_for_parsability to 0, then we should not call parse_records on it
+        If the stream parser sets parser_max_n_files_for_parsability to 0, then we should not call parse_records on it
         """
-        self._parser.override_max_n_files_for_parsability = 0
+        self._parser.parser_max_n_files_for_parsability = 0
         self._stream.list_files.return_value = [_FILE_WITH_UNKNOWN_EXTENSION]
 
         is_available, reason = self._strategy.check_availability_and_parsability(self._stream, Mock(), Mock())

--- a/airbyte-cdk/python/unit_tests/sources/file_based/discovery_policy/test_default_discovery_policy.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/discovery_policy/test_default_discovery_policy.py
@@ -8,6 +8,7 @@ from airbyte_cdk.sources.file_based.discovery_policy.default_discovery_policy im
 
 from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 
+
 class DefaultDiscoveryPolicyTest(unittest.TestCase):
     def setUp(self) -> None:
         self._policy = DefaultDiscoveryPolicy()

--- a/airbyte-cdk/python/unit_tests/sources/file_based/discovery_policy/test_default_discovery_policy.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/discovery_policy/test_default_discovery_policy.py
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import unittest
+from unittest.mock import Mock
+from airbyte_cdk.sources.file_based.discovery_policy.default_discovery_policy import DefaultDiscoveryPolicy
+
+from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
+
+class DefaultDiscoveryPolicyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._policy = DefaultDiscoveryPolicy()
+
+        self._parser = Mock(spec=FileTypeParser)
+        self._parser.parser_max_n_files_for_schema_inference = None
+
+    def test_hardcoded_schema_inference_file_limit_is_returned(self) -> None:
+        """
+        If the parser is not providing a limit, then we should use the hardcoded limit
+        """
+        assert self._policy.get_max_n_files_for_schema_inference(self._parser) == 10
+
+    def test_parser_limit_is_respected(self) -> None:
+        """
+        If the parser is providing a limit, then we should use that limit
+        """
+        self._parser.parser_max_n_files_for_schema_inference = 1
+
+        assert self._policy.get_max_n_files_for_schema_inference(self._parser) == 1

--- a/airbyte-cdk/python/unit_tests/sources/file_based/discovery_policy/test_default_discovery_policy.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/discovery_policy/test_default_discovery_policy.py
@@ -4,8 +4,8 @@
 
 import unittest
 from unittest.mock import Mock
-from airbyte_cdk.sources.file_based.discovery_policy.default_discovery_policy import DefaultDiscoveryPolicy
 
+from airbyte_cdk.sources.file_based.discovery_policy.default_discovery_policy import DefaultDiscoveryPolicy
 from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/helpers.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/helpers.py
@@ -16,6 +16,7 @@ from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.schema_validation_policies import AbstractSchemaValidationPolicy
 from airbyte_cdk.sources.file_based.stream.cursor import DefaultFileBasedCursor
 from unit_tests.sources.file_based.in_memory_files_source import InMemoryFilesStreamReader
+from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 
 
 class EmptySchemaParser(CsvParser):
@@ -26,8 +27,7 @@ class EmptySchemaParser(CsvParser):
 
 
 class LowInferenceLimitDiscoveryPolicy(DefaultDiscoveryPolicy):
-    @property
-    def max_n_files_for_schema_inference(self) -> int:
+    def get_max_n_files_for_schema_inference(self, parser: FileTypeParser) -> int:
         return 1
 
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/helpers.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/helpers.py
@@ -11,12 +11,12 @@ from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileB
 from airbyte_cdk.sources.file_based.discovery_policy import DefaultDiscoveryPolicy
 from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader, FileReadMode
 from airbyte_cdk.sources.file_based.file_types.csv_parser import CsvParser
+from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 from airbyte_cdk.sources.file_based.file_types.jsonl_parser import JsonlParser
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.schema_validation_policies import AbstractSchemaValidationPolicy
 from airbyte_cdk.sources.file_based.stream.cursor import DefaultFileBasedCursor
 from unit_tests.sources.file_based.in_memory_files_source import InMemoryFilesStreamReader
-from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 
 
 class EmptySchemaParser(CsvParser):

--- a/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
@@ -138,6 +138,28 @@ class DefaultFileBasedStreamTest(unittest.TestCase):
         assert messages[0].log.level == Level.ERROR
         assert messages[1].log.level == Level.WARN
 
+    def test_override_max_n_files_for_schema_inference_is_respected(self) -> None:
+        self._discovery_policy.max_n_files_for_schema_inference = 10
+        self._discovery_policy.n_concurrent_requests = 1
+        self._stream.config.input_schema = None
+        self._stream.config.schemaless = None
+        self._parser.override_max_n_files_for_schema_inference = 3
+        self._parser.infer_schema.return_value = {"data": {"type": "string"}}
+        files = [RemoteFile(uri=f"file{i}", last_modified=self._NOW) for i in range(10)]
+        self._stream_reader.get_matching_files.return_value = files
+
+        schema = self._stream.get_json_schema()
+
+        assert schema == {
+            "type": "object",
+            "properties": {
+                "_ab_source_file_last_modified": {"type": "string"},
+                "_ab_source_file_url": {"type": "string"},
+                "data": {"type": ["null", "string"]},
+            },
+        }
+        assert self._parser.infer_schema.call_count == 3
+
     def _iter(self, x: Iterable[Any]) -> Iterator[Any]:
         for item in x:
             if isinstance(item, Exception):

--- a/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/stream/test_default_file_based_stream.py
@@ -139,11 +139,10 @@ class DefaultFileBasedStreamTest(unittest.TestCase):
         assert messages[1].log.level == Level.WARN
 
     def test_override_max_n_files_for_schema_inference_is_respected(self) -> None:
-        self._discovery_policy.max_n_files_for_schema_inference = 10
         self._discovery_policy.n_concurrent_requests = 1
+        self._discovery_policy.get_max_n_files_for_schema_inference.return_value = 3
         self._stream.config.input_schema = None
         self._stream.config.schemaless = None
-        self._parser.override_max_n_files_for_schema_inference = 3
         self._parser.infer_schema.return_value = {"data": {"type": "string"}}
         files = [RemoteFile(uri=f"file{i}", last_modified=self._NOW) for i in range(10)]
         self._stream_reader.get_matching_files.return_value = files


### PR DESCRIPTION
## What

This is preparing the split out part from https://github.com/airbytehq/airbyte/pull/31209

It adds two optional properties to the `FileParser` class - `override_max_n_files_for_schema_inference` and `override_max_n_files_for_parsability`.

If they are set to None (which is the default), the behavior doesn't change. If they are set, the availability strategy and the schema check respect them to limit the amounts of files that are parsed using the parser.

The intended use case is to be able to limit the amount of resource use when possible (e.g. for unstructured files the number of files that are parsed during the check and discover can be minimized to speed up the process as large files can take a while to parse).
