### PR TITLE
Run license check on repo

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/utils/analytics_message.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/analytics_message.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import time
 from typing import Any, Optional
 

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/click_decorators.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/click_decorators.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import functools
 import inspect
 from functools import wraps

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/lazy_group.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/lazy_group.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 # Source: https://click.palletsprojects.com/en/8.1.x/complex/
 
 import importlib

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/click_pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/click_pipeline_context.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import sys
 from typing import Any, Callable, Optional
 

--- a/airbyte-ci/connectors/pipelines/pipelines/models/singleton.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/singleton.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 from typing import Any, Type
 
 

--- a/airbyte-ci/connectors/pipelines/tests/test_cli/test_click_decorators.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_cli/test_click_decorators.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import asyncclick as click
 import pytest
 from asyncclick.testing import CliRunner

--- a/airbyte-ci/connectors/pipelines/tests/test_models/test_click_pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_models/test_click_pipeline_context.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 from unittest.mock import patch
 
 import asyncclick as click

--- a/airbyte-ci/connectors/pipelines/tests/test_models/test_singleton.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_models/test_singleton.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 from pipelines.models.singleton import Singleton
 
 

--- a/airbyte-integrations/connectors/source-azure-blob-storage/source_azure_blob_storage/stream_reader.py
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/source_azure_blob_storage/stream_reader.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import logging
 from contextlib import contextmanager
 from io import IOBase

--- a/airbyte-integrations/connectors/source-azure-blob-storage/unit_tests/unit_tests.py
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/unit_tests/unit_tests.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 from source_azure_blob_storage.legacy_config_transformer import LegacyConfigTransformer
 
 

--- a/airbyte-integrations/connectors/source-github/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/conftest.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import os
 
 os.environ["REQUEST_CACHE_PATH"] = "REQUEST_CACHE_PATH"

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/conftest.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import os
 
 os.environ["REQUEST_CACHE_PATH"] = "REQUEST_CACHE_PATH"

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/zip_reader.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/zip_reader.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import io
 import struct
 import zipfile

--- a/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_zip_reader.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_zip_reader.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import datetime
 import io
 import struct

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/conftest.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import os
 
 import pytest

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/conftest.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import os
 
 os.environ["REQUEST_CACHE_PATH"] = "REQUEST_CACHE_PATH"


### PR DESCRIPTION
Run license check - Our old one didn't seem to catch these files. This makes the dependent format command PR actually pass the new CI.

TODO: Replace all the 3-line licenses with 1-line licenses for consistency's sake - that's what the new license checker will add. 