### PR TITLE
airbyte-ci: test format fix/check all

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/commands.py
@@ -92,7 +92,16 @@ async def all_checks(ctx: click.Context):
 async def all_fix(ctx: click.Context):
     """Run code format checks and fix any failures."""
     parent_command = ctx.parent.command
+
     logger = logging.getLogger(parent_command.name)
+
+    # We have to run license command sequentially because it modifies the same set of files as other commands.
+    # If we ran it concurrently with language commands, we face race condition issues.
+    # We also want to run it before language specific formatter as they might reformat the license header.
+    sequential_commands = [
+        FORMATTERS_FIX_COMMANDS[Formatter.LICENSE].disable_logging().dont_exit_on_failure(),
+    ]
+    command_results = await invoke_commands_sequentially(ctx, sequential_commands)
 
     # We can run language commands concurrently because they modify different set of files.
     # We disable logging and exit on failure because its this the current command that takes care of reporting.
@@ -102,14 +111,7 @@ async def all_fix(ctx: click.Context):
         FORMATTERS_FIX_COMMANDS[Formatter.JS].disable_logging().dont_exit_on_failure(),
     ]
 
-    # We have to run license command sequentially because it modifies the same set of files as other commands.
-    # If we ran it concurrently with language commands, we face race condition issues.
-    sequential_commands = [
-        FORMATTERS_FIX_COMMANDS[Formatter.LICENSE].disable_logging().dont_exit_on_failure(),
-    ]
-
-    command_results = await invoke_commands_concurrently(ctx, concurrent_commands)
-    command_results += await invoke_commands_sequentially(ctx, sequential_commands)
+    command_results += await invoke_commands_concurrently(ctx, concurrent_commands)
     failure = any([r.status is StepStatus.FAILURE for r in command_results])
 
     log_options = LogOptions(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/configuration.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/configuration.py
@@ -2,15 +2,13 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from pipelines.airbyte_ci.format.consts import CACHE_MOUNT_PATH, Formatter
+from pipelines.airbyte_ci.format.consts import CACHE_MOUNT_PATH, LICENSE_FILE_NAME, Formatter
 from pipelines.airbyte_ci.format.containers import (
     format_java_container,
     format_js_container,
     format_license_container,
     format_python_container,
 )
-
-LICENSE_FILE_NAME = "LICENSE_SHORT"
 
 FORMATTERS_CONFIGURATIONS = {
     # Run spotless on all java and gradle files.

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
@@ -6,6 +6,8 @@ from enum import Enum
 REPO_MOUNT_PATH = "/src"
 CACHE_MOUNT_PATH = "/cache"
 
+LICENSE_FILE_NAME = "LICENSE_SHORT"
+
 DEFAULT_FORMAT_IGNORE_LIST = [
     "**/__pycache__",
     '"**/.pytest_cache',
@@ -45,6 +47,7 @@ DEFAULT_FORMAT_IGNORE_LIST = [
     "**/tools/git_hooks/tests/test_spec_linter.py",
     "**/tools/schema_generator/schema_generator/infer_schemas.py",
     "**/.git",
+    "airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code",  # This is a test directory with badly formatted code
 ]
 
 
@@ -63,4 +66,5 @@ WARM_UP_INCLUSIONS = {
         "tools/gradle/codestyle/java-google-style.xml",
     ],
     Formatter.PYTHON: ["pyproject.toml", "poetry.lock"],
+    Formatter.LICENSE: [LICENSE_FILE_NAME],
 }

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
@@ -110,11 +110,13 @@ def format_js_container(dagger_client: dagger.Client, js_code: dagger.Directory)
 
 def format_license_container(dagger_client: dagger.Client, license_code: dagger.Directory) -> dagger.Container:
     """Create a Go container with addlicense installed with mounted code to format."""
+    warmup_dir = dagger_client.host().directory(".", include=WARM_UP_INCLUSIONS[Formatter.LICENSE], exclude=DEFAULT_FORMAT_IGNORE_LIST)
     return build_container(
         dagger_client,
         base_image=GO_IMAGE,
         dir_to_format=license_code,
         install_commands=["go get -u github.com/google/addlicense"],
+        warmup_dir=warmup_dir,
     )
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/commands.py
@@ -30,7 +30,19 @@ async def test(pipeline_context: ClickPipelineContext):
     logger.info(f"Running tests for {poetry_package_path}")
 
     # The following directories are always mounted because a lot of tests rely on them
-    directories_to_always_mount = [".git", ".github", "docs", "airbyte-integrations", "airbyte-ci", "airbyte-cdk", "pyproject.toml"]
+    directories_to_always_mount = [
+        ".git", # This is needed as some package tests rely on being in a git repo
+        ".github",
+        "docs",
+        "airbyte-integrations",
+        "airbyte-ci",
+        "airbyte-cdk",
+        "pyproject.toml",
+        "LICENSE_SHORT",
+        "poetry.lock",
+        "spotless-maven-pom.xml",
+        "tools/gradle/codestyle/java-google-style.xml",
+    ]
     directories_to_mount = list(set([poetry_package_path, *directories_to_always_mount]))
 
     pipeline_name = f"Unit tests for {poetry_package_path}"
@@ -60,6 +72,7 @@ async def test(pipeline_context: ClickPipelineContext):
                 include=directories_to_mount,
             ),
         )
