### PR TITLE
pass airbytestream instead of configured stream to as_airbyte_message

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -87,6 +87,7 @@ class AirbyteEntrypoint(object):
 
         if hasattr(parsed_args, "debug") and parsed_args.debug:
             self.logger.setLevel(logging.DEBUG)
+            logger.setLevel(logging.DEBUG)
             self.logger.debug("Debug logs enabled")
         else:
             self.logger.setLevel(logging.INFO)

--- a/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
@@ -111,7 +111,6 @@ class AbstractSource(Source, ABC):
                     )
 
                 try:
-                    self._apply_log_level_to_stream_logger(logger, stream_instance)
                     timer.start_event(f"Syncing stream {configured_stream.stream.name}")
                     stream_is_available, reason = stream_instance.check_availability(logger, self)
                     if not stream_is_available:
@@ -258,15 +257,6 @@ class AbstractSource(Source, ABC):
                 total_records_counter += 1
                 if internal_config.is_limit_reached(total_records_counter):
                     return
-
-    @staticmethod
-    def _apply_log_level_to_stream_logger(logger: logging.Logger, stream_instance: Stream) -> None:
-        """
-        Necessary because we use different loggers at the source and stream levels. We must
-        apply the source's log level to each stream's logger.
-        """
-        if hasattr(logger, "level"):
-            stream_instance.logger.setLevel(logger.level)
 
     def _get_message(self, record_data_or_message: Union[StreamData, AirbyteMessage], stream: Stream) -> AirbyteMessage:
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
@@ -117,7 +117,7 @@ class AbstractSource(Source, ABC):
                         logger.warning(f"Skipped syncing stream '{stream_instance.name}' because it was unavailable. {reason}")
                         continue
                     logger.info(f"Marking stream {configured_stream.stream.name} as STARTED")
-                    yield stream_status_as_airbyte_message(configured_stream, AirbyteStreamStatus.STARTED)
+                    yield stream_status_as_airbyte_message(configured_stream.stream, AirbyteStreamStatus.STARTED)
                     yield from self._read_stream(
                         logger=logger,
                         stream_instance=stream_instance,
@@ -126,15 +126,15 @@ class AbstractSource(Source, ABC):
                         internal_config=internal_config,
                     )
                     logger.info(f"Marking stream {configured_stream.stream.name} as STOPPED")
-                    yield stream_status_as_airbyte_message(configured_stream, AirbyteStreamStatus.COMPLETE)
+                    yield stream_status_as_airbyte_message(configured_stream.stream, AirbyteStreamStatus.COMPLETE)
                 except AirbyteTracedException as e:
-                    yield stream_status_as_airbyte_message(configured_stream, AirbyteStreamStatus.INCOMPLETE)
+                    yield stream_status_as_airbyte_message(configured_stream.stream, AirbyteStreamStatus.INCOMPLETE)
                     raise e
                 except Exception as e:
                     yield from self._emit_queued_messages()
                     logger.exception(f"Encountered an exception while reading stream {configured_stream.stream.name}")
                     logger.info(f"Marking stream {configured_stream.stream.name} as STOPPED")
-                    yield stream_status_as_airbyte_message(configured_stream, AirbyteStreamStatus.INCOMPLETE)
+                    yield stream_status_as_airbyte_message(configured_stream.stream, AirbyteStreamStatus.INCOMPLETE)
                     display_message = stream_instance.get_error_display_message(e)
                     if display_message:
                         raise AirbyteTracedException.from_exception(e, message=display_message) from e
@@ -196,7 +196,7 @@ class AbstractSource(Source, ABC):
                 if record_counter == 1:
                     logger.info(f"Marking stream {stream_name} as RUNNING")
                     # If we just read the first record of the stream, emit the transition to the RUNNING state
