### PR TITLE
Fix connector builder tutorial setup section

### DIFF
--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -32,8 +32,8 @@ Before we get started, you'll need to generate an API access key for the Exchang
 This can be done by signing up for the Free tier plan on [Exchange Rates API](https://apilayer.com/marketplace/exchangerates_data-api):
 
 1. Visit https://apilayer.com and click Sign In on the top right - either sign into an existing account or sign up for a new account on the free tier.
-3. Once you're signed in, visit https://apilayer.com/marketplace/exchangerates_data-api and click "Live Demo".
-4. Inside that editor, you'll see an API key. This is your API key.
+2. Once you're signed in, visit https://apilayer.com/marketplace/exchangerates_data-api
+3. You should see an API Key displayed with a `Copy API Key` button next to it. This is your API key.
 
 ### Setting up the environment
 

--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -29,11 +29,10 @@ The output schema of our stream will look like the following:
 ### Setting up Exchange Rates API key
 
 Before we get started, you'll need to generate an API access key for the Exchange Rates API.
-This can be done by signing up for the Free tier plan on [Exchange Rates API](https://exchangeratesapi.io/):
+This can be done by signing up for the Free tier plan on [Exchange Rates API](https://apilayer.com/marketplace/exchangerates_data-api):
 
-1. Visit https://exchangeratesapi.io and click "Get free API key" on the top right
-2. You'll be taken to https://apilayer.com -- finish the sign up process, signing up for the free tier
-3. Once you're signed in, visit https://apilayer.com/marketplace/exchangerates_data-api#documentation-tab and click "Live Demo"
+1. Visit https://apilayer.com and click Sign In on the top right - either sign into an existing account or sign up for a new account on the free tier.
+3. Once you're signed in, visit https://apilayer.com/marketplace/exchangerates_data-api and click "Live Demo".
 4. Inside that editor, you'll see an API key. This is your API key.
 
 ### Setting up the environment


### PR DESCRIPTION
## What
A user left some negative feedback about the builder, which prompted me to watch their fullstory session and try to reproduce their error. See slack thread with context [here](https://airbytehq-team.slack.com/archives/C04NC4AP8JC/p1698427682197919).

Basically, the Exchange Rates API website changed what happens when you click `Get free API key` - this no longer redirects the user to `apilayer.com`, but instead directs them to a signup page within the Exchange Rates API website itself.

This breaks the rest of the tutorial because the API would now have to be accessed through a different URL with different authentication methods, etc.

## How
To correct this, I am slightly modifying the setup instructions in the tutorial to stay fully within apilayer.com, so that the user never visits the exchange rates API website. This means that the rest of the tutorial can stay the same since it is written assuming the user is signing up for apilayer.com.