### PR TITLE
Source Notion: add request size throttling on 504 errors

### DIFF
--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6e00b415-b02e-4160-bf02-58176a0ae687
-  dockerImageTag: 2.0.6
+  dockerImageTag: 2.0.8
   dockerRepository: airbyte/source-notion
   documentationUrl: https://docs.airbyte.com/integrations/sources/notion
   githubIssueLabel: source-notion

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6e00b415-b02e-4160-bf02-58176a0ae687
-  dockerImageTag: 2.0.8
+  dockerImageTag: 2.0.7
   dockerRepository: airbyte/source-notion
   documentationUrl: https://docs.airbyte.com/integrations/sources/notion
   githubIssueLabel: source-notion

--- a/airbyte-integrations/connectors/source-notion/source_notion/streams.py
+++ b/airbyte-integrations/connectors/source-notion/source_notion/streams.py
@@ -136,7 +136,7 @@ class NotionStream(HttpStream, ABC):
         # If page_size has been reduced after encountering a 504 Gateway Timeout error,
         # we increase it back to the default of 100 once a success response is achieved, for the following API calls.
         if response.status_code == 200 and self.page_size != 100:
-            self.logger.info(f"Successfully reconnected after a server timeout. Increasing request page size to 100.")
+            self.logger.info("Successfully reconnected after a server timeout. Increasing request page size to 100.")
             self.page_size = 100
         # sometimes notion api returns response without results object
         data = response.json().get("results", [])

--- a/airbyte-integrations/connectors/source-notion/source_notion/streams.py
+++ b/airbyte-integrations/connectors/source-notion/source_notion/streams.py
@@ -110,8 +110,8 @@ class NotionStream(HttpStream, ABC):
         # If page_size has been reduced after encountering a 504 Gateway Timeout error,
         # we increase it back to the default of 100 once a success response is achieved, for the following API calls.
         if response.status_code == 200 and self.page_size != 100:
-            self.logger.info("Successfully reconnected after a server timeout. Increasing request page size to 100.")
             self.page_size = 100
+            self.logger.info(f"Successfully reconnected after a server timeout. Increasing request page size to {self.page_size}.")
 
         return response.status_code == 400 or super().should_retry(response)
 

--- a/airbyte-integrations/connectors/source-notion/source_notion/streams.py
+++ b/airbyte-integrations/connectors/source-notion/source_notion/streams.py
@@ -98,7 +98,7 @@ class NotionStream(HttpStream, ABC):
             return 10
         if response.status_code == 504:
             self.page_size = self.throttle_request_page_size(self.page_size)
-            self.logger.info(f"Encountered a server timeout. Adjusting request page size to {self.page_size} and retrying.")
+            self.logger.info(f"Encountered a server timeout. Reducing request page size to {self.page_size} and retrying.")
         return super().backoff_time(response)
 
     def should_retry(self, response: requests.Response) -> bool:
@@ -130,7 +130,7 @@ class NotionStream(HttpStream, ABC):
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
 
         # If page_size has been reduced after encountering a 504 Gateway Timeout error,
-        # we increase it back to the default of 100 once a request is successful.
+        # we increase it back to the default of 100 once a success response is achieved, for the following API calls.
         if response.status_code == 200 and self.page_size != 100:
             self.logger.info(f"Successfully reconnected after a server timeout. Increasing request page size to 100.")
             self.page_size = 100

--- a/airbyte-integrations/connectors/source-notion/source_notion/streams.py
+++ b/airbyte-integrations/connectors/source-notion/source_notion/streams.py
@@ -78,7 +78,7 @@ class NotionStream(HttpStream, ABC):
             message = response.json().get("message", "")
             if message.startswith("The start_cursor provided is invalid: "):
                 return message