-                    yield stream_status_as_airbyte_message(configured_stream, AirbyteStreamStatus.RUNNING)
+                    yield stream_status_as_airbyte_message(configured_stream.stream, AirbyteStreamStatus.RUNNING)
             yield from self._emit_queued_messages()
             yield record
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -98,10 +98,6 @@ class ManifestDeclarativeSource(DeclarativeSource):
             )
             for stream_config in self._stream_configs(self._source_config)
         ]
-
-        for stream in source_streams:
-            # make sure the log level is always applied to the stream's logger
-            self._apply_log_level_to_stream_logger(self.logger, stream)
         return source_streams
 
     def spec(self, logger: logging.Logger) -> ConnectorSpecification:

--- a/airbyte-cdk/python/airbyte_cdk/utils/is_cloud_environment.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/is_cloud_environment.py
@@ -7,7 +7,7 @@ import os
 CLOUD_DEPLOYMENT_MODE = "cloud"
 
 
-def is_cloud_environment():
+def is_cloud_environment() -> bool:
     """
     Returns True if the connector is running in a cloud environment, False otherwise.
 

--- a/airbyte-cdk/python/airbyte_cdk/utils/stream_status_utils.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/stream_status_utils.py
@@ -7,17 +7,17 @@ from datetime import datetime
 
 from airbyte_cdk.models import (
     AirbyteMessage,
+    AirbyteStream,
     AirbyteStreamStatus,
     AirbyteStreamStatusTraceMessage,
     AirbyteTraceMessage,
-    ConfiguredAirbyteStream,
     StreamDescriptor,
     TraceType,
 )
 from airbyte_cdk.models import Type as MessageType
 
 
-def as_airbyte_message(stream: ConfiguredAirbyteStream, current_status: AirbyteStreamStatus) -> AirbyteMessage:
+def as_airbyte_message(stream: AirbyteStream, current_status: AirbyteStreamStatus) -> AirbyteMessage:
     """
     Builds an AirbyteStreamStatusTraceMessage for the provided stream
     """
@@ -28,7 +28,7 @@ def as_airbyte_message(stream: ConfiguredAirbyteStream, current_status: AirbyteS
         type=TraceType.STREAM_STATUS,
         emitted_at=now_millis,
         stream_status=AirbyteStreamStatusTraceMessage(
-            stream_descriptor=StreamDescriptor(name=stream.stream.name, namespace=stream.stream.namespace),
+            stream_descriptor=StreamDescriptor(name=stream.name, namespace=stream.namespace),
             status=current_status,
         ),
     )

--- a/airbyte-cdk/python/unit_tests/utils/test_stream_status_utils.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_stream_status_utils.py
@@ -2,71 +2,60 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from airbyte_cdk.models import (
-    AirbyteMessage,
-    AirbyteStream,
-    AirbyteStreamStatus,
-    ConfiguredAirbyteStream,
-    DestinationSyncMode,
-    SyncMode,
-    TraceType,
-)
+from airbyte_cdk.models import AirbyteMessage, AirbyteStream, AirbyteStreamStatus, SyncMode, TraceType
 from airbyte_cdk.models import Type as MessageType
 from airbyte_cdk.utils.stream_status_utils import as_airbyte_message as stream_status_as_airbyte_message
 
 stream = AirbyteStream(name="name", namespace="namespace", json_schema={}, supported_sync_modes=[SyncMode.full_refresh])
-configured_stream = ConfiguredAirbyteStream(
-    stream=stream, sync_mode=SyncMode.full_refresh, destination_sync_mode=DestinationSyncMode.overwrite
-)
 
 
 def test_started_as_message():
     stream_status = AirbyteStreamStatus.STARTED
-    airbyte_message = stream_status_as_airbyte_message(configured_stream, stream_status)
+    airbyte_message = stream_status_as_airbyte_message(stream, stream_status)
 
     assert type(airbyte_message) == AirbyteMessage
     assert airbyte_message.type == MessageType.TRACE
     assert airbyte_message.trace.type == TraceType.STREAM_STATUS
     assert airbyte_message.trace.emitted_at > 0
-    assert airbyte_message.trace.stream_status.stream_descriptor.name == configured_stream.stream.name
-    assert airbyte_message.trace.stream_status.stream_descriptor.namespace == configured_stream.stream.namespace
+    assert airbyte_message.trace.stream_status.stream_descriptor.name == stream.name
+    assert airbyte_message.trace.stream_status.stream_descriptor.namespace == stream.namespace
     assert airbyte_message.trace.stream_status.status == stream_status
 
 
 def test_running_as_message():
     stream_status = AirbyteStreamStatus.RUNNING
-    airbyte_message = stream_status_as_airbyte_message(configured_stream, stream_status)
+    airbyte_message = stream_status_as_airbyte_message(stream, stream_status)
 
     assert type(airbyte_message) == AirbyteMessage
     assert airbyte_message.type == MessageType.TRACE
     assert airbyte_message.trace.type == TraceType.STREAM_STATUS
     assert airbyte_message.trace.emitted_at > 0
-    assert airbyte_message.trace.stream_status.stream_descriptor.name == configured_stream.stream.name
-    assert airbyte_message.trace.stream_status.stream_descriptor.namespace == configured_stream.stream.namespace
+    assert airbyte_message.trace.stream_status.stream_descriptor.name == stream.name
+    assert airbyte_message.trace.stream_status.stream_descriptor.namespace == stream.namespace
     assert airbyte_message.trace.stream_status.status == stream_status
 
 
 def test_complete_as_message():
     stream_status = AirbyteStreamStatus.COMPLETE
-    airbyte_message = stream_status_as_airbyte_message(configured_stream, stream_status)
+    airbyte_message = stream_status_as_airbyte_message(stream, stream_status)
 
     assert type(airbyte_message) == AirbyteMessage
     assert airbyte_message.type == MessageType.TRACE
     assert airbyte_message.trace.type == TraceType.STREAM_STATUS
     assert airbyte_message.trace.emitted_at > 0
-    assert airbyte_message.trace.stream_status.stream_descriptor.name == configured_stream.stream.name
-    assert airbyte_message.trace.stream_status.stream_descriptor.namespace == configured_stream.stream.namespace
+    assert airbyte_message.trace.stream_status.stream_descriptor.name == stream.name
+    assert airbyte_message.trace.stream_status.stream_descriptor.namespace == stream.namespace
     assert airbyte_message.trace.stream_status.status == stream_status
 
 
 def test_incomplete_failed_as_message():
     stream_status = AirbyteStreamStatus.INCOMPLETE
-    airbyte_message = stream_status_as_airbyte_message(configured_stream, stream_status)
+    airbyte_message = stream_status_as_airbyte_message(stream, stream_status)
 
     assert type(airbyte_message) == AirbyteMessage
     assert airbyte_message.type == MessageType.TRACE
     assert airbyte_message.trace.type == TraceType.STREAM_STATUS
     assert airbyte_message.trace.emitted_at > 0
-    assert airbyte_message.trace.stream_status.stream_descriptor.name == configured_stream.stream.name
-    assert airbyte_message.trace.stream_status.stream_descriptor.namespace == configured_stream.stream.namespace
+    assert airbyte_message.trace.stream_status.stream_descriptor.name == stream.name
+    assert airbyte_message.trace.stream_status.stream_descriptor.namespace == stream.namespace
     assert airbyte_message.trace.stream_status.status == stream_status


### PR DESCRIPTION
## What
* Change the interface of the `as_airbyte_message` method which creates AirbyteMessage with a stream status
* Pass the `AirbyteStream` instead of the `AirbyteConfiguredStream` since the method does not care about the configuration
* The new interface is easier to use for the concurrent source ([implemented in a follow up PR](https://github.com/airbytehq/airbyte/pull/32411))

## How
* Update the method
* Update the tests
* Update the `AbstractSource`