### PR TITLE
source-mssql: add and adopt MsSQLTestDatabase

### DIFF
--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation project(':airbyte-integrations:connectors:source-mssql')
     implementation libs.jooq
 
+    testImplementation testFixtures(project(':airbyte-integrations:connectors:source-mssql'))
     testImplementation 'org.apache.commons:commons-lang3:3.11'
     testImplementation libs.testcontainers.mssqlserver
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mssql_strict_encrypt/MssqlStrictEncryptSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mssql_strict_encrypt/MssqlStrictEncryptSourceAcceptanceTest.java
@@ -5,94 +5,48 @@
 package io.airbyte.integrations.source.mssql_strict_encrypt;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
-import io.airbyte.cdk.db.Database;
-import io.airbyte.cdk.db.factory.DSLContextFactory;
-import io.airbyte.cdk.db.factory.DatabaseDriver;
-import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.cdk.integrations.base.ssh.SshHelpers;
 import io.airbyte.cdk.integrations.standardtest.source.SourceAcceptanceTest;
 import io.airbyte.cdk.integrations.standardtest.source.TestDestinationEnv;
-import io.airbyte.cdk.integrations.util.HostPortResolver;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.integrations.source.mssql.MsSQLContainerFactory;
+import io.airbyte.integrations.source.mssql.MsSQLTestDatabase;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.protocol.models.v0.CatalogHelpers;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.v0.ConnectorSpecification;
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.jooq.DSLContext;
-import org.junit.jupiter.api.AfterAll;
-import org.testcontainers.containers.MSSQLServerContainer;
 
 public class MssqlStrictEncryptSourceAcceptanceTest extends SourceAcceptanceTest {
 
   protected static final String SCHEMA_NAME = "dbo";
   protected static final String STREAM_NAME = "id_and_name";
-  protected static MSSQLServerContainer<?> db;
-  protected JsonNode config;
 
-  @AfterAll
-  public static void closeContainer() {
-    if (db != null) {
-      db.close();
-      db.stop();
-    }
+  private MsSQLTestDatabase testdb;
+
+  @Override
+  protected void setupEnvironment(final TestDestinationEnv environment) {
+    final var container = new MsSQLContainerFactory().shared("mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04");
+    testdb = new MsSQLTestDatabase(container);
+    testdb = testdb
+        .withConnectionProperty("encrypt", "true")
+        .withConnectionProperty("trustServerCertificate", "true")
+        .withConnectionProperty("databaseName", testdb.getDatabaseName())
+        .initialized()
+        .with("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200), born DATETIMEOFFSET(7));")
+        .with("INSERT INTO id_and_name (id, name, born) VALUES " +
+            "(1,'picard', '2124-03-04T01:01:01Z'),  " +
+            "(2, 'crusher', '2124-03-04T01:01:01Z'), " +
+            "(3, 'vash', '2124-03-04T01:01:01Z');");
   }
 
   @Override
-  protected void setupEnvironment(final TestDestinationEnv environment) throws SQLException {
-    if (db == null) {
-      db = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04").acceptLicense();
-      db.start();
-    }
-
-    final JsonNode configWithoutDbName = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(db))
-        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(db))
-        .put(JdbcUtils.USERNAME_KEY, db.getUsername())
-        .put(JdbcUtils.PASSWORD_KEY, db.getPassword())
-        .build());
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
-
-    try (final DSLContext dslContext = DSLContextFactory.create(
-        configWithoutDbName.get(JdbcUtils.USERNAME_KEY).asText(),
-        configWithoutDbName.get(JdbcUtils.PASSWORD_KEY).asText(),
-        DatabaseDriver.MSSQLSERVER.getDriverClassName(),
-        String.format("jdbc:sqlserver://%s:%d;encrypt=true;trustServerCertificate=true;",
-            db.getHost(),
-            db.getFirstMappedPort()),
-        null)) {
-      final Database database = getDatabase(dslContext);
-      database.query(ctx -> {
-        ctx.fetch(String.format("CREATE DATABASE %s;", dbName));
-        ctx.fetch(String.format("USE %s;", dbName));
-        ctx.fetch("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200), born DATETIMEOFFSET(7));");
-        ctx.fetch(
-            "INSERT INTO id_and_name (id, name, born) VALUES " +
-                "(1,'picard', '2124-03-04T01:01:01Z'),  " +
-                "(2, 'crusher', '2124-03-04T01:01:01Z'), " +
-                "(3, 'vash', '2124-03-04T01:01:01Z');");
-        return null;
-      });
-    }
-
-    config = Jsons.clone(configWithoutDbName);
-    ((ObjectNode) config).put(JdbcUtils.DATABASE_KEY, dbName);
-    ((ObjectNode) config).put("ssl_method", Jsons.jsonNode(Map.of("ssl_method", "encrypted_trust_server_certificate")));
+  protected void tearDown(final TestDestinationEnv testEnv) {
+    testdb.close();
   }
