### PR TITLE
airbyte-ci: Reword the connector changelog entry when using `migrate-to-base-image`

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -398,6 +398,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 2.0.1   | [#31545](https://github.com/airbytehq/airbyte/pull/31545)  | Reword the changelog entry when using `migrate-to-base-image`.                                                            |
 | 2.0.0   | [#31424](https://github.com/airbytehq/airbyte/pull/31424)  | Remove `airbyte-ci connectors format` command.                                                            |
 | 1.9.4   | [#31478](https://github.com/airbytehq/airbyte/pull/31478)  | Fix running tests for connector-ops package.                                                              |
 | 1.9.3   | [#31457](https://github.com/airbytehq/airbyte/pull/31457)  | Improve the connector documentation for connectors migrated to our base image.                            |

--- a/airbyte-ci/connectors/pipelines/pipelines/connector_changes/base_image_version_migration.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/connector_changes/base_image_version_migration.py
@@ -320,7 +320,7 @@ async def run_connector_migration_to_base_image_pipeline(context: ConnectorConte
                 context,
                 bump_version_in_metadata_result.output_artifact,
                 new_version,
-                "Use our base image and remove Dockerfile",
+                "Base image migration: remove Dockerfile and use the python-connector-base image",
                 pull_request_number,
             )
             add_changelog_entry_result = await add_changelog_entry.run()

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.0.0"
+version = "2.0.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
Reword the changelog entry when using `migrate-to-base-image`:

*Use our base image and remove Dockerfile* > *Base image migration: remove Dockerfile and use the python-connector-base image*