### PR TITLE
Update docs on writing docs

### DIFF
--- a/docs/contributing-to-airbyte/writing-docs.md
+++ b/docs/contributing-to-airbyte/writing-docs.md
@@ -94,9 +94,45 @@ As a general rule, features that introduce new behavior or prevent certain conte
 :::
 
 #### Jump to the relevant documentation section when specific Connector Builder inputs are focused with `<FieldAnchor>`
-In the documentation, the relevant section needs to be wrapped in a `<FieldAnchor field="path.to.field" />` component. When a user focuses the field identified by the `field` attribute in the Connector Builder UI, the documentation pane will automatically scroll to the associated section of the documentation, highlighting all content contained inside the `<FieldAnchor></FieldAnchor>` tag. These are rendered as regular divs in the documentation site, so they have no effect in places other than the in-app documentation panel—however, note that there must be blank lines between a custom tag like `FieldAnchor` the content it wraps for the documentation site to render markdown syntax inside the custom tag to html.
+In the documentation, the relevant section needs to be wrapped in a `<FieldAnchor field="path.to.field" />` component. When a user focuses the field identified by the `field` attribute in the connector setup UI, the documentation pane will automatically scroll to the associated section of the documentation, highlighting all content contained inside the `<FieldAnchor></FieldAnchor>` tag. These are rendered as regular divs in the documentation site, so they have no effect in places other than the in-app documentation panel—however, note that there must be blank lines between a custom tag like `FieldAnchor` the content it wraps for the documentation site to render markdown syntax inside the custom tag to html.
 
-The `field` attribute must be a valid json path to one of the properties nested under `connectionSpecification.properties` in that connector's `spec.json` or `spec.yaml` file. For example, if the connector spec contains a `connectionSpecification.properties.replication_method.replication_slot`, you would mark the start of the related documentation section with `<FieldAnchor field="replication_method.replication_slot" />` and its end with `</FieldAnchor>`. To mark a section as highlighted after the user picks an option from a `oneOf`: use a `field` prop like `path.to.field[value-of-selection-key]`, where the `value-of-selection-key` is the value of a `const` field nested inside that `oneOf`; for example, if the replication method should be one of `Standard` or `CDC`, you can wrap a specific replication method's documentation section with a `<FieldAnchor field="replication_method[CDC]">...</FieldAnchor>` tag, and it will be highlighted if the user selects that replication method in the UI. It's also possible to highlight the same section for multiple fields by separating them with commas, like `<FieldAnchor path="replication_method.replication_slot,replication_method.queue_size">`.
+The `field` attribute must be a valid json path to one of the properties nested under `connectionSpecification.properties` in that connector's `spec.json` or `spec.yaml` file. For example, if the connector spec contains a `connectionSpecification.properties.replication_method.replication_slot`, you would mark the start of the related documentation section with `<FieldAnchor field="replication_method.replication_slot">` and its end with `</FieldAnchor>`. To mark a section as highlighted after the user picks an option from a `oneOf`: use a `field` prop like `path.to.field[value-of-selection-key]`, where the `value-of-selection-key` is the value of a `const` field nested inside that `oneOf`. For example, if the specification of the `oneOf` field is:
+
+```json
+"replication_method": {
+  "type": "object",
+  "title": "Update Method",
+  "oneOf": [
+    {
+      "title": "Read Changes using Binary Log (CDC)",
+      "required": ["method"],
+      "properties": {
+        "method": {
+          "type": "string",
+          "const": "CDC",
+          "order": 0
+        },
+        "initial_waiting_seconds": {
+          "type": "integer",
+          "title": "Initial Waiting Time in Seconds (Advanced)",
+        },
+      }
+    },
+    {
+      "title": "Scan Changes with User Defined Cursor",
+      "required": ["method"],
+      "properties": {
+        "method": {
+          "type": "string",
+          "const": "STANDARD",
+          "order": 0
+        }
+      }
+    }
+  ]
+}
+```
+then the const values are `CDC` and `STANDARD`, so you can wrap a specific replication method's documentation section with a `<FieldAnchor field="replication_method[CDC]">...</FieldAnchor>` tag, and it will be highlighted if the user selects that replication method in the UI. It's also possible to highlight the same section for multiple fields by separating them with commas, like `<FieldAnchor path="replication_method.replication_slot,replication_method.queue_size">`.
 
 #### Prevent specific content from rendering in the UI with `<HideInUI>`
 Certain content is important to document, but unhelpful in the context of the Airbyte UI's inline documentation views: 

