### PR TITLE
fix failing metadata tests on master

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_digest_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_digest_does_not_exists.yaml
@@ -12,11 +12,11 @@ data:
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-exists-1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
-  githubIssueLabel: source-zendesk-chat
-  icon: zendesk-chat.svg
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  githubIssueLabel: source-alloy-db
+  icon: alloy-db.svg
   license: MIT
-  name: Zendesk Chat
+  name: AlloyDB for PostgreSQL
   registries:
     cloud:
       enabled: true

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_digest_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_digest_does_not_exists.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
-  dockerRepository: airbyte/source-zendesk-chat
+  dockerRepository: airbyte/source-exists-1
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
   githubIssueLabel: source-zendesk-chat
   icon: zendesk-chat.svg

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_name_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_name_does_not_exists.yaml
@@ -12,11 +12,11 @@ data:
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-exists-1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
-  githubIssueLabel: source-zendesk-chat
-  icon: zendesk-chat.svg
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  githubIssueLabel: source-alloy-db
+  icon: alloy-db.svg
   license: MIT
-  name: Zendesk Chat
+  name: AlloyDB for PostgreSQL
   registries:
     cloud:
       enabled: true

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_name_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_name_does_not_exists.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
-  dockerRepository: airbyte/source-zendesk-chat
+  dockerRepository: airbyte/source-exists-1
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
   githubIssueLabel: source-zendesk-chat
   icon: zendesk-chat.svg

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_tag_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_tag_does_not_exists.yaml
@@ -12,11 +12,11 @@ data:
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-exists-1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
-  githubIssueLabel: source-zendesk-chat
-  icon: zendesk-chat.svg
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  githubIssueLabel: source-alloy-db
+  icon: alloy-db.svg
   license: MIT
-  name: Zendesk Chat
+  name: AlloyDB for PostgreSQL
   registries:
     cloud:
       enabled: true

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_tag_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_tag_does_not_exists.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
-  dockerRepository: airbyte/source-zendesk-chat
+  dockerRepository: airbyte/source-exists-1
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
   githubIssueLabel: source-zendesk-chat
   icon: zendesk-chat.svg

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_base_image_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_base_image_exists.yaml
@@ -12,11 +12,11 @@ data:
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-exists-1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
-  githubIssueLabel: source-zendesk-chat
-  icon: zendesk-chat.svg
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  githubIssueLabel: source-alloy-db
+  icon: alloy-db.svg
   license: MIT
-  name: Zendesk Chat
+  name: AlloyDB for PostgreSQL
   registries:
     cloud:
       enabled: true

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_base_image_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_base_image_exists.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
-  dockerRepository: airbyte/source-zendesk-chat
+  dockerRepository: airbyte/source-exists-1
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
   githubIssueLabel: source-zendesk-chat
   icon: zendesk-chat.svg


### PR DESCRIPTION
Now that tests are running again, some tests were failing on master. This fixes those tests. 

Steps to fix: 
- docker images need to follow our exists/doesn't exist pattern for stubs
- doc url needs to be the stubbed doc url 
- changed the info to say alloydb because the stubbed doc url is alloydb. This wasn't strictly necessary to get them passing. I'll update the mock to be more general in [another pr](https://github.com/airbytehq/airbyte/pull/33128). 