### PR TITLE
source-postgres CI perf: reduce benchmark workflow frequency

### DIFF
--- a/.github/workflows/tmp-source-postgres-test.yml
+++ b/.github/workflows/tmp-source-postgres-test.yml
@@ -8,8 +8,8 @@ name: source-postgres ci - for testing only
 
 on:
   schedule:
-    # Runs every hour to observe variance
-    - cron: "0 * * * *"
+    # Runs four times a day to observe variance
+    - cron: "0 6,12,16,20 * * *"
   workflow_dispatch:
     inputs:
       runner:


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
I believe the original hourly frequency of our CI perf benchmarking workflow for source-postgres has a negative impact our DockerHub rate limit.

I want to reduce the frequency to 4 times a day.
