### PR TITLE
airbyte-ci: Add more info about setting up GSM secrets

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -47,7 +47,15 @@ _Note: `--force` is required to ensure updates are applied on subsequent install
 _Note: `--python=python3.10` is required to ensure the correct python version is used._
 _Note: `--editable` is required to ensure the correct python version is used._
 
-If you face any installation problem feel free to reach out the Airbyte Connectors Operations team.
+If you face any installation problems feel free to reach out the Airbyte Connectors Operations team.
+
+### Setting up connector secrets access
+
+If you plan to use Airbyte CI to run CAT (Connector Acceptance Tests), we recommend setting up GSM
+access so that Airbyte CI can pull remote secrets from GSM. For setup instructions, see the 
+CI Credentials package (which Airbyte CI uses under the hood) README's 
+[Get GSM Access](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/ci_credentials/README.md#get-gsm-access)
+instructions.
 
 ### Updating the airbyte-ci tool
 To reinstall airbyte-ci:
@@ -73,7 +81,7 @@ poetry shell
 cd ../../
 ```
 
-At this point you can run `airbyte-ci` commands from the root of the repository.
+At this point you can run `airbyte-ci` commands.
 
 ## Commands reference
 - [`airbyte-ci` command group](#airbyte-ci)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
@@ -105,7 +105,7 @@ def validate_environment(is_local: bool, use_remote_secrets: bool):
                 raise click.UsageError(f"When running in a CI context a {required_env_var} environment variable must be set.")
     if use_remote_secrets and os.getenv("GCP_GSM_CREDENTIALS") is None:
         raise click.UsageError(
-            "You have to set the GCP_GSM_CREDENTIALS if you want to download secrets from GSM. Set the --use-remote-secrets option to false otherwise."
+            "You have to set the GCP_GSM_CREDENTIALS if you want to download secrets from GSM. See README for instructions ('Setting up connector secrets access'). Set the --use-remote-secrets option to false otherwise."
         )
 
 


### PR DESCRIPTION
Add more info about setting up secrets right after airbyte ci setup - most people running airbyte ci probably want to do this. 

From [slack thread](https://airbytehq-team.slack.com/archives/C03VDJ4FMJB/p1698073193161789)