### PR TITLE
🐛 source-paypal-transaction: retroactively mark 2.1.0 as a breaking change

### DIFF
--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -25,6 +25,11 @@ data:
       enabled: true
   releaseDate: 2021-06-10
   releaseStage: generally_available
+  releases:
+    breakingChanges:
+      2.0.1:
+        message: 'Version 2.0.1 changes the format of the state. The format of the cursor changed from "2021-06-18T16:24:13+03:00" to "2021-06-18T16:24:13Z". The state key for the transactions stream changed to "transaction_updated_date" and the key for the balances stream change to "as_of_time". The upgrade is safe, but rolling back is not.'
+        upgradeDeadline: "2023-09-14"
   supportLevel: certified
   tags:
     - language:low-code

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -29,7 +29,7 @@ data:
     breakingChanges:
       2.0.1:
         message: 'Version 2.0.1 changes the format of the state. The format of the cursor changed from "2021-06-18T16:24:13+03:00" to "2021-06-18T16:24:13Z". The state key for the transactions stream changed to "transaction_updated_date" and the key for the balances stream change to "as_of_time". The upgrade is safe, but rolling back is not.'
-        upgradeDeadline: "2023-09-14"
+        upgradeDeadline: "2023-09-18"
   supportLevel: certified
   tags:
     - language:low-code

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -27,8 +27,8 @@ data:
   releaseStage: generally_available
   releases:
     breakingChanges:
-      2.0.1:
-        message: 'Version 2.0.1 changes the format of the state. The format of the cursor changed from "2021-06-18T16:24:13+03:00" to "2021-06-18T16:24:13Z". The state key for the transactions stream changed to "transaction_updated_date" and the key for the balances stream change to "as_of_time". The upgrade is safe, but rolling back is not.'
+      2.1.0:
+        message: 'Version 2.1.0 changes the format of the state. The format of the cursor changed from "2021-06-18T16:24:13+03:00" to "2021-06-18T16:24:13Z". The state key for the transactions stream changed to "transaction_updated_date" and the key for the balances stream change to "as_of_time". The upgrade is safe, but rolling back is not.'
         upgradeDeadline: "2023-09-18"
   supportLevel: certified
   tags:

--- a/docs/integrations/sources/paypal-transaction-migrations.md
+++ b/docs/integrations/sources/paypal-transaction-migrations.md
@@ -1,8 +1,8 @@
 # Paypal Transaction Migration Guide
 
-## Upgrading to 2.0.1
+## Upgrading to 2.1.0
 
-Version 2.0.1 changes the format of the state object. Upgrading to 2.0.1 is safe, but downgrading to 2.0.0 is not.
+Version 2.1.0 changes the format of the state object. Upgrading to 2.1.0 is safe, but downgrading to 2.0.0 is not.
 
 To downgrade to 2.0.0:
 - Edit your connection state:

--- a/docs/integrations/sources/paypal-transaction-migrations.md
+++ b/docs/integrations/sources/paypal-transaction-migrations.md
@@ -1,0 +1,11 @@
+# Paypal Transaction Migration Guide
+
+## Upgrading to 2.0.1
+
+Version 2.0.1 changes the format of the state object. Upgrading to 2.0.1 is safe, but downgrading to 2.0.0 is not.
+
+To downgrade to 2.0.0:
+- Edit your connection state:
+  - Change the the keys for the transactions and balances streams to "date"
+  - Change the format of the cursor to "yyyy-MM-dd'T'HH:mm:ss+00:00"
+Alternatively, you can also reset your connection.


### PR DESCRIPTION
## What
* Retroactively mark 2.1.0 as a breaking change because the format of the state object changed.
* [As discussed in this separate PR](https://github.com/airbytehq/airbyte/pull/31759#discussion_r1369422043)