### PR TITLE
Rebuild docs.airbyte.com once a day with latest metadata

### DIFF
--- a/.github/workflows/rebuild-docs-yml
+++ b/.github/workflows/rebuild-docs-yml
@@ -1,0 +1,12 @@
+name: Rebuild Docs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call Deploy Hook
+        run: curl -X POST ${{ secrets.VERCEL_DOCS_DEPLOY_HOOK_URL }}

--- a/.github/workflows/rebuild-docs-yml
+++ b/.github/workflows/rebuild-docs-yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  stale:
+  rebuild-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Call Deploy Hook


### PR DESCRIPTION
After https://github.com/airbytehq/airbyte/pull/32334 we pull in connector metadata information as we build the docs site.  However, that information could get stale if the docs aren't updated regularly.  This PR adds a cron job action to rebuild the docs once a day.  This will keep the metadata headers fresh on the page.

This makes use of a Vercel deploy hook https://vercel.com/docs/deployments/deploy-hooks