### PR TITLE
ci: fix review request paths

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -63,7 +63,7 @@ def write_review_requirements_file():
     mandatory_reviewers = find_mandatory_reviewers()
 
     if mandatory_reviewers:
-        requirements_file_content = [dict(r, paths="unmatched") for r in mandatory_reviewers]
+        requirements_file_content = [dict(r, paths="*") for r in mandatory_reviewers]
         with open(REVIEW_REQUIREMENTS_FILE_PATH, "w") as requirements_file:
             yaml.safe_dump(requirements_file_content, requirements_file)
         print("CREATED_REQUIREMENTS_FILE=true")

--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -63,7 +63,7 @@ def write_review_requirements_file():
     mandatory_reviewers = find_mandatory_reviewers()
 
     if mandatory_reviewers:
-        requirements_file_content = [dict(r, paths=["*"]) for r in mandatory_reviewers]
+        requirements_file_content = [dict(r, paths=["**"]) for r in mandatory_reviewers]
         with open(REVIEW_REQUIREMENTS_FILE_PATH, "w") as requirements_file:
             yaml.safe_dump(requirements_file_content, requirements_file)
         print("CREATED_REQUIREMENTS_FILE=true")

--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -63,7 +63,7 @@ def write_review_requirements_file():
     mandatory_reviewers = find_mandatory_reviewers()
 
     if mandatory_reviewers:
-        requirements_file_content = [dict(r, paths="*") for r in mandatory_reviewers]
+        requirements_file_content = [dict(r, paths=["*"]) for r in mandatory_reviewers]
         with open(REVIEW_REQUIREMENTS_FILE_PATH, "w") as requirements_file:
             yaml.safe_dump(requirements_file_content, requirements_file)
         print("CREATED_REQUIREMENTS_FILE=true")

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector_ops"
-version = "0.3.0"
+version = "0.3.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

The old paths spec was causing an subsequent requirements to be skipped when another requirement was already specified:

```
Checking requirement "GA Connectors"...
  Matches the following files:
     - airbyte-integrations/connectors/source-stripe/metadata.yaml
  Checking reviewers...
    Union of these:
      Members of gl-python: <empty set>
    => <empty set>
Error: Requirement "GA Connectors" is not satisfied by the existing reviews.
Checking requirement "Breaking Changes"...
  Matches files that haven't been matched yet, but all files have.
Requirement "Breaking Changes" does not apply to any files in this PR.
```

## How

Fix by matching on all paths rather than when no other path is matched
