### PR TITLE
✨ Source RSS: Adding Header options

### DIFF
--- a/airbyte-integrations/connectors/source-rss/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rss/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 0efee448-6948-49e2-b786-17db50647908
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-rss
   githubIssueLabel: source-rss
   icon: rss.svg

--- a/airbyte-integrations/connectors/source-rss/source_rss/spec.yaml
+++ b/airbyte-integrations/connectors/source-rss/source_rss/spec.yaml
@@ -9,3 +9,10 @@ connectionSpecification:
     url:
       type: string
       description: RSS Feed URL
+    headers:
+      type: object
+      description: Request Header Information
+      properties:
+        User-Agent:
+          type: string
+          description: Header information about the user agent

--- a/docs/integrations/sources/rss.md
+++ b/docs/integrations/sources/rss.md
@@ -25,6 +25,7 @@ This source is capable of syncing the following streams:
 ### Requirements / Setup Guide
 
 Only the `url` of an RSS feed is required.
+Optionally a `User-Agent`can be added a element for a html request.
 
 ## Performance considerations
 
@@ -32,6 +33,7 @@ None
 
 ## Changelog
 
-| Version | Date | Pull Request | Subject |
-| :--- | :--- | :--- | :--- |
-| 0.1.0 | 2022-10-12 | [18838](https://github.com/airbytehq/airbyte/pull/18838) | Initial release supporting RSS |
+| Version | Date       | Pull Request | Subject                        |
+|:--------|:-----------| :--- |:-------------------------------|
+| 0.1.0   | 2022-10-12 | [18838](https://github.com/airbytehq/airbyte/pull/18838) | Initial release supporting RSS |
+| 0.2.0   | 2023-11-09 |  | Adding Header options          |

--- a/docs/integrations/sources/rss.md
+++ b/docs/integrations/sources/rss.md
@@ -33,7 +33,7 @@ None
 
 ## Changelog
 
-| Version | Date       | Pull Request | Subject                        |
-|:--------|:-----------| :--- |:-------------------------------|
+| Version | Date       | Pull Request                                             | Subject                        |
+|:--------|:-----------|:---------------------------------------------------------|:-------------------------------|
 | 0.1.0   | 2022-10-12 | [18838](https://github.com/airbytehq/airbyte/pull/18838) | Initial release supporting RSS |
-| 0.2.0   | 2023-11-09 |  | Adding Header options          |
+| 0.2.0   | 2023-11-09 | [32344](https://github.com/airbytehq/airbyte/pull/32344) | Adding Header options          |


### PR DESCRIPTION
## What
Some sources require specific headers. In such cases this connector currently results in a 403. 

## How
to solve this an optional parameter headers with the property "User agent" was added.


## 🚨 User Impact 🚨
This adds a non-required parameter to a connector's spec and is therefore a minor change.

### Community member or Airbyter

- **Community member**
- Unit & integration tests added and passing. 
![image](https://github.com/airbytehq/airbyte/assets/132888473/d7951c97-4cd5-41ff-99fd-431cc4ed8969)

- Connector version is set to `0.2.0`
- Documentation updated
    - `docs/integrations/sources/rss.md.md` including changelog with an entry for the initial version.

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).



