### PR TITLE
remove path_ignore on airbyte-ci-test

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -11,8 +11,6 @@ on:
       - opened
       - reopened
       - synchronize
-    paths-ignore:
-      - "**/*.md"
 jobs:
   run-airbyte-ci-tests:
     name: Run Airbyte CI tests


### PR DESCRIPTION
This worfklow is marked as required to merge on master but the path_ignore rules means they won't get triggered on doc only PR.
These PR remains with a pending status for th Run Airbyte CI tests check.
I think remove the path_ignore will make it run on all PR but the path filtering within the step will not run the test suite if no airbyte-ci related stuff is modified.
