### PR TITLE
format: introduce CommandResult, reuse step status, make concurrent command invokation more generic

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/actions.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/actions.py
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
 
 from typing import List
 
@@ -6,7 +8,7 @@ import dagger
 from pipelines.helpers.utils import sh_dash_c
 
 
-async def run_check(
+def run_check(
     container: dagger.Container,
     check_commands: List[str],
 ) -> dagger.Container:
@@ -15,7 +17,7 @@ async def run_check(
         container: (dagger.Container): The container to run the formatting check in
         check_commands (List[str]): The list of commands to run to check the formatting
     """
-    await container.with_exec(sh_dash_c(check_commands), skip_entrypoint=True)
+    return container.with_exec(sh_dash_c(check_commands), skip_entrypoint=True)
 
 
 async def run_format(
@@ -28,7 +30,7 @@ async def run_format(
         format_commands (List[str]): The list of commands to run to format the repository
     """
     format_container = container.with_exec(sh_dash_c(format_commands), skip_entrypoint=True)
-    await format_container.directory("/src").export(".")
+    return await format_container.directory("/src").export(".")
 
 
 def mount_repo_for_formatting(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/check/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/check/commands.py
@@ -3,7 +3,10 @@
 #
 
 
+import logging
+
 import asyncclick as click
+import dagger
 from pipelines.airbyte_ci.format.actions import run_check
 from pipelines.airbyte_ci.format.containers import (
     format_java_container,
@@ -11,8 +14,18 @@ from pipelines.airbyte_ci.format.containers import (
     format_license_container,
     format_python_container,
 )
-from pipelines.helpers.cli import LogOptions, run_all_subcommands
+from pipelines.helpers.cli import LogOptions, invoke_commands_concurrently, log_command_results
 from pipelines.models.contexts.click_pipeline_context import ClickPipelineContext, pass_pipeline_context
+from pipelines.models.steps import CommandResult, StepStatus
+
+
+# HELPERS
+async def get_check_command_result(click_command: click.Command, checks_commands, container) -> CommandResult:
+    try:
+        stdout = await run_check(container, checks_commands).stdout()
+        return CommandResult(click_command, status=StepStatus.SUCCESS, stdout=stdout)
+    except dagger.ExecError as e:
+        return CommandResult(click_command, status=StepStatus.FAILURE, stderr=e.stderr, stdout=e.stdout, exc_info=e)
 
 
 @click.group(
@@ -26,27 +39,47 @@ async def check():
 @check.command(name="all")
 @click.option("--list-errors", is_flag=True, default=False, help="Show detailed error messages for failed checks.")
 @click.pass_context
-@pass_pipeline_context
-async def all_languages(ctx: click.Context, pipeline_context: ClickPipelineContext, list_errors: bool):
+async def all_checks(ctx: click.Context, list_errors: bool):
     """
     Run all format checks and fail if any checks fail.
     """
-    await pipeline_context.get_dagger_client(pipeline_name="Check all languages")
+    commands_to_invoke = [command for command_name, command in check.commands.items() if command_name != ctx.command.name]
+    command_results = await invoke_commands_concurrently(ctx, commands_to_invoke)
+    failure = any([r.status is StepStatus.FAILURE for r in command_results])
+    parent_command = ctx.parent.command
+    logger = logging.getLogger(parent_command.name)
     log_options = LogOptions(
         list_errors=list_errors,
         help_message="Run `airbyte-ci format check all --list-errors` to see detailed error messages for failed checks. Run `airbyte-ci format fix all` for a best effort fix.",
     )
-    await run_all_subcommands(ctx, log_options)
+    log_command_results(ctx, logger, log_options, command_results)
+    if failure:
+        raise click.Abort()
 
 
 @check.command()
 @pass_pipeline_context
-async def java(pipeline_context: ClickPipelineContext):
+async def python(pipeline_context: ClickPipelineContext) -> CommandResult:
+    """Format python code via black and isort."""
+
+    dagger_client = await pipeline_context.get_dagger_client(pipeline_name="Check python formatting")
+    container = format_python_container(dagger_client)
+    check_commands = [
+        "poetry install --no-root",
+        "poetry run isort --settings-file pyproject.toml --check-only .",
+        "poetry run black --config pyproject.toml --check .",
+    ]
+    return await get_check_command_result(check.commands["python"], check_commands, container)
+
+
+@check.command()
+@pass_pipeline_context
+async def java(pipeline_context: ClickPipelineContext) -> CommandResult:
     """Format java, groovy, and sql code via spotless."""
     dagger_client = await pipeline_context.get_dagger_client(pipeline_name="Check java formatting")
     container = format_java_container(dagger_client)
     check_commands = ["./gradlew spotlessCheck --scan"]
-    await run_check(container, check_commands)
+    return await get_check_command_result(check.commands["java"], check_commands, container)
 
 
 @check.command()
@@ -56,7 +89,7 @@ async def js(pipeline_context: ClickPipelineContext):
     dagger_client = await pipeline_context.get_dagger_client(pipeline_name="Check js formatting")
     container = format_js_container(dagger_client)
     check_commands = ["prettier --check ."]
-    await run_check(container, check_commands)
+    return await get_check_command_result(check.commands["js"], check_commands, container)
 
 
 @check.command("license")
@@ -67,18 +100,4 @@ async def license_check(pipeline_context: ClickPipelineContext):
     dagger_client = await pipeline_context.get_dagger_client(pipeline_name="Check license header")
     container = format_license_container(dagger_client, license_file)
     check_commands = [f"addlicense -c 'Airbyte, Inc.' -l apache -v -f {license_file} --check ."]
-    await run_check(container, check_commands)
-
-
-@check.command()
-@pass_pipeline_context
-async def python(pipeline_context: ClickPipelineContext):
-    """Format python code via black and isort."""
-    dagger_client = await pipeline_context.get_dagger_client(pipeline_name="Check python formatting")
-    container = format_python_container(dagger_client)
-    check_commands = [
-        "poetry install --no-root",
-        "poetry run isort --settings-file pyproject.toml --check-only .",
-        "poetry run black --config pyproject.toml --check .",
-    ]
-    await run_check(container, check_commands)
+    return await get_check_command_result(check.commands["license"], check_commands, container)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/fix/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/fix/commands.py
@@ -2,7 +2,10 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+from typing import List
+
 import asyncclick as click
+import dagger
 from pipelines.airbyte_ci.format.actions import run_format
 from pipelines.airbyte_ci.format.containers import (
     format_java_container,
@@ -11,8 +14,32 @@ from pipelines.airbyte_ci.format.containers import (
     format_python_container,
 )
 from pipelines.cli.click_decorators import click_ignore_unused_kwargs
-from pipelines.helpers.cli import run_all_subcommands
+from pipelines.helpers.cli import invoke_commands_concurrently, invoke_commands_sequentially
 from pipelines.models.contexts.click_pipeline_context import ClickPipelineContext, pass_pipeline_context
+from pipelines.models.steps import CommandResult, StepStatus
+
+# HELPERS
+LANGUAGE_FIX_COMMAND_NAMES = ["python", "java", "js"]
+
+
+async def get_format_command_result(click_command: click.Command, container: dagger.Container, format_commands: List[str]) -> CommandResult:
+    """Run a format command and return the CommandResult.
+    A command is considered successful if the export operation of run_format is successful.
+
+    Args:
+        click_command (click.Command): The click command to run
+        container (dagger.Container): The container to run the format_commands in
+        format_commands (List[str]): The list of commands to run to format the repository
+
+    Returns:
+        CommandResult: The result of running the command
+    """
+    try:
+        successful_export = await run_format(container, format_commands)
+        status = StepStatus.SUCCESS if successful_export else StepStatus.FAILURE
+        return CommandResult(click_command, status=status)
+    except dagger.ExecError as e:
+        return CommandResult(click_command, status=StepStatus.FAILURE, stderr=e.stderr, stdout=e.stdout, exc_info=e)
 
 
 @click.group(
@@ -25,50 +52,58 @@ async def fix():
 
 @fix.command(name="all")
 @click.pass_context
-@pass_pipeline_context
-async def all_languages(ctx: click.Context, pipeline_context: ClickPipelineContext):
+async def all_fix(ctx: click.Context):
     """Run code format checks and fix any failures."""
-    await pipeline_context.get_dagger_client(pipeline_name="Fix all languages")
-    await run_all_subcommands(ctx)
+    # We can run language commands concurrently because they modify different set of files.
+    commands_to_invoke_concurrently = [fix.commands[command_name] for command_name in LANGUAGE_FIX_COMMAND_NAMES]
+    command_results = await invoke_commands_concurrently(ctx, commands_to_invoke_concurrently)
+
+    # We have to run license command sequentially because it modifies the same set of files as other commands.
+    # If we ran it concurrently with language commands, we face race condition issues.
+    command_results += await invoke_commands_sequentially(ctx, [fix.commands["license"]])
+    failure = any([r.status is StepStatus.FAILURE for r in command_results])
+
+    if failure:
+        raise click.Abort()
 
 
 @fix.command()
 @pass_pipeline_context
 @click_ignore_unused_kwargs
-async def java(ctx: ClickPipelineContext):
+async def java(ctx: ClickPipelineContext) -> CommandResult:
     """Format java, groovy, and sql code via spotless."""
     dagger_client = await ctx.get_dagger_client(pipeline_name="Format java")
     container = format_java_container(dagger_client)
     format_commands = ["./gradlew spotlessApply --scan"]
-    await run_format(container, format_commands)
+    return await get_format_command_result(fix.commands["java"], container, format_commands)
 
 
 @fix.command()
 @pass_pipeline_context
 @click_ignore_unused_kwargs
-async def js(ctx: ClickPipelineContext):
+async def js(ctx: ClickPipelineContext) -> CommandResult:
     dagger_client = await ctx.get_dagger_client(pipeline_name="Format js")
     container = format_js_container(dagger_client)
     format_commands = ["prettier --write ."]
-    await run_format(container, format_commands)
+    return await get_format_command_result(fix.commands["js"], container, format_commands)
 
 
 @fix.command("license")
 @pass_pipeline_context
 @click_ignore_unused_kwargs
-async def license_fix(ctx: ClickPipelineContext):
+async def license_fix(ctx: ClickPipelineContext) -> CommandResult:
     """Add license to python and java code via addlicense."""
     license_file = "LICENSE_SHORT"
     dagger_client = await ctx.get_dagger_client(pipeline_name="Add license")
     container = format_license_container(dagger_client, license_file)
     format_commands = [f"addlicense -c 'Airbyte, Inc.' -l apache -v -f {license_file} ."]
-    await run_format(container, format_commands)
+    return await get_format_command_result(fix.commands["license"], container, format_commands)
 
 
 @fix.command()
 @pass_pipeline_context
 @click_ignore_unused_kwargs
-async def python(ctx: ClickPipelineContext):
+async def python(ctx: ClickPipelineContext) -> CommandResult:
     """Format python code via black and isort."""
     dagger_client = await ctx.get_dagger_client(pipeline_name="Format python")
     container = format_python_container(dagger_client)
@@ -77,4 +112,4 @@ async def python(ctx: ClickPipelineContext):
         "poetry run isort --settings-file pyproject.toml .",
         "poetry run black --config pyproject.toml .",
     ]
-    await run_format(container, format_commands)
+    return await get_format_command_result(fix.commands["python"], container, format_commands)


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
I'm not totally inline with the implementation of the `airbyte-ci format check all` command introduced by https://github.com/airbytehq/airbyte/pull/31831/commits/22b19f37d3880618ed897c0afb686482ccf54f16

Why:
* I feel like we're re-inventing the wheel of processing and reporting execution error. I think we should re-use the `StepStatus` / `StepResult` "pattern"
* Command execution results are store in a global ctx object mutated by async tasks. Using `asyncer` with `soonify` can help us gather task execution results, which is the pattern we've used so far.
* The `_run_subcommand` function is called from a subcommand, not from a group which is misleading. I tried to make this function more generic so that it can accept any command and put the control flow back to the `all_languages` subcommand.

