### PR TITLE
🐛 Source Google Analytics Data API: Add handling for `JSONDecodeError` while checking for `api qouta` limits

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.0.1
+  dockerImageTag: 2.0.2
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/api_quota.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/api_quota.py
@@ -8,6 +8,7 @@ from functools import wraps
 from typing import Any, Iterable, Mapping, Optional
 
 import requests
+from requests.exceptions import JSONDecodeError
 
 from .utils import API_LIMIT_PER_HOUR
 
@@ -144,7 +145,7 @@ class GoogleAnalyticsApiQuotaBase:
                     self._set_retry_attrs_for_quota(quota_name)
                     self.logger.warn(f"The `{quota_name}` quota is exceeded!")
                     return None
-        except AttributeError as attr_e:
+        except (AttributeError, JSONDecodeError) as attr_e:
             self.logger.warning(
                 f"`GoogleAnalyticsApiQuota._check_for_errors`: Received non JSON response from the API. Full error: {attr_e}. Bypassing."
             )
@@ -159,7 +160,7 @@ class GoogleAnalyticsApiQuota(GoogleAnalyticsApiQuotaBase):
         # try get json from response
         try:
             parsed_response = response.json()
-        except AttributeError as e:
+        except (AttributeError, JSONDecodeError) as e:
             self.logger.warn(
                 f"`GoogleAnalyticsApiQuota._check_quota`: Received non JSON response from the API. Full error: {e}. Bypassing."
             )

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -275,6 +275,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version | Date       | Pull Request                                             | Subject                                                                          |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------|
+| 2.0.2 | 2023-11-02 | [32094](https://github.com/airbytehq/airbyte/pull/32094) | Added handling for `JSONDecodeError` while checking for `api qouta` limits |
 | 2.0.1 | 2023-10-18 | [31543](https://github.com/airbytehq/airbyte/pull/31543) | Base image migration: remove Dockerfile and use the python-connector-base image |
 | 2.0.0   | 2023-09-29 | [30930](https://github.com/airbytehq/airbyte/pull/30930) | Use distinct stream naming in case there are multiple properties in the config.  |
 | 1.6.0   | 2023-09-19 | [30460](https://github.com/airbytehq/airbyte/pull/30460) | Migrated custom reports from string to array; add `FilterExpressions` support    |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/oncall/issues/3435

## How 
- added `JSONDecodeError` to the list of exceptions to handle in `api_qouta.py`

## 🚨 User Impact 🚨
No impact is expected.