### PR TITLE
Weaviate: Fix memory leak

### DIFF
--- a/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
+++ b/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
@@ -41,8 +41,6 @@ class WeaviateIndexer(Indexer):
 
     def __init__(self, config: WeaviateIndexingConfigModel):
         super().__init__(config)
-        self.buffered_objects: MutableMapping[str, BufferedObject] = {}
-        self.objects_with_error: MutableMapping[str, BufferedObject] = {}
 
     def _create_client(self):
         headers = {
@@ -132,7 +130,6 @@ class WeaviateIndexer(Indexer):
                 object_id = str(uuid.uuid4())
                 class_name = self.stream_to_class_name(chunk.record.stream)
                 self.client.batch.add_data_object(weaviate_object, class_name, object_id, vector=chunk.embedding)
-                self.buffered_objects[object_id] = BufferedObject(object_id, weaviate_object, chunk.embedding, class_name)
             self._flush()
 
     def stream_to_class_name(self, stream_name: str) -> str:

--- a/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
+++ b/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
@@ -9,8 +9,7 @@ import os
 import re
 import uuid
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import Any, List, Mapping, Optional
+from typing import Optional
 
 import weaviate
 from airbyte_cdk.destinations.vector_db_based.document_processor import METADATA_RECORD_ID_FIELD

--- a/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
+++ b/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
@@ -10,7 +10,7 @@ import re
 import uuid
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, List, Mapping, MutableMapping, Optional
+from typing import Any, List, Mapping, Optional
 
 import weaviate
 from airbyte_cdk.destinations.vector_db_based.document_processor import METADATA_RECORD_ID_FIELD
@@ -26,14 +26,6 @@ class WeaviatePartialBatchError(Exception):
 
 
 CLOUD_DEPLOYMENT_MODE = "cloud"
-
-
-@dataclass
-class BufferedObject:
-    id: str
-    properties: Mapping[str, Any]
-    vector: Optional[List[Any]]
-    class_name: str
 
 
 class WeaviateIndexer(Indexer):

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: 7b7d7a0d-954c-45a0-bcfc-39a634b97736
-  dockerImageTag: 0.2.4
+  dockerImageTag: 0.2.5
   dockerRepository: airbyte/destination-weaviate
   documentationUrl: https://docs.airbyte.com/integrations/destinations/weaviate
   githubIssueLabel: destination-weaviate

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -83,6 +83,7 @@ As properties have to start will a lowercase letter in Weaviate, field names mig
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| 0.2.5   | 2023-10-24 | [#31563](https://github.com/airbytehq/airbyte/pull/31563) | Fix memory leak |
 | 0.2.4   | 2023-10-23 | [#31563](https://github.com/airbytehq/airbyte/pull/31563) | Add field mapping option, improve append+dedupe sync performance and remove unnecessary retry logic |
 | 0.2.3 | 2023-10-19 | [#31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image |
 | 0.2.2   | 2023-10-15 | [#31329](https://github.com/airbytehq/airbyte/pull/31329) | Add OpenAI-compatible embedder option |

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -83,7 +83,7 @@ As properties have to start will a lowercase letter in Weaviate, field names mig
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
-| 0.2.5   | 2023-10-24 | [#31563](https://github.com/airbytehq/airbyte/pull/31563) | Fix memory leak |
+| 0.2.5   | 2023-10-24 | [#31953](https://github.com/airbytehq/airbyte/pull/31953) | Fix memory leak |
 | 0.2.4   | 2023-10-23 | [#31563](https://github.com/airbytehq/airbyte/pull/31563) | Add field mapping option, improve append+dedupe sync performance and remove unnecessary retry logic |
 | 0.2.3 | 2023-10-19 | [#31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image |
 | 0.2.2   | 2023-10-15 | [#31329](https://github.com/airbytehq/airbyte/pull/31329) | Add OpenAI-compatible embedder option |


### PR DESCRIPTION
Fixes https://github.com/airbytehq/airbyte/issues/31949

There was a leftover in the code that would buffer all processed objects which would eventually overflow the memory on larger syncs.

This PR removes the leftover code