### PR TITLE
simplify postgres base images

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractPostgresSourceSSLCertificateAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractPostgresSourceSSLCertificateAcceptanceTest.java
@@ -41,7 +41,7 @@ public abstract class AbstractPostgresSourceSSLCertificateAcceptanceTest extends
 
   @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
-    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE, ContainerModifier.CERT)
+    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16, ContainerModifier.CERT)
         .with("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200));")
         .with("INSERT INTO id_and_name (id, name) VALUES (1,'picard'),  (2, 'crusher'), (3, 'vash');")
         .with("CREATE TABLE starships(id INTEGER, name VARCHAR(200));")

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractSshPostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractSshPostgresSourceAcceptanceTest.java
@@ -86,7 +86,7 @@ public abstract class AbstractSshPostgresSourceAcceptanceTest extends AbstractPo
   // requiring data to already be in place.
   @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
-    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE, ContainerModifier.NETWORK);
+    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16, ContainerModifier.NETWORK);
     bastion.initAndStartBastion(testdb.getContainer().getNetwork());
     populateDatabaseTestData();
   }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CDCPostgresSourceCaCertificateSslAcceptanceLegacyCtidTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CDCPostgresSourceCaCertificateSslAcceptanceLegacyCtidTest.java
@@ -10,7 +10,7 @@ public class CDCPostgresSourceCaCertificateSslAcceptanceLegacyCtidTest extends C
 
   @Override
   protected BaseImage getServerImage() {
-    return BaseImage.POSTGRES_12_BULLSEYE;
+    return BaseImage.POSTGRES_12;
   }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CDCPostgresSourceCaCertificateSslAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CDCPostgresSourceCaCertificateSslAcceptanceTest.java
@@ -20,7 +20,7 @@ public class CDCPostgresSourceCaCertificateSslAcceptanceTest extends AbstractCdc
 
   @Override
   protected BaseImage getServerImage() {
-    return BaseImage.POSTGRES_16_BULLSEYE;
+    return BaseImage.POSTGRES_16;
   }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CDCPostgresSourceFullCertificateSslAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CDCPostgresSourceFullCertificateSslAcceptanceTest.java
@@ -24,7 +24,7 @@ public class CDCPostgresSourceFullCertificateSslAcceptanceTest extends AbstractC
 
   @Override
   protected BaseImage getServerImage() {
-    return BaseImage.POSTGRES_16_BULLSEYE;
+    return BaseImage.POSTGRES_16;
   }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcInitialSnapshotPostgresSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcInitialSnapshotPostgresSourceDatatypeTest.java
@@ -25,7 +25,7 @@ public class CdcInitialSnapshotPostgresSourceDatatypeTest extends AbstractPostgr
 
   @Override
   protected Database setupDatabase() throws Exception {
-    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE, ContainerModifier.CONF)
+    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16, ContainerModifier.CONF)
         .with("CREATE EXTENSION hstore;")
         .with("CREATE SCHEMA TEST;")
         .with("CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');")

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcPostgresSourceAcceptanceLegacyCtidTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcPostgresSourceAcceptanceLegacyCtidTest.java
@@ -10,7 +10,7 @@ public class CdcPostgresSourceAcceptanceLegacyCtidTest extends CdcPostgresSource
 
   @Override
   protected BaseImage getServerImage() {
-    return BaseImage.POSTGRES_12_BULLSEYE;
+    return BaseImage.POSTGRES_12;
   }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcPostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcPostgresSourceAcceptanceTest.java
@@ -171,7 +171,7 @@ public class CdcPostgresSourceAcceptanceTest extends AbstractPostgresSourceAccep
   }
 
   protected BaseImage getServerImage() {
-    return BaseImage.POSTGRES_16_BULLSEYE;
+    return BaseImage.POSTGRES_16;
   }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcWalLogsPostgresSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcWalLogsPostgresSourceDatatypeTest.java
