### PR TITLE
airbyte-ci: add missing env var to gradle format container

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
@@ -76,6 +76,7 @@ def format_java_container(dagger_client: dagger.Client) -> dagger.Container:
             "yum install -y findutils",  # gradle requires xargs, which is shipped in findutils.
             "yum clean all",
         ],
+        env_vars={"RUN_IN_AIRBYTE_CI": "1"},
     )
 
 


### PR DESCRIPTION
When called from airbyte-ci format, we want gradle to be aware it is running from within airbyte-ci.
