### PR TITLE
cdk:db-sources: fix flaky test by using correct offset

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/java/io/airbyte/cdk/integrations/debezium/internals/PostgresDebeziumStateUtilTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/java/io/airbyte/cdk/integrations/debezium/internals/PostgresDebeziumStateUtilTest.java
@@ -179,6 +179,7 @@ public class PostgresDebeziumStateUtilTest {
       database.execute("CREATE TABLE public.test_table (id int primary key, name varchar(256));");
       database.execute("insert into public.test_table values (1, 'foo');");
       database.execute("insert into public.test_table values (2, 'bar');");
+      database.execute("CHECKPOINT");
 
       final var slotStateAtTheBeginning = getReplicationSlot(database, fullReplicationSlot, plugin, dbName);
       final Lsn lsnAtTheBeginning = Lsn.valueOf(slotStateAtTheBeginning.get("confirmed_flush_lsn").asText());

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/java/io/airbyte/cdk/integrations/debezium/internals/PostgresDebeziumStateUtilTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/java/io/airbyte/cdk/integrations/debezium/internals/PostgresDebeziumStateUtilTest.java
@@ -199,31 +199,31 @@ public class PostgresDebeziumStateUtilTest {
 
       // Now check that maybeReplicationStreamIntervalHasRecords behaves as expected.
 
-      final long lsnCommitted = lsnAfterCommit.asLong();
+      final long lsnBeforeBookkeepingStatements = PostgresUtils.getLsn(database).asLong();
 
       database.execute("SELECT txid_current();");
       database.execute("CHECKPOINT");
       final long lsnAfterBookkeepingStatements = PostgresUtils.getLsn(database).asLong();
-      Assertions.assertNotEquals(lsnCommitted, lsnAfterBookkeepingStatements);
+      Assertions.assertNotEquals(lsnBeforeBookkeepingStatements, lsnAfterBookkeepingStatements);
 
       Assertions.assertFalse(postgresDebeziumStateUtil.maybeReplicationStreamIntervalHasRecords(
           Jsons.jsonNode(databaseConfig),
           fullReplicationSlot,
           publication,
           plugin,
-          lsnCommitted,
+          lsnBeforeBookkeepingStatements,
           lsnAfterBookkeepingStatements));
 
       database.execute("INSERT INTO public.test_table VALUES (3, 'baz');");
       final long lsnAfterMeaningfulStatement = PostgresUtils.getLsn(database).asLong();
-      Assertions.assertNotEquals(lsnCommitted, lsnAfterMeaningfulStatement);
+      Assertions.assertNotEquals(lsnBeforeBookkeepingStatements, lsnAfterMeaningfulStatement);
 
       Assertions.assertTrue(postgresDebeziumStateUtil.maybeReplicationStreamIntervalHasRecords(
           Jsons.jsonNode(databaseConfig),
           fullReplicationSlot,
           publication,
           plugin,
-          lsnCommitted,
+          lsnBeforeBookkeepingStatements,
           lsnAfterMeaningfulStatement));
       Assertions.assertTrue(postgresDebeziumStateUtil.maybeReplicationStreamIntervalHasRecords(
           Jsons.jsonNode(databaseConfig),


### PR DESCRIPTION
I've noticed that `PostgresDebeziumStateUtilTest` was flaky lately, specifically because of the assertions I added in https://github.com/airbytehq/airbyte/pull/31976

These assertions use the wrong starting offset, they use the flushed offset when they should be using the latest offset. Predictably, when not running the test under load there's no difference, but under load the assertion on line 209 fails, because, yeah, in that (larger) offset interval the WAL does contain interesting records.