-
-  private static Database getDatabase(final DSLContext dslContext) {
-    return new Database(dslContext);
-  }
-
-  @Override
-  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {}
 
   @Override
   protected String getImageName() {
@@ -106,7 +60,9 @@ public class MssqlStrictEncryptSourceAcceptanceTest extends SourceAcceptanceTest
 
   @Override
   protected JsonNode getConfig() {
-    return config;
+    return testdb.integrationTestConfigBuilder()
+        .withSsl(Map.of("ssl_method", "encrypted_trust_server_certificate"))
+        .build();
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -25,12 +25,13 @@ application {
 dependencies {
     implementation libs.postgresql
 
-
     implementation libs.debezium.sqlserver
     implementation 'com.microsoft.sqlserver:mssql-jdbc:10.2.1.jre8'
     implementation 'org.codehaus.plexus:plexus-utils:3.4.2'
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation libs.testcontainers.mssqlserver
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
+
+    testImplementation libs.testcontainers.mssqlserver
+    testFixturesImplementation libs.testcontainers.mssqlserver
 }

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/AbstractMssqlSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/AbstractMssqlSourceDatatypeTest.java
@@ -4,18 +4,14 @@
 
 package io.airbyte.integrations.source.mssql;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.cdk.integrations.standardtest.source.AbstractSourceDatabaseTypeTest;
 import io.airbyte.cdk.integrations.standardtest.source.TestDataHolder;
+import io.airbyte.cdk.integrations.standardtest.source.TestDestinationEnv;
 import io.airbyte.protocol.models.JsonSchemaType;
-import org.jooq.DSLContext;
-import org.testcontainers.containers.MSSQLServerContainer;
 
 public abstract class AbstractMssqlSourceDatatypeTest extends AbstractSourceDatabaseTypeTest {
 
-  protected static MSSQLServerContainer<?> container;
-  protected JsonNode config;
-  protected DSLContext dslContext;
+  protected MsSQLTestDatabase testdb;
 
   @Override
   protected String getNameSpace() {
@@ -28,14 +24,11 @@ public abstract class AbstractMssqlSourceDatatypeTest extends AbstractSourceData
   }
 
   @Override
-  protected JsonNode getConfig() {
-    return config;
+  protected void tearDown(final TestDestinationEnv testEnv) {
+    testdb.close();
   }
 
-  protected static final String DB_NAME = "comprehensive";
-
-  protected static final String CREATE_TABLE_SQL =
-      "USE " + DB_NAME + "\nCREATE TABLE %1$s(%2$s INTEGER PRIMARY KEY, %3$s %4$s)";
+  protected static final String CREATE_TABLE_SQL = "CREATE TABLE %1$s(%2$s INTEGER PRIMARY KEY, %3$s %4$s)";
 
   @Override
   protected void initTests() {

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceAcceptanceTest.java
@@ -5,19 +5,10 @@
 package io.airbyte.integrations.source.mssql;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
-import io.airbyte.cdk.db.Database;
-import io.airbyte.cdk.db.factory.DSLContextFactory;
-import io.airbyte.cdk.db.factory.DataSourceFactory;
-import io.airbyte.cdk.db.factory.DatabaseDriver;
-import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.cdk.integrations.base.ssh.SshHelpers;
 import io.airbyte.cdk.integrations.standardtest.source.SourceAcceptanceTest;
 import io.airbyte.cdk.integrations.standardtest.source.TestDestinationEnv;
-import io.airbyte.cdk.integrations.util.HostPortResolver;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.string.Strings;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.protocol.models.v0.CatalogHelpers;
@@ -25,61 +16,28 @@ import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.v0.ConnectorSpecification;
 import java.sql.SQLException;
 import java.util.HashMap;
-import java.util.Map;
-import org.jooq.DSLContext;
-import org.junit.jupiter.api.AfterAll;
-import org.testcontainers.containers.MSSQLServerContainer;
 
 public class MssqlSourceAcceptanceTest extends SourceAcceptanceTest {
 
   protected static final String SCHEMA_NAME = "dbo";
   protected static final String STREAM_NAME = "id_and_name";
-  protected static MSSQLServerContainer<?> db;
-  protected JsonNode config;
 
-  @AfterAll
-  public static void closeContainer() {
-    if (db != null) {
-      db.close();
-      db.stop();
-    }
-  }
+  protected MsSQLTestDatabase testdb;
 
   @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws SQLException {
-    if (db == null) {
-      db = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04").acceptLicense();
-      db.start();
-    }
-    final JsonNode configWithoutDbName = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(db))
-        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(db))
-        .put(JdbcUtils.USERNAME_KEY, db.getUsername())
-        .put(JdbcUtils.PASSWORD_KEY, db.getPassword())
-        .build());
-    final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
-
-    try (final DSLContext dslContext = getDslContext(configWithoutDbName)) {
-      final Database database = getDatabase(dslContext);
-      database.query(ctx -> {
-        ctx.fetch(String.format("CREATE DATABASE %s;", dbName));
-        ctx.fetch(String.format("USE %s;", dbName));
-        ctx.fetch("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200), born DATETIMEOFFSET(7));");
-        ctx.fetch(
-            "INSERT INTO id_and_name (id, name, born) VALUES " +
-                "(1,'picard', '2124-03-04T01:01:01Z'),  " +
-                "(2, 'crusher', '2124-03-04T01:01:01Z'), (3, 'vash', '2124-03-04T01:01:01Z');");
-        return null;
-      });
-    }
-
-    config = Jsons.clone(configWithoutDbName);
-    ((ObjectNode) config).put(JdbcUtils.DATABASE_KEY, dbName);
-    ((ObjectNode) config).put("ssl_method", Jsons.jsonNode(Map.of("ssl_method", "unencrypted")));
+    testdb = MsSQLTestDatabase.in("mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04")
+        .with("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200), born DATETIMEOFFSET(7));")
+        .with("INSERT INTO id_and_name (id, name, born) VALUES " +
+            "(1, 'picard', '2124-03-04T01:01:01Z'), " +
+            "(2, 'crusher', '2124-03-04T01:01:01Z'), " +
+            "(3, 'vash', '2124-03-04T01:01:01Z');");
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {}
+  protected void tearDown(final TestDestinationEnv testEnv) {
+    testdb.close();
+  }
 
   @Override
   protected String getImageName() {
@@ -93,7 +51,9 @@ public class MssqlSourceAcceptanceTest extends SourceAcceptanceTest {
 
   @Override
   protected JsonNode getConfig() {
-    return config;
+    return testdb.integrationTestConfigBuilder()
+        .withoutSsl()
+        .build();
   }
 
   @Override
@@ -109,21 +69,6 @@ public class MssqlSourceAcceptanceTest extends SourceAcceptanceTest {
   @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
-  }
-
-  private static DSLContext getDslContext(final JsonNode config) {
-    return DSLContextFactory.create(DataSourceFactory.create(
-        config.get(JdbcUtils.USERNAME_KEY).asText(),
-        config.get(JdbcUtils.PASSWORD_KEY).asText(),
-        DatabaseDriver.MSSQLSERVER.getDriverClassName(),
-        String.format("jdbc:sqlserver://%s:%d;",
-            db.getHost(),
-            db.getFirstMappedPort()),
-        Map.of("encrypt", "false")), null);
-  }
-
-  private static Database getDatabase(final DSLContext dslContext) {
-    return new Database(dslContext);
   }
 
 }

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceDatatypeTest.java
@@ -5,70 +5,21 @@
 package io.airbyte.integrations.source.mssql;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
 import io.airbyte.cdk.db.Database;
-import io.airbyte.cdk.db.factory.DSLContextFactory;
-import io.airbyte.cdk.db.factory.DataSourceFactory;
-import io.airbyte.cdk.db.factory.DatabaseDriver;
-import io.airbyte.cdk.db.jdbc.JdbcUtils;
-import io.airbyte.cdk.integrations.standardtest.source.TestDestinationEnv;
-import io.airbyte.cdk.integrations.util.HostPortResolver;
-import io.airbyte.commons.json.Jsons;
-import java.util.Map;
-import org.jooq.DSLContext;
-import org.testcontainers.containers.MSSQLServerContainer;
 
 public class MssqlSourceDatatypeTest extends AbstractMssqlSourceDatatypeTest {
 
   @Override
-  protected Database setupDatabase() throws Exception {
-    container = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-latest")
-        .acceptLicense();
-    container.start();
-
-    final JsonNode configWithoutDbName = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(container))
-        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(container))
-        .put(JdbcUtils.USERNAME_KEY, container.getUsername())
-        .put(JdbcUtils.PASSWORD_KEY, container.getPassword())
-        .build());
-
-    dslContext = getDslContext(configWithoutDbName);
-    final Database database = getDatabase(dslContext);
-    database.query(ctx -> {
-      ctx.fetch(String.format("CREATE DATABASE %s;", DB_NAME));
-      ctx.fetch(String.format("USE %s;", DB_NAME));
-      return null;
-    });
-
-    config = Jsons.clone(configWithoutDbName);
-    ((ObjectNode) config).put(JdbcUtils.DATABASE_KEY, DB_NAME);
-    ((ObjectNode) config).put("ssl_method", Jsons.jsonNode(Map.of("ssl_method", "unencrypted")));
-
-    return database;
-  }
-
-  private static DSLContext getDslContext(final JsonNode config) {
-    return DSLContextFactory.create(DataSourceFactory.create(
-        config.get(JdbcUtils.USERNAME_KEY).asText(),
-        config.get(JdbcUtils.PASSWORD_KEY).asText(),
-        DatabaseDriver.MSSQLSERVER.getDriverClassName(),
-        String.format("jdbc:sqlserver://%s:%d;",
-            container.getHost(),
-            container.getFirstMappedPort()),
-        Map.of("encrypt", "false")), null);
-  }
-
-  private static Database getDatabase(final DSLContext dslContext) {
-    return new Database(dslContext);
+  protected Database setupDatabase() {
+    testdb = MsSQLTestDatabase.in("mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04");
+    return testdb.getDatabase();
   }
 
   @Override
-  protected void tearDown(final TestDestinationEnv testEnv) {
-    dslContext.close();
-    container.stop();
-    container.close();
+  protected JsonNode getConfig() {
+    return testdb.integrationTestConfigBuilder()
+        .withoutSsl()
+        .build();
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/SslEnabledMssqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/SslEnabledMssqlSourceAcceptanceTest.java
@@ -5,80 +5,32 @@
 package io.airbyte.integrations.source.mssql;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
-import io.airbyte.cdk.db.Database;
-import io.airbyte.cdk.db.factory.DSLContextFactory;
-import io.airbyte.cdk.db.factory.DatabaseDriver;
-import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.cdk.integrations.standardtest.source.TestDestinationEnv;
-import io.airbyte.cdk.integrations.util.HostPortResolver;
-import io.airbyte.commons.json.Jsons;
-import java.sql.SQLException;
 import java.util.Map;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.jooq.DSLContext;
-import org.junit.jupiter.api.AfterAll;
-import org.testcontainers.containers.MSSQLServerContainer;
 
 public class SslEnabledMssqlSourceAcceptanceTest extends MssqlSourceAcceptanceTest {
 
-  @AfterAll
-  public static void closeContainer() {
-    if (db != null) {
-      db.close();
-      db.stop();
-    }
+  @Override
+  protected JsonNode getConfig() {
+    return testdb.integrationTestConfigBuilder()
+        .withSsl(Map.of("ssl_method", "encrypted_trust_server_certificate"))
+        .build();
   }
 
   @Override
-  protected void setupEnvironment(final TestDestinationEnv environment) throws SQLException {
-    if (db == null) {
-      db = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04").acceptLicense();
-      db.start();
-    }
-
-    final JsonNode configWithoutDbName = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, HostPortResolver.resolveHost(db))
-        .put(JdbcUtils.PORT_KEY, HostPortResolver.resolvePort(db))
-        .put(JdbcUtils.USERNAME_KEY, db.getUsername())
-        .put(JdbcUtils.PASSWORD_KEY, db.getPassword())
-        .build());
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
-
-    try (final DSLContext dslContext = getDslContext(configWithoutDbName)) {
-      final Database database = getDatabase(dslContext);
-      database.query(ctx -> {
-        ctx.fetch(String.format("CREATE DATABASE %s;", dbName));
-        ctx.fetch(String.format("USE %s;", dbName));
-        ctx.fetch("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200), born DATETIMEOFFSET(7));");
-        ctx.fetch(
-            "INSERT INTO id_and_name (id, name, born) VALUES " +
-                "(1,'picard', '2124-03-04T01:01:01Z'),  " +
-                "(2, 'crusher', '2124-03-04T01:01:01Z'), " +
-                "(3, 'vash', '2124-03-04T01:01:01Z');");
-        return null;
-      });
-    }
-
-    config = Jsons.clone(configWithoutDbName);
-    ((ObjectNode) config).put(JdbcUtils.DATABASE_KEY, dbName);
-    ((ObjectNode) config).put("ssl_method", Jsons.jsonNode(Map.of("ssl_method", "encrypted_trust_server_certificate")));
-  }
-
-  private DSLContext getDslContext(final JsonNode baseConfig) {
-    return DSLContextFactory.create(
-        baseConfig.get(JdbcUtils.USERNAME_KEY).asText(),
-        baseConfig.get(JdbcUtils.PASSWORD_KEY).asText(),
-        DatabaseDriver.MSSQLSERVER.getDriverClassName(),
-        String.format("jdbc:sqlserver://%s:%d;encrypt=true;trustServerCertificate=true;",
-            db.getHost(),
-            db.getFirstMappedPort()),
-        null);
-  }
-
-  private static Database getDatabase(final DSLContext dslContext) {
-    return new Database(dslContext);
+  protected void setupEnvironment(final TestDestinationEnv environment) {
+    final var container = new MsSQLContainerFactory().shared("mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04");
+    testdb = new MsSQLTestDatabase(container);
+    testdb = testdb
+        .withConnectionProperty("encrypt", "true")
+        .withConnectionProperty("trustServerCertificate", "true")
+        .withConnectionProperty("databaseName", testdb.getDatabaseName())
+        .initialized()
+        .with("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200), born DATETIMEOFFSET(7));")
+        .with("INSERT INTO id_and_name (id, name, born) VALUES " +
+            "(1, 'picard', '2124-03-04T01:01:01Z'), " +
+            "(2, 'crusher', '2124-03-04T01:01:01Z'), " +
+            "(3, 'vash', '2124-03-04T01:01:01Z');");
   }
 
 }

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
@@ -9,17 +9,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import io.airbyte.cdk.db.Database;
-import io.airbyte.cdk.db.factory.DSLContextFactory;
-import io.airbyte.cdk.db.factory.DataSourceFactory;
-import io.airbyte.cdk.db.factory.DatabaseDriver;
-import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.commons.exceptions.ConfigErrorException;
-import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.string.Strings;
 import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
@@ -29,67 +20,44 @@ import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.v0.DestinationSyncMode;
 import io.airbyte.protocol.models.v0.SyncMode;
-import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.*;
-import org.testcontainers.containers.MSSQLServerContainer;
 
 class MssqlSourceTest {
 
-  private static final String DB_NAME = "dbo";
   private static final String STREAM_NAME = "id_and_name";
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog().withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
       STREAM_NAME,
-      DB_NAME,
+      "dbo",
       Field.of("id", JsonSchemaType.INTEGER),
       Field.of("name", JsonSchemaType.STRING),
       Field.of("born", JsonSchemaType.STRING_TIMESTAMP_WITH_TIMEZONE))
       .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
       .withSourceDefinedPrimaryKey(List.of(List.of("id")))));
 
-  private JsonNode configWithoutDbName;
-  private JsonNode config;
-
-  private static MSSQLServerContainer<?> db;
-
-  @BeforeAll
-  static void init() {
-    db = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-latest").acceptLicense();
-    db.start();
-  }
+  private MsSQLTestDatabase testdb;
 
   // how to interact with the mssql test container manaully.
   // 1. exec into mssql container (not the test container container)
   // 2. /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "A_Str0ng_Required_Password"
   @BeforeEach
-  void setup() throws SQLException {
-    configWithoutDbName = getConfig(db);
-    final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
-
-    try (final DSLContext dslContext = getDslContext(configWithoutDbName)) {
-      final Database database = getDatabase(dslContext);
-      database.query(ctx -> {
-        ctx.fetch(String.format("CREATE DATABASE %s;", dbName));
-        ctx.fetch(String.format("USE %s;", dbName));
-        ctx.fetch("CREATE TABLE id_and_name(id INTEGER NOT NULL, name VARCHAR(200), born DATETIMEOFFSET(7));");
-        ctx.fetch(
-            "INSERT INTO id_and_name (id, name, born) VALUES (1,'picard', '2124-03-04T01:01:01Z'),  (2, 'crusher', '2124-03-04T01:01:01Z'), (3, 'vash', '2124-03-04T01:01:01Z');");
-        return null;
-      });
-    }
-
-    config = Jsons.clone(configWithoutDbName);
-    ((ObjectNode) config).put(JdbcUtils.DATABASE_KEY, dbName);
-    ((ObjectNode) config).put("ssl_method", Jsons.jsonNode(Map.of("ssl_method", "unencrypted")));
+  void setup() {
+    testdb = MsSQLTestDatabase.in("mcr.microsoft.com/mssql/server:2022-latest")
+        .with("CREATE TABLE id_and_name(id INTEGER NOT NULL, name VARCHAR(200), born DATETIMEOFFSET(7));")
+        .with("INSERT INTO id_and_name (id, name, born) VALUES (1,'picard', '2124-03-04T01:01:01Z'),  (2, 'crusher', " +
+            "'2124-03-04T01:01:01Z'), (3, 'vash', '2124-03-04T01:01:01Z');");
   }
 
-  @AfterAll
-  static void cleanUp() {
-    db.stop();
-    db.close();
+  @AfterEach
+  void cleanUp() {
+    testdb.close();
+  }
+
+  private JsonNode getConfig() {
+    return testdb.testConfigBuilder()
+        .withoutSsl()
+        .build();
   }
 
   // if a column in mssql is used as a primary key and in a separate index the discover query returns
@@ -97,82 +65,43 @@ class MssqlSourceTest {
   // this tests that this de-duplication is successful.
   @Test
   void testDiscoverWithPk() throws Exception {
-    try (final DSLContext dslContext = getDslContext(configWithoutDbName)) {
-      final Database database = getDatabase(dslContext);
-      database.query(ctx -> {
-        ctx.fetch(String.format("USE %s;", config.get(JdbcUtils.DATABASE_KEY)));
-        ctx.execute("ALTER TABLE id_and_name ADD CONSTRAINT i3pk PRIMARY KEY CLUSTERED (id);");
-        ctx.execute("CREATE INDEX i1 ON id_and_name (id);");
-        return null;
-      });
-    }
-
-    final AirbyteCatalog actual = new MssqlSource().discover(config);
+    testdb
+        .with("ALTER TABLE id_and_name ADD CONSTRAINT i3pk PRIMARY KEY CLUSTERED (id);")
+        .with("CREATE INDEX i1 ON id_and_name (id);");
+    final AirbyteCatalog actual = new MssqlSource().discover(getConfig());
     assertEquals(CATALOG, actual);
   }
 
   @Test
   @Disabled("See https://github.com/airbytehq/airbyte/pull/23908#issuecomment-1463753684, enable once communication is out")
   public void testTableWithNullCursorValueShouldThrowException() throws Exception {
-    try (final DSLContext dslContext = getDslContext(configWithoutDbName)) {
-      final Database database = getDatabase(dslContext);
-      database.query(ctx -> {
-        ctx.fetch(String.format("USE %s;", config.get(JdbcUtils.DATABASE_KEY)));
-        ctx.execute("ALTER TABLE id_and_name ALTER COLUMN id INTEGER NULL");
-        ctx.execute("INSERT INTO id_and_name(id) VALUES (7), (8), (NULL)");
-        return null;
-      });
+    testdb
+        .with("ALTER TABLE id_and_name ALTER COLUMN id INTEGER NULL")
+        .with("INSERT INTO id_and_name(id) VALUES (7), (8), (NULL)");
 
-      ConfiguredAirbyteStream configuredAirbyteStream = new ConfiguredAirbyteStream().withSyncMode(
-          SyncMode.INCREMENTAL)
-          .withCursorField(Lists.newArrayList("id"))
-          .withDestinationSyncMode(DestinationSyncMode.APPEND)
-          .withSyncMode(SyncMode.INCREMENTAL)
-          .withStream(CatalogHelpers.createAirbyteStream(
-              STREAM_NAME,
-              DB_NAME,
-              Field.of("id", JsonSchemaType.INTEGER),
-              Field.of("name", JsonSchemaType.STRING),
-              Field.of("born", JsonSchemaType.STRING))
-              .withSupportedSyncModes(
-                  Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
-              .withSourceDefinedPrimaryKey(List.of(List.of("id"))));
+    ConfiguredAirbyteStream configuredAirbyteStream = new ConfiguredAirbyteStream().withSyncMode(
+        SyncMode.INCREMENTAL)
+        .withCursorField(Lists.newArrayList("id"))
+        .withDestinationSyncMode(DestinationSyncMode.APPEND)
+        .withSyncMode(SyncMode.INCREMENTAL)
+        .withStream(CatalogHelpers.createAirbyteStream(
+            STREAM_NAME,
+            testdb.getDatabaseName(),
+            Field.of("id", JsonSchemaType.INTEGER),
+            Field.of("name", JsonSchemaType.STRING),
+            Field.of("born", JsonSchemaType.STRING))
+            .withSupportedSyncModes(
+                Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+            .withSourceDefinedPrimaryKey(List.of(List.of("id"))));
 
-      final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(
-          Collections.singletonList(configuredAirbyteStream));
+    final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(
+        Collections.singletonList(configuredAirbyteStream));
 
-      final Throwable throwable = catchThrowable(() -> MoreIterators.toSet(
-          new MssqlSource().read(config, catalog, null)));
-      assertThat(throwable).isInstanceOf(ConfigErrorException.class)
-          .hasMessageContaining(
-              "The following tables have invalid columns selected as cursor, please select a column with a well-defined ordering with no null values as a cursor. {tableName='dbo.id_and_name', cursorColumnName='id', cursorSqlType=INTEGER, cause=Cursor column contains NULL value}");
-    }
-  }
-
-  private JsonNode getConfig(final MSSQLServerContainer<?> db) {
-    return Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, db.getHost())
-        .put(JdbcUtils.PORT_KEY, db.getFirstMappedPort())
-        .put(JdbcUtils.USERNAME_KEY, db.getUsername())
-        .put(JdbcUtils.PASSWORD_KEY, db.getPassword())
-        .build());
-  }
-
-  private static DSLContext getDslContext(final JsonNode config) {
-    return DSLContextFactory.create(DataSourceFactory.create(
-        config.get(JdbcUtils.USERNAME_KEY).asText(),
-        config.get(JdbcUtils.PASSWORD_KEY).asText(),
-        DatabaseDriver.MSSQLSERVER.getDriverClassName(),
-        String.format("jdbc:sqlserver://%s:%d;",
-            config.get(JdbcUtils.HOST_KEY).asText(),
-            config.get(JdbcUtils.PORT_KEY).asInt()),
-        Map.of("encrypt", "false")), null);
-  }
-
-  public static Database getDatabase(final DSLContext dslContext) {
-    // todo (cgardens) - rework this abstraction so that we do not have to pass a null into the
-    // constructor. at least explicitly handle it, even if the impl doesn't change.
-    return new Database(dslContext);
+    final Throwable throwable = catchThrowable(() -> MoreIterators.toSet(
+        new MssqlSource().read(getConfig(), catalog, null)));
+    assertThat(throwable).isInstanceOf(ConfigErrorException.class)
+        .hasMessageContaining(
+            "The following tables have invalid columns selected as cursor, please select a column with a well-defined ordering with no null values as a cursor. {tableName='dbo.id_and_name', cursorColumnName='id', cursorSqlType=INTEGER, cause=Cursor column contains NULL value}");
   }
 
 }

--- a/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLContainerFactory.java
+++ b/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLContainerFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.mssql;
+
+import io.airbyte.cdk.testutils.ContainerFactory;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+
+public class MsSQLContainerFactory implements ContainerFactory<MSSQLServerContainer<?>> {
+
+  @Override
+  public MSSQLServerContainer<?> createNewContainer(DockerImageName imageName) {
+    return new MSSQLServerContainer<>(imageName.asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server")).acceptLicense();
+  }
+
+  @Override
+  public Class<?> getContainerClass() {
+    return MSSQLServerContainer.class;
+  }
+
+  /**
+   * Create a new network and bind it to the container.
+   */
+  public void withNetwork(MSSQLServerContainer<?> container) {
+    container.withNetwork(Network.newNetwork());
+  }
+
+  public void withAgent(MSSQLServerContainer<?> container) {
+    container.addEnv("MSSQL_AGENT_ENABLED", "True");
+  }
+
+}

--- a/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLTestDatabase.java
+++ b/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLTestDatabase.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.mssql;
+
+import io.airbyte.cdk.db.factory.DatabaseDriver;
+import io.airbyte.cdk.db.jdbc.JdbcUtils;
+import io.airbyte.cdk.testutils.TestDatabase;
+import io.debezium.connector.sqlserver.Lsn;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.jooq.SQLDialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MSSQLServerContainer;
+
+public class MsSQLTestDatabase extends TestDatabase<MSSQLServerContainer<?>, MsSQLTestDatabase, MsSQLTestDatabase.MsSQLConfigBuilder> {
+
+  static private final Logger LOGGER = LoggerFactory.getLogger(MsSQLTestDatabase.class);
+
+  static public final int MAX_RETRIES = 60;
+
+  static public MsSQLTestDatabase in(String imageName, String... methods) {
+    final var container = new MsSQLContainerFactory().shared(imageName, methods);
+    final var testdb = new MsSQLTestDatabase(container);
+    return testdb
+        .withConnectionProperty("encrypt", "false")
+        .withConnectionProperty("databaseName", testdb.getDatabaseName())
+        .initialized();
+  }
+
+  public MsSQLTestDatabase(MSSQLServerContainer<?> container) {
+    super(container);
+  }
+
+  public MsSQLTestDatabase withSnapshotIsolation() {
+    return with("ALTER DATABASE %s SET ALLOW_SNAPSHOT_ISOLATION ON;", getDatabaseName());
+  }
+
+  public MsSQLTestDatabase withoutSnapshotIsolation() {
+    return with("ALTER DATABASE %s SET ALLOW_SNAPSHOT_ISOLATION OFF;", getDatabaseName());
+  }
+
+  public MsSQLTestDatabase withCdc() {
+    return with("EXEC sys.sp_cdc_enable_db;");
+  }
+
+  public MsSQLTestDatabase withoutCdc() {
+    return with("EXEC sys.sp_cdc_disable_db;");
+  }
+
+  public MsSQLTestDatabase withAgentStarted() {
+    return with("EXEC master.dbo.xp_servicecontrol N'START', N'SQLServerAGENT';");
+  }
+
+  public MsSQLTestDatabase withAgentStopped() {
+    return with("EXEC master.dbo.xp_servicecontrol N'STOP', N'SQLServerAGENT';");
+  }
+
+  public MsSQLTestDatabase withWaitUntilAgentRunning() {
+    waitForAgentState(true);
+    return self();
+  }
+
+  public MsSQLTestDatabase withWaitUntilAgentStopped() {
+    waitForAgentState(false);
+    return self();
+  }
+
+  private void waitForAgentState(final boolean running) {
+    final String expectedValue = running ? "Running." : "Stopped.";
+    LOGGER.debug("Waiting for SQLServerAgent state to change to '{}'.", expectedValue);
+    for (int i = 0; i < MAX_RETRIES; i++) {
+      try {
+        final var r = query(ctx -> ctx.fetch("EXEC master.dbo.xp_servicecontrol 'QueryState', N'SQLServerAGENT';").get(0));
+        if (expectedValue.equalsIgnoreCase(r.getValue(0).toString())) {
+          LOGGER.debug("SQLServerAgent state is '{}', as expected.", expectedValue);
+          return;
+        }
+        LOGGER.debug("Retrying, SQLServerAgent state {} does not match expected '{}'.", r, expectedValue);
+      } catch (SQLException e) {
+        LOGGER.debug("Retrying agent state query after catching exception {}.", e.getMessage());
+      }
+      try {
+        Thread.sleep(1_000); // Wait one second between retries.
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    throw new RuntimeException("Exhausted retry attempts while polling for agent state");
+  }
+
+  public MsSQLTestDatabase withWaitUntilMaxLsnAvailable() {
+    LOGGER.debug("Waiting for max LSN to become available for database {}.", getDatabaseName());
+    for (int i = 0; i < MAX_RETRIES; i++) {
+      try {
+        final var maxLSN = query(ctx -> ctx.fetch("SELECT sys.fn_cdc_get_max_lsn();").get(0).get(0, byte[].class));
+        if (maxLSN != null) {
+          LOGGER.debug("Max LSN available for database {}: {}", getDatabaseName(), Lsn.valueOf(maxLSN));
+          return self();
+        }
+        LOGGER.debug("Retrying, max LSN still not available for database {}.", getDatabaseName());
+      } catch (SQLException e) {
+        LOGGER.warn("Retrying max LSN query after catching exception {}", e.getMessage());
+      }
+      try {
+        Thread.sleep(1_000); // Wait one second between retries.
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    throw new RuntimeException("Exhausted retry attempts while polling for max LSN availability");
+  }
+
+  @Override
+  public String getPassword() {
+    return "S00p3rS33kr3tP4ssw0rd!";
+  }
+
+  @Override
+  public String getJdbcUrl() {
+    return String.format("jdbc:sqlserver://%s:%d", getContainer().getHost(), getContainer().getFirstMappedPort());
+  }
+
+  @Override
+  protected Stream<Stream<String>> inContainerBootstrapCmd() {
+    return Stream.of(
+        mssqlCmd(Stream.of(String.format("CREATE DATABASE %s", getDatabaseName()))),
+        mssqlCmd(Stream.of(
+            String.format("USE %s", getDatabaseName()),
+            String.format("CREATE LOGIN %s WITH PASSWORD = '%s', DEFAULT_DATABASE = %s", getUserName(), getPassword(), getDatabaseName()),
+            String.format("ALTER SERVER ROLE [sysadmin] ADD MEMBER %s", getUserName()),
+            String.format("CREATE USER %s FOR LOGIN %s WITH DEFAULT_SCHEMA = [dbo]", getUserName(), getUserName()),
+            String.format("ALTER ROLE [db_owner] ADD MEMBER %s", getUserName()))));
+  }
+
+  /**
+   * Don't drop anything when closing the test database. Instead, if cleanup is required, call
+   * {@link #dropDatabaseAndUser()} explicitly. Implicit cleanups may result in deadlocks and so
+   * aren't really worth it.
+   */
+  @Override
+  protected Stream<String> inContainerUndoBootstrapCmd() {
+    return Stream.empty();
+  }
+
+  public void dropDatabaseAndUser() {
+    execInContainer(mssqlCmd(Stream.of(
+        String.format("USE master"),
+        String.format("ALTER DATABASE %s SET single_user WITH ROLLBACK IMMEDIATE", getDatabaseName()),
+        String.format("DROP DATABASE %s", getDatabaseName()))));
+  }
+
+  public Stream<String> mssqlCmd(Stream<String> sql) {
+    return Stream.of("/opt/mssql-tools/bin/sqlcmd",
+        "-U", getContainer().getUsername(),
+        "-P", getContainer().getPassword(),
+        "-Q", sql.collect(Collectors.joining("; ")),
+        "-b", "-e");
+  }
+
+  @Override
+  public DatabaseDriver getDatabaseDriver() {
+    return DatabaseDriver.MSSQLSERVER;
+  }
+
+  @Override
+  public SQLDialect getSqlDialect() {
+    return SQLDialect.DEFAULT;
+  }
+
+  @Override
+  public MsSQLConfigBuilder configBuilder() {
+    return new MsSQLConfigBuilder(this);
+  }
+
+  static public class MsSQLConfigBuilder extends ConfigBuilder<MsSQLTestDatabase, MsSQLConfigBuilder> {
+
+    protected MsSQLConfigBuilder(MsSQLTestDatabase testDatabase) {
+      super(testDatabase);
+    }
+
+    public MsSQLConfigBuilder withCdcReplication() {
+      return with("replication_method", Map.of(
+          "method", "CDC",
+          "data_to_sync", "Existing and New",
+          "initial_waiting_seconds", DEFAULT_CDC_REPLICATION_INITIAL_WAIT.getSeconds(),
+          "snapshot_isolation", "Snapshot"));
+    }
+
+    public MsSQLConfigBuilder withSchemas(String... schemas) {
+      return with(JdbcUtils.SCHEMAS_KEY, List.of(schemas));
+    }
+
+    @Override
+    public MsSQLConfigBuilder withoutSsl() {
+      return withSsl(Map.of("ssl_method", "unencrypted"));
+    }
+
+    @Override
+    public MsSQLConfigBuilder withSsl(Map<Object, Object> sslMode) {
+      return with("ssl_method", sslMode);
+    }
+
+  }
+
+}


### PR DESCRIPTION
The recently added TestDatabase class is subclassed into MsSQLTestDatabase and added as a source-mssql test fixture and all integration- and most "unit" tests are redefined using it.