### PR TITLE
🐛 Source Jira - better handling of invalid domain in check

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -44,7 +44,7 @@ pipx install --editable --force --python=python3.10 airbyte-ci/connectors/pipeli
 This command installs `airbyte-ci` and makes it globally available in your terminal.
 
 _Note: `--force` is required to ensure updates are applied on subsequent installs._
-_Note: `--python=python3.10` is required to ensure the correct python Oversion is used._
+_Note: `--python=python3.10` is required to ensure the correct python version is used._
 _Note: `--editable` is required to ensure the correct python version is used._
 
 If you face any installation problems feel free to reach out the Airbyte Connectors Operations team.

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -44,7 +44,7 @@ pipx install --editable --force --python=python3.10 airbyte-ci/connectors/pipeli
 This command installs `airbyte-ci` and makes it globally available in your terminal.
 
 _Note: `--force` is required to ensure updates are applied on subsequent installs._
-_Note: `--python=python3.10` is required to ensure the correct python version is used._
+_Note: `--python=python3.10` is required to ensure the correct python Oversion is used._
 _Note: `--editable` is required to ensure the correct python version is used._
 
 If you face any installation problems feel free to reach out the Airbyte Connectors Operations team.

--- a/airbyte-integrations/connectors/source-jira/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-jira/acceptance-test-config.yml
@@ -12,6 +12,8 @@ acceptance_tests:
         status: "succeed"
       - config_path: "integration_tests/invalid_config.json"
         status: "failed"
+      - config_path: "integration_tests/invalid_config_domain.json"
+        status: "failed"
   discovery:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-jira/integration_tests/invalid_config_domain.json
+++ b/airbyte-integrations/connectors/source-jira/integration_tests/invalid_config_domain.json
@@ -1,0 +1,5 @@
+{
+  "api_token": "some_token",
+  "domain": "https://withprotocol.atlassian.net",
+  "start_date": "2021-09-25T00:00:00Z"
+}

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
-  dockerImageTag: 0.10.1
+  dockerImageTag: 0.10.2
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   githubIssueLabel: source-jira

--- a/airbyte-integrations/connectors/source-jira/source_jira/source.py
+++ b/airbyte-integrations/connectors/source-jira/source_jira/source.py
@@ -105,17 +105,24 @@ class SourceJira(AbstractSource):
         except ValidationError as validation_error:
             return False, validation_error
         except requests.exceptions.RequestException as request_error:
-            if request_error.response.status_code == requests.codes.not_found:
+            has_response = request_error.response is not None
+            is_invalid_domain = isinstance(request_error, requests.exceptions.InvalidURL) \
+                or has_response and request_error.response.status_code == requests.codes.not_found
+
+            if is_invalid_domain:
                 raise AirbyteTracedException(
-                    message="Config validation error: please validate your domain.",
+                    message="Config validation error: please check that your domain is valid and does not include protocol (e.g: https://).",
                     internal_message=str(request_error),
                     failure_type=FailureType.config_error,
                 ) from None
+            
             # sometimes jira returns non json response
-            message = ""
-            if request_error.response.headers.get("content-type") == "application/json":
+            if has_response and request_error.response.headers.get("content-type") == "application/json":
                 message = " ".join(map(str, request_error.response.json().get("errorMessages", "")))
-            return False, f"{message} {request_error}"
+                return False, f"{message} {request_error}"
+        
+            # we don't know what this is, rethrow it
+            raise request_error
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         config = self._validate_and_transform(config)

--- a/airbyte-integrations/connectors/source-jira/source_jira/source.py
+++ b/airbyte-integrations/connectors/source-jira/source_jira/source.py
@@ -106,8 +106,11 @@ class SourceJira(AbstractSource):
             return False, validation_error
         except requests.exceptions.RequestException as request_error:
             has_response = request_error.response is not None
-            is_invalid_domain = isinstance(request_error, requests.exceptions.InvalidURL) \
-                or has_response and request_error.response.status_code == requests.codes.not_found
+            is_invalid_domain = (
+                isinstance(request_error, requests.exceptions.InvalidURL)
+                or has_response
+                and request_error.response.status_code == requests.codes.not_found
+            )
 
             if is_invalid_domain:
                 raise AirbyteTracedException(
@@ -115,12 +118,12 @@ class SourceJira(AbstractSource):
                     internal_message=str(request_error),
                     failure_type=FailureType.config_error,
                 ) from None