@@ -73,7 +73,7 @@ public class CdcWalLogsPostgresSourceDatatypeTest extends AbstractPostgresSource
 
   @Override
   protected Database setupDatabase() {
-    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE, ContainerModifier.CONF)
+    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16, ContainerModifier.CONF)
         .with("CREATE EXTENSION hstore;")
         .with("CREATE SCHEMA TEST;")
         .with("CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');")

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CloudDeploymentPostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CloudDeploymentPostgresSourceAcceptanceTest.java
@@ -51,7 +51,7 @@ public class CloudDeploymentPostgresSourceAcceptanceTest extends SourceAcceptanc
 
   @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
-    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE, ContainerModifier.CERT);
+    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16, ContainerModifier.CERT);
     testdb.query(ctx -> {
       ctx.fetch("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200));");
       ctx.fetch("INSERT INTO id_and_name (id, name) VALUES (1,'picard'),  (2, 'crusher'), (3, 'vash');");

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceAcceptanceLegacyCtidTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceAcceptanceLegacyCtidTest.java
@@ -10,7 +10,7 @@ public class PostgresSourceAcceptanceLegacyCtidTest extends PostgresSourceAccept
 
   @Override
   protected BaseImage getServerImage() {
-    return BaseImage.POSTGRES_12_BULLSEYE;
+    return BaseImage.POSTGRES_12;
   }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceAcceptanceTest.java
@@ -202,7 +202,7 @@ public class PostgresSourceAcceptanceTest extends AbstractPostgresSourceAcceptan
   }
 
   protected BaseImage getServerImage() {
-    return BaseImage.POSTGRES_16_BULLSEYE;
+    return BaseImage.POSTGRES_16;
   }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceDatatypeTest.java
@@ -22,7 +22,7 @@ public class PostgresSourceDatatypeTest extends AbstractPostgresSourceDatatypeTe
 
   @Override
   protected Database setupDatabase() throws SQLException {
-    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE, ContainerModifier.CONF)
+    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16, ContainerModifier.CONF)
         .with("CREATE SCHEMA %S;", SCHEMA_NAME)
         .with("CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');")
         .with("CREATE TYPE inventory_item AS (name text, supplier_id integer, price numeric);")

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/XminPostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/XminPostgresSourceAcceptanceTest.java
@@ -47,7 +47,7 @@ public class XminPostgresSourceAcceptanceTest extends AbstractPostgresSourceAcce
 
   @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
-    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_12_BULLSEYE)
+    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_12)
         .with("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200));")
         .with("INSERT INTO id_and_name (id, name) VALUES (1,'picard'),  (2, 'crusher'), (3, 'vash');")
         .with("CREATE TABLE starships(id INTEGER, name VARCHAR(200));")

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
@@ -891,7 +891,7 @@ public class CdcPostgresSourceTest extends CdcSourceTest<PostgresSource, Postgre
   }
 
   protected static BaseImage getServerImage() {
-    return BaseImage.POSTGRES_16_BULLSEYE;
+    return BaseImage.POSTGRES_16;
   }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CloudDeploymentPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CloudDeploymentPostgresSourceTest.java
