### PR TITLE
bump cdk version to 0.4.1 to fix bad 0.4.0 release

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.4.0
+version=0.4.1


### PR DESCRIPTION
0.4.0 does not contain all of the expected changes. Re-releasing as 0.4.1.