### PR TITLE
🐛 source-pokeapi: Downgrade pokeapi

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -5,8 +5,10 @@ data:
   registries:
     oss:
       enabled: true
+      dockerImageTag: 0.1.5
     cloud:
       enabled: true
+      dockerImageTag: 0.1.5
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968


### PR DESCRIPTION
## What
* Add version overrides to pokeapi because 2.0.0 is breaking platform tests