### PR TITLE
fix references to metadata_service changed files

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -55,11 +55,11 @@ jobs:
               - 'airbyte-ci/connectors/pipelines/**'
               - '!**/*.md'
             metadata_lib:
-              - 'airbyte-ci/connectors/metadata/lib/**'
+              - 'airbyte-ci/connectors/metadata_service/lib/**'
               - '!**/*.md'
             metadata_orchestrator:
-              - 'airbyte-ci/connectors/metadata/lib/**'
-              - 'airbyte-ci/connectors/metadata/orchestrator/**'
+              - 'airbyte-ci/connectors/metadata_service/lib/**'
+              - 'airbyte-ci/connectors/metadata_service/orchestrator/**'
               - '!**/*.md'
 
       - name: Run airbyte-ci/connectors/connector_ops tests


### PR DESCRIPTION
Reference the correct file path. See https://github.com/airbytehq/airbyte/pull/33126 to see the change in action (correctly runs the metadata tests)