### PR TITLE
doc: update connector tutorials to reference airbyte-ci for connector build

### DIFF
--- a/docs/connector-development/config-based/tutorial/0-getting-started.md
+++ b/docs/connector-development/config-based/tutorial/0-getting-started.md
@@ -44,6 +44,7 @@ This can be done by signing up for the Free tier plan on [Exchange Rates Data AP
 - Python >= 3.9
 - Docker must be running
 - NodeJS
+- [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#L1) CLI
 
 ## Next Steps
 

--- a/docs/connector-development/config-based/tutorial/6-testing.md
+++ b/docs/connector-development/config-based/tutorial/6-testing.md
@@ -27,11 +27,10 @@ and `integration_tests/abnormal_state.json` with
 }
 ```
 
-You can run the acceptance tests with the following commands:
+You can run the [acceptance tests](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md#L1) with the following commands using [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#L1):
 
 ```bash
-docker build . -t airbyte/source-exchange-rates-tutorial:dev
-python -m pytest integration_tests -p integration_tests.acceptance
+airbyte-ci connectors --use-remote-secrets=false --name source-exchange-rates-tutorial test
 ```
 
 ## Next steps:

--- a/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md
+++ b/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md
@@ -32,8 +32,38 @@ _Note: Not all types of tests work for all connectors, only configure the ones t
 
 Build your connector image if needed.
 
-```text
-docker build .
+**Option A: Building the docker image with `airbyte-ci`**
+
+If you want to open source your connector we encourage you to use our [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) tool to build your connector. 
+It will not use a Dockerfile but will build the connector image from our [base image](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/base_images/README.md) and use our internal build logic to build an image from your Python connector code.
+
+Running `airbyte-ci connectors --name source-<source-name> build` will build your connector image.
+Once the command is done, you will find your connector image in your local docker host: `airbyte/source-<source-name>:dev`.
+
+
+
+**Option B: Building the docker image with a Dockerfile**
+
+If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile.
+
+Create a `Dockerfile` in the root of your connector directory. The `Dockerfile` should look something like this:
+```Dockerfile
+
+FROM airbyte/python-connector-base:1.1.0
+
+COPY . ./airbyte/integration_code
+RUN pip install ./airbyte/integration_code
+
+# The entrypoint and default env vars are already set in the base image
+# ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+# ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+```
+
+Please use this as an example. This is not optimized.
+
+Build your image:
+```bash
+docker build . -t airbyte/source-example-python:dev
 ```
 
 And test via one of the two following Options

--- a/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md
+++ b/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md
@@ -34,6 +34,8 @@ Build your connector image if needed.
 
 **Option A: Building the docker image with `airbyte-ci`**
 
+This is the preferred method for building and testing connectors.
+
 If you want to open source your connector we encourage you to use our [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) tool to build your connector. 
 It will not use a Dockerfile but will build the connector image from our [base image](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/base_images/README.md) and use our internal build logic to build an image from your Python connector code.
 
@@ -44,7 +46,7 @@ Once the command is done, you will find your connector image in your local docke
 
 **Option B: Building the docker image with a Dockerfile**
 
-If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile.
+If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile. This method is not preferred, and is not supported for certified connectors.
 
 Create a `Dockerfile` in the root of your connector directory. The `Dockerfile` should look something like this:
 ```Dockerfile

--- a/docs/connector-development/tutorials/building-a-python-source.md
+++ b/docs/connector-development/tutorials/building-a-python-source.md
@@ -128,22 +128,55 @@ python main.py read --config secrets/config.json --catalog sample_files/configur
 
 The nice thing about this approach is that you can iterate completely within in python. The downside is that you are not quite running your source as it will actually be run by Airbyte. Specifically you're not running it from within the docker container that will house it.
 
-**Run the source using docker**
 
-If you want to run your source exactly as it will be run by Airbyte \(i.e. within a docker container\), you can use the following commands from the connector module directory \(`airbyte-integrations/connectors/source-example-python`\):
+** Build the source docker image**
 
-```text
-# First build the container
+You have to build a docker image for your connector if you want to run your source exactly as it will be run by Airbyte.
+
+**Option A: Building the docker image with `airbyte-ci`**
+
+If you want to open source your connector we encourage you to use our [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) tool to build your connector. 
+It will not use a Dockerfile but will build the connector image from our [base image](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/base_images/README.md) and use our internal build logic to build an image from your Python connector code.
+
+Running `airbyte-ci connectors --name source-<source-name> build` will build your connector image.
+Once the command is done, you will find your connector image in your local docker host: `airbyte/source-<source-name>:dev`.
+
+
+
+**Option B: Building the docker image with a Dockerfile**
+
+If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile.
+
+Create a `Dockerfile` in the root of your connector directory. The `Dockerfile` should look something like this:
+```Dockerfile
+
+FROM airbyte/python-connector-base:1.1.0
+
+COPY . ./airbyte/integration_code
+RUN pip install ./airbyte/integration_code
+
+# The entrypoint and default env vars are already set in the base image
+# ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+# ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+```
+
+Please use this as an example. This is not optimized.
+
+Build your image:
+```bash
 docker build . -t airbyte/source-example-python:dev
+```
 
-# Then use the following commands to run it
+**Run the source docker image**
+
+```
 docker run --rm airbyte/source-example-python:dev spec
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-example-python:dev check --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-example-python:dev discover --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/sample_files:/sample_files airbyte/source-example-python:dev read --config /secrets/config.json --catalog /sample_files/configured_catalog.json
 ```
 
-Note: Each time you make a change to your implementation you need to re-build the connector image. `docker build . -t airbyte/source-example-python:dev`. This ensures the new python code is added into the docker container.
+Note: Each time you make a change to your implementation you need to re-build the connector image. This ensures the new python code is added into the docker container.
 
 The nice thing about this approach is that you are running your source exactly as it will be run by Airbyte. The tradeoff is that iteration is slightly slower, because you need to re-build the connector between each change.
 

--- a/docs/connector-development/tutorials/building-a-python-source.md
+++ b/docs/connector-development/tutorials/building-a-python-source.md
@@ -135,6 +135,8 @@ You have to build a docker image for your connector if you want to run your sour
 
 **Option A: Building the docker image with `airbyte-ci`**
 
+This is the preferred method for building and testing connectors.
+
 If you want to open source your connector we encourage you to use our [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) tool to build your connector. 
 It will not use a Dockerfile but will build the connector image from our [base image](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/base_images/README.md) and use our internal build logic to build an image from your Python connector code.
 
@@ -145,7 +147,7 @@ Once the command is done, you will find your connector image in your local docke
 
 **Option B: Building the docker image with a Dockerfile**
 
-If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile.
+If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile. This method is not preferred, and is not supported for certified connectors.
 
 Create a `Dockerfile` in the root of your connector directory. The `Dockerfile` should look something like this:
 ```Dockerfile

--- a/docs/connector-development/tutorials/cdk-speedrun.md
+++ b/docs/connector-development/tutorials/cdk-speedrun.md
@@ -231,9 +231,41 @@ python main.py read --config sample_files/config.json --catalog sample_files/con
 
 If all goes well, containerize it so you can use it in the UI:
 
-```bash
-docker build . -t airbyte/source-python-http-example:dev
+
+**Option A: Building the docker image with `airbyte-ci`**
+
+If you want to open source your connector we encourage you to use our [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) tool to build your connector. 
+It will not use a Dockerfile but will build the connector image from our [base image](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/base_images/README.md) and use our internal build logic to build an image from your Python connector code.
+
+Running `airbyte-ci connectors --name source-<source-name> build` will build your connector image.
+Once the command is done, you will find your connector image in your local docker host: `airbyte/source-<source-name>:dev`.
+
+
+
+**Option B: Building the docker image with a Dockerfile**
+
+If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile.
+
+Create a `Dockerfile` in the root of your connector directory. The `Dockerfile` should look something like this:
+```Dockerfile
+
+FROM airbyte/python-connector-base:1.1.0
+
+COPY . ./airbyte/integration_code
+RUN pip install ./airbyte/integration_code
+
+# The entrypoint and default env vars are already set in the base image
+# ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+# ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 ```
+
+Please use this as an example. This is not optimized.
+
+Build your image:
+```bash
+docker build . -t airbyte/source-example-python:dev
+```
+
 
 You're done. Stop the clock :\)
 

--- a/docs/connector-development/tutorials/cdk-speedrun.md
+++ b/docs/connector-development/tutorials/cdk-speedrun.md
@@ -234,6 +234,8 @@ If all goes well, containerize it so you can use it in the UI:
 
 **Option A: Building the docker image with `airbyte-ci`**
 
+This is the preferred method for building and testing connectors.
+
 If you want to open source your connector we encourage you to use our [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) tool to build your connector. 
 It will not use a Dockerfile but will build the connector image from our [base image](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/base_images/README.md) and use our internal build logic to build an image from your Python connector code.
 
@@ -244,7 +246,7 @@ Once the command is done, you will find your connector image in your local docke
 
 **Option B: Building the docker image with a Dockerfile**
 
-If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile.
+If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile. This method is not preferred, and is not supported for certified connectors.
 
 Create a `Dockerfile` in the root of your connector directory. The `Dockerfile` should look something like this:
 ```Dockerfile

--- a/docs/connector-development/tutorials/cdk-tutorial-python-http/use-connector-in-airbyte.md
+++ b/docs/connector-development/tutorials/cdk-tutorial-python-http/use-connector-in-airbyte.md
@@ -1,6 +1,44 @@
 # Step 7: Use the Connector in Airbyte
 
-To use your connector in your own installation of Airbyte, build the docker image for your container by running `docker build . -t airbyte/source-python-http-example:dev`. Then, follow the instructions from the [building a Python source tutorial](../building-a-python-source.md#step-11-add-the-connector-to-the-api-ui) for using the connector in the Airbyte UI, replacing the name as appropriate.
+To use your connector in your own installation of Airbyte you have to build the docker image for your connector. 
+
+
+
+**Option A: Building the docker image with `airbyte-ci`**
+
+If you want to open source your connector we encourage you to use our [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) tool to build your connector. 
+It will not use a Dockerfile but will build the connector image from our [base image](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/base_images/README.md) and use our internal build logic to build an image from your Python connector code.
+
+Running `airbyte-ci connectors --name source-<source-name> build` will build your connector image.
+Once the command is done, you will find your connector image in your local docker host: `airbyte/source-<source-name>:dev`.
+
+
+
+**Option B: Building the docker image with a Dockerfile**
+
+If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile.
+
+Create a `Dockerfile` in the root of your connector directory. The `Dockerfile` should look something like this:
+```Dockerfile
+
+FROM airbyte/python-connector-base:1.1.0
+
+COPY . ./airbyte/integration_code
+RUN pip install ./airbyte/integration_code
+
+# The entrypoint and default env vars are already set in the base image
+# ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+# ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+```
+
+Please use this as an example. This is not optimized.
+
+Build your image:
+```bash
+docker build . -t airbyte/source-example-python:dev
+```
+
+Then, follow the instructions from the [building a Python source tutorial](../building-a-python-source.md#step-11-add-the-connector-to-the-api-ui) for using the connector in the Airbyte UI, replacing the name as appropriate.
 
 Note: your built docker image must be accessible to the `docker` daemon running on the Airbyte node. If you're doing this tutorial locally, these instructions are sufficient. Otherwise you may need to push your Docker image to Dockerhub.
 

--- a/docs/connector-development/tutorials/cdk-tutorial-python-http/use-connector-in-airbyte.md
+++ b/docs/connector-development/tutorials/cdk-tutorial-python-http/use-connector-in-airbyte.md
@@ -6,6 +6,8 @@ To use your connector in your own installation of Airbyte you have to build the 
 
 **Option A: Building the docker image with `airbyte-ci`**
 
+This is the preferred method for building and testing connectors.
+
 If you want to open source your connector we encourage you to use our [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) tool to build your connector. 
 It will not use a Dockerfile but will build the connector image from our [base image](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/base_images/README.md) and use our internal build logic to build an image from your Python connector code.
 
@@ -16,7 +18,7 @@ Once the command is done, you will find your connector image in your local docke
 
 **Option B: Building the docker image with a Dockerfile**
 
-If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile.
+If you don't want to rely on `airbyte-ci` to build your connector, you can build the docker image using your own Dockerfile. This method is not preferred, and is not supported for certified connectors.
 
 Create a `Dockerfile` in the root of your connector directory. The `Dockerfile` should look something like this:
 ```Dockerfile

--- a/docs/contributing-to-airbyte/resources/developing-locally.md
+++ b/docs/contributing-to-airbyte/resources/developing-locally.md
@@ -107,9 +107,11 @@ In your local `airbyte` repository, run the following command:
 ```
 
 - Then, build the connector image:
-```
-docker build ./airbyte-integrations/connectors/<connector-name> -t airbyte/<connector-name>:dev
-```
+  - Install our [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) tool to build your connector. 
+  - Running `airbyte-ci connectors --name source-<source-name> build` will build your connector image.
+  - Once the command is done, you will find your connector image in your local docker host: `airbyte/source-<source-name>:dev`.
+
+
 
 :::info
 


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Closes #31648
Update our tutorial to reference `airbyte-ci` for connector build.
