### PR TITLE
Fix Nightly Reports: Add ci job key to nightly builds

### DIFF
--- a/.github/workflows/connectors_nightly_build.yml
+++ b/.github/workflows/connectors_nightly_build.yml
@@ -35,6 +35,7 @@ jobs:
         uses: ./.github/actions/run-dagger-pipeline
         with:
           context: "master"
+          ci_job_key: "nightly_builds"
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}


### PR DESCRIPTION
## Problem
Since November 28th nightlies have not been reported. This is because we began to write report results to the wrong location

`master/master` instead of `nightly_builds/master`

## Cause
https://github.com/airbytehq/airbyte/commit/3126204d9486bf62cd2f08113fa5e308d5153ff0

## Solution
Add an explicit ci job key like we do for weeklies

## Cleanup
- [ ]  Move all reports at `master/master` to `nightly_builds/master`

