### PR TITLE
source-s3: remove useless test deps

### DIFF
--- a/airbyte-integrations/connectors/source-s3/setup.py
+++ b/airbyte-integrations/connectors/source-s3/setup.py
@@ -19,9 +19,6 @@ TEST_REQUIREMENTS = [
     "pytest-mock~=3.6.1",
     "pytest~=6.1",
     "pandas==2.0.3",
-    "psutil",
-    "pytest-order",
-    "netifaces~=0.11.0",
     "docker",
 ]
 


### PR DESCRIPTION
## What
`source-s3` declares a couple of test requirements that are not actually used and causes problem when they're installed in the test environment of airbyte-ci.
## How
Instead of making the test env compatible with these test dependencies I prefer removing them from the `TEST_REQUIREMENTS` as they're not used.
