### PR TITLE
File-based CDK: hide the primary key field from config

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
@@ -46,7 +46,8 @@ class FileBasedStreamConfig(BaseModel):
         description="The schema that will be used to validate records extracted from the file. This will override the stream schema that is auto-detected from incoming files.",
     )
     primary_key: Optional[str] = Field(
-        title="Primary Key", description="The column or columns (for a composite key) that serves as the unique identifier of a record.",
+        title="Primary Key",
+        description="The column or columns (for a composite key) that serves as the unique identifier of a record.",
         airbyte_hidden=True,  # Users can create/modify primary keys in the connection configuration so we shouldn't duplicate it here.
     )
     days_to_sync_if_history_is_full: int = Field(

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
@@ -46,7 +46,8 @@ class FileBasedStreamConfig(BaseModel):
         description="The schema that will be used to validate records extracted from the file. This will override the stream schema that is auto-detected from incoming files.",
     )
     primary_key: Optional[str] = Field(
-        title="Primary Key", description="The column or columns (for a composite key) that serves as the unique identifier of a record."
+        title="Primary Key", description="The column or columns (for a composite key) that serves as the unique identifier of a record.",
+        airbyte_hidden=True,  # Users can create/modify primary keys in the connection configuration so we shouldn't duplicate it here.
     )
     days_to_sync_if_history_is_full: int = Field(
         title="Days To Sync If History Is Full",

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -100,6 +100,7 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                     "title": "Primary Key",
                                     "description": "The column or columns (for a composite key) that serves as the unique identifier of a record.",
                                     "type": "string",
+                                    "airbyte_hidden": True,
                                 },
                                 "days_to_sync_if_history_is_full": {
                                     "title": "Days To Sync If History Is Full",


### PR DESCRIPTION
The `primary_key` option for file-based sources has a couple of problems 1) it doesn't allow users to set a composite primary key, even though the documentation suggests that they can, and more importantly 2) it duplicates functionality with setting of the primary key per connection.

This PR hides the primary key; follow up PRs will be created for file-based sources to propagate the change.