### PR TITLE
🚨🚨🐛 Source Mixapanel: Delete default primary key for Export stream

### DIFF
--- a/airbyte-integrations/connectors/source-mixpanel/integration_tests/configured_catalog_incremental.json
+++ b/airbyte-integrations/connectors/source-mixpanel/integration_tests/configured_catalog_incremental.json
@@ -20,13 +20,11 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["time"],
-        "source_defined_primary_key": [["distinct_id"], ["event"], ["time"]]
+        "default_cursor_field": ["time"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append",
-      "cursor_field": ["time"],
-      "primary_key": [["distinct_id"], ["event"], ["time"]]
+      "cursor_field": ["time"]
     },
     {
       "stream": {

--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -28,10 +28,10 @@ data:
     breakingChanges:
       2.0.0:
         message:
-          In this release, the default primary key for stream Export has been deleted, 
-          allowing users to select the key that best fits their data. 
-          Users will need to refresh the source schema and reset
-          affected streams after upgrading.
+          In this release, the default primary key for stream Export has been deleted,
+          allowing users to select the key that best fits their data.
+          Refreshing the source schema and resetting affected streams is necessary
+          only if new primary keys are to be applied following the upgrade.
         upgradeDeadline: "2023-11-30"
       1.0.0:
         message:

--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
-  dockerImageTag: 1.0.1
+  dockerImageTag: 2.0.0
   dockerRepository: airbyte/source-mixpanel
   documentationUrl: https://docs.airbyte.com/integrations/sources/mixpanel
   githubIssueLabel: source-mixpanel
@@ -26,6 +26,13 @@ data:
   releaseStage: generally_available
   releases:
     breakingChanges:
+      2.0.0:
+        message:
+          In this release, the default primary key for stream Export has been deleted, 
+          allowing users to select the key that best fits their data. 
+          Users will need to refresh the source schema and reset
+          affected streams after upgrading.
+        upgradeDeadline: "2023-11-30"
       1.0.0:
         message:
           In this release, the datetime field of stream engage has had its

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams/export.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams/export.py
@@ -75,7 +75,7 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
      3 queries per second and 60 queries per hour.
     """
 
-    primary_key: str = ["distinct_id", "event", "time"]
+    primary_key: str = None
     cursor_field: str = "time"
 
     transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)

--- a/docs/integrations/sources/mixpanel-migrations.md
+++ b/docs/integrations/sources/mixpanel-migrations.md
@@ -2,7 +2,7 @@
 
 ## Upgrading to 2.0.0
 
-In this release, the default primary key for stream Export has been deleted, allowing users to select the key that best fits their data. Users will need to refresh the source schema and reset affected streams after upgrading.
+In this release, the default primary key for stream Export has been deleted, allowing users to select the key that best fits their data. Refreshing the source schema and resetting affected streams is necessary only if new primary keys are to be applied following the upgrade.
 
 ## Upgrading to 1.0.0
 

--- a/docs/integrations/sources/mixpanel-migrations.md
+++ b/docs/integrations/sources/mixpanel-migrations.md
@@ -1,5 +1,9 @@
 # Mixpanel Migration Guide
 
+## Upgrading to 2.0.0
+
+In this release, the default primary key for stream Export has been deleted, allowing users to select the key that best fits their data. Users will need to refresh the source schema and reset affected streams after upgrading.
+
 ## Upgrading to 1.0.0
 
 In this release, the datetime field of stream engage has had its type changed from date-time to string due to inconsistent data from Mixpanel. Additionally, the primary key for stream export has been fixed to uniquely identify records. Users will need to refresh the source schema and reset affected streams after upgrading.

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -43,6 +43,10 @@ Note: Incremental sync returns duplicated \(old records\) for the state date due
 - [Cohorts](https://developer.mixpanel.com/reference/cohorts-list) \(Incremental\)
 - [Cohort Members](https://developer.mixpanel.com/reference/engage-query) \(Incremental\)
 
+### Primary key selection for Export stream
+
+Mixpanel recommends using `[insert_id, event_time, event_name, distinct_id]` as the primary key. However, note that some rows might lack an `insert_id` for certain users. Ensure you select a primary key that aligns with your data.
+
 ## Performance considerations
 
 Syncing huge date windows may take longer due to Mixpanel's low API rate-limits \(**60 reqs per hour**\).
@@ -51,7 +55,8 @@ Syncing huge date windows may take longer due to Mixpanel's low API rate-limits 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------|
-| 1.0.1 | 2023-10-19 | [31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image |
+| 2.0.0   | 2023-10-30 | [31955](https://github.com/airbytehq/airbyte/pull/31955) | Delete the default primary key for the Export stream                                                        |
+| 1.0.1   | 2023-10-19 | [31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image                             |
 | 1.0.0   | 2023-09-27 | [30025](https://github.com/airbytehq/airbyte/pull/30025) | Fix type of datetime field in engage stream; fix primary key for export stream.                             |
 | 0.1.41  | 2023-09-26 | [30149](https://github.com/airbytehq/airbyte/pull/30149) | Change config schema; set checkpointing interval; add suggested streams; add casting datetime fields.       |
 | 0.1.40  | 2022-09-20 | [30090](https://github.com/airbytehq/airbyte/pull/30090) | Handle 400 error when the credentials become expired                                                        |


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Removed the default primary key from the `Export` stream.

## How
The columns recommended by Mixpanel for the primary key - `[insert_id, event_time, event_name, distinct_id]` - may not always have an `insert_id` for certain users. This issue is discussed in detail [here](https://github.com/airbytehq/oncall/issues/2939). This PR aims to give users the flexibility to choose their primary key, as requested in this [related PR](https://github.com/airbytehq/airbyte/pull/30025).

## 🚨 User Impact 🚨
This PR introduces breaking changes due to the removal of the default primary key for the `Export` stream.
