### PR TITLE
Weaviate: Update weaviate client library

### DIFF
--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: 7b7d7a0d-954c-45a0-bcfc-39a634b97736
-  dockerImageTag: 0.2.6
+  dockerImageTag: 0.2.7
   dockerRepository: airbyte/destination-weaviate
   documentationUrl: https://docs.airbyte.com/integrations/destinations/weaviate
   githubIssueLabel: destination-weaviate

--- a/airbyte-integrations/connectors/destination-weaviate/setup.py
+++ b/airbyte-integrations/connectors/destination-weaviate/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk[vector-db-based]==0.51.41", "weaviate-client==3.23.2"]
+MAIN_REQUIREMENTS = ["airbyte-cdk[vector-db-based]==0.51.41", "weaviate-client==3.25.2"]
 
 TEST_REQUIREMENTS = ["pytest~=6.2", "docker", "pytest-docker"]
 

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -83,6 +83,7 @@ As properties have to start will a lowercase letter in Weaviate, field names mig
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| 0.2.7   | 2023-11-03 | [#32134](https://github.com/airbytehq/airbyte/pull/32134) | Upgrade weaviate client library |
 | 0.2.6   | 2023-11-01 | [#32038](https://github.com/airbytehq/airbyte/pull/32038) | Retry failed object loads |
 | 0.2.5   | 2023-10-24 | [#31953](https://github.com/airbytehq/airbyte/pull/31953) | Fix memory leak |
 | 0.2.4   | 2023-10-23 | [#31563](https://github.com/airbytehq/airbyte/pull/31563) | Add field mapping option, improve append+dedupe sync performance and remove unnecessary retry logic |


### PR DESCRIPTION
As discussed in https://github.com/airbytehq/airbyte/issues/31991#issuecomment-1792113219, it's possible that the current Weaviate client is not compatible with all Weaviate server versions. This PR is upgrading the client to ensure maximum compatibility.