### PR TITLE
Cleanup connector metadata remark plugin

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -30,7 +30,7 @@ const config = {
   projectName: "airbyte", // Usually your repo name.
 
   // Adds one off script tags to the head of each page
-  // .e.g <script async data-api-key="..." id="unifytag" src="..."></script>
+  // e.g. <script async data-api-key="..." id="unifytag" src="..."></script>
   scripts: [
     {
       src: "https://cdn.unifygtm.com/tag/v1/unify-tag-script.js",

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -183,14 +183,70 @@ img {
   min-width: 1.25rem;
 }
 
- /* These properties set the color of the active item in the navbar (background and text).
- The variables for them have been added to :root at the top of this file */
- 
- .menu__link--active,
- .menu__link--active:not(.menu__link--sublist),
- .menu__list-item-collapsible--active,
- .menu__list-item-collapsible--active:hover {
-   background: var(--color-active-nav-item-background);
-   color: var(--color-active-nav-item-text);
- }
- 
+/* These properties set the color of the active item in the navbar (background and text).
+The variables for them have been added to :root at the top of this file */
+
+.menu__link--active,
+.menu__link--active:not(.menu__link--sublist),
+.menu__list-item-collapsible--active,
+.menu__list-item-collapsible--active:hover {
+ background: var(--color-active-nav-item-background);
+ color: var(--color-active-nav-item-text);
+}
+
+.connectorIcon {
+  max-height: 40px;
+  max-width: 40px;
+  float: left;
+  margin-right: 10px;
+}
+
+.connectorMetadata {
+  background: var(--ifm-color-info-contrast-background);
+  border-radius: 2px;
+  width: 100%;
+  font-size: smaller;
+  margin: 0;
+  padding: 5px;
+  margin-bottom: 5px;
+}
+
+.connectorMetadata > div {
+  display: flex;
+  align-items: center;
+  gap: 0.2em;
+}
+
+.connectorMetadata dt {
+  display: inline;
+  font-weight: bold;
+}
+
+.connectorMetadata dd {
+  display: inline;
+  margin: 0;
+}
+
+.connectorMetadata dt::after {
+  content: ": ";
+}
+
+.connectorMetadata .availability {
+  display: inline-flex;
+  gap: 8px;
+  margin-left: 2px;
+}
+
+.connectorMetadata .availability > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.connectorMetadata .availability .unavailable {
+  color: var(--ifm-color-emphasis-600);
+}
+
+[data-theme="dark"] .connectorMetadata .availability .unavailable {
+  color: var(--ifm-color-emphasis-400);
+}

--- a/docusaurus/src/remark/docsHeaderDecoration.js
+++ b/docusaurus/src/remark/docsHeaderDecoration.js
@@ -1,6 +1,9 @@
 const fetch = require("node-fetch");
 const visit = require("unist-util-visit");
 
+const checkIcon = `<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><title>Available</title><path fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-111 111-47-47c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l64 64c9.4 9.4 24.6 9.4 33.9 0L369 209z"/></svg>`;
+const crossIcon = `<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><title>Not available</title><path fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"/></svg>`;
+
 const REGISTRY_URL =
   "https://connectors.airbyte.com/files/generated_reports/connector_registry_report.json";
 
@@ -59,27 +62,35 @@ const buildConnectorHTMLContent = (
   // note - you can't have any leading whitespace here
   const htmlContent = `<div>
     <div class="header">
-      <img src="${
-        registryEntry.iconUrl_oss
-      }" alt="connector logo" style="max-height: 40px; max-width: 40px; float: left; margin-right: 10px" />
-      <h1 id="${originalId}" style="position: relative;">${originalTitle}</h1>
+      <img src="${registryEntry.iconUrl_oss}" alt="" class="connectorIcon"  />
+      <h1 id="${originalId}">${originalTitle}</h1>
     </div>
 
-    <small>
-      <div style="width: 100%; background-color: rgb(220 220 220 / 25%); margin-bottom: 5px; padding: 5px">
-        <strong>Availability</strong>: Airbyte Cloud: ${
-          registryEntry.is_cloud ? "✅" : "❌"
-        }, Airbyte OSS: ${registryEntry.is_oss ? "✅" : "❌"}
-        <br />
-        <strong>Support Level</strong>: <a href="/project-overview/product-support-levels/">${capitalizeFirstLetter(
-          registryEntry.supportLevel_oss
-        )}</a>
-        <br />
-        <strong>Latest Version</strong>: ${registryEntry.dockerImageTag_oss}
-        <br />
-        <strong>Definition Id</strong>: ${registryEntry.definitionId}
+    <dl class="connectorMetadata">
+      <div>
+        <dt>Availability</dt>
+        <dd class="availability">
+          <span class="${registryEntry.is_cloud ? "available" : "unavailable"}">${registryEntry.is_cloud ? checkIcon : crossIcon} Airbyte Cloud</span>
+          <span class="${registryEntry.is_oss ? "available" : "unavailable"}">${registryEntry.is_oss ? checkIcon : crossIcon} Airbyte OSS</span>
+        </dd>
       </div>
-    </small>
+      <div>
+        <dt>Support Level</dt>
+        <dd>
+          <a href="/project-overview/product-support-levels/">${escape(capitalizeFirstLetter(
+            registryEntry.supportLevel_oss
+          ))}</a>
+        </dd>
+      </div>
+      <div>
+        <dt>Latest Version</dt>
+        <dd>${escape(registryEntry.dockerImageTag_oss)}</dd>
+      </div>
+      <div>
+        <dt>Definition Id</dt>
+        <dd>${escape(registryEntry.definitionId)}</dd>
+      </div>
+    </dl>
   </div>`;
 
   return htmlContent;
@@ -98,6 +109,10 @@ const isDocsPage = (vfile) => {
   }
 
   return true;
+};
+
+const escape = (string) => {
+  return string.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 };
 
 const capitalizeFirstLetter = (string) => {

--- a/docusaurus/src/remark/docsHeaderDecoration.js
+++ b/docusaurus/src/remark/docsHeaderDecoration.js
@@ -1,8 +1,8 @@
 const fetch = require("node-fetch");
 const visit = require("unist-util-visit");
 
-const checkIcon = `<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><title>Available</title><path fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-111 111-47-47c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l64 64c9.4 9.4 24.6 9.4 33.9 0L369 209z"/></svg>`;
-const crossIcon = `<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><title>Not available</title><path fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"/></svg>`;
+const CHECK_ICON = `<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><title>Available</title><path fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-111 111-47-47c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l64 64c9.4 9.4 24.6 9.4 33.9 0L369 209z"/></svg>`;
+const CROSS_ICON = `<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><title>Not available</title><path fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"/></svg>`;
 
 const REGISTRY_URL =
   "https://connectors.airbyte.com/files/generated_reports/connector_registry_report.json";
@@ -70,8 +70,8 @@ const buildConnectorHTMLContent = (
       <div>
         <dt>Availability</dt>
         <dd class="availability">
-          <span class="${registryEntry.is_cloud ? "available" : "unavailable"}">${registryEntry.is_cloud ? checkIcon : crossIcon} Airbyte Cloud</span>
-          <span class="${registryEntry.is_oss ? "available" : "unavailable"}">${registryEntry.is_oss ? checkIcon : crossIcon} Airbyte OSS</span>
+          <span class="${registryEntry.is_cloud ? "available" : "unavailable"}">${registryEntry.is_cloud ? CHECK_ICON : CROSS_ICON} Airbyte Cloud</span>
+          <span class="${registryEntry.is_oss ? "available" : "unavailable"}">${registryEntry.is_oss ? CHECK_ICON : CROSS_ICON} Airbyte OSS</span>
         </dd>
       </div>
       <div>


### PR DESCRIPTION
Cleaning up the Connector Metadata remark plugin with a couple of points:

* Improve and simplify the promise logic, to just return promises instead of writing to some registry variable
* Use `dl` for proper HTML usage
* Extract styles into CSS and make them work with light/dark mode properly
* Fix Cross site scripting vulnerability from malicious metadata service data
* Change icons to use Font Awesome instead of emojis (since they render more consistently across platforms/browsers).

**Screenshots:**
![2023-11-13_09-48_1](https://github.com/airbytehq/airbyte/assets/877229/c38ff608-d9f1-4ac2-810b-5aec2bd0908c)
![2023-11-13_09-48](https://github.com/airbytehq/airbyte/assets/877229/08c1a423-dd27-465c-a0b8-f0846af69724)

