### PR TITLE
avoid marking a test failed when CdcSourceTest.teardown fails.

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/integrations/debezium/CdcSourceTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/integrations/debezium/CdcSourceTest.java
@@ -177,7 +177,11 @@ public abstract class CdcSourceTest<S extends Source, T extends TestDatabase<?, 
 
   @AfterEach
   protected void tearDown() {
-    testdb.close();
+    try {
+      testdb.close();
+    } catch (Throwable e) {
+      LOGGER.error("exception during teardown", e);
+    }
   }
 
   protected String columnClause(final Map<String, String> columnsWithDataType, final Optional<String> primaryKey) {


### PR DESCRIPTION
Avoid failing the test when CdcSourceTest fails.

We should definitely get to the bottom of this, but right now, it's blocking most changes to source-postgres

This has been happening more and more frequently with the following error : 
```
CdcPostgresSourceTest > When a record is deleted, produces a deletion record. FAILED
    org.jooq.exception.DataAccessException: SQL [SELECT pg_drop_replication_slot('debezium_slot_ufusaxccbf');]; ERROR: replication slot "debezium_slot_ufusaxccbf" is active for PID 420
        at org.jooq_3.13.4.POSTGRES.debug(Unknown Source)
        at app//org.jooq.impl.Tools.translate(Tools.java:2753)
        at app//org.jooq.impl.DefaultExecuteContext.sqlException(DefaultExecuteContext.java:755)
        at app//org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:385)
        at app//org.jooq.impl.DefaultDSLContext.execute(DefaultDSLContext.java:1139)
        at java.base@17.0.8.1/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
        at java.base@17.0.8.1/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
        at app//io.airbyte.cdk.testutils.TestDatabase.lambda$execSQL$0(TestDatabase.java:171)
        at app//io.airbyte.cdk.db.Database.query(Database.java:23)
        at app//io.airbyte.cdk.testutils.TestDatabase.execSQL(TestDatabase.java:170)
        at app//io.airbyte.cdk.testutils.TestDatabase.close(TestDatabase.java:230)
        at app//io.airbyte.cdk.integrations.debezium.CdcSourceTest.tearDown(CdcSourceTest.java:180)
        at java.base@17.0.8.1/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base@17.0.8.1/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base@17.0.8.1/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base@17.0.8.1/java.lang.reflect.Method.invoke(Method.java:568)
        at app//org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
        at app//org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
        at app//org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
        at app//org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
        at app//org.junit.jupiter.engine.extension.TimeoutExtension.interceptLifecycleMethod(TimeoutExtension.java:128)
        at app//org.junit.jupiter.engine.extension.TimeoutExtension.interceptAfterEachMethod(TimeoutExtension.java:110)
        at app//org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
        at app//org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
        at app//org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
        at app//org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
        at app//org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
        at app//org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
        at app//org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
        at app//org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
        at app//org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeMethodInExtensionContext(ClassBasedTestDescriptor.java:520)
        at app//org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$synthesizeAfterEachMethodAdapter$24(ClassBasedTestDescriptor.java:510)
        at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeAfterEachMethods$10(TestMethodTestDescriptor.java:243)
        at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeAllAfterMethodsOrCallbacks$13(TestMethodTestDescriptor.java:276)
        at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeAllAfterMethodsOrCallbacks$14(TestMethodTestDescriptor.java:276)
        at java.base@17.0.8.1/java.util.ArrayList.forEach(ArrayList.java:1511)
        at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeAllAfterMethodsOrCallbacks(TestMethodTestDescriptor.java:275)
        at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeAfterEachMethods(TestMethodTestDescriptor.java:241)
        at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:142)
        at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
        at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
        at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at app//org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at app//org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:185)
        at app//org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.executeNonConcurrentTasks(ForkJoinPoolHierarchicalTestExecutorService.java:155)
        at app//org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.invokeAll(ForkJoinPoolHierarchicalTestExecutorService.java:135)
        at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at app//org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at app//org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:185)
        at java.base@17.0.8.1/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
        at java.base@17.0.8.1/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
        at java.base@17.0.8.1/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
        at java.base@17.0.8.1/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
        at java.base@17.0.8.1/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
        at java.base@17.0.8.1/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)

        Caused by:
        org.********ql.util.PSQLException: ERROR: replication slot "debezium_slot_ufusaxccbf" is active for PID 420
            at app//org.********ql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2713)
            at app//org.********ql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2401)
            at app//org.********ql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:368)
            at app//org.********ql.jdbc.PgStatement.executeInternal(PgStatement.java:498)
            at app//org.********ql.jdbc.PgStatement.execute(PgStatement.java:415)
            at app//org.********ql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:190)
            at app//org.********ql.jdbc.PgPreparedStatement.execute(PgPreparedStatement.java:177)
            at app//com.zaxxer.hikari.pool.ProxyPreparedStatement.execute(ProxyPreparedStatement.java:44)
            at app//com.zaxxer.hikari.pool.HikariProxyPreparedStatement.execute(HikariProxyPreparedStatement.java)
            at app//org.jooq.tools.jdbc.DefaultPreparedStatement.execute(DefaultPreparedStatement.java:209)
            at app//org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:453)
            at app//org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:371)
            ... 63 more
```