### PR TITLE
airbyte-ci: improve build instructions on connectors migrated to our base image

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -425,6 +425,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 1.9.3   | [#31457](https://github.com/airbytehq/airbyte/pull/31457)  | Improve the connector documentation for connectors migrated to our base image.                              |
 | 1.9.2   | [#31426](https://github.com/airbytehq/airbyte/pull/31426)  | Concurrent execution of java connectors tests.                                                            |
 | 1.9.1   | [#31455](https://github.com/airbytehq/airbyte/pull/31455)  | Fix `None` docker credentials on publish.                              |
 | 1.9.0   | [#30520](https://github.com/airbytehq/airbyte/pull/30520)  | New commands: `bump-version`, `upgrade-base-image`, `migrate-to-base-image`.                              |

--- a/airbyte-ci/connectors/pipelines/pipelines/connector_changes/base_image_version_migration.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/connector_changes/base_image_version_migration.py
@@ -169,13 +169,24 @@ class AddBuildInstructionsToDoc(Step):
             textwrap.dedent(
                 """
             ## Build instructions
+
+            ### Use `airbyte-ci` to build your connector
+            The Airbyte way of building this connector is to use our `airbyte-ci` tool.
+            You can follow install instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#L1).
+            Then running the following command will build your connector:
+
+            ```bash
+            airbyte-ci connectors --name {{ connector_technical_name }} build
+            ```
+            Once the command is done, you will find your connector image in your local docker registry: `{{ connector_image }}:dev`.
+
             ### Build your own connector image
             This connector is built using our dynamic built process.
             The base image used to build it is defined within the metadata.yaml file under the `connectorBuildOptions`.
             The build logic is defined using [Dagger](https://dagger.io/) [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/pipelines/builds/python_connectors.py).
             It does not rely on a Dockerfile.
 
-            If you would like to patch our connector and build your own a simple approach would be:
+            If you would like to patch our connector and build your own a simple approach would be to:
 
             1. Create your own Dockerfile based on the latest version of the connector image.
             ```Dockerfile
@@ -225,7 +236,12 @@ class AddBuildInstructionsToDoc(Step):
             )
         )
 
-        build_instructions = build_instructions_template.render({"connector_image": self.context.connector.metadata["dockerRepository"]})
+        build_instructions = build_instructions_template.render(
+            {
+                "connector_image": self.context.connector.metadata["dockerRepository"],
+                "connector_technical_name": self.context.connector.technical_name,
+            }
+        )
 
         new_doc = "\n".join(og_lines[:line_no_for_build_instructions] + [build_instructions] + og_lines[line_no_for_build_instructions:])
         return new_doc

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.9.2"
+version = "1.9.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
This PR improves the documentation template we append to connectors migrated to our base image.
It add build instruction about airbyte-ci to the README file instead of connectors doc.