### PR TITLE
airbyte-ci: use binary in CI

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -72,7 +72,7 @@ inputs:
   airbyte_ci_binary_url:
     description: "URL to airbyte-ci binary"
     required: false
-    default: https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/airbyte-ci/releases/ubuntu/latest/airbyte-ci
+    default: https://connectors.airbyte.com/airbyte-ci/releases/ubuntu/latest/airbyte-ci
 
 runs:
   using: "composite"

--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -69,6 +69,11 @@ inputs:
   s3_build_cache_secret_key:
     description: "Gradle S3 Build Cache AWS secret key"
     required: false
+  airbyte_ci_binary_url:
+    description: "URL to airbyte-ci binary"
+    required: false
+    default: https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/airbyte-ci/releases/ubuntu/latest/airbyte-ci
+
 runs:
   using: "composite"
   steps:
@@ -89,22 +94,18 @@ runs:
       id: get-start-timestamp
       shell: bash
       run: echo "name=start-timestamp=$(date +%s)" >> $GITHUB_OUTPUT
-    - name: Install Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-        token: ${{ inputs.github_token }}
-    - name: Install ci-connector-ops package
+    - name: Install airbyte-ci binary
+      id: install-airbyte-ci
       shell: bash
       run: |
-        pip install pipx
-        pipx ensurepath
-        pipx install airbyte-ci/connectors/pipelines/
+        curl -sSL ${{ inputs.airbyte_ci_binary_url }} --output airbyte-ci-bin
+        sudo mv airbyte-ci-bin /usr/local/bin/airbyte-ci
+        sudo chmod +x /usr/local/bin/airbyte-ci
     - name: Run airbyte-ci
       shell: bash
       run: |
         export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-        airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} ${{ inputs.subcommand }} ${{ inputs.options }}
+        airbyte-ci --disable-dagger-run --is-ci --gha-workflow-run-id=${{ github.run_id }} ${{ inputs.subcommand }} ${{ inputs.options }}
       env:
         _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
         CI_CONTEXT: "${{ inputs.context }}"


### PR DESCRIPTION
## What
Use our `airbyte-ci` linux binary in the CI

## How
* Remove `Install Python 3.10`  and `Install ci-connector-ops package` steps from `.github/actions/run-dagger-pipeline/action.yml`
* Add a `Install airbyte-ci binary` step to `.github/actions/run-dagger-pipeline/action.yml` which curls the binary and moves it to `/usr/local/bin`
* Expose a `airbyte_ci_binary_url` option at the action level, defaults to `latest`: can be useful to pin airbyte-ci version in the CI or tryout pre-releases
 * Fix: hide dagger logs from public GHA logs by setting `--disable-dagger-run` flag
 
## TODO
* [x] Manual check that [connector tests are still working](https://github.com/airbytehq/airbyte/actions/runs/6863207231)
* [x] Manual check that [connector publish is still working](https://github.com/airbytehq/airbyte/actions/workflows/airbyte-ci-tests.yml)
* [x] Manual check that [Connector Ops CI - Pipeline Unit Test is still wokring](https://github.com/airbytehq/airbyte/actions/workflows/airbyte-ci-tests.yml)
* [ ] Manual check that auto format is still working

## 🚨 User Impact 🚨
- Faster CI run: Python / Pipx install / airbyte-ci pix install is not required anymore: CI is ~1mn faster
- No more "please pull master to get the latest airbyte-ci bug fixes": workflows will download the latest airbyte-ci version on each run
- No more "We reached GHA rate limit on Python install": Python is not installed on each workflow run
