### PR TITLE
Revert "Update CI credentials docs to point to new GCP project (#30813)"

### DIFF
--- a/airbyte-ci/connectors/ci_credentials/README.md
+++ b/airbyte-ci/connectors/ci_credentials/README.md
@@ -46,12 +46,12 @@ If you face any installation problem feel free to reach out the Airbyte Connecto
 Download a Service account json key that has access to Google Secrets Manager.
 
 ### Create Service Account
-* Go to https://console.cloud.google.com/iam-admin/serviceaccounts/create?project=ab-connector-integration-test
+* Go to https://console.cloud.google.com/iam-admin/serviceaccounts/create?project=dataline-integration-testing
 * In step #1 `Service account details`, set a name and a relevant description
 * In step #2 `Grant this service account access to project`, select role `Owner` (there is a role that is more scope but I based this decision on others `<user>-testing` service account)
 
 ### Create Service Account Token
-* Go to https://console.cloud.google.com/iam-admin/serviceaccounts?project=ab-connector-integration-test
+* Go to https://console.cloud.google.com/iam-admin/serviceaccounts?project=dataline-integration-testing
 * Find your service account and click on it
 * Go in the tab "KEYS"
 * Click on "ADD KEY -> Create new key" and select JSON. This will download a file on your computer


### PR DESCRIPTION
## What
* Reverting instructions to old google cloud project since the new one doesn't have all the secrets we expect. FYI @wennergr since you mentioned `dataline-integration-testing` was supposed to be deprecated.