### PR TITLE
increase "format code" worfklow timeout to 40mn

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ jobs:
   format-and-commit:
     runs-on: ubuntu-latest
     name: "Apply All Formatting Rules"
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3


### PR DESCRIPTION
20mn is not always enough to run the "format code" workflow.
I'm doubling its timeout to 40mn.
Our team effort on revamping the formatting workflow would make this workflow faster soon!
