### PR TITLE
S3, Google Drive, Azure Blob Storage: Bump memory for sources with unstructured data

### DIFF
--- a/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
@@ -20,6 +20,12 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
+  resourceRequirements:
+    jobSpecific:
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 1Gi
+          memory_request: 1Gi
   supportLevel: community
   tags:
     - language:python

--- a/airbyte-integrations/connectors/source-google-drive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-drive/metadata.yaml
@@ -19,6 +19,12 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
+  resourceRequirements:
+    jobSpecific:
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 1Gi
+          memory_request: 1Gi
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-drive
   tags:
     - language:python

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -23,6 +23,12 @@ data:
     oss:
       enabled: true
   releaseStage: generally_available
+  resourceRequirements:
+    jobSpecific:
+      - jobType: sync
+        resourceRequirements:
+          memory_limit: 1Gi
+          memory_request: 1Gi
   releases:
     breakingChanges:
       4.0.0:


### PR DESCRIPTION
The document file type parser used in S3, Azure Blob Storage and Google Drive is quite memory hungry:
* Additional libraries are loaded into memory
* The full PDF file that's current processed is loaded into memory
* In some cases, the PDF is rendered in memory as well and an OCR algorithm is performed

All of this adds up in terms of memory usage. Testing locally with unconstrained memory I'm getting the following numbers:
* Before processing starts: 140MB
* During processing (small files, 3KB): 350MB
* During processing (large files, 23MB): 480MB

As the available memory in cloud is fairly constrained, this can quickly lead to OOM errors.

This PR fixes this problem in the interim by bumping available memory for the relevant sources to handle common workloads.