### PR TITLE
Stephane compiler warnings

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/acceptance-test-harness/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/acceptance-test-harness/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id "java-library"
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-try"
+    }
+}
+
 dependencies {
     annotationProcessor platform(libs.micronaut.bom)
     annotationProcessor libs.bundles.micronaut.annotation.processor
@@ -19,6 +25,7 @@ dependencies {
     implementation 'org.apache.ant:ant:1.10.10'
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation libs.bundles.datadog
+    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.2'
 
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-api')
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-commons')

--- a/airbyte-cdk/java/airbyte-cdk/airbyte-api/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/airbyte-api/build.gradle
@@ -5,6 +5,12 @@ plugins {
     id "java-library"
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-deprecation"
+    }
+}
+
 def specFile = "$projectDir/src/main/openapi/config.yaml"
 
 def generate = tasks.register('generate')

--- a/airbyte-cdk/java/airbyte-cdk/airbyte-commons-protocol/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/airbyte-commons-protocol/build.gradle
@@ -1,3 +1,9 @@
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-unchecked"
+    }
+}
+
 dependencies {
     annotationProcessor libs.bundles.micronaut.annotation.processor
     testAnnotationProcessor libs.bundles.micronaut.test.annotation.processor

--- a/airbyte-cdk/java/airbyte-cdk/airbyte-commons-protocol/src/test/resources/WellKnownTypes.json
+++ b/airbyte-cdk/java/airbyte-cdk/airbyte-commons-protocol/src/test/resources/WellKnownTypes.json
@@ -11,28 +11,63 @@
     },
     "Date": {
       "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}( BC)?$",
-      "description": "RFC 3339\u00a75.6's full-date format, extended with BC era support"
+      "oneOf": [
+        {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}( BC)?$"
+        },
+        {
+          "enum": ["+infinity", "-infinity"]
+        }
+      ],
+      "description": "RFC 3339\u00a75.6's full-date format, extended with BC era support and +/-infinity"
     },
     "TimestampWithTimezone": {
       "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+\\-]\\d{1,2}:\\d{2})( BC)?$",
-      "description": "An instant in time. Frequently simply referred to as just a timestamp, or timestamptz. Uses RFC 3339\u00a75.6's date-time format, requiring a \"T\" separator, and extended with BC era support. Note that we do _not_ accept Unix epochs here.\n"
+      "oneOf": [
+        {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+\\-]\\d{1,2}:\\d{2})( BC)?$"
+        },
+        {
+          "enum": ["+infinity", "-infinity"]
+        }
+      ],
+      "description": "An instant in time. Frequently simply referred to as just a timestamp, or timestamptz. Uses RFC 3339\u00a75.6's date-time format, requiring a \"T\" separator, and extended with BC era support and +/-infinity. Note that we do _not_ accept Unix epochs here.\n"
     },
     "TimestampWithoutTimezone": {
       "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?( BC)?$",
-      "description": "Also known as a localdatetime, or just datetime. Under RFC 3339\u00a75.6, this would be represented as `full-date \"T\" partial-time`, extended with BC era support.\n"
+      "oneOf": [
+        {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?( BC)?$"
+        },
+        {
+          "enum": ["+infinity", "-infinity"]
+        }
+      ],
+      "description": "Also known as a localdatetime, or just datetime. Under RFC 3339\u00a75.6, this would be represented as `full-date \"T\" partial-time`, extended with BC era support and +/-infinity.\n"
     },
     "TimeWithTimezone": {
       "type": "string",
-      "pattern": "^\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+\\-]\\d{1,2}:\\d{2})$",
-      "description": "An RFC 3339\u00a75.6 full-time"
+      "oneOf": [
+        {
+          "pattern": "^\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+\\-]\\d{1,2}:\\d{2})$"
+        },
+        {
+          "enum": ["+infinity", "-infinity"]
+        }
+      ],
+      "description": "An RFC 3339\u00a75.6 full-time, extended with +/-infinity"
     },
     "TimeWithoutTimezone": {
       "type": "string",
-      "pattern": "^\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?$",
-      "description": "An RFC 3339\u00a75.6 partial-time"
+      "oneOf": [
+        {
+          "pattern": "^\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?$"
+        },
+        {
+          "enum": ["+infinity", "-infinity"]
+        }
+      ],
+      "description": "An RFC 3339\u00a75.6 partial-time, extended with +/-infinity"
     },
     "Number": {
       "type": "string",

--- a/airbyte-cdk/java/airbyte-cdk/airbyte-commons/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/airbyte-commons/build.gradle
@@ -3,6 +3,12 @@ plugins {
     id 'de.undercouch.download' version "5.4.0"
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-varargs,-try,-deprecation"
+    }
+}
+
 dependencies {
     // Dependencies for this module should be specified in the top-level build.gradle. See readme for more explanation.
 

--- a/airbyte-cdk/java/airbyte-cdk/airbyte-commons/src/main/java/io/airbyte/commons/util/MoreIterators.java
+++ b/airbyte-cdk/java/airbyte-cdk/airbyte-commons/src/main/java/io/airbyte/commons/util/MoreIterators.java
@@ -22,6 +22,7 @@ public class MoreIterators {
    * @param <T> type
    * @return iterator with all elements
    */
+  @SafeVarargs
   public static <T> Iterator<T> of(final T... elements) {
     return Arrays.asList(elements).iterator();
   }

--- a/airbyte-cdk/java/airbyte-cdk/config-models-oss/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/config-models-oss/build.gradle
@@ -5,6 +5,12 @@ plugins {
     id "com.github.eirnym.js2p" version "1.0"
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-unchecked"
+    }
+}
+
 dependencies {
     annotationProcessor libs.bundles.micronaut.annotation.processor
     api libs.bundles.micronaut.annotation

--- a/airbyte-cdk/java/airbyte-cdk/core/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/core/build.gradle
@@ -1,4 +1,10 @@
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-deprecation,-try,-rawtypes,-overloads,-cast,-unchecked"
+    }
+}
+
 configurations.all {
     resolutionStrategy {
         // TODO: Diagnose conflicting dependencies and remove these force overrides:
@@ -63,8 +69,7 @@ dependencies {
     implementation libs.hikaricp
     implementation libs.bundles.debezium.bundle
 
-    implementation libs.bundles.datadog
-    // implementation 'com.datadoghq:dd-trace-api'
+    api libs.bundles.datadog
     implementation 'org.apache.sshd:sshd-mina:2.8.0'
 
     implementation libs.testcontainers

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/db/jdbc/JdbcSourceOperations.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/db/jdbc/JdbcSourceOperations.java
@@ -44,7 +44,7 @@ public class JdbcSourceOperations extends AbstractJdbcCompatibleSourceOperations
     final int columnTypeInt = resultSet.getMetaData().getColumnType(colIndex);
     final String columnName = resultSet.getMetaData().getColumnName(colIndex);
     final JDBCType columnType = safeGetJdbcType(columnTypeInt);
-
+    LOGGER.warn("SGX setCursorField value=" + json + "cursorFieldType=" + columnType);
     // https://www.cis.upenn.edu/~bcpierce/courses/629/jdkdocs/guide/jdbc/getstart/mapping.doc.html
     switch (columnType) {
       case BIT, BOOLEAN -> putBoolean(json, columnName, resultSet, colIndex);

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.2.2
+version=0.3.0

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
@@ -1,3 +1,10 @@
+
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-deprecation"
+    }
+}
+
 dependencies {
     // Depends on core CDK classes (OK 👍)
     implementation project(':airbyte-cdk:java:airbyte-cdk:core')

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
@@ -17,6 +17,13 @@ plugins {
     id "java-test-fixtures"  // https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-try,-rawtypes,-unchecked,-removal"
+    }
+}
+
+
 test {
     testLogging {
         // TODO: Remove this after debugging

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/debezium/internals/postgres/PostgresConverter.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/debezium/internals/postgres/PostgresConverter.java
@@ -17,11 +17,9 @@ import io.airbyte.cdk.db.jdbc.DateTimeConverter;
 import io.airbyte.cdk.integrations.debezium.internals.DebeziumConverterUtils;
 import io.debezium.spi.converter.CustomConverter;
 import io.debezium.spi.converter.RelationalColumn;
-import io.debezium.time.Conversions;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.format.DateTimeFormatter;
@@ -29,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -246,36 +243,18 @@ public class PostgresConverter implements CustomConverter<SchemaBuilder, Relatio
 
     registration.register(SchemaBuilder.string().optional(), x -> {
       throw new RuntimeException();/*
-      if (x == null) {
-        return DebeziumConverterUtils.convertDefaultValue(field);
-      }
-      switch (fieldType.toUpperCase(Locale.ROOT)) {
-        case "TIMETZ":
-          return DateTimeConverter.convertToTimeWithTimezone(x);
-        case "TIMESTAMPTZ":
-          return DateTimeConverter.convertToTimestampWithTimezone(x);
-        case "TIMESTAMP":
-          if (x instanceof final Long l) {
-            if (getTimePrecision(field) <= 3) {
-              return convertToTimestamp(Conversions.toInstantFromMillis(l));
-            }
-            if (getTimePrecision(field) <= 6) {
-              return convertToTimestamp(Conversions.toInstantFromMicros(l));
-            }
-          }
-          return convertToTimestamp(x);
-        case "DATE":
-          if (x instanceof Integer) {
-            return convertToDate(LocalDate.ofEpochDay((Integer) x));
-          }
-          return convertToDate(x);
-        case "TIME":
-          return resolveTime(field, x);
-        case "INTERVAL":
-          return convertInterval((PGInterval) x);
-        default:
-          throw new IllegalArgumentException("Unknown field type  " + fieldType.toUpperCase(Locale.ROOT));
-      }*/
+                                    * if (x == null) { return DebeziumConverterUtils.convertDefaultValue(field); } switch
+                                    * (fieldType.toUpperCase(Locale.ROOT)) { case "TIMETZ": return
+                                    * DateTimeConverter.convertToTimeWithTimezone(x); case "TIMESTAMPTZ": return
+                                    * DateTimeConverter.convertToTimestampWithTimezone(x); case "TIMESTAMP": if (x instanceof final
+                                    * Long l) { if (getTimePrecision(field) <= 3) { return
+                                    * convertToTimestamp(Conversions.toInstantFromMillis(l)); } if (getTimePrecision(field) <= 6) {
+                                    * return convertToTimestamp(Conversions.toInstantFromMicros(l)); } } return convertToTimestamp(x);
+                                    * case "DATE": if (x instanceof Integer) { return convertToDate(LocalDate.ofEpochDay((Integer) x));
+                                    * } return convertToDate(x); case "TIME": return resolveTime(field, x); case "INTERVAL": return
+                                    * convertInterval((PGInterval) x); default: throw new
+                                    * IllegalArgumentException("Unknown field type  " + fieldType.toUpperCase(Locale.ROOT)); }
+                                    */
     });
   }
 

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/debezium/internals/postgres/PostgresConverter.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/debezium/internals/postgres/PostgresConverter.java
@@ -245,6 +245,7 @@ public class PostgresConverter implements CustomConverter<SchemaBuilder, Relatio
     final var fieldType = field.typeName();
 
     registration.register(SchemaBuilder.string().optional(), x -> {
+      throw new RuntimeException();/*
       if (x == null) {
         return DebeziumConverterUtils.convertDefaultValue(field);
       }
@@ -274,7 +275,7 @@ public class PostgresConverter implements CustomConverter<SchemaBuilder, Relatio
           return convertInterval((PGInterval) x);
         default:
           throw new IllegalArgumentException("Unknown field type  " + fieldType.toUpperCase(Locale.ROOT));
-      }
+      }*/
     });
   }
 

--- a/airbyte-integrations/connectors-performance/destination-harness/build.gradle
+++ b/airbyte-integrations/connectors-performance/destination-harness/build.gradle
@@ -20,3 +20,10 @@ dependencies {
     implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
 
 }
+
+//This is only needed because we're using some very old libraries from airbyte-commons that were not packaged correctly
+java {
+    compileJava {
+       options.compilerArgs.remove("-Werror")
+   }
+}

--- a/airbyte-integrations/connectors-performance/source-harness/build.gradle
+++ b/airbyte-integrations/connectors-performance/source-harness/build.gradle
@@ -17,3 +17,10 @@ dependencies {
     implementation 'io.airbyte.airbyte-config:config-models:0.42.0'
     implementation 'com.datadoghq:datadog-api-client:2.16.0'
 }
+
+//This is only needed because we're using some very old libraries from airbyte-commons that were not packaged correctly
+java {
+    compileJava {
+       options.compilerArgs.remove("-Werror")
+   }
+}

--- a/airbyte-integrations/connectors/destination-csv/build.gradle
+++ b/airbyte-integrations/connectors/destination-csv/build.gradle
@@ -3,6 +3,12 @@ plugins {
     id 'airbyte-java-connector'
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-try"
+    }
+}
+
 airbyteJavaConnector {
     cdkVersionRequired = '0.2.0'
     features = ['db-destinations']

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -6,6 +6,12 @@ plugins {
     id "org.jsonschema2pojo" version "1.2.1"
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-try,-rawtypes,-unchecked"
+    }
+}
+
 airbyteJavaConnector {
     cdkVersionRequired = '0.2.2'
     features = ['db-sources']

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -9,7 +9,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.2.2'
     features = ['db-sources']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 airbyteJavaConnector.addCdkDependencies()

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSourceOperations.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSourceOperations.java
@@ -421,8 +421,9 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
   protected void putDate(ObjectNode node, String columnName, ResultSet resultSet, int index) throws SQLException {
     String strValue = resultSet.getString(index);
 
-      //even though the super just does a toString, I find it a lot cleaner to call it anyways, in case that implementation changes
-      super.putDate(node, columnName, resultSet, index);
+    // even though the super just does a toString, I find it a lot cleaner to call it anyways, in case
+    // that implementation changes
+    super.putDate(node, columnName, resultSet, index);
 
   }
 
@@ -435,7 +436,7 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
   protected void putTimestamp(final ObjectNode node, final String columnName, final ResultSet resultSet, final int index) throws SQLException {
     String strValue = resultSet.getString(index);
 
-      node.put(columnName, DateTimeConverter.convertToTimestamp(resultSet.getTimestamp(index)));
+    node.put(columnName, DateTimeConverter.convertToTimestamp(resultSet.getTimestamp(index)));
 
   }
 
@@ -447,7 +448,7 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
 
   @Override
   protected void putTimestampWithTimezone(final ObjectNode node, final String columnName, final ResultSet resultSet, final int index)
-          throws SQLException {
+      throws SQLException {
     String strValue = resultSet.getString(index);
     if (INFINITY_STRING.equals(strValue)) {
       node.put(columnName, PLUS_INFINITY_STRING);

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSourceOperations.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSourceOperations.java
@@ -63,6 +63,10 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
   private static final Map<Integer, PostgresType> POSTGRES_TYPE_DICT = new HashMap<>();
   private final Map<String, Map<String, ColumnInfo>> streamColumnInfo = new HashMap<>();
 
+  private static final String INFINITY_STRING = "infinity";
+  private static final String PLUS_INFINITY_STRING = "+infinity";
+  private static final String MINUS_INFINITY_STRING = "-infinity";
+
   static {
     Arrays.stream(PostgresType.class.getEnumConstants()).forEach(c -> POSTGRES_TYPE_DICT.put(c.type, c));
   }
@@ -408,9 +412,6 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
     node.set(columnName, arrayNode);
   }
 
-  private static final String INFINITY_STRING = "infinity";
-  private static final String PLUS_INFINITY_STRING = "+infinity";
-  private static final String MINUS_INFINITY_STRING = "-infinity";
   @Override
   protected void putDate(ObjectNode node, String columnName, ResultSet resultSet, int index) throws SQLException {
     String strValue = resultSet.getString(index);

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSourceOperations.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSourceOperations.java
@@ -92,6 +92,8 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
                              final PostgresType cursorFieldType,
                              final String value)
       throws SQLException {
+
+    LOGGER.warn("SGX setCursorField value=" + value + "cursorFieldType=" + cursorFieldType);
     switch (cursorFieldType) {
 
       case TIMESTAMP -> setTimestamp(preparedStatement, parameterIndex, value);
@@ -127,6 +129,7 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
 
   private void setTimestampWithTimezone(final PreparedStatement preparedStatement, final int parameterIndex, final String value) throws SQLException {
     try {
+      LOGGER.warn("SGX setTimestampWithTimezone value=" + value + " parsedValue=" + OffsetDateTime.parse(value));
       preparedStatement.setObject(parameterIndex, OffsetDateTime.parse(value));
     } catch (final DateTimeParseException e) {
       // attempt to parse the datetime w/o timezone. This can be caused by schema created with a different
@@ -138,6 +141,7 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
   @Override
   protected void setTimestamp(final PreparedStatement preparedStatement, final int parameterIndex, final String value) throws SQLException {
     try {
+      LOGGER.warn("SGX setTimestamp value=" + value + " parsedValue=" + LocalDateTime.parse(value));
       preparedStatement.setObject(parameterIndex, LocalDateTime.parse(value));
     } catch (final DateTimeParseException e) {
       // attempt to parse the datetime with timezone. This can be caused by schema created with an older
@@ -148,6 +152,7 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
 
   @Override
   protected void setDate(final PreparedStatement preparedStatement, final int parameterIndex, final String value) throws SQLException {
+    LOGGER.warn("SGX setDate value=" + value + " parsedValue=" + LocalDate.parse(value));
     preparedStatement.setObject(parameterIndex, LocalDate.parse(value));
   }
 
@@ -415,14 +420,10 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
   @Override
   protected void putDate(ObjectNode node, String columnName, ResultSet resultSet, int index) throws SQLException {
     String strValue = resultSet.getString(index);
-    if (INFINITY_STRING.equals(strValue)) {
-      node.put(columnName, PLUS_INFINITY_STRING);
-    } else if (MINUS_INFINITY_STRING.equals(strValue)) {
-      node.put(columnName, MINUS_INFINITY_STRING);
-    } else {
+
       //even though the super just does a toString, I find it a lot cleaner to call it anyways, in case that implementation changes
       super.putDate(node, columnName, resultSet, index);
-    }
+
   }
 
   @Override
@@ -433,13 +434,9 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
   @Override
   protected void putTimestamp(final ObjectNode node, final String columnName, final ResultSet resultSet, final int index) throws SQLException {
     String strValue = resultSet.getString(index);
-    if (INFINITY_STRING.equals(strValue)) {
-      node.put(columnName, PLUS_INFINITY_STRING);
-    } else if (MINUS_INFINITY_STRING.equals(strValue)) {
-      node.put(columnName, MINUS_INFINITY_STRING);
-    } else {
+
       node.put(columnName, DateTimeConverter.convertToTimestamp(resultSet.getTimestamp(index)));
-    }
+
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractPostgresSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractPostgresSourceDatatypeTest.java
@@ -18,7 +18,6 @@ import io.airbyte.protocol.models.JsonSchemaType;
 import java.util.Set;
 import org.jooq.DSLContext;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
 
 public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceDatabaseTypeTest {
 
@@ -634,7 +633,6 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
               .build());
     }
   }
-
 
   private void addArraysTestData() {
     addDataTypeTestData(

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractPostgresSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractPostgresSourceDatatypeTest.java
@@ -17,11 +17,12 @@ import io.airbyte.protocol.models.JsonSchemaPrimitiveUtil.JsonSchemaPrimitive;
 import io.airbyte.protocol.models.JsonSchemaType;
 import java.util.Set;
 import org.jooq.DSLContext;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceDatabaseTypeTest {
 
-  protected PostgreSQLContainer<?> container;
+  protected JdbcDatabaseContainer<?> container;
   protected JsonNode config;
   protected DSLContext dslContext;
   protected static final String SCHEMA_NAME = "test";
@@ -189,8 +190,8 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
               .sourceType("date")
               .fullSourceDataType(type)
               .airbyteType(JsonSchemaType.STRING_DATE)
-              .addInsertValues("'1999-01-08'", "'1991-02-10 BC'", "'2022/11/12'", "'1987.12.01'")
-              .addExpectedValues("1999-01-08", "1991-02-10 BC", "2022-11-12", "1987-12-01")
+              .addInsertValues("'1999-01-08'", "'1991-02-10 BC'", "'2022/11/12'", "'1987.12.01'", "'-InFinITy'", "'InFinITy'")
+              .addExpectedValues("1999-01-08", "1991-02-10 BC", "2022-11-12", "1987-12-01", "-infinity", "+infinity")
               .build());
     }
 
@@ -454,14 +455,16 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
                   "TIMESTAMP '0001-01-01 00:00:00.000000'",
                   // The last possible timestamp in BCE
                   "TIMESTAMP '0001-12-31 23:59:59.999999 BC'",
-                  "'epoch'")
+                  "'epoch'",
+                  "'-InFinITy'", "'InFinITy'")
               .addExpectedValues(
                   "2004-10-19T10:23:00.000000",
                   "2004-10-19T10:23:54.123456",
                   "3004-10-19T10:23:54.123456 BC",
                   "0001-01-01T00:00:00.000000",
                   "0001-12-31T23:59:59.999999 BC",
-                  "1970-01-01T00:00:00.000000")
+                  "1970-01-01T00:00:00.000000",
+                  "-infinity", "+infinity")
               .build());
     }
 
@@ -476,8 +479,6 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
               .addExpectedValues((String) null)
               .build());
     }
-
-    addTimestampWithInfinityValuesTest();
 
     // timestamp with time zone
     for (final String fullSourceType : Set.of("timestamptz", "timestamp with time zone")) {
@@ -497,14 +498,14 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
                   "TIMESTAMP WITH TIME ZONE '0001-12-31 16:00:00.000000-08 BC'",
                   // The last possible timestamp in BCE (15:59-08 == 23:59Z)
                   "TIMESTAMP WITH TIME ZONE '0001-12-31 15:59:59.999999-08 BC'",
-                  "null")
+                  "null", "'-InFinITy'", "'InFinITy'")
               .addExpectedValues(
                   "2004-10-19T18:23:00.000000Z",
                   "2004-10-19T18:23:54.123456Z",
                   "3004-10-19T18:23:54.123456Z BC",
                   "0001-01-01T00:00:00.000000Z",
                   "0001-12-31T23:59:59.999999Z BC",
-                  null)
+                  null, "-infinity", "+infinity")
               .build());
     }
 
