### PR TITLE
🎉 Airbyte CDK: Add CustomFileBasedException for custom errors in file-based CDK

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 
 from airbyte_cdk.sources import Source
 from airbyte_cdk.sources.file_based.availability_strategy import AbstractFileBasedAvailabilityStrategy
-from airbyte_cdk.sources.file_based.exceptions import CheckAvailabilityError, FileBasedSourceError
+from airbyte_cdk.sources.file_based.exceptions import CheckAvailabilityError, CustomFileBasedException, FileBasedSourceError
 from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.schema_helpers import conforms_to_schema
@@ -77,6 +77,8 @@ class DefaultFileBasedAvailabilityStrategy(AbstractFileBasedAvailabilityStrategy
             file = next(iter(stream.get_files()))
         except StopIteration:
             raise CheckAvailabilityError(FileBasedSourceError.EMPTY_STREAM, stream=stream.name)
+        except CustomFileBasedException as exc:
+            raise CheckAvailabilityError(str(exc), stream=stream.name) from exc
         except Exception as exc:
             raise CheckAvailabilityError(FileBasedSourceError.ERROR_LISTING_FILES, stream=stream.name) from exc
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
@@ -3,6 +3,9 @@
 #
 
 from enum import Enum
+from typing import Union
+
+from airbyte_cdk.utils import AirbyteTracedException
 
 
 class FileBasedSourceError(Enum):
@@ -38,9 +41,11 @@ class FileBasedSourceError(Enum):
 
 
 class BaseFileBasedSourceError(Exception):
-    def __init__(self, error: FileBasedSourceError, **kwargs):  # type: ignore # noqa
+    def __init__(self, error: Union[FileBasedSourceError, str], **kwargs):  # type: ignore # noqa
+        if isinstance(error, FileBasedSourceError):
+            error = FileBasedSourceError(error).value
         super().__init__(
-            f"{FileBasedSourceError(error).value} Contact Support if you need assistance.\n{' '.join([f'{k}={v}' for k, v in kwargs.items()])}"
+            f"{error} Contact Support if you need assistance.\n{' '.join([f'{k}={v}' for k, v in kwargs.items()])}"
         )
 
 
@@ -81,4 +86,13 @@ class StopSyncPerValidationPolicy(BaseFileBasedSourceError):
 
 
 class ErrorListingFiles(BaseFileBasedSourceError):
+    pass
+
+
+class CustomFileBasedException(AirbyteTracedException):
+    """
+    A specialized exception for file-based connectors.
+
+    This exception is designed to bypass the default error handling in the file-based CDK, allowing the use of custom error messages.
+    """
     pass

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
@@ -44,9 +44,7 @@ class BaseFileBasedSourceError(Exception):
     def __init__(self, error: Union[FileBasedSourceError, str], **kwargs):  # type: ignore # noqa
         if isinstance(error, FileBasedSourceError):
             error = FileBasedSourceError(error).value
-        super().__init__(
-            f"{error} Contact Support if you need assistance.\n{' '.join([f'{k}={v}' for k, v in kwargs.items()])}"
-        )
+        super().__init__(f"{error} Contact Support if you need assistance.\n{' '.join([f'{k}={v}' for k, v in kwargs.items()])}")
 
 
 class ConfigValidationError(BaseFileBasedSourceError):
@@ -95,4 +93,5 @@ class CustomFileBasedException(AirbyteTracedException):
 
     This exception is designed to bypass the default error handling in the file-based CDK, allowing the use of custom error messages.
     """
+
     pass

--- a/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py
@@ -78,12 +78,14 @@ class DefaultFileBasedAvailabilityStrategyTest(unittest.TestCase):
 
     def test_catching_and_raising_custom_file_based_exception(self) -> None:
         """
-        Test that the DefaultFileBasedAvailabilityStrategy catches CustomFileBasedException and raises CheckAvailabilityError.
+        Test if the DefaultFileBasedAvailabilityStrategy correctly handles the CustomFileBasedException
+        by raising a CheckAvailabilityError when the get_files method is called.
         """
-        # Mock the list_files method to raise CustomFileBasedException
-        self._stream.list_files.side_effect = CustomFileBasedException("Custom exception for testing.")
+        # Mock the get_files method to raise CustomFileBasedException when called
+        self._stream.get_files.side_effect = CustomFileBasedException("Custom exception for testing.")
 
-        # Check if the check_availability_and_parsability method raises CheckAvailabilityError
-        successful_check, error_massage = self._strategy.check_availability_and_parsability(self._stream, Mock(), Mock())
-        assert successful_check == False
-        assert "Custom exception for testing." in error_massage
+        # Invoke the check_availability_and_parsability method and check if it correctly handles the exception
+        is_available, error_message = self._strategy.check_availability_and_parsability(self._stream, Mock(), Mock())
+        assert is_available == False
+        assert "Custom exception for testing." in error_message
+

--- a/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py
@@ -88,4 +88,3 @@ class DefaultFileBasedAvailabilityStrategyTest(unittest.TestCase):
         is_available, error_message = self._strategy.check_availability_and_parsability(self._stream, Mock(), Mock())
         assert is_available == False
         assert "Custom exception for testing." in error_message
-


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Add custom Exception that can be raised in file-based CDK. Example of use: https://github.com/airbytehq/airbyte/pull/31383

## How
Add a new type of error - CustomFileBasedException. Also, add catching this error in AbstractFileBasedAvailabilityStrategy and raise it as CheckAvailabilityError.

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py`
2. `airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py`
3. `airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/test_default_file_based_availability_strategy.py`
