### PR TITLE
📚 Airbyte-ci docs: Fix docs by changing --version to --python

### DIFF
--- a/airbyte-ci/connectors/ci_credentials/README.md
+++ b/airbyte-ci/connectors/ci_credentials/README.md
@@ -30,13 +30,13 @@ python -m pipx ensurepath
 Once pyenv and pipx is installed then run the following:
 
 ```bash
-pipx install --editable --force --version=python3.10 airbyte-ci/connectors/ci_credentials/
+pipx install --editable --force --python=python3.10 airbyte-ci/connectors/ci_credentials/
 ```
 
 This command installs `ci_credentials` and makes it globally available in your terminal.
 
 _Note: `--force` is required to ensure updates are applied on subsequent installs._
-_Note: `--version=python3.10` is required to ensure the correct python version is used._
+_Note: `--python=python3.10` is required to ensure the correct python version is used._
 _Note: `--editable` is required to ensure the correct python version is used._
 
 If you face any installation problem feel free to reach out the Airbyte Connectors Operations team.

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -38,13 +38,13 @@ Once pyenv and pipx is installed then run the following:
 
 ```bash
 # install airbyte-ci
-pipx install --editable --force --version=python3.10 airbyte-ci/connectors/pipelines/
+pipx install --editable --force --python=python3.10 airbyte-ci/connectors/pipelines/
 ```
 
 This command installs `airbyte-ci` and makes it globally available in your terminal.
 
 _Note: `--force` is required to ensure updates are applied on subsequent installs._
-_Note: `--version=python3.10` is required to ensure the correct python version is used._
+_Note: `--python=python3.10` is required to ensure the correct python version is used._
 _Note: `--editable` is required to ensure the correct python version is used._
 
 If you face any installation problem feel free to reach out the Airbyte Connectors Operations team.
@@ -454,9 +454,9 @@ To fix this, you can either:
 
 
 ## python3.10 not found
-If you get the following error when running `pipx install --editable --force --version=python3.10 airbyte-ci/connectors/pipelines/`:
+If you get the following error when running `pipx install --editable --force --python=python3.10 airbyte-ci/connectors/pipelines/`:
 ```bash
-$ pipx install --editable --force --version=python3.10 airbyte-ci/connectors/pipelines/
+$ pipx install --editable --force --python=python3.10 airbyte-ci/connectors/pipelines/
 Error: Python 3.10 not found on your system.
 ```
 

--- a/airbyte-integrations/connectors/source-pokeapi/integration_tests/invalid_config.json
+++ b/airbyte-integrations/connectors/source-pokeapi/integration_tests/invalid_config.json
@@ -1,3 +1,3 @@
-{ 
-  "name": "datto" 
+{
+  "name": "datto"
 }

--- a/airbyte-integrations/connectors/source-pokeapi/integration_tests/sample_config.json
+++ b/airbyte-integrations/connectors/source-pokeapi/integration_tests/sample_config.json
@@ -1,3 +1,3 @@
-{ 
-  "pokemon_name": "ditto" 
+{
+  "pokemon_name": "ditto"
 }

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -16,7 +16,7 @@ data:
   icon: pokeapi.svg
   license: MIT
   name: Pokeapi
-  releaseDate: '2020-05-04'
+  releaseDate: "2020-05-04"
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/pokeapi


### PR DESCRIPTION
## Overview
Docs are incorrect, it should be the `--python` flag not the `--version` flag