### PR TITLE
cat / airbyte-ci: improve CAT container orchestration

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -231,6 +231,7 @@ flowchart TD
 | `--fail-fast`       | False    | False         | Abort after any tests fail, rather than continuing to run additional tests. Use this setting to confirm a known bug is fixed (or not), or when you only require a pass/fail result.                      |
 | `--fast-tests-only` | True     | False         | Run unit tests only, skipping integration tests or any tests explicitly tagged as slow. Use this for more frequent checks, when it is not feasible to run the entire test suite.                         |
 | `--code-tests-only` | True     | False         | Skip any tests not directly related to code updates. For instance, metadata checks, version bump checks, changelog verification, etc. Use this setting to help focus on code quality during development. |
+| `--concurrent-cat`  | False     | False         | Make CAT tests run concurrently using pytest-xdist. Be careful about source or destination API rate limits. |
 
 Note:
 
@@ -399,6 +400,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 2.3.0   | [#31699](https://github.com/airbytehq/airbyte/pull/31699)  | Support optional concurrent CAT execution.                                                                |
 | 2.2.6   | [#31752](https://github.com/airbytehq/airbyte/pull/31752)  | Only authenticate when secrets are available.
 | 2.2.5   | [#31718](https://github.com/airbytehq/airbyte/pull/31718)  | Authenticate the sidecar docker daemon to DockerHub.                                                      |
 | 2.2.4   | [#31535](https://github.com/airbytehq/airbyte/pull/31535)  | Improve gradle caching when building java connectors.                                                     |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
@@ -59,6 +59,7 @@ class ConnectorContext(PipelineContext):
         docker_hub_password: Optional[str] = None,
         s3_build_cache_access_key_id: Optional[str] = None,
         s3_build_cache_secret_key: Optional[str] = None,
+        concurrent_cat: Optional[bool] = False,
     ):
         """Initialize a connector context.
 
@@ -86,6 +87,7 @@ class ConnectorContext(PipelineContext):
             docker_hub_password (Optional[str], optional): Docker Hub password to use to read registries. Defaults to None.
             s3_build_cache_access_key_id (Optional[str], optional): Gradle S3 Build Cache credentials. Defaults to None.
             s3_build_cache_secret_key (Optional[str], optional): Gradle S3 Build Cache credentials. Defaults to None.
+            concurrent_cat (bool, optional): Whether to run the CAT tests in parallel. Defaults to False.
         """
 
         self.pipeline_name = pipeline_name
@@ -107,6 +109,7 @@ class ConnectorContext(PipelineContext):
         self.docker_hub_password = docker_hub_password
         self.s3_build_cache_access_key_id = s3_build_cache_access_key_id
         self.s3_build_cache_secret_key = s3_build_cache_secret_key
+        self.concurrent_cat = concurrent_cat
 
         super().__init__(
             pipeline_name=pipeline_name,

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
@@ -38,12 +38,20 @@ from pipelines.helpers.utils import fail_if_missing_docker_hub_creds
     type=bool,
     is_flag=True,
 )
+@click.option(
+    "--concurrent-cat",
+    help="When enabled, the CAT tests will run concurrently. Be careful about rate limits",
+    default=False,
+    type=bool,
+    is_flag=True,
+)
 @click.pass_context
 def test(
     ctx: click.Context,
     code_tests_only: bool,
     fail_fast: bool,
     fast_tests_only: bool,
+    concurrent_cat: bool,
 ) -> bool:
     """Runs a test pipeline for the selected connectors.
 
@@ -87,6 +95,7 @@ def test(
             s3_build_cache_secret_key=ctx.obj.get("s3_build_cache_secret_key"),
             docker_hub_username=ctx.obj.get("docker_hub_username"),
             docker_hub_password=ctx.obj.get("docker_hub_password"),
+            concurrent_cat=concurrent_cat,
         )
         for connector in ctx.obj["selected_connectors_with_modified_files"]
     ]

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/java_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/java_connectors.py
@@ -115,9 +115,7 @@ async def run_all_tests(context: ConnectorContext) -> List[StepResult]:
             soon_integration_tests_results = docker_build_dependent_group.soonify(IntegrationTests(context).run)(
                 connector_tar_file=connector_image_tar_file, normalization_tar_file=normalization_tar_file
             )
-            soon_cat_results = docker_build_dependent_group.soonify(AcceptanceTests(context).run)(
-                connector_under_test_image_tar=connector_image_tar_file
-            )
+            soon_cat_results = docker_build_dependent_group.soonify(AcceptanceTests(context, True).run)(connector_container)
 
         step_results += [soon_cat_results.value, soon_integration_tests_results.value]
         return step_results

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.2.6"
+version = "2.3.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+Make the container under test a sessions scoped fixture. 
+Support loading it from its Dagger container id for better performance. 
+Install pytest-xdist to support running tests in parallel.
+
 ## 2.0.2
 Make `test_two_sequential_reads` handle namespace property in stream descriptor.
 

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py
@@ -22,10 +22,10 @@ from connector_acceptance_test.base import BaseTest
 from connector_acceptance_test.config import Config, EmptyStreamConfiguration, ExpectedRecordsConfig, IgnoredFieldsConfiguration
 from connector_acceptance_test.tests import TestBasicRead
 from connector_acceptance_test.utils import (
-    ConnectorRunner,
     SecretDict,
     build_configured_catalog_from_custom_catalog,
     build_configured_catalog_from_discovered_catalog_and_empty_streams,
+    connector_runner,
     filter_output,
     load_config,
     load_yaml_or_json_path,
@@ -112,7 +112,7 @@ def configured_catalog_fixture(
         return build_configured_catalog_from_discovered_catalog_and_empty_streams(discovered_catalog, set())
 
 
-@pytest.fixture(name="image_tag")
+@pytest.fixture(name="image_tag", scope="session")
 def image_tag_fixture(acceptance_test_config) -> str:
     return acceptance_test_config.connector_image
 
@@ -166,19 +166,24 @@ async def dagger_client(anyio_backend):
         yield client
 
 
+@pytest.fixture(scope="session")
+async def connector_container(dagger_client, image_tag):
+    connector_container = await connector_runner.get_connector_container(dagger_client, image_tag)
+    if cachebuster := os.environ.get("CACHEBUSTER"):
+        connector_container = connector_container.with_env_variable("CACHEBUSTER", cachebuster)
+    return await connector_container
+
+
 @pytest.fixture(name="docker_runner", autouse=True)
-async def docker_runner_fixture(
-    image_tag, connector_config_path, custom_environment_variables, dagger_client, deployment_mode
-) -> ConnectorRunner:
-    runner = ConnectorRunner(
-        image_tag,
-        dagger_client,
+def docker_runner_fixture(
+    connector_container, connector_config_path, custom_environment_variables, deployment_mode
+) -> connector_runner.ConnectorRunner:
+    return connector_runner.ConnectorRunner(
+        connector_container,
         connector_configuration_path=connector_config_path,
         custom_environment_variables=custom_environment_variables,
         deployment_mode=deployment_mode,
     )
-    await runner.load_container()
-    return runner
 
 
 @pytest.fixture(name="previous_connector_image_name")
@@ -187,15 +192,26 @@ def previous_connector_image_name_fixture(image_tag, inputs) -> str:
     return f"{image_tag.split(':')[0]}:{inputs.backward_compatibility_tests_config.previous_connector_version}"
 
 
+@pytest.fixture()
+async def previous_version_connector_container(
+    dagger_client,
+    previous_connector_image_name,
+):
+    connector_container = await connector_runner.get_connector_container(dagger_client, previous_connector_image_name)
+    if cachebuster := os.environ.get("CACHEBUSTER"):
+        connector_container = connector_container.with_env_variable("CACHEBUSTER", cachebuster)
+    return await connector_container
+
+
 @pytest.fixture(name="previous_connector_docker_runner")
-async def previous_connector_docker_runner_fixture(previous_connector_image_name, dagger_client, deployment_mode) -> ConnectorRunner:
+async def previous_connector_docker_runner_fixture(
+    previous_version_connector_container, deployment_mode
+) -> connector_runner.ConnectorRunner:
     """Fixture to create a connector runner with the previous connector docker image.
     Returns None if the latest image was not found, to skip downstream tests if the current connector is not yet published to the docker registry.
     Raise not found error if the previous connector image is not latest and expected to be published.
     """
-    runner = ConnectorRunner(previous_connector_image_name, dagger_client, deployment_mode=deployment_mode)
-    await runner.load_container()
-    return runner
+    return connector_runner.ConnectorRunner(previous_version_connector_container, deployment_mode=deployment_mode)
 
 
 @pytest.fixture(name="empty_streams")
@@ -277,7 +293,7 @@ def find_not_seeded_streams(
 @pytest.fixture(name="discovered_catalog")
 async def discovered_catalog_fixture(
     connector_config,
-    docker_runner: ConnectorRunner,
+    docker_runner: connector_runner.ConnectorRunner,
 ) -> MutableMapping[str, AirbyteStream]:
     """JSON schemas for each stream"""
 
@@ -290,7 +306,7 @@ async def discovered_catalog_fixture(
 async def previous_discovered_catalog_fixture(
     connector_config,
     previous_connector_image_name,
-    previous_connector_docker_runner: ConnectorRunner,
+    previous_connector_docker_runner: connector_runner.ConnectorRunner,
 ) -> MutableMapping[str, AirbyteStream]:
     """JSON schemas for each stream"""
     if previous_connector_docker_runner is None:
@@ -331,7 +347,7 @@ def detailed_logger() -> Logger:
 
 
 @pytest.fixture(name="actual_connector_spec")
-async def actual_connector_spec_fixture(docker_runner: ConnectorRunner) -> ConnectorSpecification:
+async def actual_connector_spec_fixture(docker_runner: connector_runner.ConnectorRunner) -> ConnectorSpecification:
     output = await docker_runner.call_spec()
     spec_messages = filter_output(output, Type.SPEC)
     assert len(spec_messages) == 1, "Spec message should be emitted exactly once"
@@ -340,7 +356,7 @@ async def actual_connector_spec_fixture(docker_runner: ConnectorRunner) -> Conne
 
 @pytest.fixture(name="previous_connector_spec")
 async def previous_connector_spec_fixture(
-    request: BaseTest, previous_connector_docker_runner: ConnectorRunner
+    request: BaseTest, previous_connector_docker_runner: connector_runner.ConnectorRunner
 ) -> Optional[ConnectorSpecification]:
     if previous_connector_docker_runner is None:
         logging.warning(

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_full_refresh.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_full_refresh.py
@@ -100,8 +100,8 @@ class TestFullRefresh(BaseTest):
         )
         records_1 = [message.record for message in output_1 if message.type == Type.RECORD]
 
-        # sleep for 1 second to ensure that the emitted_at timestamp is different
-        time.sleep(1)
+        # sleep to ensure that the emitted_at timestamp is different
+        time.sleep(0.1)
 
         output_2 = await docker_runner.call_read(connector_config, configured_catalog, enable_caching=False)
         records_2 = [message.record for message in output_2 if message.type == Type.RECORD]

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py
@@ -8,17 +8,116 @@ import logging
 import os
 import uuid
 from pathlib import Path
-from typing import List, Mapping, Optional, Union
+from typing import Any, List, Mapping, Optional, Union
 
 import dagger
 import docker
 import pytest
-import yaml
 from airbyte_protocol.models import AirbyteMessage, ConfiguredAirbyteCatalog, OrchestratorType
 from airbyte_protocol.models import Type as AirbyteMessageType
 from anyio import Path as AnyioPath
 from connector_acceptance_test.utils import SecretDict
 from pydantic import ValidationError
+
+
+async def get_container_from_id(dagger_client: dagger.Client, container_id: str) -> dagger.Container:
+    """Get a dagger container from its id.
+    Please remind that container id are not persistent and can change between Dagger sessions.
+
+    Args:
+        dagger_client (dagger.Client): The dagger client to use to import the connector image
+    """
+    try:
+        return await dagger_client.container(dagger.ContainerID(container_id))
+    except dagger.DaggerError as e:
+        pytest.exit(f"Failed to load connector container: {e}")
+
+
+async def get_container_from_tarball_path(dagger_client: dagger.Client, tarball_path: Path):
+    if not tarball_path.exists():
+        pytest.exit(f"Connector image tarball {tarball_path} does not exist")
+    container_under_test_tar_file = (
+        dagger_client.host().directory(str(tarball_path.parent), include=tarball_path.name).file(tarball_path.name)
+    )
+    try:
+        return await dagger_client.container().import_(container_under_test_tar_file)
+    except dagger.DaggerError as e:
+        pytest.exit(f"Failed to import connector image from tarball: {e}")
+
+
+async def get_container_from_local_image(dagger_client: dagger.Client, local_image_name: str) -> Optional[dagger.Container]:
+    """Get a dagger container from a local image.
+    It will use Docker python client to export the image to a tarball and then import it into dagger.
+
+    Args:
+        dagger_client (dagger.Client): The dagger client to use to import the connector image
+        local_image_name (str): The name of the local image to import
+
+    Returns:
+        Optional[dagger.Container]: The dagger container for the local image or None if the image does not exist
+    """
+    docker_client = docker.from_env()
+
+    try:
+        image = docker_client.images.get(local_image_name)
+    except docker.errors.ImageNotFound:
+        return None
+
+    image_digest = image.id.replace("sha256:", "")
+    tarball_path = Path(f"/tmp/{image_digest}.tar")
+    if not tarball_path.exists():
+        logging.info(f"Exporting local connector image {local_image_name} to tarball {tarball_path}")
+        with open(tarball_path, "wb") as f:
+            for chunk in image.save(named=True):
+                f.write(chunk)
+    return await get_container_from_tarball_path(dagger_client, tarball_path)
+
+
+async def get_container_from_dockerhub_image(dagger_client: dagger.Client, dockerhub_image_name: str) -> dagger.Container:
+    """Get a dagger container from a dockerhub image.
+
+    Args:
+        dagger_client (dagger.Client): The dagger client to use to import the connector image
+        dockerhub_image_name (str): The name of the dockerhub image to import
+
+    Returns:
+        dagger.Container: The dagger container for the dockerhub image
+    """
+    try:
+        return await dagger_client.container().from_(dockerhub_image_name)
+    except dagger.DaggerError as e:
+        pytest.exit(f"Failed to import connector image from DockerHub: {e}")
+
+
+async def get_connector_container(dagger_client: dagger.Client, image_name_with_tag: str) -> dagger.Container:
+    """Get a dagger container for the connector image to test.
+
+    Args:
+        dagger_client (dagger.Client): The dagger client to use to import the connector image
+        image_name_with_tag (str): The docker image name and tag of the connector image to test
+
+    Returns:
+        dagger.Container: The dagger container for the connector image to test
+    """
+    # If a container_id.txt file is available, we'll use it to load the connector container
+    # We use a txt file as container ids can be too long to be passed as env vars
+    # It's used for dagger-in-dagger use case with airbyte-ci, when the connector container is built via an upstream dagger operation
+    connector_container_id_path = Path("/tmp/container_id.txt")
+    if connector_container_id_path.exists():
+        # If the CONNECTOR_CONTAINER_ID env var is set, we'll use it to load the connector container
+        return await get_container_from_id(dagger_client, connector_container_id_path.read_text())
+
+    # If the CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH env var is set, we'll use it to import the connector image from the tarball
+    if connector_image_tarball_path := os.environ.get("CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH"):
+        tarball_path = Path(connector_image_tarball_path)
+        return await get_container_from_tarball_path(dagger_client, tarball_path)
+
+    # Let's try to load the connector container from a local image
+    if connector_container := await get_container_from_local_image(dagger_client, image_name_with_tag):
+        return connector_container
+
+    # If we get here, we'll try to pull the connector image from DockerHub
+    return await get_container_from_dockerhub_image(dagger_client, image_name_with_tag)
 
 
 class ConnectorRunner:
@@ -29,35 +128,49 @@ class ConnectorRunner:
 
     def __init__(
         self,
-        image_tag: str,
-        dagger_client: dagger.Client,
+        connector_container: dagger.Container,
         connector_configuration_path: Optional[Path] = None,
         custom_environment_variables: Optional[Mapping] = {},
         deployment_mode: Optional[str] = None,
     ):
-        self._check_connector_under_test()
-        self.image_tag = image_tag
-        self.dagger_client = dagger_client
+        env_vars = (
+            custom_environment_variables
+            if deployment_mode is None
+            else {**custom_environment_variables, "DEPLOYMENT_MODE": deployment_mode.upper()}
+        )
+        self._connector_under_test_container = self.set_env_vars(connector_container, env_vars)
         self._connector_configuration_path = connector_configuration_path
-        self._custom_environment_variables = custom_environment_variables
-        self._deployment_mode = deployment_mode
-        connector_image_tarball_path = self._get_connector_image_tarball_path()
-        self._connector_under_test_container = self._get_connector_container(connector_image_tarball_path)
 
-    async def load_container(self):
-        """This is to pre-load the container following instantiation of the class.
-        This is useful to make sure that when using the connector runner fixture the costly _import is already done.
+    def set_env_vars(self, container: dagger.Container, env_vars: Mapping[str, Any]) -> dagger.Container:
+        """Set environment variables on a dagger container.
+
+        Args:
+            container (dagger.Container): The dagger container to set the environment variables on.
+            env_vars (Mapping[str, str]): The environment variables to set.
+
+        Returns:
+            dagger.Container: The dagger container with the environment variables set.
         """
-        await self._connector_under_test_container.with_exec(["spec"])
+        for k, v in env_vars.items():
+            container = container.with_env_variable(k, str(v))
+        return container
 
     async def call_spec(self, raise_container_error=False) -> List[AirbyteMessage]:
         return await self._run(["spec"], raise_container_error)
 
     async def call_check(self, config: SecretDict, raise_container_error: bool = False) -> List[AirbyteMessage]:
-        return await self._run(["check", "--config", self.IN_CONTAINER_CONFIG_PATH], raise_container_error, config=config)
+        return await self._run(
+            ["check", "--config", self.IN_CONTAINER_CONFIG_PATH],
+            raise_container_error,
+            config=config,
+        )
 
     async def call_discover(self, config: SecretDict, raise_container_error: bool = False) -> List[AirbyteMessage]:
-        return await self._run(["discover", "--config", self.IN_CONTAINER_CONFIG_PATH], raise_container_error, config=config)
+        return await self._run(
+            ["discover", "--config", self.IN_CONTAINER_CONFIG_PATH],
+            raise_container_error,
+            config=config,
+        )
 
     async def call_read(
         self, config: SecretDict, catalog: ConfiguredAirbyteCatalog, raise_container_error: bool = False, enable_caching: bool = True
@@ -105,52 +218,6 @@ class ConnectorRunner:
         entrypoint = await self._connector_under_test_container.entrypoint()
         return " ".join(entrypoint)
 
-    def _get_connector_image_tarball_path(self) -> Optional[Path]:
-        if "CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH" not in os.environ and not self.image_tag.endswith(":dev"):
-            return None
-        if "CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH" in os.environ:
-            connector_under_test_image_tar_path = Path(os.environ["CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH"])
-        elif self.image_tag.endswith(":dev"):
-            connector_under_test_image_tar_path = self._export_local_connector_image_to_tarball(self.image_tag)
-        assert connector_under_test_image_tar_path.exists(), "Connector image tarball does not exist"
-        return connector_under_test_image_tar_path
-
-    def _export_local_connector_image_to_tarball(self, local_image_name: str) -> Optional[Path]:
-        tarball_path = Path("/tmp/connector_under_test_image.tar")
-
-        docker_client = docker.from_env()
-        try:
-            image = docker_client.images.get(local_image_name)
-            with open(tarball_path, "wb") as f:
-                for chunk in image.save(named=True):
-                    f.write(chunk)
-
-        except docker.errors.ImageNotFound:
-            pytest.fail(f"Image {local_image_name} not found, please make sure to build or pull it before running the tests")
-        return tarball_path
-
-    def _get_connector_container_from_tarball(self, tarball_path: Path) -> dagger.Container:
-        container_under_test_tar_file = (
-            self.dagger_client.host().directory(str(tarball_path.parent), include=tarball_path.name).file(tarball_path.name)
-        )
-        return self.dagger_client.container().import_(container_under_test_tar_file)
-
-    def _get_connector_container(self, connector_image_tarball_path: Optional[Path]) -> dagger.Container:
-        if connector_image_tarball_path is not None:
-            container = self._get_connector_container_from_tarball(connector_image_tarball_path)
-        else:
-            # Try to pull the image from DockerHub
-            container = self.dagger_client.container().from_(self.image_tag)
-        # Client might pass a cachebuster env var to force recreation of the container
-        # We pass this env var to the container to ensure the cache is busted
-        if cachebuster_value := os.environ.get("CACHEBUSTER"):
-            container = container.with_env_variable("CACHEBUSTER", cachebuster_value)
-        for key, value in self._custom_environment_variables.items():
-            container = container.with_env_variable(key, str(value))
-        if self._deployment_mode:
-            container = container.with_env_variable("DEPLOYMENT_MODE", self._deployment_mode.upper())
-        return container
-
     async def _run(
         self,
         airbyte_command: List[str],
@@ -160,7 +227,7 @@ class ConnectorRunner:
         state: Union[dict, list] = None,
         enable_caching=True,
     ) -> List[AirbyteMessage]:
-        """_summary_
+        """Run a command in the connector container and return the list of AirbyteMessages emitted by the connector.
 
         Args:
             airbyte_command (List[str]): The command to run in the connector container.
@@ -170,11 +237,8 @@ class ConnectorRunner:
             state (Union[dict, list], optional): The state to mount to the container. Defaults to None.
             enable_caching (bool, optional): Whether to enable command output caching. Defaults to True.
 
-        Raises:
-            e: _description_
-
         Returns:
-            List[AirbyteMessage]: _description_
+            List[AirbyteMessage]: The list of AirbyteMessages emitted by the connector.
         """
         container = self._connector_under_test_container
         if not enable_caching:
@@ -185,8 +249,6 @@ class ConnectorRunner:
             container = container.with_new_file(self.IN_CONTAINER_STATE_PATH, json.dumps(state))
         if catalog:
             container = container.with_new_file(self.IN_CONTAINER_CATALOG_PATH, catalog.json())
-        for key, value in self._custom_environment_variables.items():
-            container = container.with_env_variable(key, str(value))
         try:
             output = await self._read_output_from_stdout(airbyte_command, container)
         except dagger.QueryError as e:
@@ -263,16 +325,3 @@ class ConnectorRunner:
                 json.dump(new_configuration, new_configuration_file)
             logging.info(f"Stored most recent configuration value to {new_configuration_file_path}")
             return new_configuration_file_path
-
-    def _check_connector_under_test(self):
-        """
-        As a safety measure, we check that the connector under test matches the connector being tested by comparing the content of the metadata.yaml file to the CONNECTOR_UNDER_TEST_TECHNICAL_NAME environment varialbe.
-        When running CAT from airbyte-ci we set this CONNECTOR_UNDER_TEST_TECHNICAL_NAME env var name,
-        This is a safety check to ensure the correct test inputs are mounted to the CAT container.
-        """
-        if connector_under_test_technical_name := os.environ.get("CONNECTOR_UNDER_TEST_TECHNICAL_NAME"):
-            metadata = yaml.safe_load(Path("/test_input/metadata.yaml").read_text())
-            assert metadata["data"]["dockerRepository"] == f"airbyte/{connector_under_test_technical_name}", (
-                f"Connector under test env var {connector_under_test_technical_name} does not match the connector "
-                f"being tested {metadata['data']['dockerRepository']}"
-            )

--- a/airbyte-integrations/bases/connector-acceptance-test/poetry.lock
+++ b/airbyte-integrations/bases/connector-acceptance-test/poetry.lock
@@ -387,6 +387,20 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.0.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "execnet-2.0.2-py3-none-any.whl", hash = "sha256:88256416ae766bc9e8895c76a87928c0012183da3cc4fc18016e6f050e025f41"},
+    {file = "execnet-2.0.2.tar.gz", hash = "sha256:cc59bc4423742fd71ad227122eb0dd44db51efb3dc4095b45ac9a08c770096af"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "fancycompleter"
 version = "0.9.1"
 description = "colorful TAB completion for Python prompt"
@@ -1020,6 +1034,26 @@ files = [
 pytest = ">=3.6.0"
 
 [[package]]
+name = "pytest-xdist"
+version = "3.3.1"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-xdist-3.3.1.tar.gz", hash = "sha256:d5ee0520eb1b7bcca50a60a518ab7a7707992812c578198f8b44fdfac78e8c93"},
+    {file = "pytest_xdist-3.3.1-py3-none-any.whl", hash = "sha256:ff9daa7793569e6a68544850fd3927cd257cc03a7ef76c95e86915355e82b5f2"},
+]
+
+[package.dependencies]
+execnet = ">=1.1"
+pytest = ">=6.2.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1079,6 +1113,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1086,8 +1121,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1104,6 +1146,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1111,6 +1154,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1489,4 +1533,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d0bfe69918b1133a0ea31368570203e0413bccf22aabfca6b5339cca59e2df2d"
+content-hash = "15d79ace4da317a48b537ebaec3c1120e44e4a236ca6ab7050bc946d3a14a738"

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "2.0.2"
+version = "2.1.0"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"
@@ -39,6 +39,7 @@ docker = ">=6,<7"
 # Related issue: https://github.com/docker/docker-py/issues/3113
 urllib3 = "<2.0"
 requests = "<2.29.0"
+pytest-xdist = "^3.3.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/conftest.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/conftest.py
@@ -36,3 +36,8 @@ def anyio_backend():
 async def dagger_client():
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         yield client
+
+
+@pytest.fixture(scope="module")
+async def source_faker_container(dagger_client):
+    return await dagger_client.container().from_("airbyte/source-faker:latest")

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_connector_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_connector_runner.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+from pathlib import Path
 
 import pytest
 from airbyte_protocol.models import (
@@ -29,31 +30,13 @@ class TestContainerRunner:
     def released_image_name(self):
         return "airbyte/source-faker:latest"
 
-    @pytest.fixture()
-    async def local_tar_image(self, dagger_client, tmpdir, released_image_name):
-        local_image_tar_path = str(tmpdir / "local_image.tar")
-        await dagger_client.container().from_(released_image_name).export(local_image_tar_path)
-        os.environ["CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH"] = local_image_tar_path
-        yield local_image_tar_path
-        os.environ.pop("CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH")
-
-    async def test_load_container_from_tar(self, dagger_client, dev_image_name, local_tar_image):
-        runner = connector_runner.ConnectorRunner(dev_image_name, dagger_client)
-        await runner.load_container()
-        assert await runner._connector_under_test_container.with_exec(["spec"])
-
-    async def test_load_container_from_released_connector(self, dagger_client, released_image_name):
-        runner = connector_runner.ConnectorRunner(released_image_name, dagger_client)
-        await runner.load_container()
-        assert await runner._connector_under_test_container.with_exec(["spec"])
-
-    async def test_get_container_env_variable_value(self, dagger_client, dev_image_name, local_tar_image):
-        runner = connector_runner.ConnectorRunner(dev_image_name, dagger_client, custom_environment_variables={"FOO": "BAR"})
+    async def test_get_container_env_variable_value(self, source_faker_container):
+        runner = connector_runner.ConnectorRunner(source_faker_container, custom_environment_variables={"FOO": "BAR"})
         assert await runner.get_container_env_variable_value("FOO") == "BAR"
 
     @pytest.mark.parametrize("deployment_mode", ["oss", "cloud"])
-    async def test_set_deployment_mode_env(self, dagger_client, dev_image_name, local_tar_image, deployment_mode):
-        runner = connector_runner.ConnectorRunner(dev_image_name, dagger_client, deployment_mode=deployment_mode)
+    async def test_set_deployment_mode_env(self, source_faker_container, deployment_mode):
+        runner = connector_runner.ConnectorRunner(source_faker_container, deployment_mode=deployment_mode)
         assert await runner.get_container_env_variable_value("DEPLOYMENT_MODE") == deployment_mode.upper()
 
     def test_parse_airbyte_messages_from_command_output(self, mocker, tmp_path):
@@ -81,10 +64,8 @@ class TestContainerRunner:
 
         mocker.patch.object(connector_runner.ConnectorRunner, "_persist_new_configuration")
         runner = connector_runner.ConnectorRunner(
-            "source-test:dev",
             mocker.Mock(),
             connector_configuration_path=old_configuration_path,
-            custom_environment_variables={"foo": "bar"},
         )
         runner.parse_airbyte_messages_from_command_output(raw_command_output)
         runner._persist_new_configuration.assert_called_once_with(new_configuration, 1)
@@ -130,10 +111,42 @@ class TestContainerRunner:
                 json.dump(old_configuration, old_configuration_file)
         else:
             old_configuration_path = None
-        mocker.patch.object(connector_runner, "docker")
-        runner = connector_runner.ConnectorRunner("source-test:dev", mocker.MagicMock(), old_configuration_path)
+
+        runner = connector_runner.ConnectorRunner(mocker.MagicMock(), connector_configuration_path=old_configuration_path)
         new_configuration_path = runner._persist_new_configuration(new_configuration, new_configuration_emitted_at)
         if not expect_new_configuration:
             assert new_configuration_path is None
         else:
             assert new_configuration_path == tmp_path / "updated_configurations" / f"config|{new_configuration_emitted_at}.json"
+
+
+async def test_get_connector_container(mocker):
+
+    dagger_client = mocker.AsyncMock()
+    os.environ["CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH"] = "test_tarball_path"
+
+    # Mock the functions called within get_connector_container
+    mocker.patch.object(connector_runner, "get_container_from_id", new=mocker.AsyncMock())
+    mocker.patch.object(connector_runner, "get_container_from_tarball_path", new=mocker.AsyncMock())
+    mocker.patch.object(connector_runner, "get_container_from_local_image", new=mocker.AsyncMock())
+    mocker.patch.object(connector_runner, "get_container_from_dockerhub_image", new=mocker.AsyncMock())
+
+    # Test the case when the CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH is set
+    await connector_runner.get_connector_container(dagger_client, "test_image:tag")
+    connector_runner.get_container_from_tarball_path.assert_called_with(dagger_client, Path("test_tarball_path"))
+
+    # Test the case when the CONNECTOR_CONTAINER_ID is set
+    Path("/tmp/container_id.txt").write_text("test_container_id")
+    await connector_runner.get_connector_container(dagger_client, "test_image:tag")
+    connector_runner.get_container_from_id.assert_called_with(dagger_client, "test_container_id")
+    Path("/tmp/container_id.txt").unlink()
+
+    # Test the case when none of the environment variables are set
+    os.environ.pop("CONNECTOR_UNDER_TEST_IMAGE_TAR_PATH")
+    await connector_runner.get_connector_container(dagger_client, "test_image:tag")
+    connector_runner.get_container_from_local_image.assert_called_with(dagger_client, "test_image:tag")
+
+    # Test the case when all previous attempts fail
+    connector_runner.get_container_from_local_image.return_value = None
+    await connector_runner.get_connector_container(dagger_client, "test_image:tag")
+    connector_runner.get_container_from_dockerhub_image.assert_called_with(dagger_client, "test_image:tag")


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Closes #31703

This PR aims at improving how we orchestrate CAT through `airbyte-ci`.
We want to:
- Reduce test cold start duration 
- Optionally enable concurrent CAT tests 

## How
### Reducing test cold start duration
- Make the `connector_container` a `session` scoped fixture. It means the tests will reuse the same connector container.
- Load the connector container with Dagger container id instead of importing the container image as a tar. Avoiding the use of `tar` allows us to remove the long and costly `docker export` and `dagger import` steps.

### Enabling test concurrency
Pytest has `pytest-xdist` plugin which can distribute tests across multiple CPUs.
With the `--numprocesses=auto` flag in the `pytest` command this plugin will distribute tests across all the available cores.
I don't want to enable this by default on Python connectors as I'm concerned it can have a bad impact on the API connectors' rate limit. So I:
- Expose a new `--concurrent-cat` flag on `airbyte-ci connectors test` command. Defaulting to false.
- Force concurrency to true on Java connectors. Java sources are connecting to databases that are not affected by rate limits.
- We can eventually enable CAT concurrency by default when we want to make Python connector CAT faster. But a thorough investigation of its effect must be done before.

## Performance boost on `source-postgres` (with concurrency).
This change makes `source-postgres` CAT execution run in [01mn56s](https://github.com/airbytehq/airbyte/actions/runs/6611492035/job/17955472256). Which is a **~2mn boost** compared to the current [03mn54 execution on `master`](https://github.com/airbytehq/airbyte/actions/runs/6611052244/job/17954197892). 

## Perfomance boost on python connectors (no concurrency)
I used `source-google-sheets` for testing.
As I said, test concurrency is disabled by default for Python connectors.
We still get a ~1mn CAT boost due to a lower test cold start.
On master: [3mn11s](https://github.com/airbytehq/airbyte/actions/runs/6611855954/job/17956570152)
On this branch: [2mn07](https://github.com/airbytehq/airbyte/actions/runs/6611782510/job/17956361452)

## Recommended reading order
1. Changes to CAT: `airbyte-integrations/bases/connector-acceptance-test/*`
2. Changes to  `airbyte-ci`: `airbyte-ci/connectors/pipelines/*`

## 🚨 User Impact 🚨
* Significant CAT performance boost on Java connectors test thanks to concurrency. Tested for source-postgres
* 1mn  CAT performance boost on Python connectors thanks to a lower test start-up time. Tested for source-google-sheets