### PR TITLE
Destination Bigquery - Remove v2 check

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -25,5 +25,5 @@ ENV AIRBYTE_NORMALIZATION_INTEGRATION bigquery
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=2.1.5
+LABEL io.airbyte.version=2.1.6
 LABEL io.airbyte.name=airbyte/destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 2.1.5
+  dockerImageTag: 2.1.6
   dockerRepository: airbyte/destination-bigquery
   githubIssueLabel: destination-bigquery
   icon: bigquery.svg

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -373,23 +373,20 @@ public class BigQueryDestination extends BaseConnector implements Destination {
     return new BigQueryRecordStandardConsumer(
         outputRecordCollector,
         () -> {
-          final boolean use1s1t = TypingAndDedupingFlag.isDestinationV2();
-          if (use1s1t) {
-            // Set up our raw tables
-            writeConfigs.get().forEach((streamId, uploader) -> {
-              final StreamConfig stream = parsedCatalog.getStream(streamId);
-              if (stream.destinationSyncMode() == DestinationSyncMode.OVERWRITE) {
-                // For streams in overwrite mode, truncate the raw table.
-                // non-1s1t syncs actually overwrite the raw table at the end of the sync, so we only do this in
-                // 1s1t mode.
-                final TableId rawTableId = TableId.of(stream.id().rawNamespace(), stream.id().rawName());
-                bigquery.delete(rawTableId);
-                BigQueryUtils.createPartitionedTableIfNotExists(bigquery, rawTableId, DefaultBigQueryRecordFormatter.SCHEMA_V2);
-              } else {
-                uploader.createRawTable();
-              }
-            });
-          }
+          // Set up our raw tables
+          writeConfigs.get().forEach((streamId, uploader) -> {
+            final StreamConfig stream = parsedCatalog.getStream(streamId);
+            if (stream.destinationSyncMode() == DestinationSyncMode.OVERWRITE) {
+              // For streams in overwrite mode, truncate the raw table.
+              // non-1s1t syncs actually overwrite the raw table at the end of the sync, so we only do this in
+              // 1s1t mode.
+              final TableId rawTableId = TableId.of(stream.id().rawNamespace(), stream.id().rawName());
+              bigquery.delete(rawTableId);
+              BigQueryUtils.createPartitionedTableIfNotExists(bigquery, rawTableId, DefaultBigQueryRecordFormatter.SCHEMA_V2);
+            } else {
+              uploader.createRawTable();
+            }
+          });
         },
         (hasFailed) -> {
           try {

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -127,6 +127,7 @@ Now that you have set up the BigQuery destination connector, check out the follo
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.1.6   | 2023-10-23 | [\#31717](https://github.com/airbytehq/airbyte/pull/31717) | Remove inadvertent Destination v2 check                                                                                                                         |
 | 2.1.5   | 2023-10-17 | [\#30069](https://github.com/airbytehq/airbyte/pull/30069) | Staging destination async                                                                                                                                       |
 | 2.1.4   | 2023-10-17 | [\#31191](https://github.com/airbytehq/airbyte/pull/31191) | Improve typing+deduping performance by filtering new raw records on extracted_at                                                                                |
 | 2.1.3   | 2023-10-10 | [\#31358](https://github.com/airbytehq/airbyte/pull/31358) | Stringify array and object types for type:string column in final table                                                                                          |


### PR DESCRIPTION
A previous [pr](https://github.com/airbytehq/airbyte/pull/30069) inadvertently added back an "is destination v2" check which has been removed from the config and would always resolve false, causing the raw tables to not be created