### PR TITLE
✨ Orb Connector: Adding subscription version

### DIFF
--- a/airbyte-integrations/connectors/source-orb/Dockerfile
+++ b/airbyte-integrations/connectors/source-orb/Dockerfile
@@ -34,5 +34,5 @@ COPY source_orb ./source_orb
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.1.0
+LABEL io.airbyte.version=1.2.0
 LABEL io.airbyte.name=airbyte/source-orb

--- a/airbyte-integrations/connectors/source-orb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orb/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 7f0455fb-4518-4ec0-b7a3-d808bf8081cc
-  dockerImageTag: 1.1.0
+  dockerImageTag: 1.2.0
   dockerRepository: airbyte/source-orb
   githubIssueLabel: source-orb
   icon: orb.svg

--- a/airbyte-integrations/connectors/source-orb/source_orb/schemas/subscription_versions.json
+++ b/airbyte-integrations/connectors/source-orb/source_orb/schemas/subscription_versions.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": ["null", "object"],
+    "properties": {
+      "subscription_id": {
+        "type": "string"
+      },
+      "plan_id": {
+        "type": "string"
+      },
+      "start_date": {
+        "type": ["string"],
+        "format": "date-time"
+      },
+      "end_date": {
+        "type": ["string"],
+        "format": "date-time"
+      }
+    },
+    "required": ["subscription_id", "plan_id", "start_date", "end_date"]
+  }
+  

--- a/airbyte-integrations/connectors/source-orb/source_orb/source.py
+++ b/airbyte-integrations/connectors/source-orb/source_orb/source.py
@@ -178,6 +178,25 @@ class Subscriptions(IncrementalOrbStream):
 
         return subscription_record
 
+class SubscriptionVersions(IncrementalOrbStream):
+    @property
+    def cursor_field(self) -> str:
+        return "modified_at"
+    
+    def path(self, **kwargs) -> str:
+        return "subscription_versions"
+
+    def transform_record(self, subscription_version):
+        # Transform the subscription_version record to be compatible with the subscription_version schema
+        flattened_subscription_version = {}
+        
+        flattened_subscription_version["subscription_id"] = subscription_version["subscription_id"]
+        flattened_subscription_version["plan_id"] = subscription_version["plan"]["id"]
+        flattened_subscription_version["start_date"]  = subscription_version["subscription_start_date"]
+        flattened_subscription_version["end_date"]  = subscription_version["subscription_ended_at"]
+        
+        return flattened_subscription_version
+
 
 # helpers for working with pendulum dates and strings
 def to_datetime(time) -> Optional[pendulum.DateTime]:
@@ -747,4 +766,5 @@ class SourceOrb(AbstractSource):
                 plan_id=plan_id,
                 subscription_usage_grouping_key=subscription_usage_grouping_key,
             ),
+            SubscriptionVersions(authenticator=authenticator, lookback_window_days=lookback_window, start_date=start_date),
         ]

--- a/airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py
@@ -17,6 +17,7 @@ from source_orb.source import (
     Plans,
     Subscriptions,
     SubscriptionUsage,
+    SubscriptionVersions,
 )
 
 
@@ -662,3 +663,26 @@ def test_source_defined_cursor(patch_incremental_base_class):
 def test_stream_checkpoint_interval(patch_incremental_base_class):
     stream = IncrementalOrbStream()
     assert stream.state_checkpoint_interval is None
+
+
+@pytest.mark.parametrize(
+    ("current_stream_state", "latest_record", "expected_state"),
+    [
+        # No state
+        (
+            {},
+            dict(modified_at="2022-01-26T12:00:00+00:00"),
+            dict(modified_at="2022-01-26T12:00:00+00:00"),
+        ),
+        # Existing state
+        (
+            dict(modified_at="2022-01-26T12:00:00+00:00"),
+            dict(modified_at="2023-01-26T12:00:00+00:00"),
+            dict(modified_at="2023-01-26T12:00:00+00:00"),
+        ),
+    ],
+)
+def test_subscription_versions_get_updated_state(mocker, current_stream_state, latest_record, expected_state):
+    stream = SubscriptionVersions()
+    inputs = {"current_stream_state": current_stream_state, "latest_record": latest_record}
+    assert stream.get_updated_state(**inputs) == expected_state


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*
In Orb, subscriptions can change over time and have different plans associated with them in different time frames. This PR exposes the concept of a `SubscriptionVersion`, which includes the `subscription_id`, `plan_id`, `start_date` and `end_date`.

## How
*Describe the solution*
We call the `subscription_versions` endpoint in the Orb API, which we can paginate through.

## Recommended reading order
1. `airbyte-integrations/connectors/source-orb/source_orb/schemas/subscription_version.json`
2. `airbyte-integrations/connectors/source-orb/source_orb/source.py`
3. `airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*
None since this is adding a new object.
 
*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
