### PR TITLE
Remove facebook pages from cloud registry

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
@@ -17,7 +17,7 @@ data:
   name: Facebook Pages
   registries:
     cloud:
-      enabled: false  # hide from cloud until https://github.com/airbytehq/airbyte/issues/25515 is finished
+      enabled: false # hide from cloud until https://github.com/airbytehq/airbyte/issues/25515 is finished
     oss:
       enabled: true
   releaseStage: beta

--- a/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
@@ -17,7 +17,7 @@ data:
   name: Facebook Pages
   registries:
     cloud:
-      enabled: true
+      enabled: false  # hide from cloud until https://github.com/airbytehq/airbyte/issues/25515 is finished
     oss:
       enabled: true
   releaseStage: beta


### PR DESCRIPTION
Facebook pages needs to be updated to a new API version for successful connectors. It's currently hidden from cloud, but it is still listed as available in cloud, because we thought it would be migrated during hacktoberfest. 

Removing this from the cloud registry until a fix is available.

Ref: https://github.com/airbytehq/airbyte/issues/25515