### PR TITLE
Metadata: Retry dockerhub fetch on metadata post publish fail

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
@@ -27,7 +27,7 @@ def get_docker_hub_auth_token() -> str:
     return token
 
 
-def is_image_on_docker_hub(image_name: str, version: str, digest: Optional[str] = None, retries: int = 0) -> bool:
+def is_image_on_docker_hub(image_name: str, version: str, digest: Optional[str] = None, retries: int = 0, wait_sec: int = 30) -> bool:
     """Check if a given image and version exists on Docker Hub.
 
     Args:
@@ -35,6 +35,7 @@ def is_image_on_docker_hub(image_name: str, version: str, digest: Optional[str] 
         version (str): The version of the image to check.
         digest (str, optional): The digest of the image to check. Defaults to None.
         retries (int, optional): The number of times to retry the request. Defaults to 0.
+        wait_sec (int, optional): The number of seconds to wait between retries. Defaults to 30.
     Returns:
         bool: True if the image and version exists on Docker Hub, False otherwise.
     """
@@ -48,10 +49,12 @@ def is_image_on_docker_hub(image_name: str, version: str, digest: Optional[str] 
         response = requests.get(tag_url, headers=headers)
         if response.ok:
             break
-        time.sleep(30)
+        time.sleep(wait_sec)
 
     if not response.ok:
+        response.raise_for_status()
         return False
+
     # If a digest is provided, check that it matches the digest of the image on Docker Hub.
     if digest is not None:
         return f"sha256:{digest}" == response.json()["digest"]

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
@@ -3,11 +3,10 @@
 #
 
 import os
+import time
 from typing import Optional
 
 import requests
-import time
-from typing import Optional
 
 
 def get_docker_hub_auth_token() -> str:
@@ -27,12 +26,8 @@ def get_docker_hub_auth_token() -> str:
     token = response.json().get("token")
     return token
 
-def is_image_on_docker_hub(
-    image_name: str,
-    version: str,
-    digest: Optional[str] = None,
-    retries: int = 0
-) -> bool:
+
+def is_image_on_docker_hub(image_name: str, version: str, digest: Optional[str] = None, retries: int = 0) -> bool:
     """Check if a given image and version exists on Docker Hub.
 
     Args:

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/validators/metadata_validator.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/validators/metadata_validator.py
@@ -164,7 +164,8 @@ def validate_metadata_base_images_in_dockerhub(
     tag = tag_with_sha_prefix.split("@")[0]
 
     print(f"Checking that the base images is on dockerhub: {image_address}")
-    if not is_image_on_docker_hub(image_name, tag, digest):
+
+    if not is_image_on_docker_hub(image_name, tag, digest, retries=3):
         return False, f"Image {image_address} does not exist in DockerHub"
 
     return True, None


### PR DESCRIPTION
## Problem
The dockerhub api can be stale and not return an image even though its published

From this slack discussion
https://airbytehq-team.slack.com/archives/C03VDJ4FMJB/p1700182656932749

## Solution
Metadata validation will retry up to 3 times 30 seconds apart to find the image

## Future
We may be able to rework this to work off the local instance of docker which downloads these images much faster

