### PR TITLE
Move the facebook pages doc's first heading above danger admonition

### DIFF
--- a/docs/integrations/sources/facebook-pages.md
+++ b/docs/integrations/sources/facebook-pages.md
@@ -1,8 +1,8 @@
+# Facebook Pages
+
 :::danger
 The Facebook Pages API utilized by this connector has been deprecated.  You will not be able to make a successful connection.  If you would like to make a community contribution or track API upgrade status, visit: https://github.com/airbytehq/airbyte/issues/25515.
 :::
-
-# Facebook Pages
 
 This page contains the setup guide and reference information for the Facebook Pages source connector.
 


### PR DESCRIPTION
The prior version worked great with a dev server, but production builds would throw the following error when generating the production sidebar:

```
[ERROR] Error: Could not parse title from integrations/sources/facebook-pages. Make sure there's no content above the first heading!
    at /home/amb/c/airbyte/docusaurus/sidebars.js:32:15
    at Array.map (<anonymous>)
    at getFilenamesInDir (/home/amb/c/airbyte/docusaurus/sidebars.js:25:6)
    at getSourceConnectors (/home/amb/c/airbyte/docusaurus/sidebars.js:62:10)
    at Object.<anonymous> (/home/amb/c/airbyte/docusaurus/sidebars.js:278:47)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
```

It was a mystery why the build was borked since I have no access to Vercel logs, but once I figured out how to reproduce the error locally, it was a very short path to fixing it.