@@ -38,7 +38,7 @@ public class CloudDeploymentPostgresSourceTest {
 
   @BeforeAll
   static void setupContainers() {
-    DB_NO_SSL_WITH_NETWORK = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE, ContainerModifier.NETWORK);
+    DB_NO_SSL_WITH_NETWORK = PostgresTestDatabase.in(BaseImage.POSTGRES_16, ContainerModifier.NETWORK);
     NETWORK_NO_SSL = DB_NO_SSL_WITH_NETWORK.getContainer().getNetwork();
     BASTION_NO_SSL = new SshBastionContainer();
     BASTION_NO_SSL.initAndStartBastion(NETWORK_NO_SSL);

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresCdcGetPublicizedTablesTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresCdcGetPublicizedTablesTest.java
@@ -28,7 +28,7 @@ class PostgresCdcGetPublicizedTablesTest {
 
   @BeforeEach
   void setup() {
-    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE, ContainerModifier.CONF)
+    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16, ContainerModifier.CONF)
         .with("create table table_1 (id serial primary key, text_column text);")
         .with("create table table_2 (id serial primary key, text_column text);")
         .with("create table table_irrelevant (id serial primary key, text_column text);")

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresJdbcSourceAcceptanceTest.java
@@ -90,7 +90,7 @@ class PostgresJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest<Postgres
 
   @Override
   protected PostgresTestDatabase createTestDatabase() {
-    return PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE);
+    return PostgresTestDatabase.in(BaseImage.POSTGRES_16);
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceOperationsTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceOperationsTest.java
@@ -35,7 +35,7 @@ class PostgresSourceOperationsTest {
 
   @BeforeEach
   public void init() {
-    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE, ContainerModifier.CONF);
+    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16, ContainerModifier.CONF);
   }
 
   @AfterEach

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -137,7 +137,7 @@ class PostgresSourceTest {
 
   @BeforeEach
   void setup() {
-    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE)
+    testdb = PostgresTestDatabase.in(BaseImage.POSTGRES_16)
         .with("CREATE TABLE id_and_name(id NUMERIC(20, 10) NOT NULL, name VARCHAR(200) NOT NULL, power double precision NOT NULL, PRIMARY KEY (id));")
         .with("CREATE INDEX i1 ON id_and_name (id);")
         .with("INSERT INTO id_and_name (id, name, power) VALUES (1,'goku', 'Infinity'), (2, 'vegeta', 9000.1), ('NaN', 'piccolo', '-Infinity');")
@@ -225,7 +225,7 @@ class PostgresSourceTest {
   public void testCanReadUtf8() throws Exception {
     // force the db server to start with sql_ascii encoding to verify the source can read UTF8 even when
     // default settings are in another encoding
-    try (final var asciiTestDB = PostgresTestDatabase.in(BaseImage.POSTGRES_16_BULLSEYE, ContainerModifier.ASCII)
+    try (final var asciiTestDB = PostgresTestDatabase.in(BaseImage.POSTGRES_16, ContainerModifier.ASCII)
         .with("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200));")
         .with("INSERT INTO id_and_name (id, name) VALUES (1,E'\\u2013 someutfstring'),  (2, E'\\u2215');")) {
       final var config = asciiTestDB.testConfigBuilder().withSchemas(SCHEMA_NAME).withoutSsl().build();

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/XminPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/XminPostgresSourceTest.java
@@ -92,7 +92,7 @@ class XminPostgresSourceTest {
   protected PostgresTestDatabase testdb;
 
   protected BaseImage getDatabaseImage() {
-    return BaseImage.POSTGRES_12_BULLSEYE;
+    return BaseImage.POSTGRES_12;
   }
 
   @BeforeEach

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/XminPostgresWithOldServerSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/XminPostgresWithOldServerSourceTest.java
@@ -27,7 +27,7 @@ public class XminPostgresWithOldServerSourceTest extends XminPostgresSourceTest 
 
   @Override
   protected BaseImage getDatabaseImage() {
-    return BaseImage.POSTGRES_9_ALPINE;
+    return BaseImage.POSTGRES_9;
   }
 
   @Test

--- a/airbyte-integrations/connectors/source-postgres/src/testFixtures/java/io/airbyte/integrations/source/postgres/PostgresTestDatabase.java
+++ b/airbyte-integrations/connectors/source-postgres/src/testFixtures/java/io/airbyte/integrations/source/postgres/PostgresTestDatabase.java
@@ -21,9 +21,9 @@ public class PostgresTestDatabase extends
 
   public static enum BaseImage {
 
-    POSTGRES_16_BULLSEYE("postgres:16-bullseye"),
-    POSTGRES_12_BULLSEYE("postgres:12-bullseye"),
-    POSTGRES_9_ALPINE("postgres:9-alpine"),
+    POSTGRES_16("postgres:16-bullseye"),
+    POSTGRES_12("postgres:12-bullseye"),
+    POSTGRES_9("postgres:9-alpine"),
     POSTGRES_SSL_DEV("marcosmarxm/postgres-ssl:dev");
 
     private final String reference;


### PR DESCRIPTION
remove mentions of the debian release (alpine, bullseye), using latest instead.