### PR TITLE
Weaviate: Normalize property names

### DIFF
--- a/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
+++ b/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
@@ -135,11 +135,11 @@ class WeaviateIndexer(Indexer):
 
     def _normalize_property_name(self, field_name: str) -> str:
         # Remove invalid characters and replace spaces with underscores
-        normalized = re.sub(r'[^0-9A-Za-z_]', '', field_name.replace(' ', '_'))
+        normalized = re.sub(r"[^0-9A-Za-z_]", "", field_name.replace(" ", "_"))
 
         # Ensure the name starts with a letter or underscore
-        if not re.match(r'^[_A-Za-z]', normalized):
-            normalized = '_' + normalized
+        if not re.match(r"^[_A-Za-z]", normalized):
+            normalized = "_" + normalized
 
         return normalized[0].lower() + normalized[1:]
 

--- a/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
+++ b/airbyte-integrations/connectors/destination-weaviate/destination_weaviate/indexer.py
@@ -70,7 +70,7 @@ class WeaviateIndexer(Indexer):
         classes = {c["class"]: c for c in self.client.schema.get().get("classes", [])}
         self.has_record_id_metadata = defaultdict(lambda: False)
         for stream in catalog.streams:
-            class_name = self.stream_to_class_name(stream.stream.name)
+            class_name = self._stream_to_class_name(stream.stream.name)
             schema = classes[class_name] if class_name in classes else None
             if stream.destination_sync_mode == DestinationSyncMode.overwrite and schema is not None:
                 self.client.schema.delete_class(class_name=class_name)
@@ -103,7 +103,7 @@ class WeaviateIndexer(Indexer):
 
     def delete(self, delete_ids, namespace, stream):
         if len(delete_ids) > 0:
