### PR TITLE
Destination redshift: improve memory usage?

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/integrations/destination/buffered_stream_consumer/RecordWriter.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/integrations/destination/buffered_stream_consumer/RecordWriter.java
@@ -6,11 +6,11 @@ package io.airbyte.cdk.integrations.destination.buffered_stream_consumer;
 
 import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
-import java.util.List;
+import java.util.stream.Stream;
 
-public interface RecordWriter<T> extends CheckedBiConsumer<AirbyteStreamNameNamespacePair, List<T>, Exception> {
+public interface RecordWriter<T> extends CheckedBiConsumer<AirbyteStreamNameNamespacePair, Stream<T>, Exception> {
 
   @Override
-  void accept(AirbyteStreamNameNamespacePair stream, List<T> records) throws Exception;
+  void accept(AirbyteStreamNameNamespacePair stream, Stream<T> records) throws Exception;
 
 }

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
@@ -75,7 +75,7 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
   @Override
   public void flushSingleBuffer(final AirbyteStreamNameNamespacePair stream, final SerializableBuffer buffer) throws Exception {
     LOGGER.info("Flushing single stream {}: {} records", stream.getName(), streamBuffer.get(stream).size());
-    recordWriter.accept(stream, streamBuffer.get(stream));
+    recordWriter.accept(stream, streamBuffer.get(stream).stream());
     LOGGER.info("Flushing completed for {}", stream.getName());
   }
 
@@ -84,7 +84,7 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
     for (final Map.Entry<AirbyteStreamNameNamespacePair, List<AirbyteRecordMessage>> entry : streamBuffer.entrySet()) {
       LOGGER.info("Flushing {}: {} records ({})", entry.getKey().getName(), entry.getValue().size(),
           FileUtils.byteCountToDisplaySize(bufferSizeInBytes));
-      recordWriter.accept(entry.getKey(), entry.getValue());
+      recordWriter.accept(entry.getKey(), entry.getValue().stream());
       if (checkAndRemoveRecordWriter != null) {
         fileName = checkAndRemoveRecordWriter.apply(entry.getKey(), fileName);
       }

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/AbstractJdbcDestination.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/AbstractJdbcDestination.java
@@ -27,7 +27,6 @@ import io.airbyte.protocol.models.v0.AirbyteConnectionStatus.Status;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/AbstractJdbcDestination.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/AbstractJdbcDestination.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
@@ -135,7 +136,7 @@ public abstract class AbstractJdbcDestination extends BaseConnector implements D
       // verify if user has permission to make SQL INSERT queries
       try {
         if (attemptInsert) {
-          sqlOps.insertRecords(database, List.of(getDummyRecord()), outputSchema, outputTableName);
+          sqlOps.insertRecords(database, Stream.of(getDummyRecord()), outputSchema, outputTableName);
         }
       } finally {
         sqlOps.dropTableIfExists(database, outputSchema, outputTableName);

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java
@@ -78,7 +78,7 @@ public class JdbcBufferedConsumerFactory {
         onCloseFunction(use1s1t, typerDeduper),
         new JdbcInsertFlushFunction(recordWriterFunction(database, sqlOperations, writeConfigs, catalog)),
         catalog,
-        new BufferManager((long) (Runtime.getRuntime().maxMemory() * 0.2)),
+        new BufferManager((long) (Runtime.getRuntime().maxMemory() * 0.1)),
         defaultNamespace,
         Executors.newFixedThreadPool(1));
   }

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java
@@ -80,7 +80,7 @@ public class JdbcBufferedConsumerFactory {
         catalog,
         new BufferManager((long) (Runtime.getRuntime().maxMemory() * 0.2)),
         defaultNamespace,
-        Executors.newFixedThreadPool(2));
+        Executors.newFixedThreadPool(1));
   }
 
   private static List<WriteConfig> createWriteConfigs(final NamingConventionTransformer namingResolver,

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcInsertFlushFunction.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcInsertFlushFunction.java
@@ -22,9 +22,7 @@ public class JdbcInsertFlushFunction implements DestinationFlushFunction {
 
   @Override
   public void flush(final StreamDescriptor desc, final Stream<PartialAirbyteMessage> stream) throws Exception {
-    recordWriter.accept(
-        new AirbyteStreamNameNamespacePair(desc.getName(), desc.getNamespace()),
-        stream.toList());
+    recordWriter.accept(new AirbyteStreamNameNamespacePair(desc.getName(), desc.getNamespace()), stream);
   }
 
   @Override

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcInsertFlushFunction.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcInsertFlushFunction.java
@@ -29,7 +29,7 @@ public class JdbcInsertFlushFunction implements DestinationFlushFunction {
   public long getOptimalBatchSizeBytes() {
     // TODO tune this value - currently SqlOperationUtils partitions 10K records per insert statement,
     // but we'd like to stop doing that and instead control sql insert statement size via batch size.
-    return GlobalDataSizeConstants.DEFAULT_MAX_BATCH_SIZE_BYTES;
+    return 10 * 1024 * 1024;
   }
 
 }

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcInsertFlushFunction.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcInsertFlushFunction.java
@@ -5,7 +5,6 @@
 package io.airbyte.cdk.integrations.destination.jdbc;
 
 import io.airbyte.cdk.integrations.destination.buffered_stream_consumer.RecordWriter;
-import io.airbyte.cdk.integrations.destination.jdbc.constants.GlobalDataSizeConstants;
 import io.airbyte.cdk.integrations.destination_async.DestinationFlushFunction;
 import io.airbyte.cdk.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcSqlOperations.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/JdbcSqlOperations.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 
@@ -149,7 +150,7 @@ public abstract class JdbcSqlOperations implements SqlOperations {
 
   @Override
   public final void insertRecords(final JdbcDatabase database,
-                                  final List<PartialAirbyteMessage> records,
+                                  final Stream<PartialAirbyteMessage> records,
                                   final String schemaName,
                                   final String tableName)
       throws Exception {
@@ -162,7 +163,7 @@ public abstract class JdbcSqlOperations implements SqlOperations {
   }
 
   protected abstract void insertRecordsInternal(JdbcDatabase database,
-                                                List<PartialAirbyteMessage> records,
+                                                Stream<PartialAirbyteMessage> records,
                                                 String schemaName,
                                                 String tableName)
       throws Exception;

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/SqlOperations.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/SqlOperations.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.cdk.db.jdbc.JdbcDatabase;
 import io.airbyte.cdk.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import java.util.List;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +99,7 @@ public interface SqlOperations {
    * @param tableName Name of table
    * @throws Exception exception
    */
-  void insertRecords(JdbcDatabase database, List<PartialAirbyteMessage> records, String schemaName, String tableName) throws Exception;
+  void insertRecords(JdbcDatabase database, Stream<PartialAirbyteMessage> records, String schemaName, String tableName) throws Exception;
 
   /**
    * Query to insert all records from source table to destination table. Both tables must be in the

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/SqlOperationsUtils.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/SqlOperationsUtils.java
@@ -5,16 +5,18 @@
 package io.airbyte.cdk.integrations.destination.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterables;
 import io.airbyte.cdk.db.jdbc.JdbcDatabase;
 import io.airbyte.cdk.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 public class SqlOperationsUtils {
 
@@ -32,7 +34,7 @@ public class SqlOperationsUtils {
   public static void insertRawRecordsInSingleQuery(final String insertQueryComponent,
                                                    final String recordQueryComponent,
                                                    final JdbcDatabase jdbcDatabase,
-                                                   final List<PartialAirbyteMessage> records)
+                                                   final Stream<PartialAirbyteMessage> records)
       throws SQLException {
     insertRawRecordsInSingleQuery(insertQueryComponent, recordQueryComponent, jdbcDatabase, records, UUID::randomUUID, true);
   }
@@ -53,7 +55,7 @@ public class SqlOperationsUtils {
   public static void insertRawRecordsInSingleQueryNoSem(final String insertQueryComponent,
                                                         final String recordQueryComponent,
                                                         final JdbcDatabase jdbcDatabase,
-                                                        final List<PartialAirbyteMessage> records)
+                                                        final Stream<PartialAirbyteMessage> records)
       throws SQLException {
     insertRawRecordsInSingleQuery(insertQueryComponent, recordQueryComponent, jdbcDatabase, records, UUID::randomUUID, false);
   }
@@ -62,41 +64,43 @@ public class SqlOperationsUtils {
   static void insertRawRecordsInSingleQuery(final String insertQueryComponent,
                                             final String recordQueryComponent,
                                             final JdbcDatabase jdbcDatabase,
-                                            final List<PartialAirbyteMessage> records,
+                                            final Stream<PartialAirbyteMessage> records,
                                             final Supplier<UUID> uuidSupplier,
                                             final boolean sem)
       throws SQLException {
-    if (records.isEmpty()) {
+    final Iterator<PartialAirbyteMessage> iterator = records.iterator();
+    if (!iterator.hasNext()) {
       return;
     }
-
     jdbcDatabase.execute(connection -> {
-
       // Strategy: We want to use PreparedStatement because it handles binding values to the SQL query
       // (e.g. handling formatting timestamps). A PreparedStatement statement is created by supplying the
       // full SQL string at creation time. Then subsequently specifying which values are bound to the
       // string. Thus there will be two loops below.
-      // 1) Loop over records to build the full string.
-      // 2) Loop over the records and bind the appropriate values to the string.
+      // 1) Loop over records to build the full string and query parameters
+      // 2) Loop over the params and bind the appropriate values to the PreparedStatement.
       // We also partition the query to run on 10k records at a time, since some DBs set a max limit on
       // how many records can be inserted at once
       // TODO(sherif) this should use a smarter, destination-aware partitioning scheme instead of 10k by
       // default
-      for (final List<PartialAirbyteMessage> partition : Iterables.partition(records, 10_000)) {
+      while (iterator.hasNext()) {
         final StringBuilder sql = new StringBuilder(insertQueryComponent);
-        partition.forEach(r -> sql.append(recordQueryComponent));
+        final List<Object> params = new ArrayList<>();
+        for (int i = 0; i < 10_000 && iterator.hasNext(); i++) {
+          final PartialAirbyteMessage record = iterator.next();
+          sql.append(recordQueryComponent);
+          params.add(uuidSupplier.get().toString());
+          params.add(record.getSerialized());
+          params.add(Timestamp.from(Instant.ofEpochMilli(record.getRecord().getEmittedAt())));
+        }
+
         final String s = sql.toString();
         final String s1 = s.substring(0, s.length() - 2) + (sem ? ";" : "");
-
         try (final PreparedStatement statement = connection.prepareStatement(s1)) {
           // second loop: bind values to the SQL string.
-          int i = 1;
-          for (final PartialAirbyteMessage message : partition) {
-            // 1-indexed
-            statement.setString(i, uuidSupplier.get().toString());
-            statement.setString(i + 1, message.getSerialized());
-            statement.setTimestamp(i + 2, Timestamp.from(Instant.ofEpochMilli(message.getRecord().getEmittedAt())));
-            i += 3;
+          for (int i = 0; i < params.size(); i++) {
+            // Note that params are 1-indexed.
+            statement.setObject(i + 1, params.get(i));
           }
 
           statement.execute();

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/copy/CopyConsumerFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/copy/CopyConsumerFactory.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,9 +94,9 @@ public class CopyConsumerFactory {
   private static RecordWriter<AirbyteRecordMessage> recordWriterFunction(final Map<AirbyteStreamNameNamespacePair, StreamCopier> pairToCopier,
                                                                          final SqlOperations sqlOperations,
                                                                          final Map<AirbyteStreamNameNamespacePair, Long> pairToIgnoredRecordCount) {
-    return (AirbyteStreamNameNamespacePair pair, List<AirbyteRecordMessage> records) -> {
+    return (final AirbyteStreamNameNamespacePair pair, final Stream<AirbyteRecordMessage> records) -> {
       final var fileName = pairToCopier.get(pair).prepareStagingFile();
-      for (final AirbyteRecordMessage recordMessage : records) {
+      for (final AirbyteRecordMessage recordMessage : (Iterable<AirbyteRecordMessage>) records::iterator) {
         final var id = UUID.randomUUID();
         if (sqlOperations.isValidData(recordMessage.getData())) {
           // TODO Truncate json data instead of throwing whole record away?
@@ -109,7 +110,7 @@ public class CopyConsumerFactory {
   }
 
   private static CheckAndRemoveRecordWriter removeStagingFilePrinter(final Map<AirbyteStreamNameNamespacePair, StreamCopier> pairToCopier) {
-    return (AirbyteStreamNameNamespacePair pair, String stagingFileName) -> {
+    return (final AirbyteStreamNameNamespacePair pair, final String stagingFileName) -> {
       final String currentFileName = pairToCopier.get(pair).getCurrentFile();
       if (stagingFileName != null && currentFileName != null && !stagingFileName.equals(currentFileName)) {
         pairToCopier.get(pair).closeNonCurrentStagingFileWriters();

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/test/java/io/airbyte/cdk/integrations/destination/jdbc/TestJdbcSqlOperations.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/test/java/io/airbyte/cdk/integrations/destination/jdbc/TestJdbcSqlOperations.java
@@ -7,7 +7,7 @@ package io.airbyte.cdk.integrations.destination.jdbc;
 import io.airbyte.cdk.db.jdbc.JdbcDatabase;
 import io.airbyte.cdk.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import java.sql.SQLException;
-import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -16,7 +16,7 @@ public class TestJdbcSqlOperations extends JdbcSqlOperations {
 
   @Override
   public void insertRecordsInternal(final JdbcDatabase database,
-                                    final List<PartialAirbyteMessage> records,
+                                    final Stream<PartialAirbyteMessage> records,
                                     final String schemaName,
                                     final String tableName)
       throws Exception {

--- a/airbyte-integrations/connectors/destination-redshift/build.gradle
+++ b/airbyte-integrations/connectors/destination-redshift/build.gradle
@@ -6,7 +6,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.6.0'
     features = ['db-destinations', 's3-destinations']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 //remove once upgrading the CDK version to 0.4.x or later

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperations.java
@@ -10,7 +10,7 @@ import io.airbyte.cdk.integrations.destination.jdbc.JdbcSqlOperations;
 import io.airbyte.cdk.integrations.destination.jdbc.SqlOperationsUtils;
 import io.airbyte.cdk.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import java.sql.SQLException;
-import java.util.List;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,12 +37,10 @@ public class RedshiftSqlOperations extends JdbcSqlOperations {
 
   @Override
   public void insertRecordsInternal(final JdbcDatabase database,
-                                    final List<PartialAirbyteMessage> records,
+                                    final Stream<PartialAirbyteMessage> records,
                                     final String schemaName,
                                     final String tmpTableName)
       throws SQLException {
-    LOGGER.info("actual size of batch: {}", records.size());
-
     // query syntax:
     // INSERT INTO public.users (ab_id, data, emitted_at) VALUES
     // (?, ?::jsonb, ?),


### PR DESCRIPTION
* Pass `Stream<PartialAirbyteMessage>` instead of List
* go to one thread instead of two

@gisripa + my theory is that every thread effectively duplicates the data in a batch of records (by rendering it into a giant SQL blob). So going down to one thread should reduce the memory pressure we're seeing.

Sticking with a stream instead of list probably won't be a _huge_ impact since the underlying "big data" elements are passed by reference, but it does reduce the number of object references we're dealing with and is a better interface anyway.

Largely similar to https://github.com/airbytehq/airbyte/pull/33070, but based on master instead of the dv2 branch.

prerelease publish running https://github.com/airbytehq/airbyte/actions/runs/7093320413; I'll test this in the dv1 perf test connection https://cloud.airbyte.com/workspaces/b61bc266-ef3c-460c-af2f-f70da4a2993c/connections/3a93c4ec-9b61-42f8-b6f2-4ec052129dfc/job-history