### PR TITLE
formatting: airbyte-cdk + normalization fix flakeCheck

### DIFF
--- a/airbyte-cdk/python/unit_tests/__init__.py
+++ b/airbyte-cdk/python/unit_tests/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/destinations/__init__.py
+++ b/airbyte-cdk/python/unit_tests/destinations/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/singer/__init__.py
+++ b/airbyte-cdk/python/unit_tests/singer/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/declarative/decoders/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/decoders/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/file_based/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/availability_strategy/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/file_based/config/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/config/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/file_based/discovery_policy/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/discovery_policy/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/file_based/stream/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/stream/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/message/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/message/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/streams/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/auth/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/auth/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/__init__.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/test/__init__.py
+++ b/airbyte-cdk/python/unit_tests/test/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/test/http/__init__.py
+++ b/airbyte-cdk/python/unit_tests/test/http/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-cdk/python/unit_tests/utils/__init__.py
+++ b/airbyte-cdk/python/unit_tests/utils/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-

--- a/airbyte-integrations/bases/base-normalization/integration_tests/__init__.py
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/pull/33250 added missing license headers to `__init__.py` files.
But black and flake rules are clashing:
blacks adds two new lines after a comment while flake fails if there are two new lines at the end of a file.


## How
Respect flake rules on cdk to make `flakeCheck` pass. Will resolve the rules conflicts in a different PR.
