### PR TITLE
doc: add command to the base image migration doc to list migrated/not migrated connectors

### DIFF
--- a/docs/connector-development/migration-to-base-image.md
+++ b/docs/connector-development/migration-to-base-image.md
@@ -65,3 +65,14 @@ async def post_connector_install(connector_container: Container) -> Container:
     return await connector_container.with_env_variable("MY_POST_BUILD_ENV_VAR", "my_post_build_env_var_value")
 ```
 
+### Listing migrated / non migrated connectors:
+
+To list all migrated certified connectors you can ran: 
+```bash
+airbyte-ci connectors --support-level=certified --metadata-query="data.connectorBuildOptions.baseImage is not None" list
+```
+
+To list all non migrated certified connectors you can ran: 
+```bash
+airbyte-ci connectors --metadata-query="data.supportLevel == 'certified' and 'connectorBuildOptions' not in data.keys()" list
+```


### PR DESCRIPTION
Closes #30244

Document how to list migrated / not migrated connectors