### PR TITLE
bump breaking change upgrade deadlines

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -24,7 +24,7 @@ data:
     breakingChanges:
       2.0.0:
         message: "Deprecated FBA reports will be removed permanently from Cloud and Brand Analytics Reports will be removed temporarily. Updates on Brand Analytics Reports can be tracked here: [#32353](https://github.com/airbytehq/airbyte/issues/32353)"
-        upgradeDeadline: "2023-11-29"
+        upgradeDeadline: "2023-12-11"
   supportLevel: community
   tags:
     - language:python

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -43,7 +43,7 @@ data:
         message: >
           Version 2.0.0 updates schemas for all hourly reports (end in report_hourly), and the following streams: Accounts, Campaigns, Search Query Performance Report, AppInstallAds, AppInstallAdLabels, Labels, Campaign Labels, Keyword Labels, Ad Group Labels, Keywords, and Budget Summary Report.
           Users will need to refresh the source schema and reset affected streams after upgrading.
-        upgradeDeadline: "2023-11-29"
+        upgradeDeadline: "2023-12-11"
   suggestedStreams:
     streams:
       - campaigns

--- a/airbyte-integrations/connectors/source-faker/source_faker/spec.json
+++ b/airbyte-integrations/connectors/source-faker/source_faker/spec.json
@@ -8,7 +8,7 @@
     "additionalProperties": true,
     "properties": {
       "count": {
-        "title": "Count",
+        "title": "Count again",
         "description": "How many users should be generated in total.  This setting does not apply to the purchases or products stream.",
         "type": "integer",
         "minimum": 1,

--- a/airbyte-integrations/connectors/source-faker/source_faker/spec.json
+++ b/airbyte-integrations/connectors/source-faker/source_faker/spec.json
@@ -8,7 +8,7 @@
     "additionalProperties": true,
     "properties": {
       "count": {
-        "title": "Count again",
+        "title": "Count",
         "description": "How many users should be generated in total.  This setting does not apply to the purchases or products stream.",
         "type": "integer",
         "minimum": 1,

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -25,7 +25,7 @@ data:
         message:
           This release introduces a default primary key for the streams UserLifetimeInsights and UserInsights.
           Additionally, the format of timestamp fields has been updated in the UserLifetimeInsights, UserInsights, Media and Stories streams to include timezone information.
-        upgradeDeadline: "2023-12-03"
+        upgradeDeadline: "2023-12-11"
   suggestedStreams:
     streams:
       - media

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -37,7 +37,7 @@ data:
         message:
           Version 5.0.0 introduces fixes for the `CheckoutSessions`, `CheckoutSessionsLineItems` and `Refunds` streams. The cursor field is changed for the `CheckoutSessionsLineItems` and `Refunds` streams. This will prevent data loss during incremental syncs.
           Also, the `Invoices`, `Subscriptions` and `SubscriptionSchedule` stream schemas have been updated.
-        upgradeDeadline: "2023-11-30"
+        upgradeDeadline: "2023-12-11"
   suggestedStreams:
     streams:
       - customers


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

Some email notifications were missed from being sent out. This bumps the upgrade deadline for affected breaking changes to give users ample time to upgrade after receiving the notification.

The affected connectors are:

- Amazon Seller Partner (email date: nov 16, OG deadline: nov 29)
- Stripe (email: nov 16, deadline: nov 30)
- Instagram (email: nov 17, deadline: dec 3)
- Bing ads (email: nov 17, deadline: nov 29)

## How

Bump deadline to december 11 for affected connectors. After this is in we should:
- Update deadlines in DB
- Regenerate emails
- Send emails