-            
+
             # sometimes jira returns non json response
             if has_response and request_error.response.headers.get("content-type") == "application/json":
                 message = " ".join(map(str, request_error.response.json().get("errorMessages", "")))
                 return False, f"{message} {request_error}"
-        
+
             # we don't know what this is, rethrow it
             raise request_error
 

--- a/airbyte-integrations/connectors/source-jira/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/test_source.py
@@ -65,7 +65,7 @@ def test_check_connection_404_error(config):
     with pytest.raises(AirbyteTracedException) as e:
         source.check_connection(logger=logger_mock, config=config)
 
-    assert e.value.message == "Config validation error: please validate your domain."
+    assert e.value.message == "Config validation error: please check that your domain is valid and does not include protocol (e.g: https://)."
 
 
 def test_get_authenticator(config):

--- a/airbyte-integrations/connectors/source-jira/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-jira/unit_tests/test_source.py
@@ -65,7 +65,9 @@ def test_check_connection_404_error(config):
     with pytest.raises(AirbyteTracedException) as e:
         source.check_connection(logger=logger_mock, config=config)
 
-    assert e.value.message == "Config validation error: please check that your domain is valid and does not include protocol (e.g: https://)."
+    assert (
+        e.value.message == "Config validation error: please check that your domain is valid and does not include protocol (e.g: https://)."
+    )
 
 
 def test_get_authenticator(config):

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -124,8 +124,9 @@ The Jira connector should not run into Jira API limitations under normal usage. 
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                 |
 |:--------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------|
-| 0.10.1 | 2023-10-23 | [31702](https://github.com/airbytehq/airbyte/pull/31702) | Base image migration: remove Dockerfile and use the python-connector-base image |
-| 0.10.0   | 2023-10-13 | [\#31385](https://github.com/airbytehq/airbyte/pull/31385) | Fixed `aggregatetimeoriginalestimate, timeoriginalestimate` field types for the `Issues` stream schema |
+| 0.10.2  | 2023-10-26 | [31896](https://github.com/airbytehq/airbyte/pull/31896)   | Provide better guidance when configuring the connector with an invalid domain                                           |
+| 0.10.1  | 2023-10-23 | [31702](https://github.com/airbytehq/airbyte/pull/31702)   | Base image migration: remove Dockerfile and use the python-connector-base image                                         |
+| 0.10.0  | 2023-10-13 | [\#31385](https://github.com/airbytehq/airbyte/pull/31385) | Fixed `aggregatetimeoriginalestimate, timeoriginalestimate` field types for the `Issues` stream schema                  |
 | 0.9.0   | 2023-09-26 | [\#30688](https://github.com/airbytehq/airbyte/pull/30688) | Added `createdDate` field to sprints schema, Removed `Expand Issues stream` from spec                                   |
 | 0.8.0   | 2023-09-26 | [\#30755](https://github.com/airbytehq/airbyte/pull/30755) | Add new streams: `Issue custom field options`, `IssueTypes`, `Project Roles`                                            |
 | 0.7.2   | 2023-09-19 | [\#30675](https://github.com/airbytehq/airbyte/pull/30675) | Ensure invalid URL does not trigger Sentry alert                                                                        |


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

We've gotten paged a couple times due to an unhandled exception raised when a user inputs an invalid domain while configuring Jira. Specifically, this happens when the user inputs the domain with protocol (e.g. `https://airbyte.atlassian.net` rather than the expected `airbyte.atlassian.net`).

Previously invalid domains were attempted to be handled as a config error, but there's an edge case in there with how invalid urls are handled and raised.

(see [sentry issue](https://airbytehq.sentry.io/issues/4511446155/events/86237b50ee3b4845bf8cf4bc31f2447d/?alert_rule_id=11478402&alert_type=issue&notification_uuid=16e6e7c0-eb51-47e6-88b3-a4d20d5cd830&project=6527718&referrer=previous-event))

## How

Fix by checking if response is None before accessing any fields in it. Also, handle the InvalidURL error so it raises the same config error. The messging for the error has also been tweaked to hint at protocol inclusion.

Then, updated any tests as needed.

