### PR TITLE
airbyte-ci: remove wonky PR diff detection

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
@@ -27,7 +27,6 @@ from pipelines.helpers.git import (
     get_current_git_revision,
     get_modified_files_in_branch,
     get_modified_files_in_commit,
-    get_modified_files_in_pull_request,
 )
 from pipelines.helpers.utils import get_current_epoch_time, transform_strs_to_paths
 
@@ -142,9 +141,7 @@ def set_working_directory_to_root() -> None:
     os.chdir(working_dir)
 
 
-async def get_modified_files(
-    git_branch: str, git_revision: str, diffed_branch: str, is_local: bool, ci_context: CIContext, pull_request: PullRequest
-) -> List[str]:
+async def get_modified_files(git_branch: str, git_revision: str, diffed_branch: str, is_local: bool, ci_context: CIContext) -> List[str]:
     """Get the list of modified files in the current git branch.
     If the current branch is master, it will return the list of modified files in the head commit.
     The head commit on master should be the merge commit of the latest merged pull request as we squash commits on merge.
@@ -154,15 +151,12 @@ async def get_modified_files(
     If the current branch is not master, it will return the list of modified files in the current branch.
     This latest case is the one we encounter when running the pipeline locally, on a local branch, or manually on GHA with a workflow dispatch event.
     """
-    if ci_context is CIContext.MASTER or ci_context is CIContext.NIGHTLY_BUILDS:
+    if (
+        ci_context is CIContext.MASTER
+        or ci_context is CIContext.NIGHTLY_BUILDS
+        or (ci_context is CIContext.MANUAL and git_branch == "master")
+    ):
         return await get_modified_files_in_commit(git_branch, git_revision, is_local)
-    if ci_context is CIContext.PULL_REQUEST and pull_request is not None:
-        return get_modified_files_in_pull_request(pull_request)
-    if ci_context is CIContext.MANUAL:
-        if git_branch == "master":
-            return await get_modified_files_in_commit(git_branch, git_revision, is_local)
-        else:
-            return await get_modified_files_in_branch(git_branch, git_revision, diffed_branch, is_local)
     return await get_modified_files_in_branch(git_branch, git_revision, diffed_branch, is_local)
 
 
@@ -251,7 +245,6 @@ async def get_modified_files_str(ctx: click.Context):
         ctx.obj["diffed_branch"],
         ctx.obj["is_local"],
         ctx.obj["ci_context"],
-        ctx.obj["pull_request"],
     )
     return transform_strs_to_paths(modified_files)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/git.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/git.py
@@ -3,11 +3,10 @@
 #
 
 import functools
-from typing import List, Set
+from typing import Set
 
 import git
 from dagger import Connection
-from github import PullRequest
 from pipelines.dagger.containers.git import checked_out_git_container
 from pipelines.helpers.utils import DAGGER_CONFIG, DIFF_FILTER
 
@@ -74,11 +73,6 @@ async def get_modified_files_in_commit(current_git_branch: str, current_git_revi
         return get_modified_files_in_commit_local(current_git_revision)
     else:
         return await get_modified_files_in_commit_remote(current_git_branch, current_git_revision)
-
-
-def get_modified_files_in_pull_request(pull_request: PullRequest) -> List[str]:
-    """Retrieve the list of modified files in a pull request."""
-    return [f.filename for f in pull_request.get_files()]
 
 
 @functools.cache


### PR DESCRIPTION
The pull request changeset detection in airbyte-ci is broken.
This is readily apparent in PRs which are based on other PRs instead of master.
Previously, only the changes in the PR itself were used, ignoring parent PRs.
This is a problem when doing java CDK development in a stack of PRs, we may have a situation where a parent PR modifies a connector by telling it to use the local CDK, and the child PR can have changes to the CDK which impact the connector in the parent PR, but the CI never tests this.

This PR fixes airbyte-ci by checking for changes all the way to the merge-base, to capture the full changeset.
