### PR TITLE
format: `airbyte-ci format fix all` on PR / `airbyte-ci format check all` on master

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -1,0 +1,56 @@
+name: Check for formatting errors on master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+jobs:
+  format-check:
+    runs-on: "conn-prod-xlarge-runner"
+    name: "Check for formatting errors on master"
+    timeout-minutes: 40
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
+
+      - name: Run airbyte-ci format check
+        uses: ./.github/actions/run-dagger-pipeline
+        with:
+          context: "master"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          subcommand: "format check all"
+
+      # This is helpful in the case that we change a previously committed generated file to be ignored by git.
+      - name: Remove any files that have been gitignored
+        run: git ls-files -i -c --exclude-from=.gitignore | xargs -r git rm --cached
+
+      - name: Match GitHub User to Slack User
+        id: match-github-to-slack-user
+        uses: ./.github/actions/match-github-to-slack-user
+        env:
+          AIRBYTE_TEAM_BOT_SLACK_TOKEN: ${{ secrets.SLACK_AIRBYTE_TEAM_READ_USERS }}
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Format Failure on Master Slack Channel
+        uses: abinoda/slack-action@master
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+        with:
+          args: >-
+            {\"channel\":\"C03BEADRPNY\", \"blocks\":[
+            {\"type\":\"divider\"},
+            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Formatting is broken on master! :bangbang: \n\n\"}},
+            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"_merged by_: *${{ github.actor }}* \n\"}},
+            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}> \n\"}},
+            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\" :octavia-shocked: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Action Run> :octavia-shocked: \n\"}},
+            {\"type\":\"divider\"}]}

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -1,4 +1,4 @@
-name: Check for formatting errors on master
+name: Check for formatting errors on head ref
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -11,7 +11,7 @@ on:
 jobs:
   format-check:
     runs-on: "conn-prod-xlarge-runner"
-    name: "Check for formatting errors on master"
+    name: "Check for formatting errors on ${{ github.head_ref }}"
     timeout-minutes: 40
     steps:
       - name: Checkout Airbyte
@@ -21,7 +21,9 @@ jobs:
           token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
 
       - name: Run airbyte-ci format check
+        id: airbyte_ci_format_check_all
         uses: ./.github/actions/run-dagger-pipeline
+        continue-on-error: true
         with:
           context: "master"
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -42,6 +44,7 @@ jobs:
           AIRBYTE_TEAM_BOT_SLACK_TOKEN: ${{ secrets.SLACK_AIRBYTE_TEAM_READ_USERS }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Format Failure on Master Slack Channel
+        if: steps.airbyte_ci_format_check_all.outcome == 'failure'
         uses: abinoda/slack-action@master
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}

--- a/.github/workflows/format_fix.yml
+++ b/.github/workflows/format_fix.yml
@@ -1,4 +1,4 @@
-name: Check for formatting errors
+name: Automatic Formatting on PRs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -7,9 +7,6 @@ concurrency:
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
   pull_request:
 jobs:
   format-fix:
@@ -67,32 +64,3 @@ jobs:
           commit_message: Automated Commit - Formatting Changes
           commit_user_name: Octavia Squidington III
           commit_user_email: octavia-squidington-iii@users.noreply.github.com
-
-  notify-failure-slack-channel:
-    name: "Notify Slack Channel on Build Failures"
-    runs-on: ubuntu-latest
-    needs:
-      - format-fix
-    if: ${{ failure() && github.ref == 'refs/heads/master' }}
-    steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@v3
-      - name: Match GitHub User to Slack User
-        id: match-github-to-slack-user
-        uses: ./.github/actions/match-github-to-slack-user
-        env:
-          AIRBYTE_TEAM_BOT_SLACK_TOKEN: ${{ secrets.SLACK_AIRBYTE_TEAM_READ_USERS }}
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Format Failure on Master Slack Channel
-        uses: abinoda/slack-action@master
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
-        with:
-          args: >-
-            {\"channel\":\"C03BEADRPNY\", \"blocks\":[
-            {\"type\":\"divider\"},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Formatting is broken on master! :bangbang: \n\n\"}},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"_merged by_: *${{ github.actor }}* \n\"}},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}> \n\"}},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\" :octavia-shocked: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Action Run> :octavia-shocked: \n\"}},
-            {\"type\":\"divider\"}]}

--- a/.github/workflows/format_fix.yml
+++ b/.github/workflows/format_fix.yml
@@ -41,7 +41,7 @@ jobs:
               - '**/*'
               - '!**/*.md'
 
-      - name: Run airbyte-ci format fix
+      - name: Run airbyte-ci format fix all
         uses: ./.github/actions/run-dagger-pipeline
         with:
           context: "pull_request"
@@ -64,3 +64,14 @@ jobs:
           commit_message: Automated Commit - Formatting Changes
           commit_user_name: Octavia Squidington III
           commit_user_email: octavia-squidington-iii@users.noreply.github.com
+
+      - name: Run airbyte-ci format check all
+        uses: ./.github/actions/run-dagger-pipeline
+        with:
+          context: "pull_request"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          subcommand: "format check all"


### PR DESCRIPTION
## What
I think we want two separate worfklows for `format`:
* One which automatically fix format on PRs 
* One which checks format on `master` and yells in slack if something is not formatted on `master`

## How
* Split `format.yml` in two worfklows
* `format_fix.yml`: Runs `airbyte format fix all` on PRs + commit changes
* `format_check.yml` : Runs `airbyte format check all` on merge to master and sends a slack message in case of failure.

