### PR TITLE
🐛 Source Shopify: Fixed the issue caused by the `missing access token` while setup the new source and not yet authenticated.

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify/Dockerfile
@@ -31,5 +31,5 @@ COPY source_shopify ./source_shopify
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.1.2
+LABEL io.airbyte.version=1.1.3
 LABEL io.airbyte.name=airbyte/source-shopify

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9da77001-af33-4bcd-be46-6252bf9342b9
-  dockerImageTag: 1.1.2
+  dockerImageTag: 1.1.3
   dockerRepository: airbyte/source-shopify
   documentationUrl: https://docs.airbyte.com/integrations/sources/shopify
   githubIssueLabel: source-shopify

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/auth.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/auth.py
@@ -8,6 +8,12 @@ from typing import Any, Dict, Mapping
 from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
 
 
+class MissingAccessTokenError(Exception):
+    """
+    Raised when the token is `None` instead of the real value
+    """
+
+
 class NotImplementedAuth(Exception):
     """Not implemented Auth option error"""
 
@@ -34,7 +40,11 @@ class ShopifyAuthenticator(TokenAuthenticator):
         auth_method: str = credentials.get("auth_method")
 
         if auth_method in ["oauth2.0", "access_token"]:
-            return {auth_header: credentials.get("access_token")}
+            access_token = credentials.get("access_token")
+            if access_token:
+                return {auth_header: credentials.get("access_token")}
+            else:
+                raise MissingAccessTokenError
         elif auth_method == "api_password":
             return {auth_header: credentials.get("api_password")}
         else:

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/auth.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/auth.py
@@ -42,7 +42,7 @@ class ShopifyAuthenticator(TokenAuthenticator):
         if auth_method in ["oauth2.0", "access_token"]:
             access_token = credentials.get("access_token")
             if access_token:
-                return {auth_header: credentials.get("access_token")}
+                return {auth_header: access_token}
             else:
                 raise MissingAccessTokenError
         elif auth_method == "api_password":

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/source.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/source.py
@@ -940,7 +940,7 @@ class ConnectionCheckTest:
             "connection_error": f"Connection could not be established using `Shopify Store`: {shop_name}. Make sure it's valid and try again.",
             "request_exception": f"Request was not successfull, check your `input configuation` and try again. Details: {details}",
             "index_error": f"Failed to access the Shopify store `{shop_name}`. Verify the entered Shopify store or API Key in `input configuration`.",
-            "missing_token_error": "The `access_token` is missing or wasn't obtained correctly, please `Re-authenticate` in the `Source > Settings`.",
+            "missing_token_error": "Authentication was unsuccessful. Please verify your authentication credentials or login is correct.",
             # add the other patterns and description, if needed...
         }
         return connection_check_errors_map.get(pattern)

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/source.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/source.py
@@ -16,7 +16,7 @@ from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 from requests.exceptions import ConnectionError, InvalidURL, JSONDecodeError, RequestException, SSLError
 
-from .auth import ShopifyAuthenticator
+from .auth import MissingAccessTokenError, ShopifyAuthenticator
 from .graphql import get_query_products
 from .transform import DataTypeEnforcer
 from .utils import SCOPES_MAPPING, ApiTypeEnum
@@ -940,6 +940,7 @@ class ConnectionCheckTest:
             "connection_error": f"Connection could not be established using `Shopify Store`: {shop_name}. Make sure it's valid and try again.",
             "request_exception": f"Request was not successfull, check your `input configuation` and try again. Details: {details}",
             "index_error": f"Failed to access the Shopify store `{shop_name}`. Verify the entered Shopify store or API Key in `input configuration`.",
+            "missing_token_error": "The `access_token` is missing or wasn't obtained correctly, please `Re-authenticate` in the `Source > Settings`.",
             # add the other patterns and description, if needed...
         }
         return connection_check_errors_map.get(pattern)
@@ -963,6 +964,8 @@ class ConnectionCheckTest:
             return False, self.describe_error("request_exception", details=req_error)
         except IndexError:
             return False, self.describe_error("index_error", shop_name, response)
