### PR TITLE
Update the title of the advanced option raw_data_schema

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/resources/spec.json
@@ -220,7 +220,8 @@
       "raw_data_dataset": {
         "type": "string",
         "description": "The dataset to write raw tables into",
-        "title": "Destinations V2 Raw Table Dataset",
+        "title": "Raw Table Dataset Name",
+        "default": "airbyte_internal",
         "order": 7,
         "group": "advanced"
       }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/resources/spec.json
@@ -219,9 +219,8 @@
       },
       "raw_data_dataset": {
         "type": "string",
-        "description": "The dataset to write raw tables into",
+        "description": "The dataset to write raw tables into (default: airbyte_internal)",
         "title": "Raw Table Dataset Name",
-        "default": "airbyte_internal",
         "order": 7,
         "group": "advanced"
       }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
@@ -164,7 +164,8 @@
       "raw_data_schema": {
         "type": "string",
         "description": "The schema to write raw tables into",
-        "title": "Destinations V2 Raw Table Schema",
+        "title": "Raw Table Schema Name",
+        "default": "airbyte_internal",
         "order": 10
       }
     }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
@@ -163,9 +163,8 @@
       },
       "raw_data_schema": {
         "type": "string",
-        "description": "The schema to write raw tables into",
+        "description": "The schema to write raw tables into (default: airbyte_internal)",
         "title": "Raw Table Schema Name",
-        "default": "airbyte_internal",
         "order": 10
       }
     }


### PR DESCRIPTION
From [slack](https://airbytehq-team.slack.com/archives/C03C4AVJWG4/p1698179095845789)

This PR clarifies the title of the `raw_data_schema` and shows that the default value is `(default: airbyte_internal)`. I prefer this method rather than providing an actual default value because I think it is meaningful to know if this value is present or not (e.g. the user made a change vs the config supplied the default value)

I'm not releasing these changes as new connector versions; the next release will pick them up