### PR TITLE
✨ Source Close.com: add support for custom fields

### DIFF
--- a/airbyte-integrations/connectors/source-close-com/Dockerfile
+++ b/airbyte-integrations/connectors/source-close-com/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.4.3
+LABEL io.airbyte.version=0.5.0
 LABEL io.airbyte.name=airbyte/source-close-com

--- a/airbyte-integrations/connectors/source-close-com/source_close_com/__init__.py
+++ b/airbyte-integrations/connectors/source-close-com/source_close_com/__init__.py
@@ -22,6 +22,6 @@
 
 
 from .datetime_incremental_sync import CustomDatetimeIncrementalSync
-from .source_lc import SourceCloseCom
+from .source import SourceCloseCom
 
 __all__ = ["SourceCloseCom", "CustomDatetimeIncrementalSync"]

--- a/airbyte-integrations/connectors/source-close-com/source_close_com/source.py
+++ b/airbyte-integrations/connectors/source-close-com/source_close_com/source.py
@@ -68,21 +68,6 @@ class CloseComStream(HttpStream, ABC):
 
         return params
 
-    def get_custom_field_schema(self) -> Mapping[str, Any]:
-        """Get custom field schema if it exists."""
-        if self.path() not in {"lead", "contact", "opportunity", "activity"}:
-            return {}
-        resp = requests.request("GET", url=f"{self.url_base}/custom_field/{self.path()}/", headers=self.authenticator.get_auth_header())
-        resp.raise_for_status()
-        resp_json: Mapping[str, Any] = resp.json()["data"]
-        return {f"custom.{data['id']}": {"type": ["null", "string", "number", "boolean"]} for data in resp_json}
-
-    def get_json_schema(self):
-        """Override default get_json_schema method to add custom fields to schema."""
-        schema = super().get_json_schema()
-        schema["properties"].update(self.get_custom_field_schema())
-        return schema
-
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         yield from response.json()["data"]
 
@@ -101,6 +86,23 @@ class CloseComStream(HttpStream, ABC):
         return backoff_time
 
 
+class CloseComStreamCustomFields(CloseComStream):
+    """Class to get custom fields for close objects that support them."""
+
+    def get_custom_field_schema(self) -> Mapping[str, Any]:
+        """Get custom field schema if it exists."""
+        resp = requests.request("GET", url=f"{self.url_base}/custom_field/{self.path()}/", headers=self.authenticator.get_auth_header())
+        resp.raise_for_status()
+        resp_json: Mapping[str, Any] = resp.json()["data"]
+        return {f"custom.{data['id']}": {"type": ["null", "string", "number", "boolean"]} for data in resp_json}
+
+    def get_json_schema(self):
+        """Override default get_json_schema method to add custom fields to schema."""
+        schema = super().get_json_schema()
+        schema["properties"].update(self.get_custom_field_schema())
+        return schema
+
+
 class IncrementalCloseComStream(CloseComStream):
     cursor_field = "date_updated"
 
@@ -116,6 +118,10 @@ class IncrementalCloseComStream(CloseComStream):
         if not current_stream_state:
             current_stream_state = {self.cursor_field: self.start_date}
         return {self.cursor_field: max(latest_record.get(self.cursor_field, ""), current_stream_state.get(self.cursor_field, ""))}
+
+
+class IncrementalCloseComStreamCustomFields(CloseComStreamCustomFields, IncrementalCloseComStream):
+    """Class to get custom fields for close objects using incremental stream."""
 
 
 class CloseComActivitiesStream(IncrementalCloseComStream):
@@ -246,7 +252,7 @@ class Events(IncrementalCloseComStream):
         return params
 
 
-class Leads(IncrementalCloseComStream):
+class Leads(IncrementalCloseComStreamCustomFields):
     """
     Get leads on a specific date
     API Docs: https://developer.close.com/#leads
@@ -417,7 +423,7 @@ class Users(CloseComStream):
         return "user"
 
 
-class Contacts(CloseComStream):
+class Contacts(CloseComStreamCustomFields):
     """
     Get contacts for Close.com account organization
     API Docs: https://developer.close.com/#contacts
@@ -429,7 +435,7 @@ class Contacts(CloseComStream):
         return "contact"
 
 
-class Opportunities(IncrementalCloseComStream):
+class Opportunities(IncrementalCloseComStreamCustomFields):
     """
     Get opportunities on a specific date
     API Docs: https://developer.close.com/#opportunities

--- a/docs/integrations/sources/close-com.md
+++ b/docs/integrations/sources/close-com.md
@@ -105,8 +105,9 @@ The Close.com connector is subject to rate limits. For more information on this 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------|
-| 0.4.3   | 2023-10-28 | [31534](https://github.com/airbytehq/airbyte/pull/31534) | Fixed Email Activities Stream Pagination                                            |
-| 0.4.2   | 2023-08-08 | [29206](https://github.com/airbytehq/airbyte/pull/29206) | Fixed the issue with `DatePicker` format for `start date`                                            |
+| 0.5.0   | 2023-11-30 | [32984](https://github.com/airbytehq/airbyte/pull/32984) | Add support for custom fields                                                                          |
+| 0.4.3   | 2023-10-28 | [31534](https://github.com/airbytehq/airbyte/pull/31534) | Fixed Email Activities Stream Pagination                                                               |
+| 0.4.2   | 2023-08-08 | [29206](https://github.com/airbytehq/airbyte/pull/29206) | Fixed the issue with `DatePicker` format for `start date`                                              |
 | 0.4.1   | 2023-07-04 | [27950](https://github.com/airbytehq/airbyte/pull/27950) | Add human readable titles to API Key and Start Date fields                                             |
 | 0.4.0   | 2023-06-27 | [27776](https://github.com/airbytehq/airbyte/pull/27776) | Update the `Email Followup Tasks` stream schema                                                        |
 | 0.3.0   | 2023-05-12 | [26024](https://github.com/airbytehq/airbyte/pull/26024) | Update the `Email sequences` stream schema                                                             |


### PR DESCRIPTION
## What
This is adding custom fields to the close source connector for streams that contain custom fields. Without this change, custom fields cannot be imported, as the entire schema is static.

## How
*Describe the solution*
We add to the yaml schema dynamically by loading custom fields from an api endpoint. The static schema fields are not changed (and there is no api endpoint to get these).
Custom field docs: https://developer.close.com/resources/custom-fields/

## Recommended reading order
1. `airbyte-integrations/connectors/source-close-com/source_close_com/source.py`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*
No breaking changes, just more fields available in the schema if the user has custom fields attached to an object.
Minor version bump

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
