### PR TITLE
airbyte-ci bin release: trigger on all PRs

### DIFF
--- a/.github/workflows/airbyte-ci-release.yml
+++ b/.github/workflows/airbyte-ci-release.yml
@@ -6,8 +6,6 @@ concurrency:
 
 on:
   push:
-    branches:
-      - master
     paths:
       - "airbyte-ci/connectors/pipelines/**"
   workflow_dispatch:


### PR DESCRIPTION
The branch filter in the GHA workflow releasing `airbyte-ci` binary did not trigger automatic binary pre-release on `airbyte-ci` related branches that touch the `pipelines` code