### PR TITLE
Source Iterable: fix invalid chunk length error during discovery

### DIFF
--- a/airbyte-integrations/connectors/source-iterable/Dockerfile
+++ b/airbyte-integrations/connectors/source-iterable/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.30
+LABEL io.airbyte.version=0.1.31
 LABEL io.airbyte.name=airbyte/source-iterable

--- a/airbyte-integrations/connectors/source-iterable/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-iterable/acceptance-test-config.yml
@@ -102,6 +102,8 @@ acceptance_tests:
   incremental:
     tests:
       - config_path: "secrets/config.json"
+        # Excluding empty streams from testing as they producing empty state
+        # which leads to failure of `test_read_sequential_slices` test
         configured_catalog_path: "integration_tests/configured_catalog_incremental.json"
         future_state:
           future_state_path: "integration_tests/abnormal_state.json"

--- a/airbyte-integrations/connectors/source-iterable/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-iterable/acceptance-test-config.yml
@@ -102,7 +102,7 @@ acceptance_tests:
   incremental:
     tests:
       - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+        configured_catalog_path: "integration_tests/configured_catalog_incremental.json"
         future_state:
           future_state_path: "integration_tests/abnormal_state.json"
           missing_streams:

--- a/airbyte-integrations/connectors/source-iterable/integration_tests/configured_catalog_incremental.json
+++ b/airbyte-integrations/connectors/source-iterable/integration_tests/configured_catalog_incremental.json
@@ -1,0 +1,36 @@
+{
+    "streams": [
+        {
+            "stream": {
+                "name": "users",
+                "json_schema": {},
+                "supported_sync_modes": [
+                    "full_refresh",
+                    "incremental"
+                ],
+                "source_defined_cursor": true,
+                "default_cursor_field": [
+                    "profileUpdatedAt"
+                ]
+            },
+            "sync_mode": "incremental",
+            "destination_sync_mode": "append"
+        },
+        {
+            "stream": {
+                "name": "templates",
+                "json_schema": {},
+                "supported_sync_modes": [
+                    "full_refresh",
+                    "incremental"
+                ],
+                "source_defined_cursor": true,
+                "default_cursor_field": [
+                    "createdAt"
+                ]
+            },
+            "sync_mode": "incremental",
+            "destination_sync_mode": "append"
+        }
+    ]
+}

