### PR TITLE
✨Destination Teradata: Added ENCRYPTDATA=ON for non-TLS connections for airbyte cloud

### DIFF
--- a/airbyte-integrations/connectors/destination-teradata/Dockerfile
+++ b/airbyte-integrations/connectors/destination-teradata/Dockerfile
@@ -22,5 +22,5 @@ ENV APPLICATION destination-teradata
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/destination-teradata

--- a/airbyte-integrations/connectors/destination-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-teradata/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 58e6f9da-904e-11ed-a1eb-0242ac120002
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.4
   dockerRepository: airbyte/destination-teradata
   githubIssueLabel: destination-teradata
   icon: teradata.svg

--- a/airbyte-integrations/connectors/destination-teradata/src/main/java/io/airbyte/integrations/destination/teradata/TeradataDestination.java
+++ b/airbyte-integrations/connectors/destination-teradata/src/main/java/io/airbyte/integrations/destination/teradata/TeradataDestination.java
@@ -73,9 +73,8 @@ public class TeradataDestination extends AbstractJdbcDestination implements Dest
             } else {
                 additionalParameters.put(PARAM_SSLMODE, REQUIRE);
             }
-        } else {
-       	     additionalParameters.put(ENCRYPTDATA, ENCRYPTDATA_ON);
-    	}
+        } 
+       	additionalParameters.put(ENCRYPTDATA, ENCRYPTDATA_ON);
         return additionalParameters;
     }
 

--- a/airbyte-integrations/connectors/destination-teradata/src/main/java/io/airbyte/integrations/destination/teradata/TeradataDestination.java
+++ b/airbyte-integrations/connectors/destination-teradata/src/main/java/io/airbyte/integrations/destination/teradata/TeradataDestination.java
@@ -50,6 +50,10 @@ public class TeradataDestination extends AbstractJdbcDestination implements Dest
 
     protected static final String CA_CERT_KEY = "ssl_ca_certificate";
 
+    protected static final String ENCRYPTDATA = "ENCRYPTDATA";
+
+    protected static final String ENCRYPTDATA_ON = "ON";
+
     public static void main(String[] args) throws Exception {
         new IntegrationRunner(new TeradataDestination()).run(args);
     }
@@ -69,7 +73,9 @@ public class TeradataDestination extends AbstractJdbcDestination implements Dest
             } else {
                 additionalParameters.put(PARAM_SSLMODE, REQUIRE);
             }
-        }
+        } else {
+       	     additionalParameters.put(ENCRYPTDATA, ENCRYPTDATA_ON);
+    	}
         return additionalParameters;
     }
 

--- a/docs/integrations/destinations/teradata.md
+++ b/docs/integrations/destinations/teradata.md
@@ -6,17 +6,17 @@ This page guides you through the process of setting up the Teradata destination 
 
 To use the Teradata destination connector, you'll need:
 
-* Access to a Teradata Vantage instance
+- Access to a Teradata Vantage instance
 
