### PR TITLE
ci: only request required reviewers when PR is not draft mode

### DIFF
--- a/.github/workflows/connector_teams_review_requirements.yml
+++ b/.github/workflows/connector_teams_review_requirements.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Check if a review is required from Connector teams"
     runs-on: ubuntu-latest
 
-    if: ${{ github.repository == 'airbytehq/airbyte' }}
+    if: ${{ github.repository == 'airbytehq/airbyte' && github.event.pull_request.draft == false }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3

--- a/.github/workflows/connector_teams_review_requirements.yml
+++ b/.github/workflows/connector_teams_review_requirements.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Check if a review is required from Connector teams"
     runs-on: ubuntu-latest
 
-    if: ${{ github.repository == 'airbytehq/airbyte' && github.event.pull_request.draft == false }}
+    if: ${{ github.repository == 'airbytehq/airbyte' }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
         id: get-mandatory-reviewers
         run: print-mandatory-reviewers >> $GITHUB_OUTPUT
       - name: Check if the review requirements are met
-        if: steps.write-review-requirements-file.outputs.CREATED_REQUIREMENTS_FILE == 'true'
+        if: ! github.event.pull_request.draft && steps.write-review-requirements-file.outputs.CREATED_REQUIREMENTS_FILE == 'true'
         uses: Automattic/action-required-review@v3
         with:
           status: ${{ steps.get-mandatory-reviewers.outputs.MANDATORY_REVIEWERS  }}

--- a/.github/workflows/connector_teams_review_requirements.yml
+++ b/.github/workflows/connector_teams_review_requirements.yml
@@ -2,6 +2,11 @@ name: Connector Ops CI - Check review requirements
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
     paths:
       - "airbyte-integrations/connectors/source-**"
   pull_request_review:
@@ -12,7 +17,7 @@ jobs:
     name: "Check if a review is required from Connector teams"
     runs-on: ubuntu-latest
 
-    if: ${{ github.repository == 'airbytehq/airbyte' }}
+    if: ${{ github.repository == 'airbytehq/airbyte' && github.event.pull_request.draft == false }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
@@ -34,7 +39,7 @@ jobs:
         id: get-mandatory-reviewers
         run: print-mandatory-reviewers >> $GITHUB_OUTPUT
       - name: Check if the review requirements are met
-        if: ! github.event.pull_request.draft && steps.write-review-requirements-file.outputs.CREATED_REQUIREMENTS_FILE == 'true'
+        if: steps.write-review-requirements-file.outputs.CREATED_REQUIREMENTS_FILE == 'true'
         uses: Automattic/action-required-review@v3
         with:
           status: ${{ steps.get-mandatory-reviewers.outputs.MANDATORY_REVIEWERS  }}


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

We changed the action behavior to auto-request review, but you probably don't want this if your PR is still in draft mode. So... let's change that!

## How

- Add conditional to not run on draft PRs
- Add the `ready_for_review` event triggers
