### PR TITLE
Connector Report: remove divide by 100

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/templates/render.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/templates/render.py
@@ -43,10 +43,8 @@ def test_badge_html(test_summary_url: str) -> str:
 
 
 def internal_level_html(level_value: float) -> str:
-    level = level_value / 100
-
-    # remove trailing zeros
-    level = f"{level:.2f}".rstrip("0").rstrip(".")
+    # cast to int to remove decimal places
+    level = int(level_value)
 
     return f"Level <b>{level}</b>"
 


### PR DESCRIPTION
## Overview
@katmarkham asked that we show the full sl and ql levels instead of reducing them down to 1 digit. e.g. `100` -> `1`