### PR TITLE
airbyte-ci-test: remove the paths condition

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -11,8 +11,6 @@ on:
       - opened
       - reopened
       - synchronize
-    paths:
-      - "airbyte-ci/**"
     paths-ignore:
       - "**/*.md"
 jobs:


### PR DESCRIPTION
`paths` and `paths-ignore` can't be combined. As we have a first step already filtering the by changes on airbyte-ci/ I think we 
can remove the paths condition. 
