### PR TITLE
source-freshsales: improve 1.0.0 breaking change messaging

### DIFF
--- a/airbyte-integrations/connectors/source-freshsales/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshsales/metadata.yaml
@@ -13,7 +13,7 @@ data:
     breakingChanges:
       1.0.0:
         message: "This version migrates the Freshsales connector to our low-code framework for greater maintainability. It also introduces changes to data types across most streams. You will need to run a reset after upgrading to continue syncing data with the connector."
-        upgradeDeadline: "2023-11-23"
+        upgradeDeadline: "2023-11-29"
   dockerRepository: airbyte/source-freshsales
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshsales
   githubIssueLabel: source-freshsales

--- a/airbyte-integrations/connectors/source-freshsales/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshsales/metadata.yaml
@@ -12,7 +12,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: "Large update in schema data types. Need refresh data"
+        message: "This version migrates the Freshsales connector to our low-code framework for greater maintainability. It also introduces changes to data types across most streams. You will need to run a reset after upgrading to continue syncing data with the connector."
         upgradeDeadline: "2023-11-23"
   dockerRepository: airbyte/source-freshsales
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshsales

--- a/docs/integrations/sources/freshsales-migrations.md
+++ b/docs/integrations/sources/freshsales-migrations.md
@@ -2,5 +2,6 @@
 
 ## Upgrading to 1.0.0
 
-All streams data types were updated to match the correct return from the API.
-Need refresh schema to match latest updates.
+This version migrates the Freshsales connector to our low-code framework for greater maintainability. 
+
+As part of this release, we've also updated data types across streams to match the correct return types from the upstream API. You will need to run a reset on connections using this connector after upgrading to continue syncing.


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

Updates the messaging for the breaking change introduced in https://github.com/airbytehq/airbyte/pull/31685 to be more clear and user-centric.

It also bumps the deadline to be after the thanksgiving freeze per [this conversation](https://airbytehq-team.slack.com/archives/C05T3DJM94Y/p1699995671966149?thread_ts=1699966823.848389&cid=C05T3DJM94Y).