### PR TITLE
update helm deploy instructions

### DIFF
--- a/docs/deploying-airbyte/on-kubernetes-via-helm.md
+++ b/docs/deploying-airbyte/on-kubernetes-via-helm.md
@@ -104,6 +104,8 @@ In order to do so, run the command:
 helm install %release_name% airbyte/airbyte
 ```
 
+**Note**: `release_name` should only contain lowercase letters and optionally dashes (`release_name` must start with a letter).
+
 ### Custom deployment
 
 In order to customize your deployment, you need to create `values.yaml` file in the local folder and populate it with default configuration override values.


### PR DESCRIPTION
## What
mention constraints on helm `release_name` in the docs

This constraint exists because in our helm charts we use the `release_name` as part of k8s svc names, so `release_name` can only use characters that are valid for an individual dns label.

## 🚨 User Impact 🚨
better docs
no breaking changes
