### PR TITLE
✨ Source Intercom: add new substream ContactSegments

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/Dockerfile
+++ b/airbyte-integrations/connectors/source-intercom/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.9.11-alpine3.15 as base
+
+# build and load all requirements
+FROM base as builder
+WORKDIR /airbyte/integration_code
+
+# upgrade pip to the latest version
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base
+
+
+COPY setup.py ./
+# install necessary packages to a temporary folder
+RUN pip install --prefix=/install .
+
+# build a clean environment
+FROM base
+WORKDIR /airbyte/integration_code
+
+# copy all loaded and built libraries to a pure basic image
+COPY --from=builder /install /usr/local
+# add default timezone settings
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
+
+# bash is installed for more convenient debugging.
+RUN apk --no-cache add bash
+
+# copy payload code only
+COPY main.py ./
+COPY source_intercom ./source_intercom
+
+ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+
+LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.name=airbyte/source-intercom

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -258,7 +258,27 @@ definitions:
           partition_field: "id"
     retriever:
       $ref: "#/definitions/substream_semi_incremental/retriever"
-
+  contact_segments:
+    $ref: "#/definitions/substream_semi_incremental"
+    $parameters:
+      name: "contact_segments"
+      primary_key: "id"
+      path: "/contacts/{{ stream_slice.id }}/segments"
+    incremental_sync:
+      $ref: "#/definitions/substream_semi_incremental/incremental_sync"
+      # parent_complete_fetch: true
+      parent_stream_configs:
+        - type: ParentStreamConfig
+          stream: "#/definitions/contacts"
+          parent_key: "id"
+          partition_field: "id"
+    transformations:
+      - type: AddFields
+        fields:
+          - path: ["contact_id"]
+            value: "'{{ stream_slice.id }}'"
+    retriever:
+      $ref: "#/definitions/substream_semi_incremental/retriever"
   # incremental search
   stream_incremental_search:
     description: "https://developers.intercom.com/intercom-api-reference/reference/pagination-sorting-search"
@@ -309,6 +329,7 @@ streams:
   - "#/definitions/conversations"
   - "#/definitions/conversation_parts"
   - "#/definitions/company_segments"
+  - "#/definitions/contact_segments"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contact_segments.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/contact_segments.json
@@ -1,0 +1,29 @@
+{
+    "type": "object",
+    "properties": {
+        "type": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null","string"]
+        },
+        "name": {
+            "type": ["null","string"]
+        },
+        "created_at": {
+            "type": ["null", "integer"]
+        },
+        "updated_at": {
+            "type": ["null", "integer"]
+        },
+        "person_type": {
+            "type": ["null", "string"]
+        },
+        "count": {
+            "type": ["null", "string"]
+        },
+        "contact_id": {
+            "type": ["null", "string"]
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
adding a substream fetching the segments object individually from the contacts streams, adding an additional contact id field to the substream

feat(source-intercom): add contact_segments stream with Dockerfile setup

This commit introduces the 'contact_segments' stream to the source-intercom connector, extending its functionality. The update includes a new manifest section, JSON schema file, and the necessary Dockerfile configuration for proper environment setup.

- The Dockerfile has been created to set up a lightweight Python environment using Alpine Linux as a base image.

- A new manifest entry for the 'contact_segments' substream outlines incremental sync capabilities along with requisite transformations.

- The corresponding JSON schema for 'contact_segments' specifies its data structure and types.

This enhancement allows users to retrieve segment information associated with contacts directly from Intercom through Airbyte's integration system, improving the completeness of available data for synchronization tasks.

## How
Creating a new substream i.e. contact_segment based of the parent stream i.e. contact. This substream waits till the parent stream has been completed running and than retrieves the segment information for each of the contact. 

## Recommended reading order
1. `manifest.yaml`
2. `schema/contact_segments.json`
3. `Dockerfile`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

This pr introduces **_no_** breaking changes. 
