### PR TITLE
🎉 Source TikTok Marketing: update `metadata`, fix  `ads` schema duplicates

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   ab_internal:
     ql: 400
-    sl: 200
+    sl: 300
   allowedHosts:
     hosts:
       - sandbox-ads.tiktok.com
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 3.9.0
+  dockerImageTag: 3.9.1
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   githubIssueLabel: source-tiktok-marketing
@@ -27,4 +27,13 @@ data:
   supportLevel: certified
   tags:
     - language:python
+  suggestedStreams:
+    streams:
+      - ads_reports_daily
+      - ads
+      - campaigns
+      - campaigns_reports_daily
+      - ad_groups
+      - ad_groups_reports_daily
+      - advertisers_reports_daily
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/ads.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/ads.json
@@ -22,9 +22,6 @@
     "ad_name": {
       "type": "string"
     },
-    "tracking_pixel_id": {
-      "type": ["null", "number"]
-    },
     "tracking_app_id": {
       "type": ["null", "string"]
     },

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -586,6 +586,7 @@ The connector is restricted by [requests limitation](https://ads.tiktok.com/mark
 
 | Version | Date       | Pull Request                                             | Subject                                                                                          |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------|
+| 3.9.1   | 2023-10-25 | [31812](https://github.com/airbytehq/airbyte/pull/31812) | Update `support level` in `metadata`,  removed duplicated `tracking_pixel_id` field from `Ads` stream schema                           |
 | 3.9.0   | 2023-10-23 | [31623](https://github.com/airbytehq/airbyte/pull/31623) | Add AdsAudienceReportsByProvince stream and expand base report metrics                           |
 | 3.8.0   | 2023-10-19 | [31610](https://github.com/airbytehq/airbyte/pull/31610) | Add Creative Assets and Audiences streams                                                        |
 | 3.7.1   | 2023-10-19 | [31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image                  |


### PR DESCRIPTION
## What
- Based on the checklist : https://docs.google.com/spreadsheets/d/1qMvE1owZvrDti87O--N759fpy28C60kOUbBy1hUDEuE/edit#gid=1700962388

1) We need to update the `metadata.yaml` with:
- suggested streams
- sl: 300

2) remove the duplicated `tracking_pixel_id: type "number"` duplicated field from `ads` stream schema.

## How 
- updated `metadata.yaml`
- updated `ads` stream schema

## 🚨 User Impact 🚨
No impact is expected, since removing the field in this case will not affect the Customers, because the `tracking_pixel_id` field is picked up with the right  `integer` data-type.
