### PR TITLE
enable parallelism on bigquery tests

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/gradle.properties
+++ b/airbyte-integrations/connectors/destination-bigquery/gradle.properties
@@ -1,0 +1,1 @@
+testExecutionConcurrency=-1


### PR DESCRIPTION
Make destination-bigquery tests fast again by reenabling parallelism.

I'm still not sure why destination-snowflake tests are also slower. It already has a gradle.properties file with parallelism set to 4. [Metabase](https://airbyte.metabaseapp.com/question/8047-java-connectors-ci-performance-on-pr) says destination-snowflake tests got slower around the same time, so presumably https://github.com/airbytehq/airbyte/pull/32108/files#diff-a3dd6be9c3819c1fcfd593b0f11c29663912e686e0dd74cae14610ac9c282480 did something? But I'm not sure what exactly.

Would it break things to set testExecutionConcurrency=-1 by default? My understanding is that tests need to opt into concurrent execution (with `@Execution(ExecutionMode.CONCURRENT)`).