### PR TITLE
update CDK to export the proper API packages, fix warnings

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/acceptance-test-harness/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/acceptance-test-harness/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id "java-library"
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-try"
+    }
+}
+
 dependencies {
     annotationProcessor platform(libs.micronaut.bom)
     annotationProcessor libs.bundles.micronaut.annotation.processor
@@ -19,6 +25,7 @@ dependencies {
     implementation 'org.apache.ant:ant:1.10.10'
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation libs.bundles.datadog
+    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.2'
 
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-api')
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-commons')

--- a/airbyte-cdk/java/airbyte-cdk/airbyte-api/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/airbyte-api/build.gradle
@@ -5,6 +5,12 @@ plugins {
     id "java-library"
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-deprecation"
+    }
+}
+
 def specFile = "$projectDir/src/main/openapi/config.yaml"
 
 def generate = tasks.register('generate')

--- a/airbyte-cdk/java/airbyte-cdk/airbyte-commons-protocol/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/airbyte-commons-protocol/build.gradle
@@ -1,3 +1,9 @@
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-unchecked"
+    }
+}
+
 dependencies {
     annotationProcessor libs.bundles.micronaut.annotation.processor
     testAnnotationProcessor libs.bundles.micronaut.test.annotation.processor

--- a/airbyte-cdk/java/airbyte-cdk/airbyte-commons/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/airbyte-commons/build.gradle
@@ -3,6 +3,12 @@ plugins {
     id 'de.undercouch.download' version "5.4.0"
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-varargs,-try,-deprecation"
+    }
+}
+
 dependencies {
     // Dependencies for this module should be specified in the top-level build.gradle. See readme for more explanation.
 

--- a/airbyte-cdk/java/airbyte-cdk/airbyte-commons/src/main/java/io/airbyte/commons/util/MoreIterators.java
+++ b/airbyte-cdk/java/airbyte-cdk/airbyte-commons/src/main/java/io/airbyte/commons/util/MoreIterators.java
@@ -22,6 +22,7 @@ public class MoreIterators {
    * @param <T> type
    * @return iterator with all elements
    */
+  @SafeVarargs
   public static <T> Iterator<T> of(final T... elements) {
     return Arrays.asList(elements).iterator();
   }

--- a/airbyte-cdk/java/airbyte-cdk/config-models-oss/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/config-models-oss/build.gradle
@@ -5,6 +5,12 @@ plugins {
     id "com.github.eirnym.js2p" version "1.0"
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-unchecked"
+    }
+}
+
 dependencies {
     annotationProcessor libs.bundles.micronaut.annotation.processor
     api libs.bundles.micronaut.annotation

--- a/airbyte-cdk/java/airbyte-cdk/core/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/core/build.gradle
@@ -1,4 +1,10 @@
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-deprecation,-try,-rawtypes,-overloads,-cast,-unchecked"
+    }
+}
+
 configurations.all {
     resolutionStrategy {
         // TODO: Diagnose conflicting dependencies and remove these force overrides:
@@ -63,8 +69,7 @@ dependencies {
     implementation libs.hikaricp
     implementation libs.bundles.debezium.bundle
 
-    implementation libs.bundles.datadog
-    // implementation 'com.datadoghq:dd-trace-api'
+    api libs.bundles.datadog
     implementation 'org.apache.sshd:sshd-mina:2.8.0'
 
     implementation libs.testcontainers

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.3.0
+version=0.4.0

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
@@ -1,3 +1,10 @@
+
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-deprecation"
+    }
+}
+
 dependencies {
     // Depends on core CDK classes (OK 👍)
     implementation project(':airbyte-cdk:java:airbyte-cdk:core')

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
@@ -17,6 +17,13 @@ plugins {
     id "java-test-fixtures"  // https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures
 }
 
+java {
+    compileJava {
+        options.compilerArgs += "-Xlint:-try,-rawtypes,-unchecked,-removal"
+    }
+}
+
+
 test {
     testLogging {
         // TODO: Remove this after debugging

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/relationaldb/state/AbstractStateManager.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/relationaldb/state/AbstractStateManager.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
  * @param <T> The type associated with the state object managed by this manager.
  * @param <S> The type associated with the state object stored in the state managed by this manager.
  */
-public abstract class AbstractStateManager<T, S> implements StateManager<T, S> {
+public abstract class AbstractStateManager<T, S> implements StateManager {
 
   /**
    * The {@link CursorManager} responsible for keeping track of the current cursor value for each

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/relationaldb/state/StateManager.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/relationaldb/state/StateManager.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * @param <T> The type of the state maintained by the manager.
  * @param <S> The type of the stream(s) stored within the state maintained by the manager.
  */
-public interface StateManager<T, S> {
+public interface StateManager {
 
   Logger LOGGER = LoggerFactory.getLogger(StateManager.class);
 


### PR DESCRIPTION
This is a no-op in term of features or bugs. This is part 1 of a series of PRs

I'm only trying to use as many compiler warnings as possible. They're cheap and can help with a lot of bugs.
Unfortunately, our CDK is currently packaged in a way that causes warnings in any package that uses it. I fixed that by making swagger an api-level dependency (which means it'll be exported to projects that depend on airbyte-cdk), but all projects that depend on it will have a warning, which means we can't turn those into errors.

So I'm releasing a new version of the CDK number 0.4.0, and allowing the enablement of -Werror for any component that depends on a newer CDK version.

For the projects that don't depend on CDK, I'm disabling the errors that are present, rather than making a sweeping change across all projects. I'll try to fix as many of those as possible, and remove the special cases.
