### PR TITLE
Connector Ops: Add ignore comment check to HTTPS URL validation

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py
@@ -208,6 +208,8 @@ def check_connector_https_url_only(connector: Connector) -> bool:
         bool: Wether the connector code contains only https url.
     """
     files_with_http_url = set()
+    ignore_comment = "# ignore-https-check"  # Define the ignore comment pattern
+
     for filename, line in read_all_files_in_directory(
         connector.code_directory, IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS, IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS
     ):
@@ -215,6 +217,8 @@ def check_connector_https_url_only(connector: Connector) -> bool:
             continue
         line = line.lower()
         if is_comment(line, filename):
+            continue
+        if ignore_comment in line:
             continue
         for prefix in IGNORED_URLS_PREFIX:
             line = line.replace(prefix, "")

--- a/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py
@@ -170,6 +170,10 @@ IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS = {
     ".hypothesis",
 }
 
+IGNORED_FILES_FOR_HTTPS_CHECKS = {
+    "airbyte-integrations/connectors/source-s3/source_s3/v4/config.py",  # This file has regex pattern using http:// .
+}
+
 IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS = {"*Test.java", "*.jar", "*.pyc", "*.gz", "*.svg"}
 IGNORED_URLS_PREFIX = {
     "http://json-schema.org",
@@ -207,6 +211,8 @@ def check_connector_https_url_only(connector: Connector) -> bool:
     for filename, line in read_all_files_in_directory(
         connector.code_directory, IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS, IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS
     ):
+        if str(filename) in IGNORED_FILES_FOR_HTTPS_CHECKS:
+            continue
         line = line.lower()
         if is_comment(line, filename):
             continue

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector_ops"
-version = "0.3.2"
+version = "0.3.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector_ops"
-version = "0.3.1"
+version = "0.3.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/connector_ops/tests/test_qa_checks.py
+++ b/airbyte-ci/connectors/connector_ops/tests/test_qa_checks.py
@@ -114,6 +114,7 @@ def test_run_qa_checks_error(capsys, mocker):
     "file_name, file_line, expected_in_stdout",
     [
         ("file_with_http_url.foo", "http://foo.bar", True),
+        ("file_with_http_url_and_ignore_comment.foo", "http://foo.bar # ignore-https-check", False),
         ("file_without_https_url.foo", "", False),
         ("file_with_https_url.foo", "https://airbyte.com", False),
         ("file_with_http_url_and_ignored.foo", "http://localhost http://airbyte.com", True),

--- a/airbyte-integrations/connectors/source-s3/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-s3/integration_tests/spec.json
@@ -316,8 +316,13 @@
       },
       "endpoint": {
         "title": "Endpoint",
-        "description": "Endpoint to an S3 compatible service. Leave empty to use AWS.",
+        "description": "Endpoint to an S3 compatible service. Leave empty to use AWS. The custom endpoint must be secure, but the 'https' prefix is not required.",
         "default": "",
+        "examples": [
+          "my-s3-endpoint.com",
+          "https://my-s3-endpoint.com"
+        ],
+        "pattern": "^(?!http://).*$",
         "order": 4,
         "type": "string"
       },

--- a/airbyte-integrations/connectors/source-s3/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-s3/integration_tests/spec.json
@@ -318,10 +318,7 @@
         "title": "Endpoint",
         "description": "Endpoint to an S3 compatible service. Leave empty to use AWS. The custom endpoint must be secure, but the 'https' prefix is not required.",
         "default": "",
-        "examples": [
-          "my-s3-endpoint.com",
-          "https://my-s3-endpoint.com"
-        ],
+        "examples": ["my-s3-endpoint.com", "https://my-s3-endpoint.com"],
         "pattern": "^(?!http://).*$",
         "order": 4,
         "type": "string"

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
-  dockerImageTag: 4.1.4
+  dockerImageTag: 4.1.5
   dockerRepository: airbyte/source-s3
   documentationUrl: https://docs.airbyte.com/integrations/sources/s3
   githubIssueLabel: source-s3

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
@@ -24,7 +24,7 @@ class Config(AbstractFileBasedSpec):
         title="AWS Access Key ID",
         default=None,
         description="In order to access private Buckets stored on AWS S3, this connector requires credentials with the proper "
-                    "permissions. If accessing publicly available data, this field is not necessary.",
+        "permissions. If accessing publicly available data, this field is not necessary.",
         airbyte_secret=True,
         order=2,
     )
@@ -33,7 +33,7 @@ class Config(AbstractFileBasedSpec):
         title="AWS Secret Access Key",
         default=None,
         description="In order to access private Buckets stored on AWS S3, this connector requires credentials with the proper "
-                    "permissions. If accessing publicly available data, this field is not necessary.",
+        "permissions. If accessing publicly available data, this field is not necessary.",
         airbyte_secret=True,
         order=3,
     )
@@ -42,10 +42,10 @@ class Config(AbstractFileBasedSpec):
         default="",
         title="Endpoint",
         description="Endpoint to an S3 compatible service. Leave empty to use AWS. "
-                    "The custom endpoint must be secure, but the 'https' prefix is not required.",
+        "The custom endpoint must be secure, but the 'https' prefix is not required.",
         examples=["my-s3-endpoint.com", "https://my-s3-endpoint.com"],
         pattern="^(?!http://).*$",
-        order=4
+        order=4,
     )
 
     @root_validator

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
@@ -50,4 +50,10 @@ class Config(AbstractFileBasedSpec):
             raise ValidationError(
                 "`aws_access_key_id` and `aws_secret_access_key` are both required to authenticate with AWS.", model=Config
             )
+
+        endpoint = values.get("endpoint")
+        if endpoint:
+            if endpoint.startswith("http://"):
+                raise ValidationError("The endpoint must be a secure HTTPS endpoint.", model=Config)
+
         return values

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
@@ -24,7 +24,7 @@ class Config(AbstractFileBasedSpec):
         title="AWS Access Key ID",
         default=None,
         description="In order to access private Buckets stored on AWS S3, this connector requires credentials with the proper "
-        "permissions. If accessing publicly available data, this field is not necessary.",
+                    "permissions. If accessing publicly available data, this field is not necessary.",
         airbyte_secret=True,
         order=2,
     )
@@ -33,13 +33,19 @@ class Config(AbstractFileBasedSpec):
         title="AWS Secret Access Key",
         default=None,
         description="In order to access private Buckets stored on AWS S3, this connector requires credentials with the proper "
-        "permissions. If accessing publicly available data, this field is not necessary.",
+                    "permissions. If accessing publicly available data, this field is not necessary.",
         airbyte_secret=True,
         order=3,
     )
 
     endpoint: Optional[str] = Field(
-        "", title="Endpoint", description="Endpoint to an S3 compatible service. Leave empty to use AWS.", order=4
+        default="",
+        title="Endpoint",
+        description="Endpoint to an S3 compatible service. Leave empty to use AWS. "
+                    "The custom endpoint must be secure, but the 'https' prefix is not required.",
+        examples=["my-s3-endpoint.com", "https://my-s3-endpoint.com"],
+        pattern="^(?!http://).*$",
+        order=4
     )
 
     @root_validator

--- a/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_config.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_config.py
@@ -21,14 +21,15 @@ logger = logging.Logger("")
             None,
             id="config-created-with-aws-info",
         ),
-        pytest.param({"bucket": "test", "streams": [], "endpoint": "http://test.com"}, None, id="config-created-with-endpoint"),
+        pytest.param({"bucket": "test", "streams": [], "endpoint": "https://test.com"}, None, id="config-created-with-endpoint"),
+        pytest.param({"bucket": "test", "streams": [], "endpoint": "http://test.com"}, ValidationError, id="http-endpoint-error"),
         pytest.param(
             {
                 "bucket": "test",
                 "streams": [],
                 "aws_access_key_id": "access_key",
                 "aws_secret_access_key": "secret_access_key",
-                "endpoint": "http://test.com",
+                "endpoint": "https://test.com",
             },
             None,
             id="config-created-with-endpoint-and-aws-info",

--- a/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_stream_reader.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_stream_reader.py
@@ -22,7 +22,7 @@ from source_s3.v4.stream_reader import SourceS3StreamReader
 
 logger = logging.Logger("")
 
-endpoint_values = ["http://fake.com", None]
+endpoint_values = ["https://fake.com", None]
 _get_matching_files_cases = [
     pytest.param([], [], False, set(), id="no-files-match-if-no-globs"),
     pytest.param(

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -238,6 +238,7 @@ The Avro parser uses the [Fastavro library](https://fastavro.readthedocs.io/en/l
 There are currently no options for JSONL parsing.
 
 <FieldAnchor field="streams.0.format[unstructured],streams.1.format[unstructured],streams.2.format[unstructured]">
+
 ### Document File Type Format (Experimental)
 
 :::warning
@@ -254,9 +255,10 @@ To perform the text extraction from PDF and Docx files, the connector uses the [
 ## Changelog
 
 | Version | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
-| :------ | :--------- | :-------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------- |
-| 4.1.4 | 2023-10-30 | [31904](https://github.com/airbytehq/airbyte/pull/31904) | Update CDK |
-| 4.1.3   | 2023-10-25 | [31654](https://github.com/airbytehq/airbyte/pull/31654)                                                        | Reduce image size                                      |
+|:--------|:-----------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
+| 4.1.5   | 2023-11-02 | [32109](https://github.com/airbytehq/airbyte/pull/32109)                                                        | Fix docs; add HTTPS validation for S3 endpoint                                                                       |
+| 4.1.4   | 2023-10-30 | [31904](https://github.com/airbytehq/airbyte/pull/31904)                                                        | Update CDK                                                                                                           |
+| 4.1.3   | 2023-10-25 | [31654](https://github.com/airbytehq/airbyte/pull/31654)                                                        | Reduce image size                                                                                                    |
 | 4.1.2   | 2023-10-23 | [31383](https://github.com/airbytehq/airbyte/pull/31383)                                                        | Add handling NoSuchBucket error                                                                                      |
 | 4.1.1   | 2023-10-19 | [31601](https://github.com/airbytehq/airbyte/pull/31601)                                                        | Base image migration: remove Dockerfile and use the python-connector-base image                                      |
 | 4.1.0   | 2023-10-17 | [31340](https://github.com/airbytehq/airbyte/pull/31340)                                                        | Add reading files inside zip archive                                                                                 |


### PR DESCRIPTION
## What

This PR introduces an update to the existing HTTPS URL validation check. Previously, all `http://` URLs were flagged during QA checks, which could impede certain necessary use cases. This change allows for exceptions where `http://` URLs are valid and required.

## How

The solution implements a comment-based override mechanism. By adding a specific comment at the end of a line containing an `http://` URL, the QA check will ignore this line, allowing for intentional use of non-HTTPS URLs where appropriate. This ensures flexibility while maintaining security standards.
