### PR TITLE
[Source-MsSQL] Rollback to 2.0.3 in case 3.0.0 fails [DO NOT MERGE]

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
-  dockerImageTag: 2.0.3
+  dockerImageTag: 3.0.0
   dockerRepository: airbyte/source-mssql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mssql
   githubIssueLabel: source-mssql
@@ -19,8 +19,10 @@ data:
   registries:
     cloud:
       dockerRepository: airbyte/source-mssql-strict-encrypt
+      dockerImageTag: 2.0.3
       enabled: true
     oss:
+      dockerImageTag: 2.0.3
       enabled: true
   releaseStage: alpha
   supportLevel: community


### PR DESCRIPTION
In the case that we need to rollback [this](https://github.com/airbytehq/airbyte/pull/31531).  This current PR redirects version 3.0.0 to point at 2.0.3 In the case that we need to rollback, this PR will be merged, and another PR will be submitted with version 2.0.3 that removes the previous changes. Also, mssql.md changelog will be updated with version 2.0.3 stating the rollback.