### PR TITLE
Source Mixpanel: exclude CohortMembers from incremental tests

### DIFF
--- a/airbyte-integrations/connectors/source-mixpanel/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-mixpanel/acceptance-test-config.yml
@@ -56,9 +56,9 @@ acceptance_tests:
   incremental:
     tests:
       - config_path: "secrets/config_incremental.json"
-        # engage stream is not part of incremental catalog as it is semi incremental,
-        # so cursor filter is not inside request, but results are filtered based on cursor state
-        # also engage can produce records without cursor field, so abnormal state test will fail
+        # The `Engage` and `CohortMembers` streams are not part of incremental catalog as they are semi-incremental,
+        # so cursor filter is not inside request, but results are filtered based on the cursor value.
+        # Also, these streams can produce records without cursor field, so abnormal state test would fail.
         configured_catalog_path: "integration_tests/configured_catalog_incremental.json"
         future_state:
           future_state_path: "integration_tests/abnormal_state.json"

--- a/airbyte-integrations/connectors/source-mixpanel/integration_tests/configured_catalog_incremental.json
+++ b/airbyte-integrations/connectors/source-mixpanel/integration_tests/configured_catalog_incremental.json
@@ -44,20 +44,6 @@
     },
     {
       "stream": {
-        "name": "cohort_members",
-        "json_schema": {},
-        "supported_sync_modes": ["full_refresh", "incremental"],
-        "source_defined_cursor": false,
-        "default_cursor_field": ["last_seen"],
-        "source_defined_primary_key": [["distinct_id"]]
-      },
-      "sync_mode": "incremental",
-      "destination_sync_mode": "append",
-      "cursor_field": ["last_seen"],
-      "primary_key": [["distinct_id"]]
-    },
-    {
-      "stream": {
         "name": "revenue",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],


### PR DESCRIPTION
## What
Fix build for the Mixpanel source connector

## How
- Exclude one of the streams from incremental tests as it is actually semi-incremental and can not be tested by CAT