### PR TITLE
airbyte-ci: fix None docker creds

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -425,6 +425,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 1.9.1   | [#31455](https://github.com/airbytehq/airbyte/pull/31455)  | Fix `None` docker credentials on publish.                              |
 | 1.9.0   | [#30520](https://github.com/airbytehq/airbyte/pull/30520)  | New commands: `bump-version`, `upgrade-base-image`, `migrate-to-base-image`.                              |
 | 1.8.0   | [#30520](https://github.com/airbytehq/airbyte/pull/30520)  | New commands: `bump-version`, `upgrade-base-image`, `migrate-to-base-image`.                              |
 | 1.7.2   | [#31343](https://github.com/airbytehq/airbyte/pull/31343)  | Bind Pytest integration tests to a dockerhost.                                                            |

--- a/airbyte-ci/connectors/pipelines/pipelines/contexts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/contexts.py
@@ -547,9 +547,6 @@ class PublishConnectorContext(ConnectorContext):
         self.metadata_bucket_name = metadata_bucket_name
         self.spec_cache_gcs_credentials = sanitize_gcs_credentials(spec_cache_gcs_credentials)
         self.metadata_service_gcs_credentials = sanitize_gcs_credentials(metadata_service_gcs_credentials)
-        self.docker_hub_username = docker_hub_username
-        self.docker_hub_password = docker_hub_password
-
         pipeline_name = f"Publish {connector.technical_name}"
         pipeline_name = pipeline_name + " (pre-release)" if pre_release else pipeline_name
 
@@ -569,6 +566,8 @@ class PublishConnectorContext(ConnectorContext):
             reporting_slack_channel=reporting_slack_channel,
             ci_gcs_credentials=ci_gcs_credentials,
             should_save_report=True,
+            docker_hub_username=docker_hub_username,
+            docker_hub_password=docker_hub_password,
         )
 
     @property

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.9.0"
+version = "1.9.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
Fix `dockerhub_username` and `dockerhub_password` being `None`

## How
Fix a the regression introduced by  https://github.com/airbytehq/airbyte/pull/30520 :
Adding optional `docker_hub_*` attributes to the `ConnectorContext` class and calling `super` from the `PublishContext(ConnectorContext)` after setting these attribute on `PublishContext` led a a re-assignation of the `docker_hub_` attributes to `None`

