### PR TITLE
🐛  fix error message for postgres standby error

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -28,10 +28,13 @@ subprojects { subproject ->
                 artifact subproject.tasks.testFixturesJar
             }
         }
+        // This repository is only defined and used in the context of an artifact publishing
+        // It's different from the 'airbyte-public-jars' defined in settings.graddle only in its omission 
+        // of the 'public' directory. Any artifacts publish here will be available in the 'airbyte-public-jars' repo
         repositories {
             maven {
                 name 'airbyte-repo'
-                url 'https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars/' //This is only used to publish. 
+                url 'https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars/' 
                 credentials {
                     username System.getenv('CLOUDREPO_USER')
                     password System.getenv('CLOUDREPO_PASSWORD')

--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -31,7 +31,7 @@ subprojects { subproject ->
         repositories {
             maven {
                 name 'airbyte-repo'
-                url 'https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars/'
+                url 'https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars/' //This is only used to publish. 
                 credentials {
                     username System.getenv('CLOUDREPO_USER')
                     password System.getenv('CLOUDREPO_PASSWORD')

--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -30,7 +30,7 @@ subprojects { subproject ->
         }
         repositories {
             maven {
-                name 'airbyte-public-jars'
+                name 'airbyte-repo'
                 url 'https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars/'
                 credentials {
                     username System.getenv('CLOUDREPO_USER')

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.1.12
+version=0.1.13


### PR DESCRIPTION
## What
fixes #31357 (1 of 2) 
simply changing the error message with the correct bitly
I took the opportunity to cleanup the CDK code a bit.
Finally, all postgres connectors should use this new CDK version so that they all have the new error message. That will be done in another PR

## 🚨 User Impact 🚨
no breaking change



Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
