### PR TITLE
airbyte-ci: mount docker auth secrets to validation container 

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -243,8 +243,7 @@ async def run_connector_publish_pipeline(context: PublishConnectorContext, semap
 
             results = []
 
-            metadata_validation_results = await MetadataValidation(context=context).run()
-
+            metadata_validation_results = await MetadataValidation(context).run()
             results.append(metadata_validation_results)
 
             # Exit early if the metadata file is invalid.

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -243,7 +243,12 @@ async def run_connector_publish_pipeline(context: PublishConnectorContext, semap
 
             results = []
 
-            metadata_validation_results = await MetadataValidation(context).run()
+            metadata_validation_results = await MetadataValidation(
+                context=context,
+                docker_hub_username_secret=context.docker_hub_username_secret,
+                docker_hub_password_secret=context.docker_hub_password_secret,
+            ).run()
+
             results.append(metadata_validation_results)
 
             # Exit early if the metadata file is invalid.

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -243,11 +243,7 @@ async def run_connector_publish_pipeline(context: PublishConnectorContext, semap
 
             results = []
 
-            metadata_validation_results = await MetadataValidation(
-                context=context,
-                docker_hub_username_secret=context.docker_hub_username_secret,
-                docker_hub_password_secret=context.docker_hub_password_secret,
-            ).run()
+            metadata_validation_results = await MetadataValidation(context=context).run()
 
             results.append(metadata_validation_results)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -21,7 +21,7 @@ from pipelines.models.steps import MountPath, Step, StepResult
 
 
 class MetadataValidation(SimpleDockerStep):
-    def __init__(self, context: ConnectorContext, docker_hub_username_secret: dagger.Secret, docker_hub_password_secret: dagger.Secret):
+    def __init__(self, context: ConnectorContext):
         super().__init__(
             title=f"Validate metadata for {context.connector.technical_name}",
             context=context,
@@ -34,8 +34,8 @@ class MetadataValidation(SimpleDockerStep):
                 MountPath(INTERNAL_TOOL_PATHS.METADATA_SERVICE.value),
             ],
             secrets={
-                "DOCKER_HUB_USERNAME": docker_hub_username_secret,
-                "DOCKER_HUB_PASSWORD": docker_hub_password_secret,
+                "DOCKER_HUB_USERNAME": context.docker_hub_username_secret,
+                "DOCKER_HUB_PASSWORD": context.docker_hub_password_secret,
             },
             command=[
                 "metadata_service",

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -21,7 +21,7 @@ from pipelines.models.steps import MountPath, Step, StepResult
 
 
 class MetadataValidation(SimpleDockerStep):
-    def __init__(self, context: ConnectorContext):
+    def __init__(self, context: ConnectorContext, docker_hub_username_secret: dagger.Secret, docker_hub_password_secret: dagger.Secret):
         super().__init__(
             title=f"Validate metadata for {context.connector.technical_name}",
             context=context,
@@ -33,6 +33,10 @@ class MetadataValidation(SimpleDockerStep):
             internal_tools=[
                 MountPath(INTERNAL_TOOL_PATHS.METADATA_SERVICE.value),
             ],
+            secrets={
+                "DOCKER_HUB_USERNAME": docker_hub_username_secret,
+                "DOCKER_HUB_PASSWORD": docker_hub_password_secret,
+            },
             command=[
                 "metadata_service",
                 "validate",


### PR DESCRIPTION
Now that we are running the validation for whether the referenced base image exists, we need to make sure it exists. To do this we need docker creds in the `MetadataValidation` container, which we didn't have before. Wasn't caught on tests because the method is mocked.