### PR TITLE
✨ source-zendesk-chat + source-auth0: update the base image

### DIFF
--- a/airbyte-integrations/connectors/source-auth0/metadata.yaml
+++ b/airbyte-integrations/connectors/source-auth0/metadata.yaml
@@ -1,30 +1,30 @@
 data:
+  ab_internal:
+    ql: 100
+    sl: 100
   allowedHosts:
     hosts:
       - "*.auth0.com"
-  registries:
-    oss:
-      enabled: true
-    cloud:
-      enabled: true
   connectorBuildOptions:
-    baseImage: airbyte/python-connector-base:1.0.0
+    baseImage: docker.io/airbyte/python-connector-base:1.1.0@sha256:bd98f6505c6764b1b5f99d3aedc23dfc9e9af631a62533f60eb32b1d3dbab20c
   connectorSubtype: api
   connectorType: source
   definitionId: 6c504e48-14aa-4221-9a72-19cf5ff1ae78
-  dockerImageTag: 0.5.0
+  dockerImageTag: 0.5.1
   dockerRepository: airbyte/source-auth0
+  documentationUrl: https://docs.airbyte.com/integrations/sources/auth0
   githubIssueLabel: source-auth0
   icon: auth0.svg
   license: MIT
   name: Auth0
+  registries:
+    cloud:
+      enabled: true
+    oss:
+      enabled: true
   releaseDate: 2023-08-10
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/auth0
+  supportLevel: community
   tags:
     - language:lowcode
-  ab_internal:
-    sl: 100
-    ql: 100
-  supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -20,7 +20,7 @@ data:
   name: Paypal Transaction
   registries:
     cloud:
-      dockerImageTag: 2.0.0  #https://github.com/airbytehq/oncall/issues/3347
+      dockerImageTag: 2.0.0 #https://github.com/airbytehq/oncall/issues/3347
       enabled: true
     oss:
       enabled: true

--- a/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
@@ -1,14 +1,18 @@
 data:
+  ab_internal:
+    ql: 400
+    sl: 200
   allowedHosts:
     hosts:
       - zopim.com
   connectorBuildOptions:
-    baseImage: airbyte/python-connector-base:1.0.0
+    baseImage: docker.io/airbyte/python-connector-base:1.1.0@sha256:bd98f6505c6764b1b5f99d3aedc23dfc9e9af631a62533f60eb32b1d3dbab20c
   connectorSubtype: api
   connectorType: source
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-zendesk-chat
+  documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
   githubIssueLabel: source-zendesk-chat
   icon: zendesk-chat.svg
   license: MIT
@@ -19,11 +23,7 @@ data:
     oss:
       enabled: true
   releaseStage: generally_available
-  documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
+  supportLevel: certified
   tags:
     - language:python
-  ab_internal:
-    sl: 200
-    ql: 400
-  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/docs/integrations/sources/auth0.md
+++ b/docs/integrations/sources/auth0.md
@@ -57,6 +57,7 @@ The connector is restricted by Auth0 [rate limits](https://auth0.com/docs/troubl
 
 | Version | Date       | Pull Request                                             | Subject                                                                 |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------- |
+| 0.5.1 | 2023-10-20 | [31643](https://github.com/airbytehq/airbyte/pull/31643) | Upgrade base image to airbyte/python-connector-base:1.1.0 |
 | 0.5.0   | 2023-10-11 | [30467](https://github.com/airbytehq/airbyte/pull/30467) | Use Python base image                                                   |
 | 0.4.1   | 2023-08-24 | [29804](https://github.com/airbytehq/airbyte/pull/29804) | Fix low code migration bugs                                             |
 | 0.4.0   | 2023-08-03 | [28972](https://github.com/airbytehq/airbyte/pull/28972) | Migrate to Low-Code CDK                                                 |

--- a/docs/integrations/sources/zendesk-chat.md
+++ b/docs/integrations/sources/zendesk-chat.md
@@ -80,6 +80,7 @@ The connector is restricted by Zendesk's [requests limitation](https://developer
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                          |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------- |
+| 0.2.1 | 2023-10-20 | [31643](https://github.com/airbytehq/airbyte/pull/31643) | Upgrade base image to airbyte/python-connector-base:1.1.0 |
 | 0.2.0  | 2023-10-11 | [30526](https://github.com/airbytehq/airbyte/pull/30526) | Use the python connector base image, remove dockerfile and implement build_customization.py                                                                   |
 | 0.1.14  | 2023-02-10 | [24190](https://github.com/airbytehq/airbyte/pull/24190) | Fix remove too high min/max from account stream                                                                  |
 | 0.1.13  | 2023-02-10 | [22819](https://github.com/airbytehq/airbyte/pull/22819) | Specified date formatting in specification                                                                       |


### PR DESCRIPTION
## What
I originally tried out the base image migration with `source-auth0` and `source-zendesk-chat`.
Now that we have released a new base image version (1.1.0) we want these connector to use it.

## How
`airbyte-ci` commands only:

```bash
 airbyte-ci connectors --name=source-auth0 --name=source-zendesk-chat upgrade_base_image
 airbyte-ci connectors --name=source-auth0 --name=source-zendesk-chat bump_version patch 31643 "Upgrade base image to airbyte/python-connector-base:1.1.0"
```

