### PR TITLE
Fix: Use private MyCloudRepo URL when publishing Java CDK

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -31,7 +31,7 @@ subprojects { subproject ->
         repositories {
             maven {
                 name 'airbyte-public-jars'
-                url 'https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars/'
+                url 'https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars/'
                 credentials {
                     username System.getenv('CLOUDREPO_USER')
                     password System.getenv('CLOUDREPO_PASSWORD')


### PR DESCRIPTION
Addresses problem where CDK fails to publish with error `Received status code 405 from server: Method Not Allowed`

```
* What went wrong:
128
Execution failed for task ':airbyte-cdk:java:airbyte-cdk:db-destinations:publishMainPublicationToAirbyte-public-jarsRepository'.
129
> Failed to publish publication 'main' to repository 'airbyte-public-jars'
130
   > Could not PUT 'https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars/io/airbyte/cdk/airbyte-cdk-db-destinations/0.1.12/airbyte-cdk-db-destinations-0.1.12.jar'. Received status code 405 from server: Method Not Allowed
```

It looks like this changed when we did the Gradle consolidation. The `/public/` URL works to allow unauthenticated 'get' access, but doesn't (to my knowlege) support publishing.