### PR TITLE
Source Mailchimp: Handle empty fields in Reports stream

### DIFF
--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b03a9f3e-22a5-11eb-adc1-0242ac120002
-  dockerImageTag: 0.8.2
+  dockerImageTag: 0.8.3
   dockerRepository: airbyte/source-mailchimp
   documentationUrl: https://docs.airbyte.com/integrations/sources/mailchimp
   githubIssueLabel: source-mailchimp

--- a/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/schemas/reports.json
+++ b/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/schemas/reports.json
@@ -138,7 +138,7 @@
           "description": "The number of unique opens divided by the total number of successful deliveries."
         },
         "last_open": {
-          "type": "string",
+          "type": ["null", "string"],
           "format": "date-time",
           "title": "Last Open",
           "description": "The date and time of the last recorded open in ISO 8601 format."

--- a/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/streams.py
+++ b/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/streams.py
@@ -274,21 +274,28 @@ class Reports(IncrementalMailChimpStream):
     cursor_field = "send_time"
     data_field = "reports"
 
+    @staticmethod
+    def remove_empty_datetime_fields(record: Mapping[str, Any]) -> Mapping[str, Any]:
+        """
+        In some cases, the 'clicks.last_click' and 'opens.last_open' fields are returned as an empty string,
+        which causes validation errors on the `date-time` format.
+        To avoid this, we remove the fields if they are empty.
+        """
+        clicks = record.get("clicks", {})
+        opens = record.get("opens", {})
+        if not clicks.get("last_click"):
+            clicks.pop("last_click", None)
+        if not opens.get("last_open"):
+            opens.pop("last_open", None)
+        return record
+
     def path(self, **kwargs) -> str:
         return "reports"
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
-
         response = super().parse_response(response, **kwargs)
-
-        # In some cases, the 'last_click' field is returned as an empty string,
-        # which causes validation errors on the `date-time` format.
-        # To avoid this, we remove the field if it is empty.
         for record in response:
-            clicks = record.get("clicks", {})
-            if not clicks.get("last_click"):
-                clicks.pop("last_click", None)
-            yield record
+            yield self.remove_empty_fields(record)
 
 
 class Segments(MailChimpListSubStream):

--- a/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/streams.py
+++ b/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/streams.py
@@ -295,7 +295,7 @@ class Reports(IncrementalMailChimpStream):
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         response = super().parse_response(response, **kwargs)
         for record in response:
-            yield self.remove_empty_fields(record)
+            yield self.remove_empty_datetime_fields(record)
 
 
 class Segments(MailChimpListSubStream):

--- a/docs/integrations/sources/mailchimp.md
+++ b/docs/integrations/sources/mailchimp.md
@@ -76,7 +76,7 @@ Now that you have set up the Mailchimp source connector, check out the following
 
 | Version | Date       | Pull Request                                             | Subject                                                                    |
 |---------|------------|----------------------------------------------------------|----------------------------------------------------------------------------|
-| 0.8.3   | 2023-11-15 | []() | Handle empty datetime fields in Reports stream |
+| 0.8.3   | 2023-11-15 | [32543](https://github.com/airbytehq/airbyte/pull/32543) | Handle empty datetime fields in Reports stream                             |
 | 0.8.2   | 2023-11-13 | [32466](https://github.com/airbytehq/airbyte/pull/32466) | Improve error handling during connection check                             |
 | 0.8.1   | 2023-11-06 | [32226](https://github.com/airbytehq/airbyte/pull/32226) | Unmute expected records test after data anonymisation                      |
 | 0.8.0   | 2023-11-01 | [32032](https://github.com/airbytehq/airbyte/pull/32032) | Add ListMembers stream                                                     |

--- a/docs/integrations/sources/mailchimp.md
+++ b/docs/integrations/sources/mailchimp.md
@@ -76,6 +76,7 @@ Now that you have set up the Mailchimp source connector, check out the following
 
 | Version | Date       | Pull Request                                             | Subject                                                                    |
 |---------|------------|----------------------------------------------------------|----------------------------------------------------------------------------|
+| 0.8.3   | 2023-11-15 | []() | Handle empty datetime fields in Reports stream |
 | 0.8.2   | 2023-11-13 | [32466](https://github.com/airbytehq/airbyte/pull/32466) | Improve error handling during connection check                             |
 | 0.8.1   | 2023-11-06 | [32226](https://github.com/airbytehq/airbyte/pull/32226) | Unmute expected records test after data anonymisation                      |
 | 0.8.0   | 2023-11-01 | [32032](https://github.com/airbytehq/airbyte/pull/32032) | Add ListMembers stream                                                     |


### PR DESCRIPTION
## What
Minor fix for `opens.last_open` field in the Reports stream, which fails on `datetime` format validation in edge cases where it is an empty string.

## How
- Logic exists for handling similar cases for `clicks.last_click` by removing the field when it is an empty string. Moved the handling of both these edge cases from parse_response to a helper method.

## User Impact
Not a breaking change, only removes the fields if they are already empty