--- a/docs/contributing-to-airbyte/writing-docs.md
+++ b/docs/contributing-to-airbyte/writing-docs.md
@@ -96,7 +96,7 @@ As a general rule, features that introduce new behavior or prevent certain conte
 #### Jump to the relevant documentation section when specific Connector Builder inputs are focused with `<FieldAnchor>`
 In the documentation, the relevant section needs to be wrapped in a `<FieldAnchor field="path.to.field" />` component. When a user focuses the field identified by the `field` attribute in the connector setup UI, the documentation pane will automatically scroll to the associated section of the documentation, highlighting all content contained inside the `<FieldAnchor></FieldAnchor>` tag. These are rendered as regular divs in the documentation site, so they have no effect in places other than the in-app documentation panel—however, note that there must be blank lines between a custom tag like `FieldAnchor` the content it wraps for the documentation site to render markdown syntax inside the custom tag to html.
 
-The `field` attribute must be a valid json path to one of the properties nested under `connectionSpecification.properties` in that connector's `spec.json` or `spec.yaml` file. For example, if the connector spec contains a `connectionSpecification.properties.replication_method.replication_slot`, you would mark the start of the related documentation section with `<FieldAnchor field="replication_method.replication_slot">` and its end with `</FieldAnchor>`. To mark a section as highlighted after the user picks an option from a `oneOf`: use a `field` prop like `path.to.field[value-of-selection-key]`, where the `value-of-selection-key` is the value of a `const` field nested inside that `oneOf`. For example, if the specification of the `oneOf` field is:
+The `field` attribute must be a valid json path to one of the properties nested under `connectionSpecification.properties` in that connector's `spec.json` or `spec.yaml` file. For example, if the connector spec contains a `connectionSpecification.properties.replication_method.replication_slot`, you would mark the start of the related documentation section with `<FieldAnchor field="replication_method.replication_slot">` and its end with `</FieldAnchor>`.  It's also possible to highlight the same section for multiple fields by separating them with commas, like `<FieldAnchor path="replication_method.replication_slot,replication_method.queue_size">`. To mark a section as highlighted after the user picks an option from a `oneOf`: use a `field` prop like `path.to.field[value-of-selection-key]`, where the `value-of-selection-key` is the value of a `const` field nested inside that `oneOf`. For example, if the specification of the `oneOf` field is:
 
 ```json
 "replication_method": {
@@ -132,7 +132,8 @@ The `field` attribute must be a valid json path to one of the properties nested 
   ]
 }
 ```
-then the const values are `CDC` and `STANDARD`, so you can wrap a specific replication method's documentation section with a `<FieldAnchor field="replication_method[CDC]">...</FieldAnchor>` tag, and it will be highlighted if the user selects that replication method in the UI. It's also possible to highlight the same section for multiple fields by separating them with commas, like `<FieldAnchor path="replication_method.replication_slot,replication_method.queue_size">`.
+
+The selection keys are `CDC` and `STANDARD`, so you can wrap a specific replication method's documentation section with a `<FieldAnchor field="replication_method[CDC]">...</FieldAnchor>` tag, and it will be highlighted if the user selects CDC replication in the UI.
 
 #### Prevent specific content from rendering in the UI with `<HideInUI>`
 Certain content is important to document, but unhelpful in the context of the Airbyte UI's inline documentation views: 


### PR DESCRIPTION
## What
Fixes a pair of typos (one more significant, accidentally using "Connector Builder" instead of "connector setup"; one more trivial, an extra `/` in what should be an opening tag) introduced in https://github.com/airbytehq/airbyte/pull/31973 and expands on the `FieldAnchor` example for clarity.