### PR TITLE
airbyte-ci: improve release workflow

### DIFF
--- a/.github/workflows/airbyte-ci-release.yml
+++ b/.github/workflows/airbyte-ci-release.yml
@@ -1,4 +1,3 @@
-# TODO remove -experiment from the workflow file name after merging
 name: Connector Ops CI - Airbyte CI Release
 
 concurrency:
@@ -91,6 +90,12 @@ jobs:
         working-directory: airbyte-ci/connectors/pipelines/
         run: |
           echo "::set-output name=version::$(poetry version --short)"
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: "${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}"
 
       - name: Upload version release to GCS prod bucket
         id: upload_version_release_to_gcs


### PR DESCRIPTION
* Remove `_experiment` from workflow name
* Authenticate with the correct service account to upload binaries to prod-airbyte-cloud-connector-metadata-service
