### PR TITLE
Vector DB CDK: Fix special tokens

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/document_processor.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/document_processor.py
@@ -74,6 +74,7 @@ class DocumentProcessor:
                 chunk_overlap=chunk_overlap,
                 separators=[json.loads(s) for s in splitter_config.separators],
                 keep_separator=splitter_config.keep_separator,
+                disallowed_special=(),
             )
         if splitter_config.mode == "markdown":
             return RecursiveCharacterTextSplitter.from_tiktoken_encoder(
@@ -82,12 +83,14 @@ class DocumentProcessor:
                 separators=headers_to_split_on[: splitter_config.split_level],
                 is_separator_regex=True,
                 keep_separator=True,
+                disallowed_special=(),
             )
         if splitter_config.mode == "code":
             return RecursiveCharacterTextSplitter.from_tiktoken_encoder(
                 chunk_size=chunk_size,
                 chunk_overlap=chunk_overlap,
                 separators=RecursiveCharacterTextSplitter.get_separators_for_language(Language(splitter_config.language)),
+                disallowed_special=(),
             )
 
     def __init__(self, config: ProcessingConfigModel, catalog: ConfiguredAirbyteCatalog):

--- a/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/vector_db_based/embedder.py
@@ -96,13 +96,13 @@ class BaseOpenAIEmbedder(Embedder):
 
 class OpenAIEmbedder(BaseOpenAIEmbedder):
     def __init__(self, config: OpenAIEmbeddingConfigModel, chunk_size: int):
-        super().__init__(OpenAIEmbeddings(openai_api_key=config.openai_key, max_retries=15), chunk_size)  # type: ignore
+        super().__init__(OpenAIEmbeddings(openai_api_key=config.openai_key, max_retries=15, disallowed_special=()), chunk_size)  # type: ignore
 
 
 class AzureOpenAIEmbedder(BaseOpenAIEmbedder):
     def __init__(self, config: AzureOpenAIEmbeddingConfigModel, chunk_size: int):
         # Azure OpenAI API has — as of 20230927 — a limit of 16 documents per request
-        super().__init__(OpenAIEmbeddings(openai_api_key=config.openai_key, chunk_size=16, max_retries=15, openai_api_type="azure", openai_api_version="2023-05-15", openai_api_base=config.api_base, deployment=config.deployment), chunk_size)  # type: ignore
+        super().__init__(OpenAIEmbeddings(openai_api_key=config.openai_key, chunk_size=16, max_retries=15, openai_api_type="azure", openai_api_version="2023-05-15", openai_api_base=config.api_base, deployment=config.deployment, disallowed_special=()), chunk_size)  # type: ignore
 
 
 COHERE_VECTOR_SIZE = 1024
@@ -160,7 +160,7 @@ class OpenAICompatibleEmbedder(Embedder):
         self.config = config
         # Client is set internally
         # Always set an API key even if there is none defined in the config because the validator will fail otherwise. Embedding APIs that don't require an API key don't fail if one is provided, so this is not breaking usage.
-        self.embeddings = LocalAIEmbeddings(model=config.model_name, openai_api_key=config.api_key or "dummy-api-key", openai_api_base=config.base_url, max_retries=15)  # type: ignore
+        self.embeddings = LocalAIEmbeddings(model=config.model_name, openai_api_key=config.api_key or "dummy-api-key", openai_api_base=config.base_url, max_retries=15, disallowed_special=())  # type: ignore
 
     def check(self) -> Optional[str]:
         deployment_mode = os.environ.get("DEPLOYMENT_MODE", "")

--- a/airbyte-cdk/python/unit_tests/destinations/vector_db_based/document_processor_test.py
+++ b/airbyte-cdk/python/unit_tests/destinations/vector_db_based/document_processor_test.py
@@ -276,6 +276,18 @@ def test_process_multiple_chunks_with_relevant_fields():
             ],
         ),
         (
+            "Special tokens",
+            "Special tokens like <|endoftext|> are treated like regular text",
+            15,
+            0,
+            None,
+            [
+                "text: Special tokens like",
+                "<|endoftext|> are treated like regular",
+                "text",
+            ]
+        ),
+        (
             "Custom separator",
             "Custom \nseparatorxxxDoes not split on \n\nnewlines",
             10,


### PR DESCRIPTION
When embedding text, it is tokenized with the tiktoken library. There are some special tokens (e.g. to signify end of a document). If these are encountered, currently an exception is raised:
> Encountered text corresponding to disallowed special token '<|endoftext|>'. If you want this text to be encoded as a special token, pass it to `allowed_special`, e.g. `allowed_special={'<|endoftext|>', ...}`. If you want this text to be encoded as normal text, disable the check for this token by passing `disallowed_special=(enc.special_tokens_set - {'<|endoftext|>'})`. To disable this check for all special tokens, pass `disallowed_special=()`.

As a text like `<|endoftext|>` in a record should be treated like any other text, this PR makes sure the `disallowed_special` argument is set accordingly (also see https://github.com/langchain-ai/langchain/issues/923 )