+        except MissingAccessTokenError:
+            return False, self.describe_error("missing_token_error")
 
 
 class SourceShopify(AbstractSource):

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_auth.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_auth.py
@@ -60,5 +60,7 @@ def test_raises_notimplemented_auth(config_not_implemented_auth_method):
 def test_raises_missing_access_token(config_missing_access_token):
     config_missing_access_token["authenticator"] = ShopifyAuthenticator(config=(config_missing_access_token))
     failed_check = ConnectionCheckTest(config_missing_access_token).test_connection()
-    assert failed_check == (False, "The `access_token` is missing or wasn't obtained correctly, please `Re-authenticate` in the `Source > Settings`.")
-        
+    assert failed_check == (
+        False,
+        "The `access_token` is missing or wasn't obtained correctly, please `Re-authenticate` in the `Source > Settings`.",
+    )

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_auth.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_auth.py
@@ -5,6 +5,7 @@
 
 import pytest
 from source_shopify.auth import NotImplementedAuth, ShopifyAuthenticator
+from source_shopify.source import ConnectionCheckTest
 
 TEST_ACCESS_TOKEN = "test_access_token"
 TEST_API_PASSWORD = "test_api_password"
@@ -23,6 +24,11 @@ def config_api_password():
 @pytest.fixture
 def config_not_implemented_auth_method():
     return {"credentials": {"auth_method": "not_implemented_auth_method"}}
+
+
+@pytest.fixture
+def config_missing_access_token():
+    return {"shop": "SHOP_NAME", "credentials": {"auth_method": "oauth2.0", "access_token": None}}
 
 
 @pytest.fixture
@@ -47,6 +53,12 @@ def test_shopify_authenticator_api_password(config_api_password, expected_auth_h
 
 def test_raises_notimplemented_auth(config_not_implemented_auth_method):
     authenticator = ShopifyAuthenticator(config=(config_not_implemented_auth_method))
-    with pytest.raises(NotImplementedAuth) as not_implemented_exc:
-        print(not_implemented_exc)
+    with pytest.raises(NotImplementedAuth):
         authenticator.get_auth_header()
+
+
+def test_raises_missing_access_token(config_missing_access_token):
+    config_missing_access_token["authenticator"] = ShopifyAuthenticator(config=(config_missing_access_token))
+    failed_check = ConnectionCheckTest(config_missing_access_token).test_connection()
+    assert failed_check == (False, "The `access_token` is missing or wasn't obtained correctly, please `Re-authenticate` in the `Source > Settings`.")
+        

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_auth.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_auth.py
@@ -62,5 +62,5 @@ def test_raises_missing_access_token(config_missing_access_token):
     failed_check = ConnectionCheckTest(config_missing_access_token).test_connection()
     assert failed_check == (
         False,
-        "The `access_token` is missing or wasn't obtained correctly, please `Re-authenticate` in the `Source > Settings`.",
+        "Authentication was unsuccessful. Please verify your authentication credentials or login is correct.",
     )

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -167,6 +167,7 @@ This is expected when the connector hits the 429 - Rate Limit Exceeded HTTP Erro
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| 1.1.3   | 2023-10-17 | [31500](https://github.com/airbytehq/airbyte/pull/31500) | Fixed the issue caused by the `missing access token` while setup the new source and not yet authenticated |
 | 1.1.2   | 2023-10-13 | [31381](https://github.com/airbytehq/airbyte/pull/31381) | Fixed the issue caused by the `state` presence while fetching the `deleted events` with pagination |
 | 1.1.1   | 2023-09-18 | [30560](https://github.com/airbytehq/airbyte/pull/30560) | Performance testing - include socat binary in docker image |
 | 1.1.0   | 2023-09-07 | [30246](https://github.com/airbytehq/airbyte/pull/30246) | Added ability to fetch `destroyed` records for `Articles, Blogs, CustomCollections, Orders, Pages, PriceRules, Products` |


### PR DESCRIPTION
## What
Resolving:
- https://github.com/airbytehq/oncall/issues/3017

## How
- added new `MissingAccessTokenException` to be raised, when the `access_token` is set to `None` explicitly, when there were no authorization steps in prior.
- covered the case with unit test

## 🚨 User Impact 🚨
No impact is expected. Not a breaking change.
