### PR TITLE
schedule a workflow to gather source-postgres CI perfs

### DIFF
--- a/.github/workflows/tmp-source-postgres-test.yml
+++ b/.github/workflows/tmp-source-postgres-test.yml
@@ -1,0 +1,44 @@
+# This workflows runs airbyte-ci connectors --name=source-postgres test
+# We created this in the context of our project to improve CI performances for this connector
+# It's made to be triggered manually from the GitHub UI
+# It will allow us to collect performance metrics outside of the context of nightly builds
+# And also to use different runner types (e.g. conn-prod-xxlarge-runner) to test the connector with various resources.
+
+name: source-postgres ci - for testing only
+
+on:
+  schedule:
+    # Run three time a day to collect performance metrics and observe variance
+    - cron: "0 8,12,16 * * *"
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "The runner to use for this job"
+        default: "conn-prod-xlarge-runner"
+
+jobs:
+  source_postgres_ci:
+    name: Source Postgres CI on ${{ inputs.runner || 'conn-prod-xlarge-runner'}}
+    runs-on: ${{ inputs.runner || 'conn-prod-xlarge-runner'}}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.repo }}
+          ref: ${{ github.event.inputs.gitref }}
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        id: extract_branch
+      - name: Test source-postgres [WORKFLOW DISPATCH]
+        if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/run-dagger-pipeline
+        with:
+          context: "master"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          git_branch: ${{ steps.extract_branch.outputs.branch }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          subcommand: "connectors --name=source-postgres test"


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
I've been considering so far that nightly build performance of source-postgres was the right source of truth when considering source-postgres CI performance.

I was wrong because in nightly build, even if we disabled java connector testing concurrency, we still have python connector concurrency. In other words: a python connector can be tested concurrently to a java connector.
This can alter the performance, add variability to our metrics collection, and bias our performance assertions.


## How
To reproduce on master the same CI performance a developer would get while iterating on the postgres connector on PR I suggest to:
- schedule a workflow on master that will only test source-postgres
- run it 3 times a day to observe variability 

I'll then update our metabase question to track metrics from this workflow and not nightly build.
