### PR TITLE
fast error message on docker creation error

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.4.6
+version=0.4.7


### PR DESCRIPTION
test only change: On docker container creation error, we shouldn't return the docker container that's problematic. Instead, we should wrap the initial error message (except the 1st time it throws, where we can directly send the exception. 
This way, we fail fast, and the error message actually makes sense.

Today, the error message we get on subsequent gets is something akin to "copyFileToContainer can only be used with created / running container".

[source-postgres test report with error](https://github.com/airbytehq/airbyte/files/13302812/source-postgres.test.report.zip)