+        .with_exec(["poetry", "config", "virtualenvs.create", "false"])
         .with_workdir(f"/airbyte/{poetry_package_path}")
         .with_exec(["poetry", "install"])
         .with_unix_socket("/var/run/docker.sock", dagger_client.host().unix_socket("/var/run/docker.sock"))

--- a/airbyte-ci/connectors/pipelines/tests/test_format/__init__.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_format/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-ci/connectors/pipelines/tests/test_format/formatted_code/java.java
+++ b/airbyte-ci/connectors/pipelines/tests/test_format/formatted_code/java.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+public class BadlyFormatted {
+
+  public static void main(String[] args) {
+    System.out.println("Hello, World!");
+    for (int i = 0; i < 5; i++) {
+      System.out.println(i);
+    }
+  }
+
+}

--- a/airbyte-ci/connectors/pipelines/tests/test_format/formatted_code/json.json
+++ b/airbyte-ci/connectors/pipelines/tests/test_format/formatted_code/json.json
@@ -1,0 +1,8 @@
+{
+  "name": "John Doe",
+  "age": 25,
+  "address": {
+    "city": "XYZ",
+    "street": "123 Main St"
+  }
+}

--- a/airbyte-ci/connectors/pipelines/tests/test_format/formatted_code/python.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_format/formatted_code/python.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+
+def my_function():
+    print("Using single quotes, no newlines, and no spaces between the function name.")
+
+
+def my_other_function():
+    print("Using single quotes, no newlines, and no spaces between the function name.")

--- a/airbyte-ci/connectors/pipelines/tests/test_format/formatted_code/yaml.yaml
+++ b/airbyte-ci/connectors/pipelines/tests/test_format/formatted_code/yaml.yaml
@@ -1,0 +1,4 @@
+name: John Doe
+age: 25
+city: XYZ
+street: 123 Main St

--- a/airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/java.java
+++ b/airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/java.java
@@ -1,0 +1,8 @@
+public class BadlyFormatted {
+public static void main(String[] args) {
+System.out.println("Hello, World!");
+for (int i=0; i<5; i++){
+System.out.println(i);
+}
+}
+}

--- a/airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/json.json
+++ b/airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/json.json
@@ -1,0 +1,8 @@
+{
+    "name": "John Doe",
+    "age": 25,
+    "address": {
+    "city": "XYZ",
+    "street": "123 Main St"
+    }
+    }

--- a/airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/python.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/python.py
@@ -1,0 +1,4 @@
+def my_function():
+    print('Using single quotes, no newlines, and no spaces between the function name.')
+def my_other_function():
+    print('Using single quotes, no newlines, and no spaces between the function name.')

--- a/airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/yaml.yaml
+++ b/airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/yaml.yaml
@@ -1,0 +1,4 @@
+name: John Doe
+age: 25
+city: XYZ
+street: 123 Main St

