### PR TITLE
airbyte-ci: Fix CheckBaseImageIsUsed failing on non certified connectors

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -398,6 +398,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 |---------| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 2.2.1   | [#31653](https://github.com/airbytehq/airbyte/pull/31653)  | Fix CheckBaseImageIsUsed failing on non certified connectors.   
 | 2.2.0   | [#30527](https://github.com/airbytehq/airbyte/pull/30527)  | Add a new check for python connectors to make sure certified connectors use our base image.   
 | 2.1.1   | [#31488](https://github.com/airbytehq/airbyte/pull/31488)  | Improve `airbyte-ci` start time with Click Lazy load                                                      |
 | 2.1.0   | [#31412](https://github.com/airbytehq/airbyte/pull/31412)  | Run airbyte-ci from any where in airbyte project                                                          |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -293,7 +293,7 @@ class CheckBaseImageIsUsed(Step):
     async def _run(self, *args, **kwargs) -> StepResult:
         is_certified = self.context.connector.metadata.get("supportLevel") == "certified"
         if not is_certified:
-            self.skip("Connector is not certified, it does not require the use of our base image.")
+            return self.skip("Connector is not certified, it does not require the use of our base image.")
 
         is_using_base_image = self.context.connector.metadata.get("connectorBuildOptions", {}).get("baseImage") is not None
         migration_hint = f"Please run 'airbyte-ci connectors --name={self.context.connector.technical_name} migrate_to_base_image {self.context.pull_request.number}' and commit the changes."

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.2.0"
+version = "2.2.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_common.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_common.py
@@ -233,8 +233,8 @@ class TestAcceptanceTests:
             fourth_date_result = await cat_container.stdout()
             assert fourth_date_result != third_date_result
 
-class TestCheckBaseImageIsUsed:
 
+class TestCheckBaseImageIsUsed:
     @pytest.fixture
     def certified_connector_no_base_image(self, all_connectors):
         for connector in all_connectors:
@@ -271,7 +271,11 @@ class TestCheckBaseImageIsUsed:
 
     async def test_pass_on_certified_connector_with_base_image(self, mocker, dagger_client, certified_connector_with_base_image):
         dagger_connector_dir = dagger_client.host().directory(str(certified_connector_with_base_image.code_directory))
-        test_context = mocker.MagicMock(dagger_client=dagger_client, connector=certified_connector_with_base_image, get_connector_dir=mocker.AsyncMock(return_value=dagger_connector_dir))
+        test_context = mocker.MagicMock(
+            dagger_client=dagger_client,
+            connector=certified_connector_with_base_image,
+            get_connector_dir=mocker.AsyncMock(return_value=dagger_connector_dir),
+        )
         check_base_image_is_used_step = common.CheckBaseImageIsUsed(test_context)
         step_result = await check_base_image_is_used_step.run()
         assert step_result.status == StepStatus.SUCCESS

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_common.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_common.py
@@ -232,3 +232,52 @@ class TestAcceptanceTests:
             cat_container = cat_container.with_exec(["date"])
             fourth_date_result = await cat_container.stdout()
             assert fourth_date_result != third_date_result
+
+class TestCheckBaseImageIsUsed:
+
+    @pytest.fixture
+    def certified_connector_no_base_image(self, all_connectors):
+        for connector in all_connectors:
+            if connector.metadata.get("supportLevel") == "certified":
+                if connector.metadata.get("connectorBuildOptions", {}).get("baseImage") is None:
+                    return connector
+        pytest.skip("No certified connector without base image found")
+
+    @pytest.fixture
+    def certified_connector_with_base_image(self, all_connectors):
+        for connector in all_connectors:
+            if connector.metadata.get("supportLevel") == "certified":
+                if connector.metadata.get("connectorBuildOptions", {}).get("baseImage") is not None:
+                    return connector
+        pytest.skip("No certified connector with base image found")
+
+    @pytest.fixture
+    def community_connector_no_base_image(self, all_connectors):
+        for connector in all_connectors:
+            if connector.metadata.get("supportLevel") == "community":
+                if connector.metadata.get("connectorBuildOptions", {}).get("baseImage") is None:
+                    return connector
+        pytest.skip("No certified connector without base image found")
+
+    @pytest.fixture
+    def test_context(self, mocker, dagger_client):
+        return mocker.MagicMock(dagger_client=dagger_client)
+
+    async def test_pass_on_community_connector_no_base_image(self, mocker, dagger_client, community_connector_no_base_image):
+        test_context = mocker.MagicMock(dagger_client=dagger_client, connector=community_connector_no_base_image)
+        check_base_image_is_used_step = common.CheckBaseImageIsUsed(test_context)
+        step_result = await check_base_image_is_used_step.run()
+        assert step_result.status == StepStatus.SKIPPED
+
+    async def test_pass_on_certified_connector_with_base_image(self, mocker, dagger_client, certified_connector_with_base_image):
+        dagger_connector_dir = dagger_client.host().directory(str(certified_connector_with_base_image.code_directory))
+        test_context = mocker.MagicMock(dagger_client=dagger_client, connector=certified_connector_with_base_image, get_connector_dir=mocker.AsyncMock(return_value=dagger_connector_dir))
+        check_base_image_is_used_step = common.CheckBaseImageIsUsed(test_context)
+        step_result = await check_base_image_is_used_step.run()
+        assert step_result.status == StepStatus.SUCCESS
+
+    async def test_fail_on_certified_connector_no_base_image(self, mocker, dagger_client, certified_connector_no_base_image):
+        test_context = mocker.MagicMock(dagger_client=dagger_client, connector=certified_connector_no_base_image)
+        check_base_image_is_used_step = common.CheckBaseImageIsUsed(test_context)
+        step_result = await check_base_image_is_used_step.run()
+        assert step_result.status == StepStatus.FAILURE


### PR DESCRIPTION
## What
Our new check CheckBaseImageIsUsed should be skipped on non certified connectors.
It was not.