-    **Note:** If you need a new instance of Vantage, you can install a free version called Vantage Express in the cloud on [Google Cloud](https://quickstarts.teradata.com/vantage.express.gcp.html), [Azure](https://quickstarts.teradata.com/run-vantage-express-on-microsoft-azure.html), and [AWS](https://quickstarts.teradata.com/run-vantage-express-on-aws.html). You can also run Vantage Express on your local machine using [VMware](https://quickstarts.teradata.com/getting.started.vmware.html), [VirtualBox](https://quickstarts.teradata.com/getting.started.vbox.html), or [UTM](https://quickstarts.teradata.com/getting.started.utm.html).
+  **Note:** If you need a new instance of Vantage, you can install a free version called Vantage Express in the cloud on [Google Cloud](https://quickstarts.teradata.com/vantage.express.gcp.html), [Azure](https://quickstarts.teradata.com/run-vantage-express-on-microsoft-azure.html), and [AWS](https://quickstarts.teradata.com/run-vantage-express-on-aws.html). You can also run Vantage Express on your local machine using [VMware](https://quickstarts.teradata.com/getting.started.vmware.html), [VirtualBox](https://quickstarts.teradata.com/getting.started.vbox.html), or [UTM](https://quickstarts.teradata.com/getting.started.utm.html).
 
 You'll need the following information to configure the Teradata destination:
 
-* **Host** - The host name of the Teradata Vantage instance.
-* **Username**
-* **Password**
-* **Default Schema Name** - Specify the schema (or several schemas separated by commas) to be set in the search-path. These schemas will be used to resolve unqualified object names used in statements executed over this connection.
-* **JDBC URL Params** (optional)
+- **Host** - The host name of the Teradata Vantage instance.
+- **Username**
+- **Password**
+- **Default Schema Name** - Specify the schema (or several schemas separated by commas) to be set in the search-path. These schemas will be used to resolve unqualified object names used in statements executed over this connection.
+- **JDBC URL Params** (optional)
 
 [Refer to this guide for more details](https://downloads.teradata.com/doc/connectivity/jdbc/reference/current/jdbcug_chapter_2.html#BGBHDDGB)
 
@@ -26,23 +26,23 @@ You'll need the following information to configure the Teradata destination:
 
 Each stream will be output into its own table in Teradata. Each table will contain 3 columns:
 
-* `_airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed. The column type in Teradata is `VARCHAR(256)`.
-* `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source. The column type in Teradata is `TIMESTAMP(6)`.
-* `_airbyte_data`: a json blob representing with the event data. The column type in Teradata is `JSON`.
-
+- `_airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed. The column type in Teradata is `VARCHAR(256)`.
+- `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source. The column type in Teradata is `TIMESTAMP(6)`.
+- `_airbyte_data`: a json blob representing with the event data. The column type in Teradata is `JSON`.
 
 ### Features
 
 The Teradata destination connector supports the
 following[ sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
 
+| Feature                        | Supported?\(Yes/No\) | Notes |
+| :----------------------------- | :------------------- | :---- |
+| Full Refresh Sync              | Yes                  |       |
+| Incremental - Append Sync      | Yes                  |       |
+| Incremental - Append + Deduped | No                   |       |
+| Namespaces                     | Yes                  |       |
 
-| Feature | Supported?\(Yes/No\) | Notes |
-| :--- | :--- | :--- |
-| Full Refresh Sync | Yes |  |
-| Incremental - Append Sync | Yes |  |
-| Incremental - Deduped History | No |  |
-| Namespaces | Yes |  |
+The Teradata destination connector supports [ DBT custom transformation](https://docs.airbyte.com/operator-guides/transformation-and-normalization/transformations-with-airbyte/) type. Teradata DBT Docker image is available at https://hub.docker.com/r/teradata/dbt-teradata.
 
 ### Performance considerations
 
@@ -52,8 +52,8 @@ following[ sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-s
 
 You need a Teradata user with the following permissions:
 
-* can create tables and write permission.
-* can create schemas e.g:
+- can create tables and write permission.
+- can create schemas e.g:
 
 You can create such a user by running:
 
@@ -64,6 +64,7 @@ GRANT ALL on dbc to airbyte_user;
 ```
 
 You can also use a pre-existing user but we highly recommend creating a dedicated user for Airbyte.
+
 ### Setup guide
 
 #### Set up the Teradata Destination connector
@@ -83,7 +84,10 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 ## CHANGELOG
 
-| Version | Date       | Pull Request                                                  | Subject                          |
-|:--------|:-----------|:--------------------------------------------------------------|:---------------------------------|
-| 0.1.0   | 2022-12-13 | https://github.com/airbytehq/airbyte/pull/20428			   | New Destination Teradata Vantage |
-| 0.1.1   | 2023-03-03 | https://github.com/airbytehq/airbyte/pull/21760			   | Added SSL support                |
+| Version | Date       | Pull Request                                    | Subject                                   |
+| :------ | :--------- | :---------------------------------------------- | :---------------------------------------- |
+| 0.1.4   | 2023-12-04 | https://github.com/airbytehq/airbyte/pull/28667 | Make connector available on Airbyte Cloud |
+| 0.1.3   | 2023-08-17 | https://github.com/airbytehq/airbyte/pull/30740 | Enable custom DBT transformation          |
+| 0.1.2   | 2023-08-09 | https://github.com/airbytehq/airbyte/pull/29174 | Small internal refactor                   |
+| 0.1.1   | 2023-03-03 | https://github.com/airbytehq/airbyte/pull/21760 | Added SSL support                         |
+| 0.1.0   | 2022-12-13 | https://github.com/airbytehq/airbyte/pull/20428 | New Destination Teradata Vantage          |


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*
 Enabled TeraGSS-based encryption using ENCRYPTDATA=ON for airbyte connections to make connections secure on airbyte cloud.
Ref: https://github.com/airbytehq/airbyte/pull/28667 

## How
Currently, TLS is still an optional component for Teradata Vantage Cloud and Vantage Core. Customers using TeraGSS-based encryption for non-TLS connections on Teradata Vantage and Core. So, to support Teradata connector on airbyte cloud with secure connections, enabling TeraGSS-based encryption with ENCRYPTDATA=ON for connections making to teradata from airbyte.
When ENCRYPTDATA=ON, data exchanged between the Teradata JDBC Driver and the database is encrypted. This provides greater security, though performance is impacted.
https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/jdbcug_chapter_2.html#URL_ENCRYPTDATA

## Recommended reading order
1. `airbyte-integrations/connectors/destination-teradata/src/main/java/io/airbyte/integrations/destination/teradata/TeradataDestination.java`

## 🚨 User Impact 🚨
No Breaking changes.

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
