### PR TITLE
Source Hubspot: fix the FieldAnchor closing tag

### DIFF
--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -122,6 +122,21 @@ Next, you need to configure the appropriate scopes for the following streams. Pl
 
 </FieldAnchor>
 
+### Custom CRM Objects
+
+Custom CRM Objects and Custom Web Analytics will appear as streams available for sync, alongside the standard objects listed above.
+
+If you set up your connections before April 15th, 2023 (on Airbyte Cloud) or before 0.8.0 (OSS) then you'll need to do some additional work to sync custom CRM objects.
+
+First you need to give the connector some additional permissions:
+
+<!-- env:cloud -->
+- **If you are using OAuth on Airbyte Cloud** go to the Hubspot source settings page in the Airbyte UI and re-authenticate via OAuth to allow Airbyte the permissions to access custom objects.
+<!-- /env:cloud -->
+- **If you are using OAuth on OSS or Private App auth** go into the Hubspot UI where you created your Private App or OAuth application and add the `crm.objects.custom.read` scope to your app's scopes. See HubSpot's instructions [here](https://developers.hubspot.com/docs/api/working-with-oauth#scopes).
+
+Then, go to the replication settings of your connection and click **refresh source schema** to pull in those new streams for syncing.
+
 <HideInUI>
 
 ## Supported sync modes
@@ -183,21 +198,6 @@ The HubSpot source connector supports the following streams:
 - [GoalsWebAnalytics](https://developers.hubspot.com/docs/api/events/web-analytics) \(Incremental\)
 - [LineItemsWebAnalytics](https://developers.hubspot.com/docs/api/events/web-analytics) \(Incremental\)
 - [ProductsWebAnalytics](https://developers.hubspot.com/docs/api/events/web-analytics) \(Incremental\)
-
-### Custom CRM Objects
-
-Custom CRM Objects and Custom Web Analytics will appear as streams available for sync, alongside the standard objects listed above.
-
-If you set up your connections before April 15th, 2023 (on Airbyte Cloud) or before 0.8.0 (OSS) then you'll need to do some additional work to sync custom CRM objects.
-
-First you need to give the connector some additional permissions:
-
-<!-- env:cloud -->
-- **If you are using OAuth on Airbyte Cloud** go to the Hubspot source settings page in the Airbyte UI and re-authenticate via OAuth to allow Airbyte the permissions to access custom objects.
-<!-- /env:cloud -->
-- **If you are using OAuth on OSS or Private App auth** go into the Hubspot UI where you created your Private App or OAuth application and add the `crm.objects.custom.read` scope to your app's scopes. See HubSpot's instructions [here](https://developers.hubspot.com/docs/api/working-with-oauth#scopes).
-
-Then, go to the replication settings of your connection and click **refresh source schema** to pull in those new streams for syncing.
 
 ### Notes on the `engagements` stream
 

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -114,6 +114,14 @@ Next, you need to configure the appropriate scopes for the following streams. Pl
    `yyyy-mm-ddThh:mm:ssZ`. The data added on and after this date will be replicated.
 6. Click **Set up source** and wait for the tests to complete.
 
+<FieldAnchor field="enable_experimental_streams">
+
+### Experimental streams
+
+[Web Analytics](https://developers.hubspot.com/docs/api/events/web-analytics) streams may be enabled as an experimental feature but please note that they are based on API which is currently in beta and may change at some point of time or be unstable.
+
+</FieldAnchor>
+
 <HideInUI>
 
 ## Supported sync modes
@@ -190,14 +198,6 @@ First you need to give the connector some additional permissions:
 - **If you are using OAuth on OSS or Private App auth** go into the Hubspot UI where you created your Private App or OAuth application and add the `crm.objects.custom.read` scope to your app's scopes. See HubSpot's instructions [here](https://developers.hubspot.com/docs/api/working-with-oauth#scopes).
 
 Then, go to the replication settings of your connection and click **refresh source schema** to pull in those new streams for syncing.
-
-<FieldAnchor field="enable_experimental_streams">
-
-### Experimental streams
-
-[Web Analytics](https://developers.hubspot.com/docs/api/events/web-analytics) streams may be enabled as an experimental feature but please note that they are based on API which is currently in beta and may change at some point of time or be unstable.
-
-</FieldAnchor>
 
 ### Notes on the `engagements` stream
 

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -191,7 +191,7 @@ First you need to give the connector some additional permissions:
 
 Then, go to the replication settings of your connection and click **refresh source schema** to pull in those new streams for syncing.
 
-<FieldAnchor field="enable_experimental_streams" />
+<FieldAnchor field="enable_experimental_streams">
 
 ### Experimental streams
 


### PR DESCRIPTION
## What
*Fix the problem from https://github.com/airbytehq/airbyte/pull/33042. Documnetation is broken*

## How
*Remove autoclosing `/` from `<FieldAnchor />`*
