### PR TITLE
🐛 Source Google Analytics Data API: Fixed bug with missing `metadata` when the credntials are not valid

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.0.2
+  dockerImageTag: 2.0.3
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -55,6 +55,8 @@ class MetadataDescriptor:
     def __get__(self, instance, owner):
         if not self._metadata:
             stream = GoogleAnalyticsDataApiMetadataStream(config=instance.config, authenticator=instance.config["authenticator"])
+
+            metadata = None
             try:
                 metadata = next(stream.read_records(sync_mode=SyncMode.full_refresh), None)
             except HTTPError as e:

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -55,11 +55,10 @@ class MetadataDescriptor:
     def __get__(self, instance, owner):
         if not self._metadata:
             stream = GoogleAnalyticsDataApiMetadataStream(config=instance.config, authenticator=instance.config["authenticator"])
-
             try:
                 metadata = next(stream.read_records(sync_mode=SyncMode.full_refresh), None)
             except HTTPError as e:
-                if e.response.status_code == HTTPStatus.UNAUTHORIZED:
+                if e.response.status_code in [HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN]:
                     internal_message = "Unauthorized error reached."
                     message = "Can not get metadata with unauthorized credentials. Try to re-authenticate in source settings."
 

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
@@ -8,6 +8,7 @@ import pytest
 from airbyte_cdk.models import AirbyteConnectionStatus, FailureType, Status
 from airbyte_cdk.utils import AirbyteTracedException
 from source_google_analytics_data_api import SourceGoogleAnalyticsDataApi
+from source_google_analytics_data_api.source import GoogleAnalyticsDataApiMetadataStream, MetadataDescriptor
 from source_google_analytics_data_api.utils import NO_DIMENSIONS, NO_METRICS, NO_NAME, WRONG_JSON_SYNTAX
 
 
@@ -95,6 +96,24 @@ def test_check(requests_mock, config_gen, config_values, is_successful, message)
         with pytest.raises(AirbyteTracedException) as e:
             source.check(logger, config_gen(property_ids=["UA-11111111"]))
         assert e.value.failure_type == FailureType.config_error
+
+
+def test_missing_metadata(requests_mock):    
+    # required for MetadataDescriptor $instance input
+    class TestConfig:
+        config = {
+            "authenticator": None,
+            "property_id": 123,
+        }
+    # mocking the url for metadata
+    requests_mock.register_uri(
+        "GET", "https://analyticsdata.googleapis.com/v1beta/properties/123/metadata", json={}, status_code=403
+    )
+    
+    metadata_descriptor =  MetadataDescriptor()
+    with pytest.raises(AirbyteTracedException) as e:
+        metadata_descriptor.__get__(TestConfig(), None)
+    assert e.value.failure_type == FailureType.config_error
 
 
 def test_streams(patch_base_class, config_gen):

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
@@ -105,7 +105,7 @@ def test_check(requests_mock, config_gen, config_values, is_successful, message)
         (401),
     ],
 )
-def test_missing_metadata(requests_mock, status_code):    
+def test_missing_metadata(requests_mock, status_code):
     # required for MetadataDescriptor $instance input
     class TestConfig:
         config = {
@@ -117,8 +117,8 @@ def test_missing_metadata(requests_mock, status_code):
     requests_mock.register_uri(
         "GET", "https://analyticsdata.googleapis.com/v1beta/properties/123/metadata", json={}, status_code=status_code
     )
-    
-    metadata_descriptor =  MetadataDescriptor()
+
+    metadata_descriptor = MetadataDescriptor()
     with pytest.raises(AirbyteTracedException) as e:
         metadata_descriptor.__get__(TestConfig(), None)
     assert e.value.failure_type == FailureType.config_error

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
@@ -98,7 +98,14 @@ def test_check(requests_mock, config_gen, config_values, is_successful, message)
         assert e.value.failure_type == FailureType.config_error
 
 
-def test_missing_metadata(requests_mock):
+@pytest.mark.parametrize(
+    "status_code",
+    [
+        (403),
+        (401),
+    ],
+)
+def test_missing_metadata(requests_mock, status_code):    
     # required for MetadataDescriptor $instance input
     class TestConfig:
         config = {
@@ -107,9 +114,11 @@ def test_missing_metadata(requests_mock):
         }
 
     # mocking the url for metadata
-    requests_mock.register_uri("GET", "https://analyticsdata.googleapis.com/v1beta/properties/123/metadata", json={}, status_code=403)
-
-    metadata_descriptor = MetadataDescriptor()
+    requests_mock.register_uri(
+        "GET", "https://analyticsdata.googleapis.com/v1beta/properties/123/metadata", json={}, status_code=status_code
+    )
+    
+    metadata_descriptor =  MetadataDescriptor()
     with pytest.raises(AirbyteTracedException) as e:
         metadata_descriptor.__get__(TestConfig(), None)
     assert e.value.failure_type == FailureType.config_error

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
@@ -98,19 +98,18 @@ def test_check(requests_mock, config_gen, config_values, is_successful, message)
         assert e.value.failure_type == FailureType.config_error
 
 
-def test_missing_metadata(requests_mock):    
+def test_missing_metadata(requests_mock):
     # required for MetadataDescriptor $instance input
     class TestConfig:
         config = {
             "authenticator": None,
             "property_id": 123,
         }
+
     # mocking the url for metadata
-    requests_mock.register_uri(
-        "GET", "https://analyticsdata.googleapis.com/v1beta/properties/123/metadata", json={}, status_code=403
-    )
-    
-    metadata_descriptor =  MetadataDescriptor()
+    requests_mock.register_uri("GET", "https://analyticsdata.googleapis.com/v1beta/properties/123/metadata", json={}, status_code=403)
+
+    metadata_descriptor = MetadataDescriptor()
     with pytest.raises(AirbyteTracedException) as e:
         metadata_descriptor.__get__(TestConfig(), None)
     assert e.value.failure_type == FailureType.config_error

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
@@ -8,7 +8,7 @@ import pytest
 from airbyte_cdk.models import AirbyteConnectionStatus, FailureType, Status
 from airbyte_cdk.utils import AirbyteTracedException
 from source_google_analytics_data_api import SourceGoogleAnalyticsDataApi
-from source_google_analytics_data_api.source import GoogleAnalyticsDataApiMetadataStream, MetadataDescriptor
+from source_google_analytics_data_api.source import MetadataDescriptor
 from source_google_analytics_data_api.utils import NO_DIMENSIONS, NO_METRICS, NO_NAME, WRONG_JSON_SYNTAX
 
 

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -275,6 +275,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version | Date       | Pull Request                                             | Subject                                                                          |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------|
+| 2.0.3 | 2023-11-03 | [32149](https://github.com/airbytehq/airbyte/pull/32149) | Fixed bug with missing `metadata` when the credentials are not valid |
 | 2.0.2 | 2023-11-02 | [32094](https://github.com/airbytehq/airbyte/pull/32094) | Added handling for `JSONDecodeError` while checking for `api qouta` limits |
 | 2.0.1 | 2023-10-18 | [31543](https://github.com/airbytehq/airbyte/pull/31543) | Base image migration: remove Dockerfile and use the python-connector-base image |
 | 2.0.0   | 2023-09-29 | [30930](https://github.com/airbytehq/airbyte/pull/30930) | Use distinct stream naming in case there are multiple properties in the config.  |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/oncall/issues/2971

## How
- added handling for `403` along with `401` errors when requesting `metadata descriptions` for authenticated users (typically calling `discovery`)
- covered with unit_test: `test_souce.test_missing_metadata()`

## 🚨 User Impact 🚨
No impact is expected.
