### PR TITLE
Update alpine and python

### DIFF
--- a/airbyte-cdk/python/Dockerfile
+++ b/airbyte-cdk/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.11-alpine3.15 as base
+FROM python:3.9.18-alpine3.18 as base
 
 # build and load all requirements
 FROM base as builder


### PR DESCRIPTION
## What


A user complained about flaky DNS issues [here](https://github.com/airbytehq/airbyte/pull/31642). It was not possible to reproduce on my side. Based on this [source](https://www.theregister.com/2023/05/16/alpine_linux_318/), version 3.18 of Alpine Linux should improve the situation. I see not harm in increasing the version. 

[Changes from Alpine 15 to 18](https://www.alpinelinux.org/releases/) are mostly security related apart from 3.18 which contains bugfixes (including the DNS one).

This has one possible major side effect: Alpine 3.18 is only packaged with Python 3.9.17 and 3.9.18. We are currently using 3.9.11. Reading change logs [here](https://docs.python.org/3.9/whatsnew/changelog.html) and [here](https://www.python.org/downloads/release/python-3918/], there should not have any negative impact. I've done manual smoke testing on PokeAPI and Exchange Rates API and couldn't find any regression.

## How
Bumping the version of the base image in the Dockerfile
