### PR TITLE
speed up format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ plugins {
     id 'com.github.spotbugs' version '5.0.13'
     id 'version-catalog'
     id 'ru.vyarus.use-python'
-    id("com.dorongold.task-tree") version "2.1.1"
 }
 
 
@@ -259,9 +258,7 @@ allprojects {
             }
         }
     }
-    tasks.matching { it.name =~ /spotless.*/ }.configureEach {
-        //dependsOn tasks.matching { it.name == 'generate' }
-    }
+
     tasks.matching { it.name =~ /spotlessStyling.*/ }.configureEach {
         dependsOn rootProject.tasks.named('nodeSetup')
         dependsOn rootProject.tasks.named('npmSetup')
@@ -343,7 +340,6 @@ allprojects {
     }
 
     tasks.register('format') {
-        //dependsOn tasks.matching { it.name == 'generate' }
         dependsOn tasks.matching { it.name =~ /spotless.*Apply/ }
         dependsOn tasks.matching { it.name =~ /.*PythonFormat/ }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id 'com.github.spotbugs' version '5.0.13'
     id 'version-catalog'
     id 'ru.vyarus.use-python'
+    id("com.dorongold.task-tree") version "2.1.1"
 }
 
 
@@ -259,7 +260,7 @@ allprojects {
         }
     }
     tasks.matching { it.name =~ /spotless.*/ }.configureEach {
-        dependsOn tasks.matching { it.name == 'generate' }
+        //dependsOn tasks.matching { it.name == 'generate' }
     }
     tasks.matching { it.name =~ /spotlessStyling.*/ }.configureEach {
         dependsOn rootProject.tasks.named('nodeSetup')
@@ -342,7 +343,7 @@ allprojects {
     }
 
     tasks.register('format') {
-        dependsOn tasks.matching { it.name == 'generate' }
+        //dependsOn tasks.matching { it.name == 'generate' }
         dependsOn tasks.matching { it.name =~ /spotless.*Apply/ }
         dependsOn tasks.matching { it.name =~ /.*PythonFormat/ }
     }


### PR DESCRIPTION
I noticed a few things in our CI:
1) for lots of PRs, the format check takes the longest.
2) if the format step modifies any files, then it pushes a new commit, which triggers a second run of all the other checks (including the format check itself)
3) during the format check, a lot of time is spent building the java and generating classes, even though generated files are excluded from the format steps.

As such, I tried to remove the dependencies of format on generateJava, and as a result the format check taks half the time it was taking prior to this PR (6min vs 12 min before, as seen in https://github.com/airbytehq/airbyte/pull/32437 ). 6 minutes is still an eternity, but I don't want to spend too much time on this