### PR TITLE
🐛 Source Pipedrive: fix `None` bug, for `increment-selector` 

### DIFF
--- a/airbyte-integrations/connectors/source-pipedrive/Dockerfile
+++ b/airbyte-integrations/connectors/source-pipedrive/Dockerfile
@@ -34,5 +34,5 @@ COPY source_pipedrive ./source_pipedrive
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=2.2.0
+LABEL io.airbyte.version=2.2.1
 LABEL io.airbyte.name=airbyte/source-pipedrive

--- a/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8286229-c680-4063-8c59-23b9b391c700
-  dockerImageTag: 2.2.0
+  dockerImageTag: 2.2.1
   dockerRepository: airbyte/source-pipedrive
   documentationUrl: https://docs.airbyte.com/integrations/sources/pipedrive
   githubIssueLabel: source-pipedrive

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/manifest.yaml
@@ -11,7 +11,7 @@ definitions:
     type: RecordSelector
     extractor:
       type: DpathExtractor
-      field_path: ["data", "*", "data"]
+      field_path: ["data"]
 
   selector_users:
     type: RecordSelector

--- a/docs/integrations/sources/pipedrive.md
+++ b/docs/integrations/sources/pipedrive.md
@@ -114,6 +114,7 @@ The Pipedrive connector will gracefully handle rate limits. For more information
 
 | Version | Date       | Pull Request                                             | Subject                                                                    |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------|
+| 2.2.1   | 2023-11-03 | [32130](https://github.com/airbytehq/airbyte/pull/32130) | Fixed the `None` bug, while working with the api response for incremental streams   |
 | 2.2.0   | 2023-10-25 | [31707](https://github.com/airbytehq/airbyte/pull/31707) | Add new stream mail                                                        |
 | 2.1.0   | 2023-10-10 | [31184](https://github.com/airbytehq/airbyte/pull/31184) | Add new stream goals                                                       |
 | 2.0.1   | 2023-10-13 | [31151](https://github.com/airbytehq/airbyte/pull/31151) | Add additionalProperties in schemas to read custom fields                  |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/oncall/issues/3215

## How
- changed the `selector_increment.extractor.field_path`  to be `["data"]` in `manifest.yaml` 

## 🚨 User Impact 🚨
No impact is expected.