### PR TITLE
Destination Google Sheets: Add instructions for Airbyte OSS

### DIFF
--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -39,12 +39,18 @@ To create a Google account, visit [Google](https://support.google.com/accounts/a
 
 <!-- env:oss -->
 **For Airbyte Open Source:**
- Authentication to Google Sheets is only available using OAuth for authentication. 
- 
- 1. Select **Google Sheets** from the Source type dropdown and enter a name for this connector.
-2. Follow [Google's OAuth instructions](https://developers.google.com/identity/protocols/oauth2) to create an authentication app. You will need to grant the scopes described in the [Google Sheets API](https://developers.google.com/identity/protocols/oauth2/scopes#sheets). 
-3. Copy your Client ID, Client secret, and Refresh Token from the previous step. 
-4. Copy the Google Sheet link to **Spreadsheet Link**
+
+Authentication to Google Sheets is only available using OAuth for authentication.
+
+1. Create a new [Google Cloud project](https://console.cloud.google.com/projectcreate).
+2. Enable the [Google Sheets API](https://console.cloud.google.com/apis/library/sheets.googleapis.com).
+3. Create a new [OAuth client ID](https://console.cloud.google.com/apis/credentials/oauthclient). Select `Web application` as the Application type, give it a `name` and add `https://developers.google.com/oauthplayground` as an Authorized redirect URI.
+4. Add a `Client Secret` (Add secret), and take note of both the `Client Secret` and `Client ID`.
+5. Go to [Google OAuth Playground](https://developers.google.com/oauthplayground/)
+6. Click the cog in the top-right corner, select `Use your own OAuth credentials` and enter the `OAuth Client ID` and `OAuth Client secret` from the previous step.
+7. In the left sidebar, find and select `Google Sheets API v4`, then choose the `https://www.googleapis.com/auth/spreadsheets` scope. Click `Authorize APIs`.
+8. In **step 2**, click `Exchange authorization code for tokens`. Take note of the `Refresh token`.
+9. Set up a new destination in Airbyte, select `Google Sheets` and enter the `Client ID`, `Client Secret`, `Refresh Token` and `Spreadsheet Link` from the previous steps.
 <!-- /env:oss -->
 
 ### Output schema


### PR DESCRIPTION
## What
Adds instructions for how to use the Google Sheets destination with the self-hosted version of Airbyte.

## How
The integration already supports manually adding the oauth login credentials. However, it is not obvious how one would go about doing this.

The user experience could be further improved by only prompting the user for a client id, client secret and spreadsheet URL, and then show a sign-in with Google-button which would replace the oauth playground steps. This appears however to be somewhat complex and beyond what I'm able to contribute for the time being.

## 🚨 User Impact 🚨
No breaking changes or impact for existing users.

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>