### PR TITLE
Vector DB CDK: Prevent negative chunk size

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/config.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/config.py
@@ -85,6 +85,7 @@ class ProcessingConfigModel(BaseModel):
         ...,
         title="Chunk size",
         maximum=8191,
+        minimum=1,
         description="Size of chunks in tokens to store in vector store (make sure it is not too big for the context if your LLM)",
     )
     chunk_overlap: int = Field(


### PR DESCRIPTION
Set a minimum for the chunk size so it can't go negative (as this wouldn't be caught by the connection check but ultimately fail the sync). This implementation makes sure it can't even be entered into the UI.