### PR TITLE
gradle: remove broken mypy task

### DIFF
--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -5,10 +5,6 @@ plugins {
     id 'airbyte-python'
 }
 
-airbytePython {
-    moduleDirectory 'normalization'
-}
-
 dependencies {
     project(':airbyte-connector-test-harnesses:acceptance-test-harness')
 }

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -6,10 +6,6 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.Exec
 import ru.vyarus.gradle.plugin.python.task.PythonTask
 
-abstract class AirbytePythonExtension {
-    abstract String moduleDirectory
-}
-
 class Helpers {
     static addTestTaskIfTestFilesFound(Project project, String testFilesDirectory, String taskName, taskDependencies) {
         """
@@ -60,7 +56,6 @@ class Helpers {
 class AirbytePythonPlugin implements Plugin<Project> {
 
     void apply(Project project) {
-        def extension = project.extensions.create('airbytePython', AirbytePythonExtension)
 
         def venvDirectoryName = '.venv'
 
@@ -114,7 +109,6 @@ class AirbytePythonPlugin implements Plugin<Project> {
             // flake8 doesn't support pyproject.toml files
             // and thus there is the wrapper "pyproject-flake8" for this
             pip 'pyproject-flake8:0.0.1a2'
-            pip 'mypy:1.4.1'
             pip 'pytest:6.2.5'
             pip 'coverage[toml]:6.3.1'
         }
@@ -171,20 +165,6 @@ class AirbytePythonPlugin implements Plugin<Project> {
         }
         installTestReqs.configure {
             dependsOn installReqs
-        }
-
-        def mypyCheck = project.tasks.register('mypyCheck', PythonTask) {
-            module = "mypy"
-            command = "-m ${extension.moduleDirectory} --config-file ${project.rootProject.file('pyproject.toml').absolutePath}"
-            onlyIf {
-                extension.hasProperty('moduleDirectory') && extension.moduleDirectory != null
-            }
-        }
-        mypyCheck.configure {
-            dependsOn installTestReqs
-        }
-        project.tasks.named('check').configure {
-            dependsOn mypyCheck
         }
 
         Helpers.addTestTaskIfTestFilesFound(project, 'unit_tests', 'testPython', installTestReqs)

--- a/octavia-cli/build.gradle
+++ b/octavia-cli/build.gradle
@@ -6,10 +6,6 @@ plugins {
     id 'airbyte-docker-legacy'
 }
 
-airbytePython {
-    moduleDirectory 'octavia_cli'
-}
-
 def generateApiClient = tasks.register('generateApiClient', GenerateTask) {
     inputSpec =  "$rootDir.absolutePath/airbyte-api/src/main/openapi/config.yaml"
     outputDir = "$buildDir/airbyte_api_client"


### PR DESCRIPTION
See https://github.com/airbytehq/airbyte/pull/31346#issuecomment-1765071641 for how this originated. The `mypyCheck` task already doesn't do anything useful, because it's calling `mypy` with `-m` instead of `-p`. 