### PR TITLE
POC: Add cdk image publish

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/cdk_publish/__init__.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/cdk_publish/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/cdk_publish/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/cdk_publish/commands.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import logging
+
+import asyncclick as click
+from pipelines.cli.click_decorators import click_ignore_unused_kwargs, click_merge_args_into_context_obj
+from pipelines.consts import DOCKER_VERSION
+from pipelines.helpers.utils import sh_dash_c
+from pipelines.models.contexts.click_pipeline_context import ClickPipelineContext, pass_pipeline_context
+
+
+@click.command()
+@pass_pipeline_context
+@click_ignore_unused_kwargs
+async def cdk_publish(pipeline_context: ClickPipelineContext):
+    pipeline_name = "publish cdk"
+    dagger_client = await pipeline_context.get_dagger_client(pipeline_name=pipeline_name)
+    cdk_container = dagger_client.host().directory("airbyte-cdk/python/").docker_build()
+    await cdk_container.publish("airbyte/source-declarative-manifest:test-build")

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
@@ -267,6 +267,7 @@ async def get_modified_files_str(ctx: click.Context):
         "format": "pipelines.airbyte_ci.format.commands.format_code",
         "metadata": "pipelines.airbyte_ci.metadata.commands.metadata",
         "test": "pipelines.airbyte_ci.test.commands.test",
+        "cdk_publish": "pipelines.airbyte_ci.cdk_publish.commands.cdk_publish",
     },
 )
 @click.version_option(__installed_version__)

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -25,11 +25,11 @@ data:
   name: Bing Ads
   registries:
     cloud:
-      dockerImageTag: 1.13.0  #https://airbytehq-team.slack.com/archives/C0662JB7XPU
+      dockerImageTag: 1.13.0 #https://airbytehq-team.slack.com/archives/C0662JB7XPU
       enabled: true
     oss:
       enabled: true
-      dockerImageTag: 1.13.0  #https://airbytehq-team.slack.com/archives/C0662JB7XPU
+      dockerImageTag: 1.13.0 #https://airbytehq-team.slack.com/archives/C0662JB7XPU
   releaseStage: generally_available
   releases:
     breakingChanges:


### PR DESCRIPTION
## Overview 
This is meant as a preview of how easy it is to add the ability for `airbyte-ci` to build the cdk image

The main missing piece is uploading to dockerhub but we already have code samepls for that in our own publish pipeline