### PR TITLE
Update the AWS S3 and Datalake to use the External Id. The AWS SDK wi…

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
@@ -35,6 +35,10 @@ dependencies {
         exclude group: 'org.slf4j', module: 'slf4j-reload4j'
     }
 
+
+    // This dep pulls in the AWS S3 SDK, maybe we should be explicit about that?
+    // This also uses the V1 SDK
+    implementation("com.amazonaws:aws-java-sdk-sts:1.12.592")
     implementation 'com.github.alexmojaki:s3-stream-upload:2.2.2'
     implementation 'org.apache.commons:commons-csv:1.4'
     implementation ('org.apache.parquet:parquet-avro:1.12.3') { exclude group: 'org.slf4j', module: 'slf4j-log4j12'}

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/S3DestinationConfig.java
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/S3DestinationConfig.java
@@ -6,7 +6,6 @@ package io.airbyte.cdk.integrations.destination.s3;
 
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.ACCESS_KEY_ID;
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.ACCOUNT_ID;
-import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.EXTERNAL_ID;
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.FILE_NAME_PATTERN;
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.ROLE_ARN;
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.SECRET_ACCESS_KEY;

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/S3DestinationConfig.java
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/S3DestinationConfig.java
@@ -6,7 +6,9 @@ package io.airbyte.cdk.integrations.destination.s3;
 
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.ACCESS_KEY_ID;
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.ACCOUNT_ID;
+import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.EXTERNAL_ID;
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.FILE_NAME_PATTERN;
+import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.ROLE_ARN;
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.SECRET_ACCESS_KEY;
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.S_3_BUCKET_NAME;
 import static io.airbyte.cdk.integrations.destination.s3.constant.S3Constants.S_3_BUCKET_PATH;
@@ -24,6 +26,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.cdk.integrations.destination.s3.credential.S3AWSDefaultProfileCredentialConfig;
 import io.airbyte.cdk.integrations.destination.s3.credential.S3AccessKeyCredentialConfig;
+import io.airbyte.cdk.integrations.destination.s3.credential.S3AssumeRoleCredentialConfig;
 import io.airbyte.cdk.integrations.destination.s3.credential.S3CredentialConfig;
 import io.airbyte.cdk.integrations.destination.s3.credential.S3CredentialType;
 import java.util.Objects;
@@ -151,7 +154,9 @@ public class S3DestinationConfig {
     }
 
     final S3CredentialConfig credentialConfig;
