### PR TITLE
airbyte-ci: concurrent java tests

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -425,6 +425,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 1.9.2   | [#31426](https://github.com/airbytehq/airbyte/pull/31426)  | Concurrent execution of java connectors tests.                                                            |
 | 1.9.1   | [#31455](https://github.com/airbytehq/airbyte/pull/31455)  | Fix `None` docker credentials on publish.                              |
 | 1.9.0   | [#30520](https://github.com/airbytehq/airbyte/pull/30520)  | New commands: `bump-version`, `upgrade-base-image`, `migrate-to-base-image`.                              |
 | 1.8.0   | [#30520](https://github.com/airbytehq/airbyte/pull/30520)  | New commands: `bump-version`, `upgrade-base-image`, `migrate-to-base-image`.                              |

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/java_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/java_connectors.py
@@ -107,7 +107,6 @@ async def run_all_tests(context: ConnectorContext) -> List[StepResult]:
         connector_image_tar_file, _ = await export_container_to_tarball(context, connector_container)
 
         async with asyncer.create_task_group() as docker_build_dependent_group:
-            soon_unit_tests_results = docker_build_dependent_group.soonify(UnitTests(context).run)()
             soon_integration_tests_results = docker_build_dependent_group.soonify(IntegrationTests(context).run)(
                 connector_tar_file=connector_image_tar_file, normalization_tar_file=normalization_tar_file
             )
@@ -115,7 +114,7 @@ async def run_all_tests(context: ConnectorContext) -> List[StepResult]:
                 connector_under_test_image_tar=connector_image_tar_file
             )
 
-        step_results += [soon_cat_results.value, soon_integration_tests_results.value, soon_unit_tests_results.value]
+        step_results += [soon_cat_results.value, soon_integration_tests_results.value]
         return step_results
 
     async with asyncer.create_task_group() as test_task_group:

--- a/airbyte-ci/connectors/pipelines/pipelines/tests/java_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/tests/java_connectors.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 import anyio
 import asyncer
-from dagger import File, QueryError
+from dagger import Directory, File, QueryError
 from pipelines.actions import environments, secrets
 from pipelines.bases import StepResult, StepStatus
 from pipelines.builds.java_connectors import BuildConnectorDistributionTar, BuildConnectorImages, dist_tar_directory_path
@@ -77,41 +77,49 @@ async def run_all_tests(context: ConnectorContext) -> List[StepResult]:
     context.connector_secrets = await secrets.get_connector_secrets(context)
     step_results = []
 
-    build_distribution_tar_results = await BuildConnectorDistributionTar(context).run()
-    step_results.append(build_distribution_tar_results)
-    if build_distribution_tar_results.status is StepStatus.FAILURE:
+    build_distribution_tar_result = await BuildConnectorDistributionTar(context).run()
+    step_results.append(build_distribution_tar_result)
+    if build_distribution_tar_result.status is StepStatus.FAILURE:
         return step_results
 
-    dist_tar_dir = await build_distribution_tar_results.output_artifact.directory(dist_tar_directory_path(context))
-    build_connector_image_results = await BuildConnectorImages(context, LOCAL_BUILD_PLATFORM).run(dist_tar_dir)
-    step_results.append(build_connector_image_results)
-    if build_connector_image_results.status is StepStatus.FAILURE:
+    dist_tar_dir = build_distribution_tar_result.output_artifact.directory(dist_tar_directory_path(context))
+
+    async def run_docker_build_dependent_steps(dist_tar_dir: Directory) -> List[StepResult]:
+        step_results = []
+        build_connector_image_results = await BuildConnectorImages(context, LOCAL_BUILD_PLATFORM).run(dist_tar_dir)
+        step_results.append(build_connector_image_results)
+        if build_connector_image_results.status is StepStatus.FAILURE:
+            return step_results
+
+        if context.connector.supports_normalization:
+            normalization_image = f"{context.connector.normalization_repository}:dev"
+            context.logger.info(f"This connector supports normalization: will build {normalization_image}.")
+            build_normalization_results = await BuildOrPullNormalization(context, normalization_image, LOCAL_BUILD_PLATFORM).run()
+            normalization_container = build_normalization_results.output_artifact
+            normalization_tar_file, _ = await export_container_to_tarball(
+                context, normalization_container, tar_file_name=f"{context.connector.normalization_repository}_{context.git_revision}.tar"
+            )
+            step_results.append(build_normalization_results)
+        else:
+            normalization_tar_file = None
+
+        connector_container = build_connector_image_results.output_artifact[LOCAL_BUILD_PLATFORM]
+        connector_image_tar_file, _ = await export_container_to_tarball(context, connector_container)
+
+        async with asyncer.create_task_group() as docker_build_dependent_group:
+            soon_unit_tests_results = docker_build_dependent_group.soonify(UnitTests(context).run)()
+            soon_integration_tests_results = docker_build_dependent_group.soonify(IntegrationTests(context).run)(
+                connector_tar_file=connector_image_tar_file, normalization_tar_file=normalization_tar_file
+            )
+            soon_cat_results = docker_build_dependent_group.soonify(AcceptanceTests(context).run)(
+                connector_under_test_image_tar=connector_image_tar_file
+            )
+
+        step_results += [soon_cat_results.value, soon_integration_tests_results.value, soon_unit_tests_results.value]
         return step_results
-
-    if context.connector.supports_normalization:
-        normalization_image = f"{context.connector.normalization_repository}:dev"
-        context.logger.info(f"This connector supports normalization: will build {normalization_image}.")
-        build_normalization_results = await BuildOrPullNormalization(context, normalization_image, LOCAL_BUILD_PLATFORM).run()
-        normalization_container = build_normalization_results.output_artifact
-        normalization_tar_file, _ = await export_container_to_tarball(
-            context, normalization_container, tar_file_name=f"{context.connector.normalization_repository}_{context.git_revision}.tar"
-        )
-        step_results.append(build_normalization_results)
-    else:
-        normalization_tar_file = None
-
-    connector_container = build_connector_image_results.output_artifact[LOCAL_BUILD_PLATFORM]
-    connector_image_tar_file, _ = await export_container_to_tarball(context, connector_container)
 
     async with asyncer.create_task_group() as test_task_group:
-        soon_unit_tests_results = test_task_group.soonify(UnitTests(context).run)()
-        soon_integration_tests_results = test_task_group.soonify(IntegrationTests(context).run)(
-            connector_tar_file=connector_image_tar_file, normalization_tar_file=normalization_tar_file
-        )
-        soon_acceptance_tests_results = test_task_group.soonify(AcceptanceTests(context).run)(
-            connector_under_test_image_tar=connector_image_tar_file
-        )
+        soon_unit_tests_result = test_task_group.soonify(UnitTests(context).run)()
+        soon_docker_build_dependent_steps_results = test_task_group.soonify(run_docker_build_dependent_steps)(dist_tar_dir)
 
-    step_results += [soon_acceptance_tests_results.value, soon_integration_tests_results.value, soon_unit_tests_results.value]
-
-    return step_results
+    return step_results + [soon_unit_tests_result.value] + soon_docker_build_dependent_steps_results.value

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.9.1"
+version = "1.9.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Closes #31444

Make java connector tests run concurrently:
Unit, integration and CAT can run in parallel.

## How
Run the test steps concurrently in a task group

## Performance gain
|                   | [master](https://storage.cloud.google.com/airbyte-ci-reports-multi/airbyte-ci/connectors/test/manual/master/1697443939/99b9fc94fde1fc2fedd372165687aa4bbd8c4f28/source-postgres/3.1.13/output.html)  | [this branch](https://storage.cloud.google.com/airbyte-ci-reports-multi/airbyte-ci/connectors/test/manual/augustin_10-15-airbyte-ci_concurrent_java_tests/1697374934/b6b49f4fe545344cbdc45d9880bb3a9fcebf6096/source-postgres/3.1.13/output.html) | speed gain |
|-------------------|---------|-------------|------------|
| total duration    | 29mn38s | 20mn34s     | -9mn4s     |
| unit tests        | 15mn57s | 17mn9s     | +1mn12s    |
| integration tests | 7mn22s  | 8mn50s      | +1mn28s    |
| CAT               | 02mn12s | 3mn59s      | +1mn47s    |

Conclusion: Concurrent execution helps drastically in speeding up the total duration. We observe that the single test steps duration is increased. It probably mean that we have CPU contention. We'll find out with https://github.com/airbytehq/airbyte/issues/31443
## 🚨 User Impact 🚨
**When running tests for source-postgres locally the test crashes**: I believe this is a problem with the local resource: concurrent test run puts more pressure than my laptop can bear. It's not failing on the CI with 16 CPUs.
 
**A fail fast logic would be harder to implement**:
A fail fast logic would be harder to implement while using the task group: a task synchronization efforts should be done with `anyio` if we want to support a fail fast mode. 
I don't think it's an effort we should make in the scope of the test performance improvement.
