### PR TITLE
[ISSUE #32070] concurrent cdk improve futures handling

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/partition_enqueuer.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/partition_enqueuer.py
@@ -30,7 +30,6 @@ class PartitionEnqueuer:
 
         This method is meant to be called in a separate thread.
         :param partition_generator: The partition Generator
-        :param sync_mode: The sync mode used
         :return:
         """
         try:


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/32070

## How
Pruning the list of futures if the length of futures is bigger than the limit. 

In order to have this be thread safe, we have to use a lock. I'm not sure this is really a problem with the current implementation as submitting tasks is only done in the main thread but as we are playing with threading and the locking is not expensive (we just skip the pruning if the processing is already in progress), I added the extra safety. However, the reviewer should challenge this as much as possible

Note: I could not test the change using unit tests as all this processing is hidden from the interface. That being said, I confirmed that source-stripe still submits the same records.

## 🚨 User Impact 🚨

Before the change
![image](https://github.com/airbytehq/airbyte/assets/3360483/a400f7a9-3cfe-4446-80c9-7d5c42100eef)

After the change: I could not find `_wait_while_too_many_pending_futures` in the profiling. So I did add logging. The log is visible and now the trace is visible 
![image](https://github.com/airbytehq/airbyte/assets/3360483/2fa4b309-2330-4796-907a-182ab38d813f). My assumption is that without the log, the processing is so small that it is not shown by the profiler (as `_wait_while_too_many_pending_futures` takes 1.62% and the log takes 1.62%

![profile-before-future-handling-changes](https://github.com/airbytehq/airbyte/assets/3360483/cc5e1a91-ba40-4baf-b0de-13b161f98665) (note that the command in the SVG shows "profile-**after**-future-handling-changes" but it's only a mistake in the command as the code was the one before the change)
![profile-after-future-handling-changes](https://github.com/airbytehq/airbyte/assets/3360483/9ad26bc9-5780-4812-9724-5a53c5abb0d1)
![profile-after-future-handling-changes-adding-log](https://github.com/airbytehq/airbyte/assets/3360483/576ac099-6fdc-4453-8c54-7634b109b1d8)


