### PR TITLE
Source Airtable: add unit tests for authenticator

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/unit_tests/test_authenticator.py
+++ b/airbyte-integrations/connectors/source-airtable/unit_tests/test_authenticator.py
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+
+import pytest
+from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
+from airbyte_cdk.utils import AirbyteTracedException
+from source_airtable.auth import AirtableAuth, AirtableOAuth
+
+CONFIG_OAUTH = {"credentials": {"auth_method": "oauth2.0", "client_id": "sample_client_id", "client_secret": "sample_client_secret"}}
+
+
+@pytest.mark.parametrize(
+    "config, expected_auth_class",
+    [
+        ({"api_key": "sample_api_key"}, TokenAuthenticator),
+        (CONFIG_OAUTH, AirtableOAuth),
+        ({"credentials": {"auth_method": "api_key", "api_key": "sample_api_key"}}, TokenAuthenticator),
+    ],
+    ids=["old_config_api_key", "oauth2.0", "api_key"],
+)
+def test_airtable_auth(config, expected_auth_class):
+    auth_instance = AirtableAuth(config)
+    assert isinstance(auth_instance, expected_auth_class)
+
+
+def test_airtable_oauth():
+    auth_instance = AirtableAuth(CONFIG_OAUTH)
+    assert isinstance(auth_instance, AirtableOAuth)
+    assert auth_instance.build_refresh_request_headers() == {"Authorization": "Basic c2FtcGxlX2NsaWVudF9pZDpzYW1wbGVfY2xpZW50X3NlY3JldA==","Content-Type": "application/x-www-form-urlencoded"}
+    assert auth_instance.build_refresh_request_body() == {"grant_type": "refresh_token","refresh_token": ""}
+
+
+def test_airtable_oauth_token_refresh_exception(requests_mock):
+    auth_instance = AirtableAuth(CONFIG_OAUTH)
+    requests_mock.post("https://airtable.com/oauth2/v1/token", status_code=400, json={"error": "invalid_grant","error_description": "grant invalid"})
+    with pytest.raises(AirbyteTracedException) as e:
+        auth_instance._get_refresh_access_token_response()
+    assert e.value.message == "Refresh token is invalid or expired. Please re-authenticate to restore access to Airtable."

--- a/airbyte-integrations/connectors/source-airtable/unit_tests/test_authenticator.py
+++ b/airbyte-integrations/connectors/source-airtable/unit_tests/test_authenticator.py
@@ -28,13 +28,18 @@ def test_airtable_auth(config, expected_auth_class):
 def test_airtable_oauth():
     auth_instance = AirtableAuth(CONFIG_OAUTH)
     assert isinstance(auth_instance, AirtableOAuth)
-    assert auth_instance.build_refresh_request_headers() == {"Authorization": "Basic c2FtcGxlX2NsaWVudF9pZDpzYW1wbGVfY2xpZW50X3NlY3JldA==","Content-Type": "application/x-www-form-urlencoded"}
-    assert auth_instance.build_refresh_request_body() == {"grant_type": "refresh_token","refresh_token": ""}
+    assert auth_instance.build_refresh_request_headers() == {
+        "Authorization": "Basic c2FtcGxlX2NsaWVudF9pZDpzYW1wbGVfY2xpZW50X3NlY3JldA==",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    assert auth_instance.build_refresh_request_body() == {"grant_type": "refresh_token", "refresh_token": ""}
 
 
 def test_airtable_oauth_token_refresh_exception(requests_mock):
     auth_instance = AirtableAuth(CONFIG_OAUTH)
-    requests_mock.post("https://airtable.com/oauth2/v1/token", status_code=400, json={"error": "invalid_grant","error_description": "grant invalid"})
+    requests_mock.post(
+        "https://airtable.com/oauth2/v1/token", status_code=400, json={"error": "invalid_grant", "error_description": "grant invalid"}
+    )
     with pytest.raises(AirbyteTracedException) as e:
         auth_instance._get_refresh_access_token_response()
     assert e.value.message == "Refresh token is invalid or expired. Please re-authenticate to restore access to Airtable."

--- a/airbyte-integrations/connectors/source-airtable/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-airtable/unit_tests/test_source.py
@@ -7,15 +7,8 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
-from airbyte_cdk.models import AirbyteCatalog, ConnectorSpecification
+from airbyte_cdk.models import AirbyteCatalog
 from source_airtable.source import SourceAirtable
-
-
-def test_spec(config):
-    source = SourceAirtable()
-    logger_mock = MagicMock()
-    spec = source.spec(logger_mock)
-    assert isinstance(spec, ConnectorSpecification)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Resolving https://github.com/airbytehq/airbyte/issues/29743

## How

add unit tests increase authenticator coverage
![image](https://github.com/airbytehq/airbyte/assets/36314070/41aa1dad-9a55-4fe1-a2a5-683a68012533)


## Recommended reading order
1. `test_authenticator.py`

## 🚨 User Impact 🚨

no breaking changes


## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
