### PR TITLE
airbyte-ci: custom tag on build

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -124,17 +124,17 @@ At this point you can run `airbyte-ci` commands.
 
 #### Options
 
-| Option                                     | Default value                                                                                                                    | Mapped environment variable   | Description                                                                                 |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
-| `--enable-dagger-run/--disable-dagger-run` | `--enable-dagger-run``      |                               | Disables the Dagger terminal UI. |                               | |                               |                                                                                             |
-| `--is-local/--is-ci`                       | `--is-local`                                                                                                                     |                               | Determines the environment in which the CLI runs: local environment or CI environment.      |
-| `--git-branch`                             | The checked out git branch name                                                                                                  | `CI_GIT_BRANCH`               | The git branch on which the pipelines will run.                                             |
-| `--git-revision`                           | The current branch head                                                                                                          | `CI_GIT_REVISION`             | The commit hash on which the pipelines will run.                                            |
-| `--diffed-branch`                          | `origin/master`                                                                                                                  |                               | Branch to which the git diff will happen to detect new or modified files.                   |
-| `--gha-workflow-run-id`                    |                                                                                                                                  |                               | GHA CI only - The run id of the GitHub action workflow                                      |
-| `--ci-context`                             | `manual`                                                                                                                         |                               | The current CI context: `manual` for manual run, `pull_request`, `nightly_builds`, `master` |
-| `--pipeline-start-timestamp`               | Current epoch time                                                                                                               | `CI_PIPELINE_START_TIMESTAMP` | Start time of the pipeline as epoch time. Used for pipeline run duration computation.       |
-| `--show-dagger-logs/--hide-dagger-logs`    | `--hide-dagger-logs`                                                                                                             |                               | Flag to show or hide the dagger logs.                                                       |
+| Option                                     | Default value                                                                                                                                                      | Mapped environment variable   | Description                                                                                 |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------- |
+| `--enable-dagger-run/--disable-dagger-run` | `--enable-dagger-run``      |                               | Disables the Dagger terminal UI. |                               | |                               | |                               |                                                                                             |
+| `--is-local/--is-ci`                       | `--is-local`                                                                                                                                                       |                               | Determines the environment in which the CLI runs: local environment or CI environment.      |
+| `--git-branch`                             | The checked out git branch name                                                                                                                                    | `CI_GIT_BRANCH`               | The git branch on which the pipelines will run.                                             |
+| `--git-revision`                           | The current branch head                                                                                                                                            | `CI_GIT_REVISION`             | The commit hash on which the pipelines will run.                                            |
+| `--diffed-branch`                          | `origin/master`                                                                                                                                                    |                               | Branch to which the git diff will happen to detect new or modified files.                   |
+| `--gha-workflow-run-id`                    |                                                                                                                                                                    |                               | GHA CI only - The run id of the GitHub action workflow                                      |
+| `--ci-context`                             | `manual`                                                                                                                                                           |                               | The current CI context: `manual` for manual run, `pull_request`, `nightly_builds`, `master` |
+| `--pipeline-start-timestamp`               | Current epoch time                                                                                                                                                 | `CI_PIPELINE_START_TIMESTAMP` | Start time of the pipeline as epoch time. Used for pipeline run duration computation.       |
+| `--show-dagger-logs/--hide-dagger-logs`    | `--hide-dagger-logs`                                                                                                                                               |                               | Flag to show or hide the dagger logs.                                                       |
 
 ### <a id="connectors-command-subgroup"></a>`connectors` command subgroup
 
@@ -254,6 +254,9 @@ It's mainly purposed for local use.
 Build a single connector:
 `airbyte-ci connectors --name=source-pokeapi build`
 
+Build a single connector with a custom image tag:
+`airbyte-ci connectors --name=source-pokeapi build --tag=my-custom-tag`
+
 Build a single connector for multiple architectures:
 `airbyte-ci connectors --name=source-pokeapi build --architecture=linux/amd64 --architecture=linux/arm64`
 
@@ -303,6 +306,8 @@ flowchart TD
 | Option                | Multiple | Default value  | Description                                                       |
 | --------------------- | -------- | -------------- | ----------------------------------------------------------------- |
 | `--architecture`/`-a` | True     | Local platform | Defines for which architecture the connector image will be built. |
+| `--tag`               | False    | `dev`          | Image tag for the built image.                                    |
+
 
 ### <a id="connectors-publish-command"></a>`connectors publish` command
 Run a publish pipeline for one or multiple connectors.
