### PR TITLE
Vector DB CDK: Fix openai compatible embedder

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
@@ -159,7 +159,8 @@ class OpenAICompatibleEmbedder(Embedder):
         super().__init__()
         self.config = config
         # Client is set internally
-        self.embeddings = LocalAIEmbeddings(model=config.model_name, openai_api_key=config.api_key, openai_api_base=config.base_url, max_retries=15)  # type: ignore
+        # Always set an API key even if there is none defined in the config because the validator will fail otherwise. Embedding APIs that don't require an API key don't fail if one is provided, so this is not breaking usage.
+        self.embeddings = LocalAIEmbeddings(model=config.model_name, openai_api_key=config.api_key or "dummy-api-key", openai_api_base=config.base_url, max_retries=15)  # type: ignore
 
     def check(self) -> Optional[str]:
         deployment_mode = os.environ.get("DEPLOYMENT_MODE", "")


### PR DESCRIPTION
## What

The OpenAI-compatible embedder allows to set an API key, but for local or air-gapped solutions the self-hosted embedding API might not be secured, so it's optional.

However, if no key is set, the pydantic validation fails because the key needs to be set: https://github.com/langchain-ai/langchain/blob/44da27c07b2bd0ccac355c8236a3ab1dd26870eb/libs/langchain/langchain/embeddings/localai.py#L200

This problem is working around the upstream issue reported here: https://github.com/langchain-ai/langchain/issues/11698
