### PR TITLE
doc: add code-formatting to sidebar.js

### DIFF
--- a/docs/contributing-to-airbyte/resources/gradle.md
+++ b/docs/contributing-to-airbyte/resources/gradle.md
@@ -1,4 +1,4 @@
-# Gradle Cheatsheet
+# (DEPRECATED) Gradle Cheatsheet
 
 ## Overview
 

--- a/docs/contributing-to-airbyte/resources/python-gradle-setup.md
+++ b/docs/contributing-to-airbyte/resources/python-gradle-setup.md
@@ -1,4 +1,4 @@
-# Monorepo Python Development
+# (DEPRECATED) Monorepo Python Development 
 
 This guide contains instructions on how to setup Python with Gradle within the Airbyte Monorepo. If you are a contributor working on one or two connectors, this page is most likely not relevant to you. Instead, you should use your standard Python development flow.
 
@@ -30,21 +30,7 @@ python tools/bin/update_intellij_venv.py --all-modules --install-venv
 
 This will create a `virtualenv` and install dependencies for the connector you want to work on as well as any internal Airbyte python packages it depends on.
 
-When iterating on a single connector, you will often iterate by running
 
-```text
-./gradlew :airbyte-integrations:connectors:your-connector-dir:build
-```
-
-This command will:
-
-1. Install a virtual environment at `airbyte-integrations/connectors/<your-connector-dir>/.venv`
-2. Install local development dependencies specified in `airbyte-integrations/connectors/your-connector-dir/requirements.txt`
-3. Runs the following pip modules:
-    1. [Black](https://pypi.org/project/black/) to lint the code
-    2. [isort](https://pypi.org/project/isort/) to sort imports
-    3. [Flake8](https://pypi.org/project/flake8/) to check formatting
-    4. [MyPy](https://pypi.org/project/mypy/) to check type usage
 
 ## Formatting/linting
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -310,6 +310,7 @@ const contributeToAirbyte = {
       items: [
         "contributing-to-airbyte/resources/pull-requests-handbook",
         "contributing-to-airbyte/resources/code-style",
+        "contributing-to-airbyte/resources/code-formatting",
         "contributing-to-airbyte/resources/developing-locally",
         "contributing-to-airbyte/resources/developing-on-docker",
         "contributing-to-airbyte/resources/gradle",

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -313,8 +313,6 @@ const contributeToAirbyte = {
         "contributing-to-airbyte/resources/code-formatting",
         "contributing-to-airbyte/resources/developing-locally",
         "contributing-to-airbyte/resources/developing-on-docker",
-        "contributing-to-airbyte/resources/gradle",
-        "contributing-to-airbyte/resources/python-gradle-setup",
       ],
     },
   ],


### PR DESCRIPTION
I want [this page](https://docs.airbyte.com/contributing-to-airbyte/resources/code-formatting) to be listed here:
<img width="267" alt="Screenshot 2023-12-08 at 16 59 44" src="https://github.com/airbytehq/airbyte/assets/5551758/753973a7-1ddf-47d5-b708-947bd4f0691b">
