### PR TITLE
Airbyte CDK: make max_time optional for backoff handler external usage

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_requester.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_requester.py
@@ -62,7 +62,7 @@ class HttpRequester(Requester):
 
     _DEFAULT_MAX_RETRY = 5
     _DEFAULT_RETRY_FACTOR = 5
-    _DELAULT_MAX_TIME = 60 * 10
+    _DEFAULT_MAX_TIME = 60 * 10
 
     def __post_init__(self, parameters: Mapping[str, Any]) -> None:
         self._url_base = InterpolatedString.create(self.url_base, parameters=parameters)
@@ -177,7 +177,7 @@ class HttpRequester(Requester):
         Override if needed. Specifies maximum total waiting time (in seconds) for backoff policy. Return None for no limit.
         """
         if self.error_handler is None:
-            return self._DELAULT_MAX_TIME
+            return self._DEFAULT_MAX_TIME
         return self.error_handler.max_time
 
     @property

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
@@ -63,7 +63,7 @@ def default_backoff_handler(
 
 
 def user_defined_backoff_handler(
-    max_tries: Optional[int], max_time: Optional[int], **kwargs: Any
+    max_tries: Optional[int], max_time: Optional[int] = None, **kwargs: Any
 ) -> Callable[[SendRequestCallableType], SendRequestCallableType]:
     def sleep_on_ratelimit(details: Mapping[str, Any]) -> None:
         _, exc, _ = sys.exc_info()

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
@@ -27,7 +27,7 @@ SendRequestCallableType = Callable[[PreparedRequest, Mapping[str, Any]], Respons
 
 
 def default_backoff_handler(
-    max_tries: Optional[int], factor: float, max_time: Optional[int], **kwargs: Any
+    max_tries: Optional[int], factor: float, max_time: Optional[int] = None, **kwargs: Any
 ) -> Callable[[SendRequestCallableType], SendRequestCallableType]:
     def log_retry_attempt(details: Mapping[str, Any]) -> None:
         _, exc, _ = sys.exc_info()

--- a/airbyte-cdk/python/unit_tests/utils/test_rate_limiting.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_rate_limiting.py
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import pytest
+from airbyte_cdk.sources.streams.http.rate_limiting import default_backoff_handler
+from requests import exceptions
+
+
+def helper_with_exceptions(exception_type):
+    raise exception_type
+
+
+@pytest.mark.parametrize(
+    "max_tries, max_time, factor, exception_to_raise",
+    [
+        (1, None, 1, exceptions.ConnectTimeout),
+        (1, 1, 0, exceptions.ReadTimeout),
+        (2, 2, 1, exceptions.ConnectionError),
+        (3, 3, 1, exceptions.ChunkedEncodingError),
+    ],
+)
+def test_default_backoff_handler(max_tries: int, max_time: int, factor: int, exception_to_raise: Exception):
+    backoff_handler = default_backoff_handler(max_tries=max_tries, max_time=max_time, factor=factor)(helper_with_exceptions)
+    with pytest.raises(exception_to_raise):
+        backoff_handler(exception_to_raise)


### PR DESCRIPTION
## What

Resolve https://github.com/airbytehq/airbyte/issues/31874

## How

make `max_time` optional for backoff handler

## Recommended reading order
1. `rate_limiting.py`

## 🚨 User Impact 🚨

no breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

