### PR TITLE
Analytics: Add unifygtm tag to docs site

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -27,6 +27,17 @@ const config = {
   organizationName: "airbytehq", // Usually your GitHub org/user name.
   projectName: "airbyte", // Usually your repo name.
 
+  // Adds one off script tags to the head of each page
+  // .e.g <script async data-api-key="..." id="unifytag" src="..."></script>
+  scripts: [
+    {
+      src: "https://cdn.unifygtm.com/tag/v1/unify-tag-script.js",
+      async: true,
+      id: "unifytag",
+      "data-api-key": "wk_BEtrdAz2_2qgdexg5KRa6YWLWVwDdieFC7CAHkDKz",
+    }
+  ],
+
   plugins: [
     [
       "@docusaurus/plugin-client-redirects",

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -33,6 +33,7 @@ const config = {
     {
       src: "https://cdn.unifygtm.com/tag/v1/unify-tag-script.js",
       async: true,
+      type: "module",
       id: "unifytag",
       "data-api-key": "wk_BEtrdAz2_2qgdexg5KRa6YWLWVwDdieFC7CAHkDKz",
     }


### PR DESCRIPTION
## Overview
This adds the following tag to the `<head/>` element of all documentation pages
```
<script async data-api-key="wk_BEtrdAz2_2qgdexg5KRa6YWLWVwDdieFC7CAHkDKz" id="unifytag" src="https://cdn.unifygtm.com/tag/v1/unify-tag-script.js" type="module"></script>
```