--- a/airbyte-ci/connectors/pipelines/tests/test_format/test_commands.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_format/test_commands.py
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import shutil
+
+import pytest
+from asyncclick.testing import CliRunner
+from pipelines.airbyte_ci.format import commands
+from pipelines.models.contexts.click_pipeline_context import ClickPipelineContext
+
+pytestmark = [
+    pytest.mark.anyio,
+]
+
+PATH_TO_NON_FORMATTED_CODE = "airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code"
+PATH_TO_FORMATTED_CODE = "airbyte-ci/connectors/pipelines/tests/test_format/formatted_code"
+
+
+@pytest.fixture
+def tmp_dir_with_non_formatted_code(tmp_path):
+    """
+    This fixture creates a directory with non formatted code and a license file in the tmp_path.
+    It copies the content of non_formatted_code into the tmp_path.
+    The non_formatted_code directory has non formatted java, python, json, and yaml files missing license headers.
+    """
+    shutil.copytree(PATH_TO_NON_FORMATTED_CODE, tmp_path / "non_formatted_code")
+    return str(tmp_path / "non_formatted_code")
+
+
+@pytest.fixture
+def tmp_dir_with_formatted_code(tmp_path):
+    """
+    This fixture creates a directory with correctly formatted code and a license file in the tmp_path.
+    It copies the content of formatted_code into the tmp_path.
+    The formatted_code has correctly formatted java, python, json, and yaml files with license headers.
+    """
+    shutil.copytree(PATH_TO_FORMATTED_CODE, tmp_path / "formatted_code")
+    return str(tmp_path / "formatted_code")
+
+
+@pytest.fixture
+def now_formatted_directory(dagger_client, tmp_dir_with_non_formatted_code):
+    return dagger_client.host().directory(tmp_dir_with_non_formatted_code).with_timestamps(0)
+
+
+@pytest.fixture
+def already_formatted_directory(dagger_client, tmp_dir_with_formatted_code):
+    return dagger_client.host().directory(tmp_dir_with_formatted_code).with_timestamps(0)
+
+
+@pytest.fixture
+def directory_with_expected_formatted_code(dagger_client):
+    expected_formatted_code_path = "airbyte-ci/connectors/pipelines/tests/test_format/formatted_code"
+    return dagger_client.host().directory(expected_formatted_code_path).with_timestamps(0)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("subcommand", ["check", "fix"])
+async def test_check_and_fix_all_on_non_formatted_code(
+    mocker, subcommand, dagger_client, tmp_dir_with_non_formatted_code, now_formatted_directory, directory_with_expected_formatted_code
+):
+    """
+    Test that when given non formatted files the 'check' and 'fix' all command exit with status 1.
+    We also check that 'fix' correctly exports back the formatted code and that it matches what we expect.
+    """
+    mocker.patch.object(ClickPipelineContext, "get_dagger_client", mocker.AsyncMock(return_value=dagger_client))
+    mocker.patch.object(commands.FormatCommand, "LOCAL_REPO_PATH", tmp_dir_with_non_formatted_code)
+    runner = CliRunner()
+    result = await runner.invoke(commands.format_code, [subcommand, "all"], catch_exceptions=False)
+    if subcommand == "fix":
+        assert await now_formatted_directory.diff(directory_with_expected_formatted_code).entries() == []
+    assert result.exit_code == 1
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("subcommand", ["check", "fix"])
+async def test_check_and_fix_all_on_formatted_code(
+    mocker, subcommand, dagger_client, tmp_dir_with_formatted_code, already_formatted_directory, directory_with_expected_formatted_code
+):
+    """
+    Test that when given formatted files the 'check' and 'fix' all command exit with status 0.
+    We also check that 'fix' does not exports back any file change to the host.
+    """
+    mocker.patch.object(ClickPipelineContext, "get_dagger_client", mocker.AsyncMock(return_value=dagger_client))
+    mocker.patch.object(commands.FormatCommand, "LOCAL_REPO_PATH", tmp_dir_with_formatted_code)
+    runner = CliRunner()
+    result = await runner.invoke(commands.format_code, [subcommand, "all"], catch_exceptions=False)
+    if subcommand == "fix":
+        assert await already_formatted_directory.diff(directory_with_expected_formatted_code).entries() == []
+    assert result.exit_code == 0


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Add test which runs `airbyte-ci format fix all` and `airbyte-ci format check all`
* We assert that the `fix` and `check` commands exit with status code `1` when file are modified. And `0` when no file is modified
* We assert that the output for `fix all` on a sample of unformatted code matches a sample of formatted code.

**N.B.: as the binary used on this branch by the automatic formatting in the CI it will likely reformatted the unformatted code I added for these tests. We should cancel auto format otherwise the tests will fail. The committed unformatted code will be ignored by formatters on `master` once the latest binary is released.**