@@ -634,23 +635,6 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
     }
   }
 
-  protected void addTimestampWithInfinityValuesTest() {
-    // timestamp without time zone
-    for (final String fullSourceType : Set.of("timestamp", "timestamp without time zone", "timestamp without time zone not null default now()")) {
-      addDataTypeTestData(
-          TestDataHolder.builder()
-              .sourceType("timestamp")
-              .fullSourceDataType(fullSourceType)
-              .airbyteType(JsonSchemaType.STRING_TIMESTAMP_WITHOUT_TIMEZONE)
-              .addInsertValues(
-                  "'infinity'",
-                  "'-infinity'")
-              .addExpectedValues(
-                  "+292278994-08-16T23:00:00.000000",
-                  "+292269055-12-02T23:00:00.000000 BC")
-              .build());
-    }
-  }
 
   private void addArraysTestData() {
     addDataTypeTestData(

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcWalLogsPostgresSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcWalLogsPostgresSourceDatatypeTest.java
@@ -197,25 +197,6 @@ public class CdcWalLogsPostgresSourceDatatypeTest extends AbstractPostgresSource
   }
 
   @Override
-  protected void addTimestampWithInfinityValuesTest() {
-    // timestamp without time zone
-    for (final String fullSourceType : Set.of("timestamp", "timestamp without time zone", "timestamp without time zone not null default now()")) {
-      addDataTypeTestData(
-          TestDataHolder.builder()
-              .sourceType("timestamp")
-              .fullSourceDataType(fullSourceType)
-              .airbyteType(JsonSchemaType.STRING_TIMESTAMP_WITHOUT_TIMEZONE)
-              .addInsertValues(
-                  "'infinity'",
-                  "'-infinity'")
-              .addExpectedValues(
-                  "+294247-01-10T04:00:25.200000",
-                  "+290309-12-21T19:59:27.600000 BC")
-              .build());
-    }
-  }
-
-  @Override
   protected void addNumericValuesTest() {
     addDataTypeTestData(
         TestDataHolder.builder()

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ import com.github.spotbugs.snom.SpotBugsTask
 import ru.vyarus.gradle.plugin.python.task.PythonTask
 import com.hierynomus.gradle.license.tasks.LicenseCheck
 import com.hierynomus.gradle.license.tasks.LicenseFormat
+import org.yaml.snakeyaml.Yaml
 
 // The buildscript block defines dependencies in order for .gradle file evaluation.
 // This is separate from application dependencies.
@@ -10,6 +11,7 @@ buildscript {
     dependencies {
         classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.20.0'
         classpath 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1'
+        classpath 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0'
     }
 }
 
@@ -435,6 +437,13 @@ subprojects { subproj ->
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'com.github.spotbugs'
+
+    java {
+        compileJava {
+            options.compilerArgs += ["-Werror", "-Xlint:all,-serial,-processing"]
+        }
+    }
+
 
     java {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -37,7 +37,7 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
                 events "passed", "failed", "started"
                 exceptionFormat "full"
                 // uncomment to get the full log output
-                // showStandardStreams = true
+                showStandardStreams = true
             }
 
             outputs.upToDateWhen { false }

--- a/buildSrc/src/main/groovy/airbyte-java-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-java-connector.gradle
@@ -53,6 +53,19 @@ class AirbyteJavaConnectorExtension {
                 }
             }
         } else {
+            def versionNumbers = cdkVersionRequired.split("\\.")
+            def majorVersion = Integer.valueOf(versionNumbers[0])
+            def minorVersion = Integer.valueOf(versionNumbers[1])
+            def hasKnownWarnings = false
+            if (majorVersion = 0 || majorVersion < 3) {
+                hasKnownWarnings = true;
+            }
+            if (hasKnownWarnings) {
+                project.tasks.withType(JavaCompile).configureEach {
+                    options.compilerArgs.remove("-Werror")
+                }
+            }
+
             project.dependencies {
                 implementation "io.airbyte.cdk:airbyte-cdk-airbyte-commons:${cdkVersionRequired}"
                 implementation "io.airbyte.cdk:airbyte-cdk-airbyte-json-validation:${cdkVersionRequired}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ VERSION=0.50.33
 
 org.gradle.parallel=true
 
-org.gradle.jvmargs=-Xmx8g -Xss4m
+org.gradle.jvmargs=-Xmx12g -Xss4m
 org.gradle.caching=true
 
 # Note, this might have issues on the normal Github runner.


### PR DESCRIPTION
This is a no-op in term of features or bugs.
I'm only trying to use as many compiler warnings as possible. They're cheap and can help with a lot of bugs.
Unfortunately, our CDK is currently packaged in a way that causes warnings in any package that uses it. I fixed that by making swagger an api-level dependency (which means it'll be exported to projects that depend on airbyte-cdk), but all projects that depend on it will have a warning, which means we can't turn those into errors.
So I'm releasing a new version of the CDK number 0.3.0, and enabling -Werror for any component that depends on a newer CDK version. 

For the projects that don't depend on CDK, I'm disabling the errors that are present, rather than making a sweeping change across all projects. I'll try to fix as many of those as possible, and remove the special cases.

An extra special case is that of our performance harnesses. They use _very_ old version of our packages, and simply don't compile when migrated to the latest versions. So for those I had to special-disable all errors.