### PR TITLE
Add dummy HideInUI component

### DIFF
--- a/docusaurus/src/components/HideInUI.jsx
+++ b/docusaurus/src/components/HideInUI.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+/**
+ * HideInUI is a dummy-component in the docusaurus build but is used when the documentation is rendered in the webapp
+ * to suppress rendering of certain content.
+ *
+ * When using the HideInUI component, you must leave a blank line between the tags and its
+ * content in order for the content to be parsed as markdown and rendered to html; without
+ * a blank line, it will be rendered as plain text.
+ */
+export const HideInUI = ({ children }) => {
+  return children;
+};

--- a/docusaurus/src/theme/MDXComponents/index.js
+++ b/docusaurus/src/theme/MDXComponents/index.js
@@ -1,12 +1,14 @@
-import React from 'react';
+import React from "react";
 // Import the original mapper
-import MDXComponents from '@theme-original/MDXComponents';
-import { AppliesTo } from '@site/src/components/AppliesTo';
-import { FieldAnchor } from '@site/src/components/FieldAnchor';
+import MDXComponents from "@theme-original/MDXComponents";
+import { AppliesTo } from "@site/src/components/AppliesTo";
+import { FieldAnchor } from "@site/src/components/FieldAnchor";
+import { HideInUI } from "@site/src/components/HideInUI";
 
 export default {
   // Re-use the default mapping
   ...MDXComponents,
   AppliesTo,
-  FieldAnchor
+  FieldAnchor,
+  HideInUI,
 };


### PR DESCRIPTION
This is a component which is used in the Airbyte UI to suppress certain content from being rendered in-app; it should be ignored in docusaurus builds.

This is the `airbyte` repo counterpart to [this airbyte-platform-internal PR](https://github.com/airbytehq/airbyte-platform-internal/pull/9380); its main effect is to suppress warnings inside docusaurus, though it also prevents a superfluous `div` from being wrapped around the docusaurus presentation of hidden-in-app content.