### PR TITLE
Source Slack: increase timeout for full refresh CAT

### DIFF
--- a/airbyte-integrations/connectors/source-slack/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-slack/acceptance-test-config.yml
@@ -30,6 +30,7 @@ acceptance_tests:
     tests:
       - config_path: "secrets/config.json"
         configured_catalog_path: "integration_tests/full_refresh_catalog.json"
+        timeout_seconds: 4800
   incremental:
     tests:
       - config_path: "secrets/config.json"


### PR DESCRIPTION
## What
*Acceptance test failure because of timeout during full refresh test run.*

## How
*Increase timeout up to 4800 sec*