-            
+
     def throttle_request_page_size(self, current_page_size):
         throttled_page_size = max(current_page_size // 2, 10)
         return throttled_page_size

--- a/airbyte-integrations/connectors/source-notion/source_notion/streams.py
+++ b/airbyte-integrations/connectors/source-notion/source_notion/streams.py
@@ -78,20 +78,27 @@ class NotionStream(HttpStream, ABC):
             message = response.json().get("message", "")
             if message.startswith("The start_cursor provided is invalid: "):
                 return message
+            
+    def throttle_request_page_size(self, current_page_size):
+        throttled_page_size = max(current_page_size // 2, 10)
+        return throttled_page_size
 
     def backoff_time(self, response: requests.Response) -> Optional[float]:
         """
         Notion's rate limit is approx. 3 requests per second, with larger bursts allowed.
         For a 429 response, we can use the retry-header to determine how long to wait before retrying.
-        For 500-level errors, we use Airbyte CDK's default exponential backoff with a retry_factor of 8.
+        For 500-level errors, we use Airbyte CDK's default exponential backoff with a retry_factor of 5.
+        In the case of a 504 Gateway Timeout error, we can lower the page_size when retrying to reduce the load on the server.
         Docs: https://developers.notion.com/reference/errors#rate-limiting
-
         """
         retry_after = response.headers.get("retry-after", "5")
         if response.status_code == 429:
             return float(retry_after)
         if self.check_invalid_start_cursor(response):
             return 10
+        if response.status_code == 504:
+            self.page_size = self.throttle_request_page_size(self.page_size)
+            self.logger.info(f"Encountered a server timeout. Adjusting request page size to {self.page_size} and retrying.")
         return super().backoff_time(response)
 
     def should_retry(self, response: requests.Response) -> bool:
@@ -121,6 +128,12 @@ class NotionStream(HttpStream, ABC):
             return {"next_cursor": next_cursor}
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+
+        # If page_size has been reduced after encountering a 504 Gateway Timeout error,
+        # we increase it back to the default of 100 once a request is successful.
+        if response.status_code == 200 and self.page_size != 100:
+            self.logger.info(f"Successfully reconnected after a server timeout. Increasing request page size to 100.")
+            self.page_size = 100
         # sometimes notion api returns response without results object
         data = response.json().get("results", [])
         yield from data

--- a/airbyte-integrations/connectors/source-notion/source_notion/streams.py
+++ b/airbyte-integrations/connectors/source-notion/source_notion/streams.py
@@ -79,7 +79,11 @@ class NotionStream(HttpStream, ABC):
             if message.startswith("The start_cursor provided is invalid: "):
                 return message
 
-    def throttle_request_page_size(self, current_page_size):
+    @staticmethod
+    def throttle_request_page_size(current_page_size):
+        """
+        Helper method to halve page_size when encountering a 504 Gateway Timeout error.
+        """
         throttled_page_size = max(current_page_size // 2, 10)
         return throttled_page_size
 

--- a/airbyte-integrations/connectors/source-notion/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-notion/unit_tests/test_streams.py
@@ -297,7 +297,8 @@ def test_403_error_handling(
 def test_request_throttle(initial_page_size, expected_page_size, mock_response, reset_page_size, requests_mock):
     """
     Tests that the request page_size is halved when a 504 error is encountered.
-    Once a 200 success is encountered, the page_size is reset to 100 for the next call.
+    Once a 200 success is encountered, the page_size is reset to 100 in parse_response,
+    for use in the next call.
     """
     requests_mock.register_uri(
         "GET",

--- a/airbyte-integrations/connectors/source-notion/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-notion/unit_tests/test_streams.py
@@ -278,34 +278,36 @@ def test_403_error_handling(
     else:
         assert reason is None
 
+
 @pytest.mark.parametrize(
     "initial_page_size, expected_page_size, mock_response, reset_page_size",
     [
-        (100, 50, {'status_code': 504, 'json': {}, 'headers': {'retry-after': '1'}}, False),
-        (50, 25, {'status_code': 504, 'json': {}, 'headers': {'retry-after': '1'}}, False),
-        (100, 100, {'status_code': 429, 'json': {}, 'headers': {'retry-after': '1'}}, False),
-        (100, 100, {'status_code': 200, 'json': {'data': 'success'}, 'headers': {}}, True)
+        (100, 50, {"status_code": 504, "json": {}, "headers": {"retry-after": "1"}}, False),
+        (50, 25, {"status_code": 504, "json": {}, "headers": {"retry-after": "1"}}, False),
+        (100, 100, {"status_code": 429, "json": {}, "headers": {"retry-after": "1"}}, False),
+        (100, 100, {"status_code": 200, "json": {"data": "success"}, "headers": {}}, True),
     ],
     ids=[
-        '504 error, page_size 100 -> 50',
-        '504 error, page_size 50 -> 25',
-        '429 error, page_size 100 -> 100',
-        '200 success, page_size 100 -> 100'
-    ]
+        "504 error, page_size 100 -> 50",
+        "504 error, page_size 50 -> 25",
+        "429 error, page_size 100 -> 100",
+        "200 success, page_size 100 -> 100",
+    ],
 )
 def test_request_throttle(initial_page_size, expected_page_size, mock_response, reset_page_size, requests_mock):
     """
-    Tests that the request page_size is halved when a 504 error is encountered. 
+    Tests that the request page_size is halved when a 504 error is encountered.
     Once a 200 success is encountered, the page_size is reset to 100 for the next call.
     """
     requests_mock.register_uri(
-        'GET', 'https://api.notion.com/v1/users',
-        [{'status_code': mock_response['status_code'], 'json': mock_response['json'], 'headers': mock_response['headers']}]
+        "GET",
+        "https://api.notion.com/v1/users",
+        [{"status_code": mock_response["status_code"], "json": mock_response["json"], "headers": mock_response["headers"]}],
     )
 
     stream = Users(config={"authenticator": "auth"})
     stream.page_size = initial_page_size
-    response = requests.get('https://api.notion.com/v1/users')
+    response = requests.get("https://api.notion.com/v1/users")
 
     if response.status_code != 200:
         stream.backoff_time(response)

--- a/airbyte-integrations/connectors/source-notion/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-notion/unit_tests/test_streams.py
@@ -297,8 +297,7 @@ def test_403_error_handling(
 def test_request_throttle(initial_page_size, expected_page_size, mock_response, requests_mock):
     """
     Tests that the request page_size is halved when a 504 error is encountered.
-    Once a 200 success is encountered, the page_size is reset to 100 in parse_response,
-    for use in the next call.
+    Once a 200 success is encountered, the page_size is reset to 100, for use in the next call.
     """
     requests_mock.register_uri(
         "GET",

--- a/airbyte-integrations/connectors/source-notion/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-notion/unit_tests/test_streams.py
@@ -285,13 +285,13 @@ def test_403_error_handling(
         (100, 50, {"status_code": 504, "json": {}, "headers": {"retry-after": "1"}}, False),
         (50, 25, {"status_code": 504, "json": {}, "headers": {"retry-after": "1"}}, False),
         (100, 100, {"status_code": 429, "json": {}, "headers": {"retry-after": "1"}}, False),
-        (100, 100, {"status_code": 200, "json": {"data": "success"}, "headers": {}}, True),
+        (50, 100, {"status_code": 200, "json": {"data": "success"}, "headers": {}}, True),
     ],
     ids=[
         "504 error, page_size 100 -> 50",
         "504 error, page_size 50 -> 25",
         "429 error, page_size 100 -> 100",
-        "200 success, page_size 100 -> 100",
+        "200 success, page_size 50 -> 100",
     ],
 )
 def test_request_throttle(initial_page_size, expected_page_size, mock_response, reset_page_size, requests_mock):
@@ -316,4 +316,4 @@ def test_request_throttle(initial_page_size, expected_page_size, mock_response, 
     # invoke parse_response to check the page_size reset logic
     list(stream.parse_response(response=response))
 
-    assert stream.page_size == (100 if reset_page_size else expected_page_size)
+    assert stream.page_size == expected_page_size

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -112,6 +112,7 @@ The connector is restricted by Notion [request limits](https://developers.notion
 
 | Version | Date       | Pull Request                                             | Subject                                            |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------- |
+| 2.0.8   | 2023-10-31 | [32004](https://github.com/airtybehq/airbyte/pull/32004) | Reduce page_size on 504 errors                     |
 | 2.0.6   | 2023-10-25 | [31825](https://github.com/airbytehq/airbyte/pull/31825) | Increase max_retries on retryable errors           |
 | 2.0.5   | 2023-10-23 | [31742](https://github.com/airbytehq/airbyte/pull/31742) | Add 'synced_block' property to Blocks schema       |
 | 2.0.4   | 2023-10-19 | [31625](https://github.com/airbytehq/airbyte/pull/31625) | Fix check_connection method                        |

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -112,7 +112,7 @@ The connector is restricted by Notion [request limits](https://developers.notion
 
 | Version | Date       | Pull Request                                             | Subject                                            |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------- |
-| 2.0.8   | 2023-10-31 | [32004](https://github.com/airtybehq/airbyte/pull/32004) | Reduce page_size on 504 errors                     |
+| 2.0.7   | 2023-10-31 | [32004](https://github.com/airtybehq/airbyte/pull/32004) | Reduce page_size on 504 errors                     |
 | 2.0.6   | 2023-10-25 | [31825](https://github.com/airbytehq/airbyte/pull/31825) | Increase max_retries on retryable errors           |
 | 2.0.5   | 2023-10-23 | [31742](https://github.com/airbytehq/airbyte/pull/31742) | Add 'synced_block' property to Blocks schema       |
 | 2.0.4   | 2023-10-19 | [31625](https://github.com/airbytehq/airbyte/pull/31625) | Fix check_connection method                        |


### PR DESCRIPTION
## What

Third attempt at resolving [oncall #3268](https://github.com/airbytehq/oncall/issues/3268). Customer is experiencing recurring sync failures due to 504 Gateway Timeout issues when syncing large datasets.

## How

- When a 504 error is encountered, the request page_size is reduced by half (to a minimum of 10) for each retried request to reduce burden on the server.
- Once a successful response has been received and the sync can proceed, page_size is reset to the default of 100 in parse_response.

## User Impact
Not a breaking change, only affects handling of retryable 504 errors
