### PR TITLE
destination-s3: update configs with common defaults

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 0.5.4
+  dockerImageTag: 0.5.5
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
@@ -20,6 +20,7 @@
         "description": "The access key ID to access the S3 bucket. Airbyte requires Read and Write permissions to the given bucket. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>.",
         "title": "S3 Key ID",
         "airbyte_secret": true,
+        "always_show": true,
         "examples": ["A012345678910EXAMPLE"],
         "order": 0
       },
@@ -28,6 +29,7 @@
         "description": "The corresponding secret to the access key ID. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>",
         "title": "S3 Access Key",
         "airbyte_secret": true,
+        "always_show": true,
         "examples": ["a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY"],
         "order": 1
       },
@@ -85,6 +87,102 @@
         "type": "object",
         "description": "Format of the data output. See <a href=\"https://docs.airbyte.com/integrations/destinations/s3/#supported-output-schema\">here</a> for more details",
         "oneOf": [
+          {
+            "title": "CSV: Comma-Separated Values",
+            "required": ["format_type", "flattening"],
+            "properties": {
+              "format_type": {
+                "title": "Format Type",
+                "type": "string",
+                "enum": ["CSV"],
+                "default": "CSV"
+              },
+              "flattening": {
+                "type": "string",
+                "title": "Flattening",
+                "description": "Whether the input json data should be normalized (flattened) in the output CSV. Please refer to docs for details.",
+                "default": "No flattening",
+                "enum": ["No flattening", "Root level flattening"]
+              },
+              "compression": {
+                "title": "Compression",
+                "type": "object",
+                "description": "Whether the output files should be compressed. If compression is selected, the output filename will have an extra extension (GZIP: \".csv.gz\").",
+                "oneOf": [
+                  {
+                    "title": "No Compression",
+                    "requires": ["compression_type"],
+                    "properties": {
+                      "compression_type": {
+                        "type": "string",
+                        "enum": ["No Compression"],
+                        "default": "No Compression"
+                      }
+                    }
+                  },
+                  {
+                    "title": "GZIP",
+                    "requires": ["compression_type"],
+                    "properties": {
+                      "compression_type": {
+                        "type": "string",
+                        "enum": ["GZIP"],
+                        "default": "GZIP"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "title": "JSON Lines: Newline-delimited JSON",
+            "required": ["format_type"],
+            "properties": {
+              "format_type": {
+                "title": "Format Type",
+                "type": "string",
+                "enum": ["JSONL"],
+                "default": "JSONL"
+              },
+              "flattening": {
+                "type": "string",
+                "title": "Flattening",
+                "description": "Whether the input json data should be normalized (flattened) in the output JSON Lines. Please refer to docs for details.",
+                "default": "No flattening",
+                "enum": ["No flattening", "Root level flattening"]
+              },
+              "compression": {
+                "title": "Compression",
+                "type": "object",
+                "description": "Whether the output files should be compressed. If compression is selected, the output filename will have an extra extension (GZIP: \".jsonl.gz\").",
+                "oneOf": [
+                  {
+                    "title": "No Compression",
+                    "requires": "compression_type",
+                    "properties": {
+                      "compression_type": {
+                        "type": "string",
+                        "enum": ["No Compression"],
+                        "default": "No Compression"
+                      }
+                    }
+                  },
+                  {
+                    "title": "GZIP",
+                    "requires": "compression_type",
+                    "properties": {
+                      "compression_type": {
+                        "type": "string",
+                        "enum": ["GZIP"],
+                        "default": "GZIP"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
           {
             "title": "Avro: Apache Avro",
             "required": ["format_type", "compression_codec"],
@@ -199,102 +297,6 @@
                   }
                 ],
                 "order": 1
-              }
-            }
-          },
-          {
-            "title": "CSV: Comma-Separated Values",
-            "required": ["format_type", "flattening"],
-            "properties": {
-              "format_type": {
-                "title": "Format Type",
-                "type": "string",
-                "enum": ["CSV"],
-                "default": "CSV"
-              },
-              "flattening": {
-                "type": "string",
-                "title": "Flattening",
-                "description": "Whether the input json data should be normalized (flattened) in the output CSV. Please refer to docs for details.",
-                "default": "No flattening",
-                "enum": ["No flattening", "Root level flattening"]
-              },
-              "compression": {
-                "title": "Compression",
-                "type": "object",
-                "description": "Whether the output files should be compressed. If compression is selected, the output filename will have an extra extension (GZIP: \".csv.gz\").",
-                "oneOf": [
-                  {
-                    "title": "No Compression",
-                    "requires": ["compression_type"],
-                    "properties": {
-                      "compression_type": {
-                        "type": "string",
-                        "enum": ["No Compression"],
-                        "default": "No Compression"
-                      }
-                    }
-                  },
-                  {
-                    "title": "GZIP",
-                    "requires": ["compression_type"],
-                    "properties": {
-                      "compression_type": {
-                        "type": "string",
-                        "enum": ["GZIP"],
-                        "default": "GZIP"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "title": "JSON Lines: Newline-delimited JSON",
-            "required": ["format_type"],
-            "properties": {
-              "format_type": {
-                "title": "Format Type",
-                "type": "string",
-                "enum": ["JSONL"],
-                "default": "JSONL"
-              },
-              "flattening": {
-                "type": "string",
-                "title": "Flattening",
-                "description": "Whether the input json data should be normalized (flattened) in the output JSON Lines. Please refer to docs for details.",
-                "default": "No flattening",
-                "enum": ["No flattening", "Root level flattening"]
-              },
-              "compression": {
-                "title": "Compression",
-                "type": "object",
-                "description": "Whether the output files should be compressed. If compression is selected, the output filename will have an extra extension (GZIP: \".jsonl.gz\").",
-                "oneOf": [
-                  {
-                    "title": "No Compression",
-                    "requires": "compression_type",
-                    "properties": {
-                      "compression_type": {
-                        "type": "string",
-                        "enum": ["No Compression"],
-                        "default": "No Compression"
-                      }
-                    }
-                  },
-                  {
-                    "title": "GZIP",
-                    "requires": "compression_type",
-                    "properties": {
-                      "compression_type": {
-                        "type": "string",
-                        "enum": ["GZIP"],
-                        "default": "GZIP"
-                      }
-                    }
-                  }
-                ]
               }
             }
           },

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -171,12 +171,12 @@ A data sync may create multiple files as the output files can be partitioned by 
 
 ## Supported sync modes
 
-| Feature                        | Support | Notes                                                                                                                                                                                               |
-| :----------------------------- | :-----: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Full Refresh Sync              |   ✅    | Warning: this mode deletes all previously synced data in the configured bucket path.                                                                                                                |
+| Feature                        | Support | Notes                                                                                                                                                                                                    |
+| :----------------------------- | :-----: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Full Refresh Sync              |   ✅    | Warning: this mode deletes all previously synced data in the configured bucket path.                                                                                                                     |
 | Incremental - Append Sync      |   ✅    | Warning: Airbyte provides at-least-once delivery. Depending on your source, you may see duplicated data. Learn more [here](/using-airbyte/core-concepts/sync-modes/incremental-append#inclusive-cursors) |
-| Incremental - Append + Deduped |   ❌    |                                                                                                                                                                                                     |
-| Namespaces                     |   ❌    | Setting a specific bucket path is equivalent to having separate namespaces.                                                                                                                         |
+| Incremental - Append + Deduped |   ❌    |                                                                                                                                                                                                          |
+| Namespaces                     |   ❌    | Setting a specific bucket path is equivalent to having separate namespaces.                                                                                                                              |
 
 The Airbyte S3 destination allows you to sync data to AWS S3 or Minio S3. Each stream is written to its own directory under the bucket.
 
@@ -346,8 +346,9 @@ In order for everything to work correctly, it is also necessary that the user wh
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                              |
 | :------ | :--------- | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.5.5   | 2023-12-08 | [#xxx](https://github.com/airbytehq/airbyte/pull/xxx)      | Update UI options with common defaults.                                                                                                              |
 | 0.5.4   | 2023-11-06 | [#32193](https://github.com/airbytehq/airbyte/pull/32193)  | (incorrect filename format, do not use) Adopt java CDK version 0.4.1.                                                                                |
-| 0.5.3   | 2023-11-03 | [#32050](https://github.com/airbytehq/airbyte/pull/32050)  | (incorrect filename format, do not use) Adopt java CDK version 0.4.0. This updates filenames to include a UUID.                                       |
+| 0.5.3   | 2023-11-03 | [#32050](https://github.com/airbytehq/airbyte/pull/32050)  | (incorrect filename format, do not use) Adopt java CDK version 0.4.0. This updates filenames to include a UUID.                                      |
 | 0.5.1   | 2023-06-26 | [#27786](https://github.com/airbytehq/airbyte/pull/27786)  | Fix build                                                                                                                                            |
 | 0.5.0   | 2023-06-26 | [#27725](https://github.com/airbytehq/airbyte/pull/27725)  | License Update: Elv2                                                                                                                                 |
 | 0.4.2   | 2023-06-21 | [#27555](https://github.com/airbytehq/airbyte/pull/27555)  | Reduce image size                                                                                                                                    |

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -346,7 +346,7 @@ In order for everything to work correctly, it is also necessary that the user wh
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                              |
 | :------ | :--------- | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.5.5   | 2023-12-08 | [#xxx](https://github.com/airbytehq/airbyte/pull/xxx)      | Update UI options with common defaults.                                                                                                              |
+| 0.5.5   | 2023-12-08 | [#33264](https://github.com/airbytehq/airbyte/pull/33264)  | Update UI options with common defaults.                                                                                                              |
 | 0.5.4   | 2023-11-06 | [#32193](https://github.com/airbytehq/airbyte/pull/32193)  | (incorrect filename format, do not use) Adopt java CDK version 0.4.1.                                                                                |
 | 0.5.3   | 2023-11-03 | [#32050](https://github.com/airbytehq/airbyte/pull/32050)  | (incorrect filename format, do not use) Adopt java CDK version 0.4.0. This updates filenames to include a UUID.                                      |
 | 0.5.1   | 2023-06-26 | [#27786](https://github.com/airbytehq/airbyte/pull/27786)  | Fix build                                                                                                                                            |


### PR DESCRIPTION
Some UX updates for destination-s3:
* while still not required, `access_key_id` and `secret_access_key` should be shown on the form by default - they are very common (Closes https://github.com/airbytehq/airbyte/issues/33254)
* Make the default file format CSV

Now, as a note, these changes won't make it airbyte cloud because we have an old version of the connector pinned on Airbyte Cloud (reason: `(incorrect filename format, do not use) Adopt java CDK version 0.4.`).  We'll investigate this when we revisit S3's certification next year.  re: https://github.com/airbytehq/airbyte/pull/32228 and UUID file names vs numbers.