-            class_name = self.stream_to_class_name(stream)
+            class_name = self._stream_to_class_name(stream)
             if self.has_record_id_metadata[class_name]:
                 self.client.batch.delete_objects(
                     class_name=class_name,
@@ -123,22 +123,32 @@ class WeaviateIndexer(Indexer):
                 if chunk.page_content is not None:
                     weaviate_object[self.config.text_field] = chunk.page_content
                 object_id = str(uuid.uuid4())
-                class_name = self.stream_to_class_name(chunk.record.stream)
+                class_name = self._stream_to_class_name(chunk.record.stream)
                 self.client.batch.add_data_object(weaviate_object, class_name, object_id, vector=chunk.embedding)
             self._flush()
 
-    def stream_to_class_name(self, stream_name: str) -> str:
+    def _stream_to_class_name(self, stream_name: str) -> str:
         pattern = "[^0-9A-Za-z_]+"
         stream_name = re.sub(pattern, "", stream_name)
         stream_name = stream_name.replace(" ", "")
         return stream_name[0].upper() + stream_name[1:]
+
+    def _normalize_property_name(self, field_name: str) -> str:
+        # Remove invalid characters and replace spaces with underscores
+        normalized = re.sub(r'[^0-9A-Za-z_]', '', field_name.replace(' ', '_'))
+
+        # Ensure the name starts with a letter or underscore
+        if not re.match(r'^[_A-Za-z]', normalized):
+            normalized = '_' + normalized
+
+        return normalized[0].lower() + normalized[1:]
 
     def _normalize(self, metadata: dict) -> dict:
         result = {}
 
         for key, value in metadata.items():
             # Property names in Weaviate have to start with lowercase letter
-            normalized_key = key[0].lower() + key[1:]
+            normalized_key = self._normalize_property_name(key)
             # "id" and "additional" are reserved properties in Weaviate, prefix to disambiguate
             if key == "id" or key == "_id" or key == "_additional":
                 normalized_key = f"raw_{key}"

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: 7b7d7a0d-954c-45a0-bcfc-39a634b97736
-  dockerImageTag: 0.2.11
+  dockerImageTag: 0.2.12
   dockerRepository: airbyte/destination-weaviate
   documentationUrl: https://docs.airbyte.com/integrations/destinations/weaviate
   githubIssueLabel: destination-weaviate

--- a/airbyte-integrations/connectors/destination-weaviate/unit_tests/indexer_test.py
+++ b/airbyte-integrations/connectors/destination-weaviate/unit_tests/indexer_test.py
@@ -199,12 +199,32 @@ class TestWeaviateIndexer(unittest.TestCase):
         mock_chunk = Chunk(
             page_content="some_content",
             embedding=[1, 2, 3],
-            metadata={"someField": "some_value", "complex": {"a": [1, 2, 3]}, "UPPERCASE_NAME": "abc", "id": 12, "empty_list": []},
+            metadata={
+                "someField": "some_value", "complex": {"a": [1, 2, 3]}, "UPPERCASE_NAME": "abc", "id": 12, "empty_list": [],
+                        "referral Agency Name": "test1",
+                    "123StartsWithNumber": "test2",
+                    "special&*chars": "test3",
+                    "with spaces": "test4",
+                    "": "test5",
+                    "_startsWithUnderscore": "test6",
+                    "multiple  spaces": "test7",
+                    "SpecialCharacters!@#": "test8"
+                      },
             record=AirbyteRecordMessage(stream="test", data={"someField": "some_value"}, emitted_at=0),
         )
         self.indexer.index([mock_chunk], None, "test")
         mock_client.batch.add_data_object.assert_called_with(
-            {"someField": "some_value", "complex": '{"a": [1, 2, 3]}', "uPPERCASE_NAME": "abc", "text": "some_content", "raw_id": 12},
+            {"someField": "some_value", "complex": '{"a": [1, 2, 3]}', "uPPERCASE_NAME": "abc", "text": "some_content", "raw_id": 12,
+                 "referral_Agency_Name": "test1",
+                "_123StartsWithNumber": "test2",
+                "specialchars": "test3",
+                "with_spaces": "test4",
+                "_": "test5",
+                "_startsWithUnderscore": "test6",
+                "multiple__spaces": "test7",
+                "specialCharacters": "test8"
+
+             },
             "Test",
             ANY,
             vector=[1, 2, 3],

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -77,7 +77,7 @@ If a class doesn't exist in the schema of the cluster, it will be created using 
 
 You can also create the class in Weaviate in advance if you need more control over the schema in Weaviate. In this case, the text properies `_ab_stream` and `_ab_record_id` need to be created for bookkeeping reasons. In case a sync is run in `Overwrite` mode, the class will be deleted and recreated.
 
-As properties have to start will a lowercase letter in Weaviate, field names might be updated during the loading process. The field names `id`, `_id` and `_additional` are reserved keywords in Weaviate, so they will be renamed to `raw_id`, `raw__id` and `raw_additional` respectively.
+As properties have to start will a lowercase letter in Weaviate and can't contain spaces or special characters.  Field names might be updated during the loading process. The field names `id`, `_id` and `_additional` are reserved keywords in Weaviate, so they will be renamed to `raw_id`, `raw__id` and `raw_additional` respectively.
 
 ## Changelog
 

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -83,6 +83,7 @@ As properties have to start will a lowercase letter in Weaviate and can't contai
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| 0.2.12 | 2023-12-07 | [33218](https://github.com/airbytehq/airbyte/pull/33218) | Normalize metadata field names |
 | 0.2.11 | 2023-12-01 | [32697](https://github.com/airbytehq/airbyte/pull/32697) | Allow omitting raw text |
 | 0.2.10 | 2023-11-16 | [32608](https://github.com/airbytehq/airbyte/pull/32608) | Support deleting records for CDC sources |
 | 0.2.9 | 2023-11-13 | [32357](https://github.com/airbytehq/airbyte/pull/32357) | Improve spec schema |


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/32331

## How

By normalizing property names to fit the Weaviate requirements. This is no breaking change, as property names getting changed by this updated logic would have failed the sync in previous versions.
