### PR TITLE
🐛 Source Google Ads: Add backoff strategy for read_records method

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: 2.0.3
+  dockerImageTag: 2.0.4
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   githubIssueLabel: source-google-ads

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -278,6 +278,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version  | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:---------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| `2.0.4`  | 2023-11-10 | [32414](https://github.com/airbytehq/airbyte/pull/32414) | Add backoff strategy for read_records method                                                                                                         |
 | `2.0.3`  | 2023-11-02 | [32102](https://github.com/airbytehq/airbyte/pull/32102) | Fix incremental events streams                                                                                                       |
 | `2.0.2`  | 2023-10-31 | [32001](https://github.com/airbytehq/airbyte/pull/32001) | Added handling (retry) for `InternalServerError` while reading the streams                                                           |
 | `2.0.1`  | 2023-10-27 | [31908](https://github.com/airbytehq/airbyte/pull/31908) | Base image migration: remove Dockerfile and use the python-connector-base image                                                      |


### PR DESCRIPTION


## What
This PR introduces a retry mechanism to handle transient errors encountered while iterating over the `SearchGoogleAdsResponse` during the `parse_response` function.
Resolves: https://github.com/airbytehq/oncall/issues/3335

## How
A `generator_backoff` decorator has been implemented to manage retries for generator functions within the Google Ads API client. The standard retry methods provided by the backoff library are incompatible with generator functions, necessitating this custom solution.
The following traceback demonstrates where the error was raised:

```
  File "/airbyte/integration_code/source_google_ads/streams.py", line 100, in parse_response
    for result in response:
  File "/usr/local/lib/python3.9/site-packages/google/ads/googleads/v13/services/services/google_ads_service/pagers.py", line 77, in __iter__
    for page in this.pages:
  File "/usr/local/lib/python3.9/site-packages/google/ads/googleads/v13/services/services/google_ads_service/pagers.py", line 71, in pages
    this._response = this._method(
  File "/usr/local/lib/python3.9/site-packages/google/api_core/gapic_v1/method.py", line 113, in __call__
    return wrapped_func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/google/api_core/grpc_helpers.py", line 74, in error_remapped_callable
    raise exceptions.from_grpc_error(exc) from exc
google.api_core.exceptions.InternalServerError: 500 Internal error encountered. [type_url: "type.googleapis.com/google.ads.googleads.v13.errors.GoogleAdsFailure"
value: "\n
```