### PR TITLE
fix running connector-ops package tests via airbyte-ci

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Get changed files
         uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - run: git checkout HEAD
+          ref: ${{ github.ref }}
       - name: Get changed files
         uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - run: git checkout HEAD
       - name: Get changed files
         uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Get changed files
         uses: dorny/paths-filter@v2
         id: changes

--- a/airbyte-ci/connectors/connector_ops/README.md
+++ b/airbyte-ci/connectors/connector_ops/README.md
@@ -2,6 +2,8 @@
 
 A collection of utilities for working with Airbyte connectors.
 
+some change to get pipelines to run
+
 # Setup
 
 ## Prerequisites

--- a/airbyte-ci/connectors/connector_ops/README.md
+++ b/airbyte-ci/connectors/connector_ops/README.md
@@ -2,8 +2,6 @@
 
 A collection of utilities for working with Airbyte connectors.
 
-some change to get pipelines to run
-
 # Setup
 
 ## Prerequisites

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -424,10 +424,11 @@ This command runs the Python tests for a airbyte-ci poetry package.
 
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
-| ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| 1.9.3   | [#31457](https://github.com/airbytehq/airbyte/pull/31457)  | Improve the connector documentation for connectors migrated to our base image.                              |
+|---------| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 1.9.4   | [#31478](https://github.com/airbytehq/airbyte/pull/31478)  | Fix running tests for connector-ops package.                                                              |
+| 1.9.3   | [#31457](https://github.com/airbytehq/airbyte/pull/31457)  | Improve the connector documentation for connectors migrated to our base image.                            |
 | 1.9.2   | [#31426](https://github.com/airbytehq/airbyte/pull/31426)  | Concurrent execution of java connectors tests.                                                            |
-| 1.9.1   | [#31455](https://github.com/airbytehq/airbyte/pull/31455)  | Fix `None` docker credentials on publish.                              |
+| 1.9.1   | [#31455](https://github.com/airbytehq/airbyte/pull/31455)  | Fix `None` docker credentials on publish.                                                                 |
 | 1.9.0   | [#30520](https://github.com/airbytehq/airbyte/pull/30520)  | New commands: `bump-version`, `upgrade-base-image`, `migrate-to-base-image`.                              |
 | 1.8.0   | [#30520](https://github.com/airbytehq/airbyte/pull/30520)  | New commands: `bump-version`, `upgrade-base-image`, `migrate-to-base-image`.                              |
 | 1.7.2   | [#31343](https://github.com/airbytehq/airbyte/pull/31343)  | Bind Pytest integration tests to a dockerhost.                                                            |

--- a/airbyte-ci/connectors/pipelines/pipelines/commands/groups/tests.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/commands/groups/tests.py
@@ -46,7 +46,7 @@ async def run_test(poetry_package_path: str, test_directory: str) -> bool:
     logger = logging.getLogger(f"{poetry_package_path}.tests")
     logger.info(f"Running tests for {poetry_package_path}")
     # The following directories are always mounted because a lot of tests rely on them
-    directories_to_always_mount = [".git", "airbyte-integrations", "airbyte-ci", "airbyte-cdk", "pyproject.toml"]
+    directories_to_always_mount = [".git", ".github", "docs", "airbyte-integrations", "airbyte-ci", "airbyte-cdk", "pyproject.toml"]
     directories_to_mount = list(set([poetry_package_path, *directories_to_always_mount]))
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as dagger_client:
         try:

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "1.9.3"
+version = "1.9.4"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

`airbyte-ci` tests for `connector-ops` package are failing in CI - this PR fixes this.

## How

1. Fix issue with running git commands in the test:
- Add `fetch-depth: 0` to pull all history
- Set `ref` to the PR head to avoid a detached head and allow the commands to work correctly
2. Fix issue with files missing when running test:
- Add `docs` and `.github` dirs to the mounted test container. These are required to validate that docs exist, and that required reviewers file is written, respectively.

