### PR TITLE
gradle: connectors can have test fixtures

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-java-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-java-connector.gradle
@@ -50,11 +50,17 @@ class AirbyteJavaConnectorExtension {
         project.dependencies {
             def dep = { useLocalCdk ? project.project(projectName(it)) : jarName(it) }
             def testFixturesDep = { useLocalCdk ? testFixtures(project.project(projectName(it))) : "${jarName(it)}:test-fixtures" }
-            IMPLEMENTATION.each {implementation dep(it) }
+
+            IMPLEMENTATION.each {
+                implementation dep(it)
+                testFixturesImplementation dep(it)
+            }
             TEST_IMPLEMENTATION.each {testImplementation dep(it) }
             INTEGRATION_TEST_IMPLEMENTATION.each {integrationTestJavaImplementation dep(it) }
             (["core"] + features).each {
                 implementation dep(it)
+                testFixturesImplementation dep(it)
+                testFixturesImplementation testFixturesDep(it)
                 testImplementation dep(it)
                 testImplementation testFixturesDep(it)
                 integrationTestJavaImplementation dep(it)

--- a/buildSrc/src/main/groovy/airbyte-java-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-java-connector.gradle
@@ -72,14 +72,22 @@ class AirbyteJavaConnectorPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
 
+        project.plugins.apply('java-test-fixtures')
         project.plugins.apply(AirbyteIntegrationTestJavaPlugin)
         project.plugins.apply(AirbytePerformanceTestJavaPlugin)
+
+        project.configurations {
+            testFixturesImplementation.extendsFrom implementation
+            testFixturesRuntimeOnly.extendsFrom runtimeOnly
+        }
 
         project.dependencies {
             // Integration and performance tests should automatically
             // have access to the project's own main source sets.
             integrationTestJavaImplementation project
+            integrationTestJavaImplementation testFixtures(project)
             performanceTestJavaImplementation project
+            performanceTestJavaImplementation testFixtures(project)
         }
 
         project.extensions.create('airbyteJavaConnector', AirbyteJavaConnectorExtension, project)


### PR DESCRIPTION
modifies the airbyte-java-connector gradle plugin to allow testFixtures source sets in java connectors