### PR TITLE
:bug: concurrent-cdk: Do not set the max number of tasks to the number of workers

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/concurrent_source/concurrent_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/concurrent_source/concurrent_source.py
@@ -40,7 +40,8 @@ class ConcurrentSource:
         timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     ) -> "ConcurrentSource":
         threadpool = ThreadPoolManager(
-            concurrent.futures.ThreadPoolExecutor(max_workers=num_workers, thread_name_prefix="workerpool"), logger, num_workers
+            concurrent.futures.ThreadPoolExecutor(max_workers=num_workers, thread_name_prefix="workerpool"),
+            logger,
         )
         return ConcurrentSource(
             threadpool, logger, slice_logger, message_repository, initial_number_of_partitions_to_generate, timeout_seconds

--- a/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/exceptions.py
+++ b/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/exceptions.py
@@ -20,7 +20,9 @@ class UnauthorizedOauthError(Exception):
 
 class UnauthorizedServiceAccountError(Exception):
     def __init__(self):
-        message = "Unable to connect with provided Service Account credentials. Make sure the `sevice account credentials` provided are valid."
+        message = (
+            "Unable to connect with provided Service Account credentials. Make sure the `sevice account credentials` provided are valid."
+        )
         super().__init__(message)
 
 


### PR DESCRIPTION
## What
* The create factory method erroneously sets the maximum number of pending futures to the number of workers, which negatively affects the performance.
* This PR unsets the parameter