### PR TITLE
Fixing futures pruning

### DIFF
--- a/.github/workflows/airbyte-ci-release-experiment.yml
+++ b/.github/workflows/airbyte-ci-release-experiment.yml
@@ -14,19 +14,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ["ubuntu-latest", "macos-latest"]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.10
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
 
-    - run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+      - run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
 
-    - run: cd airbyte-ci/pipelines/airbyte_ci
-    - run: poetry install --with dev
-    - run: poetry run pyinstaller --collect-all pipelines --collect-all beartype --collect-all dagger --hidden-import strawberry --name airbyte-ci-${{ matrix.os }} --onefile pipelines/cli/airbyte_ci.py
-    - uses: actions/upload-artifact@v2
-      with:
-        path: dist/*
+      - run: cd airbyte-ci/pipelines/airbyte_ci
+      - run: poetry install --with dev
+      - run: poetry run pyinstaller --collect-all pipelines --collect-all beartype --collect-all dagger --hidden-import strawberry --name airbyte-ci-${{ matrix.os }} --onefile pipelines/cli/airbyte_ci.py
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/thread_based_concurrent_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/thread_based_concurrent_stream.py
@@ -154,7 +154,7 @@ class ThreadBasedConcurrentStream(AbstractStream):
         if len(futures) < self._max_concurrent_tasks:
             return
 
-        for index in range(len(futures)):
+        for index in reversed(range(len(futures))):
             future = futures[index]
             optional_exception = future.exception()
             if optional_exception:

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_thread_based_concurrent_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_thread_based_concurrent_stream.py
@@ -152,9 +152,6 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
         self._stream._wait_while_too_many_pending_futures(futures)
 
     def test_given_exception_then_fail_immediately(self):
-        f1 = Mock()
-        f2 = Mock()
-
         # Verify that the done() method will be called until only one future is still running
         futures = []
         for _ in range(_MAX_CONCURRENT_TASKS + 1):
@@ -163,9 +160,14 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             future.exception.return_value = None
             futures.append(future)
 
+        pending_future = Mock()
+        pending_future.done.return_value = False
+        pending_future.exception.return_value = None
+        futures.append(pending_future)
+
         self._stream._wait_while_too_many_pending_futures(futures)
 
-        assert len(futures) == 0
+        assert futures == [pending_future]
 
     def test_as_airbyte_stream(self):
         expected_airbyte_stream = AirbyteStream(


### PR DESCRIPTION
## What
Fix following https://github.com/airbytehq/airbyte/pull/32277

Since we pop in order, the list length is reduce and as soon as we remove one element, `index` is out of sync. 

## How
As we only add at the end of the list, we should have index be in reversed order
