### PR TITLE
change mock doc url to look more mock-like

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_digest_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_digest_does_not_exists.yaml
@@ -12,7 +12,7 @@ data:
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-exists-1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   githubIssueLabel: source-alloy-db
   icon: alloy-db.svg
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_name_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_name_does_not_exists.yaml
@@ -12,7 +12,7 @@ data:
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-exists-1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   githubIssueLabel: source-alloy-db
   icon: alloy-db.svg
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_tag_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/base_image_nonexistent/metadata_base_image_tag_does_not_exists.yaml
@@ -12,7 +12,7 @@ data:
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-exists-1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   githubIssueLabel: source-alloy-db
   icon: alloy-db.svg
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/repo_nonexistent/metadata_cloud_repo_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/repo_nonexistent/metadata_cloud_repo_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/repo_nonexistent/metadata_main_repo_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/repo_nonexistent/metadata_main_repo_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/does-not-exist-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/repo_nonexistent/metadata_normalization_repo_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/repo_nonexistent/metadata_normalization_repo_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/repo_nonexistent/metadata_oss_repo_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/repo_nonexistent/metadata_oss_repo_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/tag_nonexistent/metadata_cloud_image_tag_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/tag_nonexistent/metadata_cloud_image_tag_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/tag_nonexistent/metadata_main_image_tag_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/tag_nonexistent/metadata_main_image_tag_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 6.6.6 # tag does not exist
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/tag_nonexistent/metadata_normalization_image_tag_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/tag_nonexistent/metadata_normalization_image_tag_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/tag_nonexistent/metadata_oss_repo_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/tag_nonexistent/metadata_oss_repo_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/valid_overrides_but_base_image_nonexistent/metadata_main_image_tag_does_not_exist_but_is_overrode.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/valid_overrides_but_base_image_nonexistent/metadata_main_image_tag_does_not_exist_but_is_overrode.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 6.6.6 # tag does not exist
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/valid_overrides_but_base_image_nonexistent/metadata_main_repo_does_not_exist_but_is_overrode.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/valid_overrides_but_base_image_nonexistent/metadata_main_repo_does_not_exist_but_is_overrode.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/does-not-exist-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_all_images_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_all_images_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_all_images_exist_no_overrides.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_all_images_exist_no_overrides.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_all_images_exist_no_overrides_with_normalization.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_all_images_exist_no_overrides_with_normalization.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_base_image_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_base_image_exists.yaml
@@ -12,7 +12,7 @@ data:
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-exists-1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   githubIssueLabel: source-alloy-db
   icon: alloy-db.svg
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_empty_tags.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_empty_tags.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/source-alloydb-strict-encrypt
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 2.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_extra_data.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_extra_data.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_breaking_change_additional_property.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_breaking_change_additional_property.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_breaking_change_invalid_deadline.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_breaking_change_invalid_deadline.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_breaking_change_no_deadline.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_breaking_change_no_deadline.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_breaking_change_no_message.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_breaking_change_no_message.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_breaking_change_version.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_breaking_change_version.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_internal_fields.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_internal_fields.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_tag_format.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_invalid_tag_format.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/source-alloydb-strict-encrypt
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 2.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_missing_connector_type.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_missing_connector_type.yaml
@@ -5,7 +5,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_missing_definition_id.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_missing_definition_id.yaml
@@ -5,7 +5,7 @@ data:
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerRepository: airbyte/image-exists-1
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_missing_docker_image_tag.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_missing_docker_image_tag.yaml
@@ -5,7 +5,7 @@ data:
   connectorType: source
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerRepository: airbyte/image-exists-1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_missing_docker_repo.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_missing_docker_repo.yaml
@@ -5,7 +5,7 @@ data:
   connectorType: source
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_missing_version.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_missing_version.yaml
@@ -5,7 +5,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_no_lang_tag.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_no_lang_tag.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/source-alloydb-strict-encrypt
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 2.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_no_tags.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_no_tags.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/source-alloydb-strict-encrypt
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 2.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_registry_no_id_override.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_registry_no_id_override.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_registry_no_type_override.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_registry_no_type_override.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_registry_unknown_override.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_registry_unknown_override.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_unknown_support_level.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_unknown_support_level.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   supportLevel: dne

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_breaking_change_prerelease.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_breaking_change_prerelease.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 2.0.0-dev.cf3628ccf3
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_breaking_changes.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_breaking_changes.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_breaking_changes_with_migration_doc_url.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_breaking_changes_with_migration_doc_url.yaml
@@ -6,15 +6,15 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT
   releases:
-    migrationDocumentationUrl: https://docs.airbyte.com/integrations/sources/alloydb-migrations
+    migrationDocumentationUrl: https://docs.airbyte.com/integrations/sources/existingsource-migrations
     breakingChanges:
       2.0.0:
-        migrationDocumentationUrl: https://docs.airbyte.com/integrations/sources/alloydb-migrations#2.0.0
+        migrationDocumentationUrl: https://docs.airbyte.com/integrations/sources/existingsource-migrations#2.0.0
         upgradeDeadline: 2023-08-22
         message: "This version changes the connector’s authentication method from `ApiKey` to `oAuth`, per the [API guide](https://amazon-sqs.com/api/someguide)."
   tags:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_internal_fields.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_internal_fields.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_major_version_with_breaking_change_for_version.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_major_version_with_breaking_change_for_version.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 2.0.0
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_registry_allowed_hosts.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_registry_allowed_hosts.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_registry_complex_override.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_registry_complex_override.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_registry_enabled.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_registry_enabled.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_registry_required_resources.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_registry_required_resources.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_simple.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_simple.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_support_level.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/metadata_support_level.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1
-  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   supportLevel: community

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_gcs_upload.py
@@ -17,7 +17,7 @@ from pydash.objects import get
 # Version exists by default, but "666" is bad! (6.0.0 too since breaking changes regex tho)
 MOCK_VERSIONS_THAT_DO_NOT_EXIST = ["6.6.6", "6.0.0"]
 DOCS_PATH = "/docs"
-MOCK_DOC_URL_PATH = "integrations/sources/alloydb.md"
+MOCK_DOC_URL_PATH = "integrations/sources/existingsource.md"
 VALID_DOC_FILE_PATH = Path(DOCS_PATH) / MOCK_DOC_URL_PATH
 
 


### PR DESCRIPTION
It's easier to know that the url is being validated in the test if it doesn't look like a standard URL. With a standard URL, you might think that the data from any connector is valid, which it is not, because the existence check is stubbed. 