### PR TITLE
remove source-xero from Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -13,7 +13,7 @@ data:
   name: Xero
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: beta


### PR DESCRIPTION
From [slack](https://airbytehq-team.slack.com/archives/C02U6CXJQFN/p1699901495813939)

source-xero has been hidden from cloud for over a month as it is having oAuth issues.  This makes it explicit that the connector is no longer available on cloud (docs, etc).  

This will remove xero from the registry, but allow existing users to keep using the actors they have (the LaunchDarkly feature flag to hide Zero should remain enabled)