### PR TITLE
CI: Add approve-and-merge back as admin only.

### DIFF
--- a/.github/workflows/approve-and-merge-dispatch.yml
+++ b/.github/workflows/approve-and-merge-dispatch.yml
@@ -1,0 +1,48 @@
+name: Approve and Merge Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  approveAndMergeDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto Approve Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v3
+        id: scd
+        with:
+          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
+          permission: admin
+          issue-type: pull-request
+          repository: airbytehq/airbyte-cloud
+          dispatch-type: repository
+          commands: |
+            approve-and-merge
+
+      - name: Edit comment with error message
+        if: steps.scd.outputs.error-message
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          body: |
+            > Error!: ${{ steps.scd.outputs.error-message }}
+
+      - name: Checkout Airbyte
+        id: checkout
+        if:  failure() || steps.scd.outputs.error-message
+        uses: actions/checkout@v2
+
+      - name: Run get_repo_admins.sh
+        if:  failure() || steps.scd.outputs.error-message
+        id: repo_admins
+        run: |
+          echo "REPO_ADMINS=$(./tools/bin/get_repo_admins.sh ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }} airbytehq/airbyte)" >> $GITHUB_ENV
+
+      - name: Edit comment with repo admins
+        if: failure() || steps.scd.outputs.error-message
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          body: |
+            >
+            > Important: This command can only be run by one of the repository admins:
+            > ${{ env.REPO_ADMINS }}

--- a/.github/workflows/approve-and-merge-dispatch.yml
+++ b/.github/workflows/approve-and-merge-dispatch.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Checkout Airbyte
         id: checkout
-        if:  failure() || steps.scd.outputs.error-message
+        if: failure() || steps.scd.outputs.error-message
         uses: actions/checkout@v2
 
       - name: Run get_repo_admins.sh
-        if:  failure() || steps.scd.outputs.error-message
+        if: failure() || steps.scd.outputs.error-message
         id: repo_admins
         run: |
           echo "REPO_ADMINS=$(./tools/bin/get_repo_admins.sh ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }} airbytehq/airbyte)" >> $GITHUB_ENV

--- a/.github/workflows/approve-and-merge-dispatch.yml
+++ b/.github/workflows/approve-and-merge-dispatch.yml
@@ -13,7 +13,7 @@ jobs:
           token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
           permission: admin
           issue-type: pull-request
-          repository: airbytehq/airbyte-cloud
+          repository: airbytehq/airbyte-platform-internal
           dispatch-type: repository
           commands: |
             approve-and-merge

--- a/tools/bin/get_repo_admins.sh
+++ b/tools/bin/get_repo_admins.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Check if the correct number of arguments is provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <personal_access_token> <repository>"
+    exit 1
+fi
+
+# Assign arguments to variables
+TOKEN="$1"
+REPO="$2"
+
+# GitHub API URL for repository collaborators
+API_URL="https://api.github.com/repos/$REPO/collaborators"
+
+# Curl command to get the list of collaborators with admin rights
+curl -H "Authorization: token $TOKEN" \
+     -H "Accept: application/vnd.github.v3+json" \
+     "$API_URL" | jq '.[] | select(.permissions.admin == true) | "[\(.login)](\(.html_url))"' | tr -d '"' | paste -sd "\\n" -

--- a/tools/bin/get_repo_admins.sh
+++ b/tools/bin/get_repo_admins.sh
@@ -16,4 +16,4 @@ API_URL="https://api.github.com/repos/$REPO/collaborators"
 # Curl command to get the list of collaborators with admin rights
 curl -H "Authorization: token $TOKEN" \
      -H "Accept: application/vnd.github.v3+json" \
-     "$API_URL" | jq '.[] | select(.permissions.admin == true) | "[\(.login)](\(.html_url))"' | tr -d '"' | paste -sd "\\n" -
+     "$API_URL" | jq '.[] | select(.permissions.admin == true) | "[\(.login)](\(.html_url))"' | tr -d '"' | paste -sd "," -

--- a/tools/bin/get_repo_admins.sh
+++ b/tools/bin/get_repo_admins.sh
@@ -16,4 +16,4 @@ API_URL="https://api.github.com/repos/$REPO/collaborators"
 # Curl command to get the list of collaborators with admin rights
 curl -H "Authorization: token $TOKEN" \
      -H "Accept: application/vnd.github.v3+json" \
-     "$API_URL" | jq '.[] | select(.permissions.admin == true) | "[\(.login)](\(.html_url))"' | tr -d '"' | paste -sd "," -
+     "$API_URL" | jq '.[] | select(.permissions.admin == true) | "[\(.login)](\(.html_url)),"' | tr -d '"' | paste -sd " " -


### PR DESCRIPTION
## Overview
1. re-adds `/approve-and-merge` 
2. restricts it to only admins
3. Outputs the list of admins when fails.

Tested here: https://github.com/airbytehq/github-workflow-test-repo-base/pull/121#issuecomment-1836874378