### PR TITLE
default USE_STREAM_CAPABLE_STATE to true

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
@@ -25,7 +25,7 @@ public class EnvVariableFeatureFlags implements FeatureFlags {
 
   @Override
   public boolean useStreamCapableState() {
-    return getEnvOrDefault(USE_STREAM_CAPABLE_STATE, false, Boolean::parseBoolean);
+    return getEnvOrDefault(USE_STREAM_CAPABLE_STATE, true, Boolean::parseBoolean);
   }
 
   @Override


### PR DESCRIPTION
The platform has removed the ability to change `USE_STREAM_CAPABLE_STATE`, defaulting it to `true` and will soon stop passing it to the connectors.

If `USE_STREAM_CAPABLE_STATE` is not specified it should default to `true` instead of `false`.

