### PR TITLE
:bug: Source Slack: remove client side filtering

### DIFF
--- a/airbyte-integrations/connectors/source-slack/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-slack/acceptance-test-config.yml
@@ -38,3 +38,6 @@ acceptance_tests:
         future_state:
           future_state_path: "integration_tests/abnormal_state.json"
         timeout_seconds: 4800
+        # When running multiple syncs in a row, we may get the same record set because of a lookback window.
+        # This may fail the test but this is expected behavior of the connector.
+        skip_comprehensive_incremental_tests: true

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c2281cee-86f9-4a86-bb48-d23286b4c7bd
-  dockerImageTag: 0.3.5
+  dockerImageTag: 0.3.6
   dockerRepository: airbyte/source-slack
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   githubIssueLabel: source-slack

--- a/airbyte-integrations/connectors/source-slack/source_slack/source.py
+++ b/airbyte-integrations/connectors/source-slack/source_slack/source.py
@@ -296,18 +296,6 @@ class Threads(IncrementalMessageStream):
             # yield an empty slice to checkpoint state later
             yield {}
 
-    def read_records(self, stream_state: Mapping[str, Any] = None, **kwargs) -> Iterable[Mapping[str, Any]]:
-        """
-        Filtering already read records for incremental sync. Copied state value to X after the last sync
-        to really 100% make sure no one can edit the state during the run.
-        """
-
-        initial_state = copy.deepcopy(stream_state) or {}
-
-        for record in super().read_records(stream_state=stream_state, **kwargs):
-            if record.get(self.cursor_field, 0) >= initial_state.get(self.cursor_field, 0):
-                yield record
-
 
 class JoinChannelsStream(HttpStream):
     """

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -118,14 +118,13 @@ The Slack source connector supports the following [sync modes](https://docs.airb
 
 ## Supported Streams
 
+For most of the streams, the Slack source connector uses the [Conversations API](https://api.slack.com/docs/conversations-api) under the hood.
+
 * [Channels \(Conversations\)](https://api.slack.com/methods/conversations.list)
 * [Channel Members \(Conversation Members\)](https://api.slack.com/methods/conversations.members)
 * [Messages \(Conversation History\)](https://api.slack.com/methods/conversations.history) It will only replicate messages from non-archive, public channels that the Slack App is a member of.
 * [Users](https://api.slack.com/methods/users.list)
 * [Threads \(Conversation Replies\)](https://api.slack.com/methods/conversations.replies)
-* [User Groups](https://api.slack.com/methods/usergroups.list)
-* [Files](https://api.slack.com/methods/files.list)
-* [Remote Files](https://api.slack.com/methods/files.remote.list)
 
 ## Performance considerations
 
@@ -164,9 +163,10 @@ Slack has [rate limit restrictions](https://api.slack.com/docs/rate-limits).
 
 | Version | Date       | Pull Request                                             | Subject                                                                             |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------|
-| 0.3.5 | 2023-10-19 | [31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image |
+| 0.3.6   | 2023-11-21 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Threads: do not use client-side record filtering                                    |
+| 0.3.5   | 2023-10-19 | [31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image     |
 | 0.3.4   | 2023-10-06 | [31134](https://github.com/airbytehq/airbyte/pull/31134) | Update CDK and remove non iterable return from records                              |
-| 0.3.3   | 2023-09-28 | [30580](https://github.com/airbytehq/airbyte/pull/30580) | Add `bot_id` field to threads schema                               |
+| 0.3.3   | 2023-09-28 | [30580](https://github.com/airbytehq/airbyte/pull/30580) | Add `bot_id` field to threads schema                                                |
 | 0.3.2   | 2023-09-20 | [30613](https://github.com/airbytehq/airbyte/pull/30613) | Set default value for channel_filters during discover                               |
 | 0.3.1   | 2023-09-19 | [30570](https://github.com/airbytehq/airbyte/pull/30570) | Use default availability strategy                                                   |
 | 0.3.0   | 2023-09-18 | [30521](https://github.com/airbytehq/airbyte/pull/30521) | Add unexpected fields to streams `channel_messages`, `channels`, `threads`, `users` |

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -163,7 +163,7 @@ Slack has [rate limit restrictions](https://api.slack.com/docs/rate-limits).
 
 | Version | Date       | Pull Request                                             | Subject                                                                             |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------|
-| 0.3.6   | 2023-11-21 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Threads: do not use client-side record filtering                                    |
+| 0.3.6   | 2023-11-21 | [32707](https://github.com/airbytehq/airbyte/pull/32707) | Threads: do not use client-side record filtering                                    |
 | 0.3.5   | 2023-10-19 | [31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image     |
 | 0.3.4   | 2023-10-06 | [31134](https://github.com/airbytehq/airbyte/pull/31134) | Update CDK and remove non iterable return from records                              |
 | 0.3.3   | 2023-09-28 | [30580](https://github.com/airbytehq/airbyte/pull/30580) | Add `bot_id` field to threads schema                                                |


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/32143

## How
The client side filtering removes the majority of the records when the sync is run frequently with the lookback window, therefore it is removed as does not look like it has any business value

## 🚨 User Impact 🚨
Users will start syncing more data which will be deduplicated in their final tables
