### PR TITLE
airbyte-ci: fix credentials bug

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -462,6 +462,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 ## Changelog
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 2.10.7  | [#33248](https://github.com/airbytehq/airbyte/pull/33248)  | Fix bug which broke airbyte-ci connectors tests when optional DockerHub credentials env vars are not set. |
 | 2.10.6  | [#33170](https://github.com/airbytehq/airbyte/pull/33170)  | Remove Dagger logs from console output of `format`.                                                       |
 | 2.10.5  | [#33097](https://github.com/airbytehq/airbyte/pull/33097)  | Improve `format` performances, exit with 1 status code when `fix` changes files.                          |
 | 2.10.4  | [#33206](https://github.com/airbytehq/airbyte/pull/33206)  | Add "-y/--yes" Flag to allow preconfirmation of prompts                                                    |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -33,10 +33,10 @@ class MetadataValidation(SimpleDockerStep):
             internal_tools=[
                 MountPath(INTERNAL_TOOL_PATHS.METADATA_SERVICE.value),
             ],
-            secrets={
+            secrets={k: v for k,v in {
                 "DOCKER_HUB_USERNAME": context.docker_hub_username_secret,
                 "DOCKER_HUB_PASSWORD": context.docker_hub_password_secret,
-            },
+            }.items() if v},
             command=[
                 "metadata_service",
                 "validate",

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -33,10 +33,14 @@ class MetadataValidation(SimpleDockerStep):
             internal_tools=[
                 MountPath(INTERNAL_TOOL_PATHS.METADATA_SERVICE.value),
             ],
-            secrets={k: v for k,v in {
-                "DOCKER_HUB_USERNAME": context.docker_hub_username_secret,
-                "DOCKER_HUB_PASSWORD": context.docker_hub_password_secret,
-            }.items() if v},
+            secrets={
+                k: v
+                for k, v in {
+                    "DOCKER_HUB_USERNAME": context.docker_hub_username_secret,
+                    "DOCKER_HUB_PASSWORD": context.docker_hub_password_secret,
+                }.items()
+                if v
+            },
             command=[
                 "metadata_service",
                 "validate",

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.10.6"
+version = "2.10.7"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
This fixes a bug which prevents the use of airbyte-ci when a couple of env vars are not set.