### PR TITLE
airbyte-ci format: remove verbose mode on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,3 @@ repos:
         name: Run airbyte-ci format fix on git push (~30s)
         pass_filenames: false
         stages: [push]
-        verbose: true


### PR DESCRIPTION
I think we can disable the verbose mode on our pre-push hook.

I believe pre-commit default output is self explanatory:
```
Run airbyte-ci format fix on git push (~30s).............................Failed
- hook id: format-fix-all-on-push
- duration: 62.12s
- exit code: 1
- files were modified by this hook
```

When you see this message you can run `git diff` or `git status` to realize what got changed by the formatters. If you want more details you can run `airbyte-ci format check all` manually.