@@ -442,13 +447,14 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 2.10.0  | [#32819](https://github.com/airbytehq/airbyte/pull/32819)  | Add `--tag` option to connector build.                                                                    |
 | 2.9.0   | [#32816](https://github.com/airbytehq/airbyte/pull/32816)  | Add `--architecture` option to connector build.                                                           |
 | 2.8.0   | [#31930](https://github.com/airbytehq/airbyte/pull/31930)  | Move pipx install to `airbyte-ci-dev`, and add auto-update feature targeting binary                       |
-| 2.7.3   | [#32847](https://github.com/airbytehq/airbyte/pull/32847)  | Improve --modified behaviour for pull requests.                                                            |
+| 2.7.3   | [#32847](https://github.com/airbytehq/airbyte/pull/32847)  | Improve --modified behaviour for pull requests.                                                           |
 | 2.7.2   | [#32839](https://github.com/airbytehq/airbyte/pull/32839)  | Revert changes in v2.7.1.                                                                                 |
-| 2.7.1   | [#32806](https://github.com/airbytehq/airbyte/pull/32806)  | Improve --modified behaviour for pull requests.                                                            |
+| 2.7.1   | [#32806](https://github.com/airbytehq/airbyte/pull/32806)  | Improve --modified behaviour for pull requests.                                                           |
 | 2.7.0   | [#31930](https://github.com/airbytehq/airbyte/pull/31930)  | Merge airbyte-ci-internal into airbyte-ci                                                                 |
-| 2.6.0   | [#31831](https://github.com/airbytehq/airbyte/pull/31831)  | Add `airbyte-ci format` commands, remove connector-specific formatting check                               |
+| 2.6.0   | [#31831](https://github.com/airbytehq/airbyte/pull/31831)  | Add `airbyte-ci format` commands, remove connector-specific formatting check                              |
 | 2.5.9   | [#32427](https://github.com/airbytehq/airbyte/pull/32427)  | Re-enable caching for source-postgres                                                                     |
 | 2.5.8   | [#32402](https://github.com/airbytehq/airbyte/pull/32402)  | Set Dagger Cloud token for airbyters only                                                                 |
 | 2.5.7   | [#31628](https://github.com/airbytehq/airbyte/pull/31628)  | Add ClickPipelineContext class                                                                            |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/commands.py
@@ -31,8 +31,15 @@ from pipelines.consts import BUILD_PLATFORMS, LOCAL_BUILD_PLATFORM
     default=[LOCAL_BUILD_PLATFORM],
     type=click.Choice(BUILD_PLATFORMS, case_sensitive=True),
 )
+@click.option(
+    "-t",
+    "--tag",
+    help="The tag to use for the built image.",
+    default="dev",
+    type=str,
+)
 @click.pass_context
-async def build(ctx: click.Context, use_host_gradle_dist_tar: bool, build_architectures: List[str]) -> bool:
+async def build(ctx: click.Context, use_host_gradle_dist_tar: bool, build_architectures: List[str], tag: str) -> bool:
     """Runs a build pipeline for the selected connectors."""
     build_platforms = [dagger.Platform(architecture) for architecture in build_architectures]
     main_logger.info(f"Building connectors for {build_platforms}, use --architecture to change this.")
@@ -69,6 +76,7 @@ async def build(ctx: click.Context, use_host_gradle_dist_tar: bool, build_archit
         ctx.obj["concurrency"],
         ctx.obj["dagger_logs_path"],
         ctx.obj["execute_timeout"],
+        tag,
     )
 
     return True

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/__init__.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/__init__.py
@@ -32,12 +32,15 @@ async def run_connector_build(context: ConnectorContext) -> StepResult:
     return await LANGUAGE_BUILD_CONNECTOR_MAPPING[context.connector.language](context)
 
 
-async def run_connector_build_pipeline(context: ConnectorContext, semaphore: anyio.Semaphore) -> ConnectorReport:
+async def run_connector_build_pipeline(
+    context: ConnectorContext, semaphore: anyio.Semaphore, image_tag: str
+) -> ConnectorReport:
     """Run a build pipeline for a single connector.
 
     Args:
         context (ConnectorContext): The initialized connector context.
         semaphore (anyio.Semaphore): The semaphore to use to limit the number of concurrent builds.
+        image_tag (str): The tag to use for the built image.
     Returns:
         ConnectorReport: The reports holding builds results.
     """
@@ -48,7 +51,7 @@ async def run_connector_build_pipeline(context: ConnectorContext, semaphore: any
             per_platform_built_containers = build_result.output_artifact
             step_results.append(build_result)
             if context.is_local and build_result.status is StepStatus.SUCCESS:
-                load_image_result = await LoadContainerToLocalDockerHost(context, per_platform_built_containers).run()
+                load_image_result = await LoadContainerToLocalDockerHost(context, per_platform_built_containers, image_tag).run()
                 step_results.append(load_image_result)
             context.report = ConnectorReport(context, step_results, name="BUILD RESULTS")
         return context.report

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.9.0"
+version = "2.10.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_build_image/test_steps/test_common.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_build_image/test_steps/test_common.py
@@ -54,16 +54,17 @@ class TestLoadContainerToLocalDockerHost:
 
     async def test_run(self, test_context, step):
         """Test that the step runs successfully and that the image is loaded in the local docker host."""
+        assert step.image_tag == "dev"
         docker_client = docker.from_env()
-        step.IMAGE_TAG = "test-load-container"
+        step.image_tag = "test-load-container"
         try:
-            docker_client.images.remove(f"{test_context.connector.metadata['dockerRepository']}:{step.IMAGE_TAG}")
+            docker_client.images.remove(f"{test_context.connector.metadata['dockerRepository']}:{step.image_tag}")
         except docker.errors.ImageNotFound:
             pass
         result = await step.run()
         assert result.status is StepStatus.SUCCESS
-        docker_client.images.get(f"{test_context.connector.metadata['dockerRepository']}:{step.IMAGE_TAG}")
-        docker_client.images.remove(f"{test_context.connector.metadata['dockerRepository']}:{step.IMAGE_TAG}")
+        docker_client.images.get(f"{test_context.connector.metadata['dockerRepository']}:{step.image_tag}")
+        docker_client.images.remove(f"{test_context.connector.metadata['dockerRepository']}:{step.image_tag}")
 
     async def test_run_export_failure(self, step, mocker):
         """Test that the step fails if the export of the container fails."""


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Closes #31921
We want to allow `airbyte-ci` users to set a custom tag on locally built connector images

## How
* add a `--tag` option to `connector build`, defaults to `dev`
* Refactor downstream steps to propagate the option value