-    if (config.has(ACCESS_KEY_ID)) {
+    if (config.has(ROLE_ARN)) {
+      credentialConfig = new S3AssumeRoleCredentialConfig(getProperty(config, ROLE_ARN));
+    } else if (config.has(ACCESS_KEY_ID)) {
       credentialConfig = new S3AccessKeyCredentialConfig(getProperty(config, ACCESS_KEY_ID), getProperty(config, SECRET_ACCESS_KEY));
     } else {
       credentialConfig = new S3AWSDefaultProfileCredentialConfig();

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/constant/S3Constants.java
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/constant/S3Constants.java
@@ -16,6 +16,8 @@ public final class S3Constants {
   public static final String SECRET_ACCESS_KEY = "secret_access_key";
   public static final String S_3_BUCKET_NAME = "s3_bucket_name";
   public static final String S_3_BUCKET_REGION = "s3_bucket_region";
+  public static final String ROLE_ARN = "role_arn";
+  public static final String EXTERNAL_ID = "external_id";
 
   // r2 requires account_id
   public static final String ACCOUNT_ID = "account_id";

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/credential/S3AssumeRoleCredentialConfig.java
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/credential/S3AssumeRoleCredentialConfig.java
@@ -6,10 +6,8 @@ package io.airbyte.cdk.integrations.destination.s3.credential;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.regions.Regions;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 
@@ -48,9 +46,7 @@ public class S3AssumeRoleCredentialConfig implements S3CredentialConfig {
         new BasicSessionCredentials(
             credentials.getAccessKeyId(),
             credentials.getSecretAccessKey(),
-            credentials.getSessionToken()
-        )
-    );
+            credentials.getSessionToken()));
   }
 
 }

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/credential/S3AssumeRoleCredentialConfig.java
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/credential/S3AssumeRoleCredentialConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.integrations.destination.s3.credential;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+
+public class S3AssumeRoleCredentialConfig implements S3CredentialConfig {
+
+  private String roleArn;
+  private String externalId;
+
+  public S3AssumeRoleCredentialConfig(final String roleArn) {
+    this.roleArn = roleArn;
+    this.externalId = System.getenv("AWS_EXTERNAL_ID");
+  }
+
+  @Override
+  public S3CredentialType getCredentialType() {
+    return S3CredentialType.ASSUME_ROLE;
+  }
+
+  @Override
+  public AWSCredentialsProvider getS3CredentialsProvider() {
+    final var stsClient = AWSSecurityTokenServiceClient
+        .builder()
+        .withRegion(Regions.DEFAULT_REGION)
+        .build();
+
+    // Call the assumeRole method of the STSRegionalEndpointClient object.
+    var assumeRoleRequest = new AssumeRoleRequest();
+    assumeRoleRequest.setRoleArn(roleArn);
+    if (externalId != null) {
+      assumeRoleRequest.setExternalId(externalId);
+    }
+    assumeRoleRequest.setRoleSessionName("airbyte");
+    var assumeRoleResponse = stsClient.assumeRole(assumeRoleRequest);
+    final var credentials = assumeRoleResponse.getCredentials();
+    return new AWSStaticCredentialsProvider(
+        new BasicSessionCredentials(
+            credentials.getAccessKeyId(),
+            credentials.getSecretAccessKey(),
+            credentials.getSessionToken()
+        )
+    );
+  }
+
+}

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/credential/S3CredentialType.java
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/java/io/airbyte/cdk/integrations/destination/s3/credential/S3CredentialType.java
@@ -7,6 +7,7 @@ package io.airbyte.cdk.integrations.destination.s3.credential;
 public enum S3CredentialType {
 
   ACCESS_KEY,
-  DEFAULT_PROFILE
+  DEFAULT_PROFILE,
+  ASSUME_ROLE
 
 }

--- a/airbyte-integrations/connectors/destination-aws-datalake/destination_aws_datalake/aws.py
+++ b/airbyte-integrations/connectors/destination-aws-datalake/destination_aws_datalake/aws.py
@@ -3,6 +3,7 @@
 #
 
 import logging
+import os
 from decimal import Decimal
 from typing import Any, Dict, Optional
 
@@ -91,6 +92,7 @@ class AwsHandler:
             role = client.assume_role(
                 RoleArn=self._config.role_arn,
                 RoleSessionName="airbyte-destination-aws-datalake",
+                ExternalId=os.getenv("AWS_EXTERNAL_ID")
             )
             creds = role.get("Credentials", {})
             self._session = boto3.Session(

--- a/airbyte-integrations/connectors/destination-aws-datalake/destination_aws_datalake/aws.py
+++ b/airbyte-integrations/connectors/destination-aws-datalake/destination_aws_datalake/aws.py
@@ -90,9 +90,7 @@ class AwsHandler:
         elif self._config.credentials_type == CredentialsType.IAM_ROLE:
             client = boto3.client("sts")
             role = client.assume_role(
-                RoleArn=self._config.role_arn,
-                RoleSessionName="airbyte-destination-aws-datalake",
-                ExternalId=os.getenv("AWS_EXTERNAL_ID")
+                RoleArn=self._config.role_arn, RoleSessionName="airbyte-destination-aws-datalake", ExternalId=os.getenv("AWS_EXTERNAL_ID")
             )
             creds = role.get("Credentials", {})
             self._session = boto3.Session(

--- a/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
@@ -391,6 +391,15 @@
           "{sync_id}"
         ],
         "order": 8
+      },
+      "role_arn": {
+        "type": "string",
+        "description": "The Role ARn",
+        "title": "Role ARN",
+        "examples": [
+          "arn:aws:iam::667471877866:role/TestExternalId"
+        ],
+        "order": 9
       }
     }
   }


### PR DESCRIPTION
…ll automatically configure itself now because we are injecting the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as environment variables when launching the pod.



## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
