### PR TITLE
gradle: tweak s3 build cache activation

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -150,7 +150,8 @@ if (isCiServer || isAirbyteCI) {
             bucket = 'ab-ci-cache'
             prefix = "${System.getProperty('s3BuildCachePrefix', 'connectors')}-ci-cache/"
             push = isAirbyteCI
-            enabled = System.getenv().containsKey("S3_BUILD_CACHE_ACCESS_KEY_ID")
+            // Sometimes the env var is set, but with an empty value. Ignore this case.
+            enabled = !System.getenv().getOrDefault("S3_BUILD_CACHE_ACCESS_KEY_ID", "").isEmpty()
         }
     }
 }


### PR DESCRIPTION
It turns out that in our github workflow setup, it's very easy to have the credentials env var set but to an empty value. This causes the s3 build cache to be used in read-only mode, effectively. This PR fixes this.