--- a/airbyte-integrations/connectors/source-iterable/integration_tests/configured_catalog_incremental.json
+++ b/airbyte-integrations/connectors/source-iterable/integration_tests/configured_catalog_incremental.json
@@ -1,36 +1,26 @@
 {
-    "streams": [
-        {
-            "stream": {
-                "name": "users",
-                "json_schema": {},
-                "supported_sync_modes": [
-                    "full_refresh",
-                    "incremental"
-                ],
-                "source_defined_cursor": true,
-                "default_cursor_field": [
-                    "profileUpdatedAt"
-                ]
-            },
-            "sync_mode": "incremental",
-            "destination_sync_mode": "append"
-        },
-        {
-            "stream": {
-                "name": "templates",
-                "json_schema": {},
-                "supported_sync_modes": [
-                    "full_refresh",
-                    "incremental"
-                ],
-                "source_defined_cursor": true,
-                "default_cursor_field": [
-                    "createdAt"
-                ]
-            },
-            "sync_mode": "incremental",
-            "destination_sync_mode": "append"
-        }
-    ]
+  "streams": [
+    {
+      "stream": {
+        "name": "users",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["profileUpdatedAt"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "templates",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["createdAt"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
+    }
+  ]
 }

--- a/airbyte-integrations/connectors/source-iterable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-iterable/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 2e875208-0c0b-4ee4-9e92-1cb3156ea799
-  dockerImageTag: 0.1.30
+  dockerImageTag: 0.1.31
   dockerRepository: airbyte/source-iterable
   githubIssueLabel: source-iterable
   icon: iterable.svg

--- a/docs/integrations/sources/iterable.md
+++ b/docs/integrations/sources/iterable.md
@@ -75,13 +75,13 @@ The Iterable source connector supports the following [sync modes](https://docs.a
 ## Additional notes
 
 [List Users](https://api.iterable.com/api/docs#lists_getLists_0) Stream when meet `500 - Generic Error` will skip a broken slice and keep going with the next one. This is related to unexpected failures when trying to get users list for specific list ids. See #[24968](https://github.com/airbytehq/airbyte/issues/24968) issue for more details.
-[List Users](https://api.iterable.com/api/docs#lists_getLists_0) Stream may fail with `InvalidChunkLength(got length b'', 0 bytes read`. This problem is been investigated by Iterable, so [List Users](https://api.iterable.com/api/docs#lists_getLists_0) and [Events](https://api.iterable.com/api/docs#events_User_events) streams may not work. See #[3096](https://github.com/airbytehq/oncall/issues/3096) issue for more details.
+[List Users](https://api.iterable.com/api/docs#lists_getLists_0) Stream may fail with `InvalidChunkLength(got length b'', 0 bytes read` error. This problem is been investigated by Iterable, so [List Users](https://api.iterable.com/api/docs#lists_getLists_0) and [Events](https://api.iterable.com/api/docs#events_User_events) streams may not work. See #[3096](https://github.com/airbytehq/oncall/issues/3096) issue for more details.
 
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------- |
-| 0.1.31  | 2023-10-12 | [31331](https://github.com/airbytehq/airbyte/pull/31331) | Fixed InvalidChunkLength error during discovery                                                                |
+| 0.1.31  | 2023-10-12 | [31331](https://github.com/airbytehq/airbyte/pull/31331) | Fixed InvalidChunkLength error during discovery                                                              |
 | 0.1.30  | 2023-07-19 | [28457](https://github.com/airbytehq/airbyte/pull/28457) | Fixed TypeError for StreamSlice in debug mode                                                                |
 | 0.1.29  | 2023-05-24 | [26459](https://github.com/airbytehq/airbyte/pull/26459) | Added requests reading timeout 300 seconds                                                                   |
 | 0.1.28  | 2023-05-12 | [26014](https://github.com/airbytehq/airbyte/pull/26014) | Improve 500 handling for Events stream                                                                       |

--- a/docs/integrations/sources/iterable.md
+++ b/docs/integrations/sources/iterable.md
@@ -75,6 +75,7 @@ The Iterable source connector supports the following [sync modes](https://docs.a
 ## Additional notes
 
 [List Users](https://api.iterable.com/api/docs#lists_getLists_0) Stream when meet `500 - Generic Error` will skip a broken slice and keep going with the next one. This is related to unexpected failures when trying to get users list for specific list ids. See #[24968](https://github.com/airbytehq/airbyte/issues/24968) issue for more details.
+[List Users](https://api.iterable.com/api/docs#lists_getLists_0) Stream may fail with `InvalidChunkLength(got length b'', 0 bytes read`. This problem is been investigated by Iterable, so [List Users](https://api.iterable.com/api/docs#lists_getLists_0) and [Events](https://api.iterable.com/api/docs#events_User_events) streams may not work. See #[3096](https://github.com/airbytehq/oncall/issues/3096) issue for more details.
 
 ## Changelog
 

--- a/docs/integrations/sources/iterable.md
+++ b/docs/integrations/sources/iterable.md
@@ -80,6 +80,7 @@ The Iterable source connector supports the following [sync modes](https://docs.a
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------- |
+| 0.1.31  | 2023-10-12 | [31331](https://github.com/airbytehq/airbyte/pull/31331) | Fixed InvalidChunkLength error during discovery                                                                |
 | 0.1.30  | 2023-07-19 | [28457](https://github.com/airbytehq/airbyte/pull/28457) | Fixed TypeError for StreamSlice in debug mode                                                                |
 | 0.1.29  | 2023-05-24 | [26459](https://github.com/airbytehq/airbyte/pull/26459) | Added requests reading timeout 300 seconds                                                                   |
 | 0.1.28  | 2023-05-12 | [26014](https://github.com/airbytehq/airbyte/pull/26014) | Improve 500 handling for Events stream                                                                       |


### PR DESCRIPTION
## What
*Discovering schema failed/InvalidChunkLength(got length b'', 0 bytes read*
*https://github.com/airbytehq/oncall/issues/3096*

## How
*Disable cache for ListUser stream and set `{"stream": True}` for request*

