### PR TITLE
[Source-mssql] Remove reference to strict encrypt in metadata

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -18,7 +18,6 @@ data:
   name: Microsoft SQL Server (MSSQL)
   registries:
     cloud:
-      dockerRepository: airbyte/source-mssql-strict-encrypt
       enabled: true
     oss:
       enabled: true


### PR DESCRIPTION
***Description***: With the recent removal of the strict-encrypt variant for source-mssql, we need to also remove the reference in the metadata file in order to publish to the registry.