### PR TITLE
🐛Source Gitlab: handle expired access_token error with status code 400

### DIFF
--- a/airbyte-integrations/connectors/source-gitlab/Dockerfile
+++ b/airbyte-integrations/connectors/source-gitlab/Dockerfile
@@ -13,5 +13,5 @@ COPY main.py ./
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.8.1
+LABEL io.airbyte.version=1.8.2
 LABEL io.airbyte.name=airbyte/source-gitlab

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 5e6175e5-68e1-4c17-bff9-56103bbb0d80
-  dockerImageTag: 1.8.1
+  dockerImageTag: 1.8.2
   dockerRepository: airbyte/source-gitlab
   githubIssueLabel: source-gitlab
   icon: gitlab.svg

--- a/airbyte-integrations/connectors/source-gitlab/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-gitlab/unit_tests/test_source.py
@@ -47,10 +47,9 @@ def test_connection_fail_due_to_api_error(config, mocker, requests_mock):
     assert status is False, msg.startswith('Unable to connect to Gitlab API with the provided credentials - "DefaultBackoffException"')
 
 
-@pytest.mark.parametrize("status_code", (400, 401))
-def test_connection_fail_due_to_expired_access_token_error(oauth_config, requests_mock, status_code):
+def test_connection_fail_due_to_expired_access_token_error(oauth_config, requests_mock):
     expected = "Unable to refresh the `access_token`, please re-auth in Source > Settings."
-    requests_mock.post("https://gitlab.com/oauth/token", status_code=status_code)
+    requests_mock.post("https://gitlab.com/oauth/token", status_code=401)
     source = SourceGitlab()
     status, msg = source.check_connection(logging.getLogger("airbyte"), oauth_config)
     assert status is False, expected in msg

--- a/airbyte-integrations/connectors/source-gitlab/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-gitlab/unit_tests/test_source.py
@@ -47,15 +47,16 @@ def test_connection_fail_due_to_api_error(config, mocker, requests_mock):
     assert status is False, msg.startswith('Unable to connect to Gitlab API with the provided credentials - "DefaultBackoffException"')
 
 
-def test_connection_fail_due_to_expired_access_token_error(oauth_config, mocker, requests_mock):
+@pytest.mark.parametrize("status_code", (400, 401))
+def test_connection_fail_due_to_expired_access_token_error(oauth_config, requests_mock, status_code):
     expected = "Unable to refresh the `access_token`, please re-auth in Source > Settings."
-    requests_mock.post("https://gitlab.com/oauth/token", status_code=401)
+    requests_mock.post("https://gitlab.com/oauth/token", status_code=status_code)
     source = SourceGitlab()
     status, msg = source.check_connection(logging.getLogger("airbyte"), oauth_config)
     assert status is False, expected in msg
 
 
-def test_refresh_expired_access_token_on_error(oauth_config, mocker, requests_mock):
+def test_refresh_expired_access_token_on_error(oauth_config, requests_mock):
     test_response = {
         "access_token": "new_access_token",
         "expires_in": 7200,

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -112,6 +112,7 @@ Gitlab has the [rate limits](https://docs.gitlab.com/ee/user/gitlab_com/index.ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                    |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------|
+| 1.8.2   | 2023-10-17 | [31492](https://github.com/airbytehq/airbyte/pull/31492) | Expand list of possible error status codes when handling expired `access_token`            |
 | 1.8.1   | 2023-10-12 | [31375](https://github.com/airbytehq/airbyte/pull/31375) | Mark `start_date` as optional, migrate `groups` and `projects` to array                    |
 | 1.8.0   | 2023-10-12 | [31339](https://github.com/airbytehq/airbyte/pull/31339) | Add undeclared fields to streams schemas, validate date/date-time format in stream schemas |
 | 1.7.1   | 2023-10-10 | [31210](https://github.com/airbytehq/airbyte/pull/31210) | Added expired `access_token` handling, while checking the connection                       |


### PR DESCRIPTION
## What
Gracefully handle HTTP error with status code of 400 during access token refresh.
https://github.com/airbytehq/oncall/issues/2693

## How
Extend the list of codes already handled in `check_connection` and add extra params to `SingleUseRefreshTokenGitlabOAuth2Authenticator` in order to wrap 400 errors into `AirbyteTracedExcpetion`.

## Recommended reading order
1. `source.py`
2. `test_source.py`

## 🚨 User Impact 🚨
No breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
