### PR TITLE
gradle: fix mypy checks

### DIFF
--- a/airbyte-cdk/python/build.gradle
+++ b/airbyte-cdk/python/build.gradle
@@ -3,6 +3,12 @@ plugins {
     id 'airbyte-docker-legacy'
 }
 
+airbytePython {
+    // TODO: uncomment and get mypy checks to pass
+    // mypyDirectory 'airbyte_cdk'
+    // mypyConfigFile 'mypy.ini'
+}
+
 def generateComponentManifestClassFiles = tasks.register('generateComponentManifestClassFiles', Exec) {
     environment 'ROOT_DIR', rootDir.absolutePath
     commandLine 'bin/generate-component-manifest-files.sh'

--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 airbytePython {
-    moduleDirectory 'normalization'
+    mypyDirectory 'normalization'
 }
 
 dependencies {

--- a/airbyte-integrations/connectors/source-python-http-tutorial/build.gradle
+++ b/airbyte-integrations/connectors/source-python-http-tutorial/build.gradle
@@ -4,6 +4,11 @@ plugins {
     id 'airbyte-standard-source-test-file'
 }
 
+airbytePython {
+    // TODO: uncomment and get mypy checks to pass
+    // mypyDirectory 'source_python_http_tutorial'
+}
+
 airbyteStandardSourceTestFile {
     // For more information on standard source tests, see https://docs.airbyte.com/connector-development/testing-connectors
 

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -7,7 +7,8 @@ import org.gradle.api.tasks.Exec
 import ru.vyarus.gradle.plugin.python.task.PythonTask
 
 abstract class AirbytePythonExtension {
-    abstract String moduleDirectory
+    abstract String mypyDirectory
+    abstract String mypyConfigFile
 }
 
 class Helpers {
@@ -114,7 +115,7 @@ class AirbytePythonPlugin implements Plugin<Project> {
             // flake8 doesn't support pyproject.toml files
             // and thus there is the wrapper "pyproject-flake8" for this
             pip 'pyproject-flake8:0.0.1a2'
-            pip 'mypy:1.4.1'
+            pip 'mypy:1.6.0'
             pip 'pytest:6.2.5'
             pip 'coverage[toml]:6.3.1'
         }
@@ -175,9 +176,13 @@ class AirbytePythonPlugin implements Plugin<Project> {
 
         def mypyCheck = project.tasks.register('mypyCheck', PythonTask) {
             module = "mypy"
-            command = "-m ${extension.moduleDirectory} --config-file ${project.rootProject.file('pyproject.toml').absolutePath}"
+            def configFile = project.rootProject.file('pyproject.toml')
+            if (extension.hasProperty('mypyConfigFile') && extension.mypyConfigFile != null) {
+                configFile = project.file(extension.mypyConfigFile)
+            }
+            command = "-p ${extension.mypyDirectory} --config-file ${configFile.absolutePath} --install-types --non-interactive"
             onlyIf {
-                extension.hasProperty('moduleDirectory') && extension.moduleDirectory != null
+                extension.hasProperty('mypyDirectory') && extension.mypyDirectory != null
             }
         }
         mypyCheck.configure {

--- a/octavia-cli/build.gradle
+++ b/octavia-cli/build.gradle
@@ -7,7 +7,8 @@ plugins {
 }
 
 airbytePython {
-    moduleDirectory 'octavia_cli'
+    // TODO: uncomment and get mypy checks to pass
+    // mypyDirectory 'octavia_cli'
 }
 
 def generateApiClient = tasks.register('generateApiClient', GenerateTask) {


### PR DESCRIPTION
I'd mistakenly disabled all `mypyCheck` tasks for gradle projects which apply the `airbyte-python` plugin, by removing the `airbytePython { ... }` configuration blocks. This PR re-adds them.

In the process of re-adding them, I realized that `mypy` was not being called correctly: it should be called with `-p` instead of `-m`, the latter basically doesn't check anything, as evidenced by adding a `-v` flag and grepping for `Found source` in stderr. See https://mypy.readthedocs.io/en/stable/command_line.html for details on `-p` vs `-m`.

We currently have 4 gradle projects with airbyte-python and only one of these now passes `mypyCheck`. I invite the reviewers to take ownership of any action to take on the three remaining ones: octavia-cli, airbyte-cdk, and source-python-http-tutorial.

