### PR TITLE
DataSourceBuilder supports loginTimeout for mssql

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/core/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     testImplementation libs.testcontainers.jdbc
     testImplementation libs.testcontainers.mysql
     testImplementation libs.testcontainers.postgresql
+    testImplementation libs.testcontainers.mssqlserver
     implementation 'org.codehaus.plexus:plexus-utils:3.4.2'
 
     // bouncycastle is pinned to version-match the transitive dependency from kubernetes client-java

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/db/factory/DataSourceFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/db/factory/DataSourceFactory.java
@@ -205,11 +205,11 @@ public class DataSourceFactory {
      * @return DataSourceBuilder class used to create dynamic fields for DataSource
      */
     private static long getConnectionTimeoutMs(final Map<String, String> connectionProperties, String driverClassName) {
-      // TODO: the usage of CONNECT_TIMEOUT is Postgres specific, may need to extend for other databases
       final Optional<Duration> parsedConnectionTimeout = switch (DatabaseDriver.findByDriverClassName(driverClassName)) {
         case POSTGRESQL -> maybeParseDuration(connectionProperties.get(CONNECT_TIMEOUT.getName()), ChronoUnit.SECONDS)
             .or(() -> maybeParseDuration(CONNECT_TIMEOUT.getDefaultValue(), ChronoUnit.SECONDS));
         case MYSQL -> maybeParseDuration(connectionProperties.get("connectTimeout"), ChronoUnit.MILLIS);
+        case MSSQLSERVER -> maybeParseDuration(connectionProperties.get("loginTimeout"), ChronoUnit.SECONDS);
         default -> maybeParseDuration(connectionProperties.get(CONNECT_TIMEOUT_KEY), ChronoUnit.SECONDS)
             // Enforce minimum timeout duration for unspecified data sources.
             .filter(d -> d.compareTo(CONNECT_TIMEOUT_DEFAULT) >= 0);

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/db/factory/DataSourceFactoryTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/db/factory/DataSourceFactoryTest.java
@@ -17,6 +17,7 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.MySQLContainer;
 
 /**
@@ -87,6 +88,22 @@ class DataSourceFactoryTest extends CommonFactoryTest {
           mySQLContainer.getDriverClassName(),
           mySQLContainer.getJdbcUrl(),
           connectionProperties);
+      assertNotNull(dataSource);
+      assertEquals(HikariDataSource.class, dataSource.getClass());
+      assertEquals(5000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
+    }
+  }
+
+  @Test
+  void testCreatingMsSQLServerDataSourceWithConnectionTimeoutSetBelowDefault() {
+    try (var mssqlServerContainer = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-latest").acceptLicense()) {
+      mssqlServerContainer.start();
+      final DataSource dataSource = DataSourceFactory.create(
+          mssqlServerContainer.getUsername(),
+          mssqlServerContainer.getPassword(),
+          mssqlServerContainer.getDriverClassName(),
+          mssqlServerContainer.getJdbcUrl(),
+          Map.of("loginTimeout", "5"));
       assertNotNull(dataSource);
       assertEquals(HikariDataSource.class, dataSource.getClass());
       assertEquals(5000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());

--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/src/test/java/io/airbyte/integrations/source/mssql_strict_encrypt/MssqlStrictEncryptJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/src/test/java/io/airbyte/integrations/source/mssql_strict_encrypt/MssqlStrictEncryptJdbcSourceAcceptanceTest.java
@@ -7,6 +7,8 @@ package io.airbyte.integrations.source.mssql_strict_encrypt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.cdk.integrations.base.ssh.SshHelpers;
 import io.airbyte.cdk.integrations.source.jdbc.test.JdbcSourceAcceptanceTest;
 import io.airbyte.commons.json.Jsons;
@@ -33,6 +35,10 @@ public class MssqlStrictEncryptJdbcSourceAcceptanceTest extends JdbcSourceAccept
   }
 
   @Override
+  protected void maybeSetShorterConnectionTimeout(final JsonNode config) {
+    ((ObjectNode) config).put(JdbcUtils.JDBC_URL_PARAMS_KEY, "loginTimeout=1");
+  }
+
   protected JsonNode config() {
     return testdb.testConfigBuilder()
         .withSsl(Map.of("ssl_method", "encrypted_trust_server_certificate"))

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlJdbcSourceAcceptanceTest.java
@@ -55,6 +55,11 @@ public class MssqlJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest<Mssq
     return true;
   }
 
+  @Override
+  protected void maybeSetShorterConnectionTimeout(final JsonNode config) {
+    ((ObjectNode) config).put(JdbcUtils.JDBC_URL_PARAMS_KEY, "loginTimeout=1");
+  }
+
   @Test
   void testCheckIncorrectPasswordFailure() throws Exception {
     final var config = config();


### PR DESCRIPTION
enable shorter connection timeouts for source-mssql and use that to speed up some of its tests