### PR TITLE
enable @Order() annotation in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -332,6 +332,8 @@ subprojects { subproj ->
         // Effectively disable JUnit concurrency by running tests in only one thread by default.
         systemProperty 'junit.jupiter.execution.parallel.config.strategy', 'fixed'
         systemProperty 'junit.jupiter.execution.parallel.config.fixed.parallelism', 1
+        // Order test classes by annotation.
+        systemProperty 'junit.jupiter.testclass.order.default', 'org.junit.jupiter.api.ClassOrderer$OrderAnnotation'
 
         if (!subproj.hasProperty('testExecutionConcurrency')) {
             // By default, let gradle spawn as many independent workers as it wants.


### PR DESCRIPTION
Introduce a change in the `build.gradle` file to order test classes by annotation.