### PR TITLE
File CDK: Improve stream config appearance

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
@@ -26,8 +26,10 @@ class ValidationPolicy(Enum):
 class FileBasedStreamConfig(BaseModel):
     name: str = Field(title="Name", description="The name of the stream.")
     globs: Optional[List[str]] = Field(
+        default=["**"],
         title="Globs",
         description='The pattern used to specify which files should be selected from the file system. For more information on glob pattern matching look <a href="https://en.wikipedia.org/wiki/Glob_(programming)">here</a>.',
+        order=1,
     )
     legacy_prefix: Optional[str] = Field(
         title="Legacy Prefix",

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -76,6 +76,8 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                     "description": 'The pattern used to specify which files should be selected from the file system. For more information on glob pattern matching look <a href="https://en.wikipedia.org/wiki/Glob_(programming)">here</a>.',
                                     "type": "array",
                                     "items": {"type": "string"},
+                                    "order": 1,
+                                    "default": ["**"],
                                 },
                                 "legacy_prefix": {
                                     "title": "Legacy Prefix",


### PR DESCRIPTION
Currently, the "Globs" field in the per-stream configuration is shown as optional:
<img width="538" alt="Screenshot 2023-11-10 at 12 12 11" src="https://github.com/airbytehq/airbyte/assets/1508364/6e79164b-fec6-44b9-a361-a0228a97843b">

This is problematic because it makes it look like it can be omitted to sync all files which is not the case.

I can see two approaches here:
* Make the field required. Two things I'm not sure
  * There is a test explicitly checking that no glob doesn't yield results which makes me think I might have missed a reason why it's done this way
  * Compatibility with old config objects might break this (not sure about that)
* Pre-set it to the glob that will match everything (which is what I did on this PR)

I also moved the globs to the top of the stream config as it's the most important setting in there.

New:
<img width="991" alt="Screenshot 2023-11-10 at 12 08 36" src="https://github.com/airbytehq/airbyte/assets/1508364/b2186a26-4b6f-4a58-a99c-937d7ccb726a">
