### PR TITLE
qa-check: tolerate http string in expected records

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/qa_checks.py
@@ -170,7 +170,15 @@ IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS = {
     ".hypothesis",
 }
 
-IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS = {"*Test.java", "*.jar", "*.pyc", "*.gz", "*.svg"}
+IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS = {
+    "*Test.java",
+    "*.jar",
+    "*.pyc",
+    "*.gz",
+    "*.svg",
+    "expected_records.jsonl",
+    "expected_records.json",
+}
 IGNORED_URLS_PREFIX = {
     "http://json-schema.org",
     "http://localhost",

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector_ops"
-version = "0.3.2"
+version = "0.3.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
Some `expected_records.json(l)` files might contain `http` string and its fine: QA checks should not fail for this.