### PR TITLE
Connector Ops: Add ignore comment check to HTTPS URL validation

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py
@@ -204,11 +204,15 @@ def check_connector_https_url_only(connector: Connector) -> bool:
         bool: Wether the connector code contains only https url.
     """
     files_with_http_url = set()
+    ignore_comment = "# ignore-https-check"  # Define the ignore comment pattern
+
     for filename, line in read_all_files_in_directory(
         connector.code_directory, IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS, IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS
     ):
         line = line.lower()
         if is_comment(line, filename):
+            continue
+        if ignore_comment in line:
             continue
         for prefix in IGNORED_URLS_PREFIX:
             line = line.replace(prefix, "")

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector_ops"
-version = "0.3.1"
+version = "0.3.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/connector_ops/tests/test_qa_checks.py
+++ b/airbyte-ci/connectors/connector_ops/tests/test_qa_checks.py
@@ -114,6 +114,7 @@ def test_run_qa_checks_error(capsys, mocker):
     "file_name, file_line, expected_in_stdout",
     [
         ("file_with_http_url.foo", "http://foo.bar", True),
+        ("file_with_http_url_and_ignore_comment.foo", "http://foo.bar # ignore-https-check", False),
         ("file_without_https_url.foo", "", False),
         ("file_with_https_url.foo", "https://airbyte.com", False),
         ("file_with_http_url_and_ignored.foo", "http://localhost http://airbyte.com", True),


### PR DESCRIPTION
## What

This PR introduces an update to the existing HTTPS URL validation check. Previously, all `http://` URLs were flagged during QA checks, which could impede certain necessary use cases. This change allows for exceptions where `http://` URLs are valid and required.

## How

The solution implements a comment-based override mechanism. By adding a specific comment at the end of a line containing an `http://` URL, the QA check will ignore this line, allowing for intentional use of non-HTTPS URLs where appropriate. This ensures flexibility while maintaining security standards.