### PR TITLE
airbyte-ci: bump tag, update readme, remove 'nightly_builds'

### DIFF
--- a/.github/workflows/connectors_nightly_build.yml
+++ b/.github/workflows/connectors_nightly_build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Test connectors
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          context: "nightly_builds"
+          context: "master"
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}

--- a/.github/workflows/connectors_weekly_build.yml
+++ b/.github/workflows/connectors_weekly_build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Test connectors
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          context: "nightly_builds"
+          context: "master"
           ci_job_key: "weekly_alpha_test"
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -432,7 +432,8 @@ This command runs the Python tests for a airbyte-ci poetry package.
 
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
-| ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| ------- | ---------------------------------------------------------- |-----------------------------------------------------------------------------------------------------------|
+| 2.7.1   | [#32806](https://github.com/airbytehq/airbyte/pull/32806)  | Improve --modified behaviour for pull requests.                                                           |
 | 2.7.0   | [#31930](https://github.com/airbytehq/airbyte/pull/31930)  | Merge airbyte-ci-internal into airbyte-ci                                                                 |
 | 2.6.0   | [#31831](https://github.com/airbytehq/airbyte/pull/31831)  | Add `airbyte-ci format` commands, remove connector-specific formatting check                              |
 | 2.5.9   | [#32427](https://github.com/airbytehq/airbyte/pull/32427)  | Re-enable caching for source-postgres                                                                     |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -71,7 +71,7 @@ class VersionCheck(Step, ABC):
     async def _run(self) -> StepResult:
         if not self.should_run:
             return StepResult(self, status=StepStatus.SKIPPED, stdout="No modified files required a version bump.")
-        if self.context.ci_context in [CIContext.MASTER, CIContext.NIGHTLY_BUILDS]:
+        if self.context.ci_context == CIContext.MASTER:
             return StepResult(self, status=StepStatus.SKIPPED, stdout="Version check are not running in master context.")
         try:
             return self.validate()

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
@@ -76,6 +76,7 @@ def format_java_container(dagger_client: dagger.Client) -> dagger.Container:
             "yum install -y findutils",  # gradle requires xargs, which is shipped in findutils.
             "yum clean all",
         ],
+        env_vars={"RUN_IN_AIRBYTE_CI": "1"},
     )
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
@@ -27,7 +27,6 @@ from pipelines.helpers.git import (
     get_current_git_revision,
     get_modified_files_in_branch,
     get_modified_files_in_commit,
-    get_modified_files_in_pull_request,
 )
 from pipelines.helpers.utils import get_current_epoch_time, transform_strs_to_paths
 
@@ -142,9 +141,7 @@ def set_working_directory_to_root() -> None:
     os.chdir(working_dir)
 
 
-async def get_modified_files(
-    git_branch: str, git_revision: str, diffed_branch: str, is_local: bool, ci_context: CIContext, pull_request: PullRequest
-) -> List[str]:
+async def get_modified_files(git_branch: str, git_revision: str, diffed_branch: str, is_local: bool, ci_context: CIContext) -> List[str]:
     """Get the list of modified files in the current git branch.
     If the current branch is master, it will return the list of modified files in the head commit.
     The head commit on master should be the merge commit of the latest merged pull request as we squash commits on merge.
@@ -154,15 +151,12 @@ async def get_modified_files(
     If the current branch is not master, it will return the list of modified files in the current branch.
     This latest case is the one we encounter when running the pipeline locally, on a local branch, or manually on GHA with a workflow dispatch event.
     """
-    if ci_context is CIContext.MASTER or ci_context is CIContext.NIGHTLY_BUILDS:
+    if (
+        ci_context is CIContext.MASTER
+        or ci_context is CIContext.NIGHTLY_BUILDS
+        or (ci_context is CIContext.MANUAL and git_branch == "master")
+    ):
         return await get_modified_files_in_commit(git_branch, git_revision, is_local)
-    if ci_context is CIContext.PULL_REQUEST and pull_request is not None:
-        return get_modified_files_in_pull_request(pull_request)
-    if ci_context is CIContext.MANUAL:
-        if git_branch == "master":
-            return await get_modified_files_in_commit(git_branch, git_revision, is_local)
-        else:
-            return await get_modified_files_in_branch(git_branch, git_revision, diffed_branch, is_local)
     return await get_modified_files_in_branch(git_branch, git_revision, diffed_branch, is_local)
 
 
@@ -251,7 +245,6 @@ async def get_modified_files_str(ctx: click.Context):
         ctx.obj["diffed_branch"],
         ctx.obj["is_local"],
         ctx.obj["ci_context"],
-        ctx.obj["pull_request"],
     )
     return transform_strs_to_paths(modified_files)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
@@ -153,7 +153,6 @@ async def get_modified_files(git_branch: str, git_revision: str, diffed_branch: 
     """
     if (
         ci_context is CIContext.MASTER
-        or ci_context is CIContext.NIGHTLY_BUILDS
         or (ci_context is CIContext.MANUAL and git_branch == "master")
     ):
         return await get_modified_files_in_commit(git_branch, git_revision, is_local)

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
@@ -151,10 +151,7 @@ async def get_modified_files(git_branch: str, git_revision: str, diffed_branch: 
     If the current branch is not master, it will return the list of modified files in the current branch.
     This latest case is the one we encounter when running the pipeline locally, on a local branch, or manually on GHA with a workflow dispatch event.
     """
-    if (
-        ci_context is CIContext.MASTER
-        or (ci_context is CIContext.MANUAL and git_branch == "master")
-    ):
+    if ci_context is CIContext.MASTER or (ci_context is CIContext.MANUAL and git_branch == "master"):
         return await get_modified_files_in_commit(git_branch, git_revision, is_local)
     return await get_modified_files_in_branch(git_branch, git_revision, diffed_branch, is_local)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/airbyte_ci.py
@@ -10,7 +10,7 @@ import multiprocessing
 import os
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional, Set
 
 import asyncclick as click
 import docker
@@ -141,7 +141,7 @@ def set_working_directory_to_root() -> None:
     os.chdir(working_dir)
 
 
-async def get_modified_files(git_branch: str, git_revision: str, diffed_branch: str, is_local: bool, ci_context: CIContext) -> List[str]:
+async def get_modified_files(git_branch: str, git_revision: str, diffed_branch: str, is_local: bool, ci_context: CIContext) -> Set[str]:
     """Get the list of modified files in the current git branch.
     If the current branch is master, it will return the list of modified files in the head commit.
     The head commit on master should be the merge commit of the latest merged pull request as we squash commits on merge.

--- a/airbyte-ci/connectors/pipelines/pipelines/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/consts.py
@@ -58,7 +58,6 @@ class CIContext(str, Enum):
 
     MANUAL = "manual"
     PULL_REQUEST = "pull_request"
-    NIGHTLY_BUILDS = "nightly_builds"
     MASTER = "master"
 
     def __str__(self) -> str:

--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/containers/git.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/containers/git.py
@@ -1,7 +1,8 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 from typing import Optional
 
 from dagger import Client, Container
-
 from pipelines.helpers.utils import AIRBYTE_REPO_URL
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/containers/git.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/containers/git.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+from dagger import Client, Container
+
+from pipelines.helpers.utils import AIRBYTE_REPO_URL
+
+
+async def checked_out_git_container(
+    dagger_client: Client,
+    current_git_branch: str,
+    current_git_revision: str,
+    diffed_branch: Optional[str] = None,
+) -> Container:
+    """Builds git-based container with the current branch checked out."""
+    current_git_branch = current_git_branch.removeprefix("origin/")
+    diffed_branch = current_git_branch if diffed_branch is None else diffed_branch.removeprefix("origin/")
+    return await (
+        dagger_client.container()
+        .from_("alpine/git:latest")
+        .with_workdir("/repo")
+        .with_exec(["init"])
+        .with_env_variable("CACHEBUSTER", current_git_revision)
+        .with_exec(
+            [
+                "remote",
+                "add",
+                "--fetch",
+                "--track",
+                current_git_branch,
+                "--track",
+                diffed_branch if diffed_branch is not None else current_git_branch,
+                "origin",
+                AIRBYTE_REPO_URL,
+            ]
+        )
+        .with_exec(["checkout", "-t", f"origin/{current_git_branch}"])
+    )

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/git.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/git.py
@@ -3,11 +3,10 @@
 #
 
 import functools
-from typing import List, Set
+from typing import Set
 
 import git
 from dagger import Connection
-from github import PullRequest
 from pipelines.dagger.containers.git import checked_out_git_container
 from pipelines.helpers.utils import DAGGER_CONFIG, DIFF_FILTER
 
@@ -74,11 +73,6 @@ async def get_modified_files_in_commit(current_git_branch: str, current_git_revi
         return get_modified_files_in_commit_local(current_git_revision)
     else:
         return await get_modified_files_in_commit_remote(current_git_branch, current_git_revision)
-
-
-def get_modified_files_in_pull_request(pull_request: PullRequest) -> List[str]:
-    """Retrieve the list of modified files in a pull request."""
-    return [f.filename for f in pull_request.get_files()]
 
 
 @functools.cache

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/git.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/git.py
@@ -31,12 +31,10 @@ async def get_modified_files_in_branch_remote(
     return set(modified_files.split("\n"))
 
 
-def get_modified_files_in_branch_local(current_git_revision: str, diffed_branch: str = "master") -> Set[str]:
-    """Use git diff and git status to spot the modified files on the local branch."""
+def get_modified_files_local(current_git_revision: str, diffed: str = "master") -> Set[str]:
+    """Use git diff and git status to spot the modified files in the local repo."""
     airbyte_repo = git.Repo()
-    modified_files = airbyte_repo.git.diff(
-        f"--diff-filter={DIFF_FILTER}", "--name-only", f"{diffed_branch}...{current_git_revision}"
-    ).split("\n")
+    modified_files = airbyte_repo.git.diff(f"--diff-filter={DIFF_FILTER}", "--name-only", f"{diffed}...{current_git_revision}").split("\n")
     status_output = airbyte_repo.git.status("--porcelain")
     for not_committed_change in status_output.split("\n"):
         file_path = not_committed_change.strip().split(" ")[-1]
@@ -50,7 +48,7 @@ async def get_modified_files_in_branch(
 ) -> Set[str]:
     """Retrieve the list of modified files on the branch."""
     if is_local:
-        return get_modified_files_in_branch_local(current_git_revision, diffed_branch)
+        return get_modified_files_local(current_git_revision, diffed_branch)
     else:
         return await get_modified_files_in_branch_remote(current_git_branch, current_git_revision, diffed_branch)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/git.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/git.py
@@ -8,7 +8,6 @@ from typing import List, Set
 import git
 from dagger import Connection
 from github import PullRequest
-
 from pipelines.dagger.containers.git import checked_out_git_container
 from pipelines.helpers.utils import DAGGER_CONFIG, DIFF_FILTER
 

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
@@ -13,7 +13,7 @@ import sys
 import unicodedata
 from io import TextIOWrapper
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set, Tuple
 
 import anyio
 import asyncer
@@ -308,16 +308,16 @@ def sh_dash_c(lines: List[str]) -> List[str]:
     return ["sh", "-c", " && ".join(["set -o xtrace"] + lines)]
 
 
-def transform_strs_to_paths(str_paths: List[str]) -> List[Path]:
-    """Transform a list of string paths to a list of Path objects.
+def transform_strs_to_paths(str_paths: Set[str]) -> List[Path]:
+    """Transform a list of string paths to an ordered list of Path objects.
 
     Args:
-        str_paths (List[str]): A list of string paths.
+        str_paths (Set[str]): A set of string paths.
 
     Returns:
         List[Path]: A list of Path objects.
     """
-    return [Path(str_path) for str_path in str_paths]
+    return sorted([Path(str_path) for str_path in str_paths])
 
 
 def fail_if_missing_docker_hub_creds(ctx: click.Context):

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.7.0"
+version = "2.7.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
This PR gets rid of the "nightly_builds" CI_CONTEXT value.

~This PR changes the behaviour of --modified when CI_CONTEXT is "nightly_builds" or "weekly_builds".~

~Presently, when `--modified ` and either of those CI_CONTEXT values are set, airbyte-ci determines which connectors have been modified by looking only at which connectors were changed in whatever happens to be the HEAD commit on the master branch at that time. 
This is certainly not what anyone wants.~

~This PR changes this to look at the connectors changed in HEAD and all of its ancestors up until a certain date.
This cutoff date is '1 day ago' for nightlies and '1 week ago' for weeklies.~