### PR TITLE
🐛Source Instagram: skip reading MediaInsights if error code 10 received

### DIFF
--- a/airbyte-integrations/connectors/source-appfollow/Dockerfile
+++ b/airbyte-integrations/connectors/source-appfollow/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.0.13
-LABEL io.airbyte.name=airbyte/source-instagram
+LABEL io.airbyte.version=1.0.0
+LABEL io.airbyte.name=airbyte/source-appfollow

--- a/airbyte-integrations/connectors/source-appfollow/Dockerfile
+++ b/airbyte-integrations/connectors/source-appfollow/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.0.0
-LABEL io.airbyte.name=airbyte/source-appfollow
+LABEL io.airbyte.version=1.0.13
+LABEL io.airbyte.name=airbyte/source-instagram

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 1.0.12
+  dockerImageTag: 1.0.13
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
@@ -380,16 +380,23 @@ class MediaInsights(Media):
             insights = item.get_insights(params={"metric": metrics})
             return {record.get("name"): record.get("values")[0]["value"] for record in insights}
         except FacebookRequestError as error:
+            error_code = error.api_error_code()
+            error_subcode = error.api_error_subcode()
+            error_message = error.api_error_message()
+
             # An error might occur if the media was posted before the most recent time that
             # the user's account was converted to a business account from a personal account
-            if error.api_error_subcode() == 2108006:
-                details = error.body().get("error", {}).get("error_user_title") or error.api_error_message()
+            if error_subcode == 2108006:
+                details = error.body().get("error", {}).get("error_user_title") or error_message
                 self.logger.error(f"Insights error for business_account_id {account_id}: {details}")
                 # We receive all Media starting from the last one, and if on the next Media we get an Insight error,
                 # then no reason to make inquiries for each Media further, since they were published even earlier.
                 return None
-            elif error.api_error_code() == 100 and error.api_error_subcode() == 33:
-                self.logger.error(f"Check provided permissions for {account_id}: {error.api_error_message()}")
+            elif (
+                error_code == 100 and error_subcode == 33
+                or error_code == 10 and error_message == "(#10) Application does not have permission for this action"
+            ):
+                self.logger.error(f"Check provided permissions for {account_id}: {error_message}")
                 return None
             raise error
 

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
@@ -393,8 +393,10 @@ class MediaInsights(Media):
                 # then no reason to make inquiries for each Media further, since they were published even earlier.
                 return None
             elif (
-                error_code == 100 and error_subcode == 33
-                or error_code == 10 and error_message == "(#10) Application does not have permission for this action"
+                error_code == 100
+                and error_subcode == 33
+                or error_code == 10
+                and error_message == "(#10) Application does not have permission for this action"
             ):
                 self.logger.error(f"Check provided permissions for {account_id}: {error_message}")
                 return None

--- a/airbyte-integrations/connectors/source-instagram/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-instagram/unit_tests/test_streams.py
@@ -76,7 +76,7 @@ def test_media_insights_read(api, user_stories_data, user_media_insights_data, r
 def test_media_insights_read_error(api, requests_mock):
     test_id = "test_id"
     stream = MediaInsights(api=api)
-    media_response = [{"id": "test_id"}, {"id": "test_id_2"}, {"id": "test_id_3"}, {"id": "test_id_4"}]
+    media_response = [{"id": "test_id"}, {"id": "test_id_2"}, {"id": "test_id_3"}, {"id": "test_id_4"}, {"id": "test_id_5"}]
     requests_mock.register_uri("GET", FacebookSession.GRAPH + f"/{FB_API_VERSION}/{test_id}/media", json={"data": media_response})
 
     media_insights_response_test_id = {
@@ -132,6 +132,21 @@ def test_media_insights_read_error(api, requests_mock):
     }
     requests_mock.register_uri(
         "GET", FacebookSession.GRAPH + f"/{FB_API_VERSION}/test_id_4/insights", json=media_insights_response_test_id_4
+    )
+
+    error_response_wrong_permissions_code_10 = {
+        "error": {
+            "message": "(#10) Application does not have permission for this action",
+            "type": "OAuthException",
+            "code": 10,
+            "fbtrace_id": "fake_trace_id",
+        }
+    }
+    requests_mock.register_uri(
+        "GET",
+        FacebookSession.GRAPH + f"/{FB_API_VERSION}/test_id_5/insights",
+        json=error_response_wrong_permissions_code_10,
+        status_code=400,
     )
 
     records = read_full_refresh(stream)

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -86,7 +86,8 @@ AirbyteRecords are required to conform to the [Airbyte type](https://docs.airbyt
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                   |
-| :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
+|:--------|:-----------| :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
+| 1.0.13  | 2023-11-10 | [32245](https://github.com/airbytehq/airbyte/pull/32245) | Add skipping reading MediaInsights stream if an error code 10 is received                                                       |
 | 1.0.12  | 2023-11-07 | [32200](https://github.com/airbytehq/airbyte/pull/32200) | The backoff strategy has been updated to make some errors retriable                                                       |
 | 1.0.11  | 2023-08-03 | [29031](https://github.com/airbytehq/airbyte/pull/29031) | Reverted `advancedAuth` spec changes                                                                                      |
 | 1.0.10  | 2023-08-01 | [28910](https://github.com/airbytehq/airbyte/pull/28910) | Updated `advancedAuth` broken references                                                                                  |


### PR DESCRIPTION
## What
Do not raise `FacebookRequestError` with code of `10` while reading MediaInsights stream
https://github.com/airbytehq/oncall/issues/2844

## How
Skip reading MediaInsights stream if `FacebookRequestError` received with code of `10` and error message `"(#10) Application does not have permission for this action"`

## Recommended reading order
1. `streams.py`
2. `test_streams.py`

## 🚨 User Impact 🚨
No breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>