### PR TITLE
CI: Skip connector test and format on markdown only changes

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -25,6 +25,8 @@ on:
       - opened
       - synchronize
       - ready_for_review
+    paths-ignore:
+      - "**/*.md"
 jobs:
   connectors_ci:
     name: Connectors CI

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - "**/*.md"
 jobs:
   format-and-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
based on approve-and-merge reason from @girarda  in: https://github.com/airbytehq/airbyte/pull/31593#issuecomment-1769572527

ci was skipped because we were running it on a docs only pr

## Solution
have format and connector test skip when the PR is markdown only