### PR TITLE
POC: asyncio for concurrent reads in Source Salesforce

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/abstract_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/abstract_stream.py
@@ -37,7 +37,7 @@ class AbstractStream(ABC):
     """
 
     @abstractmethod
-    def generate_partitions(self) -> Iterable[Partition]:
+    async def generate_partitions(self) -> Iterable[Partition]:
         """
         Generates the partitions that will be read by this stream.
         :return: An iterable of partitions.

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/default_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/default_stream.py
@@ -34,8 +34,9 @@ class DefaultStream(AbstractStream):
         self._logger = logger
         self._namespace = namespace
 
-    def generate_partitions(self) -> Iterable[Partition]:
-        yield from self._stream_partition_generator.generate()
+    async def generate_partitions(self) -> Iterable[Partition]:
+        async for partition in self._stream_partition_generator.generate():
+            yield partition
 
     @property
     def name(self) -> str:

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/partitions/partition_generator.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/partitions/partition_generator.py
@@ -10,7 +10,7 @@ from airbyte_cdk.sources.streams.concurrent.partitions.partition import Partitio
 
 class PartitionGenerator(ABC):
     @abstractmethod
-    def generate(self) -> Iterable[Partition]:
+    async def generate(self) -> Iterable[Partition]:
         """
         Generates partitions for a given sync mode.
         :return: An iterable of partitions

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
@@ -107,7 +107,7 @@ class Stream(ABC):
         """
         return None
 
-    def read_full_refresh(
+    async def read_full_refresh(
         self,
         cursor_field: Optional[List[str]],
         logger: logging.Logger,
@@ -118,13 +118,14 @@ class Stream(ABC):
         for _slice in slices:
             if slice_logger.should_log_slice_message(logger):
                 yield slice_logger.create_slice_log_message(_slice)
-            yield from self.read_records(
+            async for record in self.read_records(
                 stream_slice=_slice,
                 sync_mode=SyncMode.full_refresh,
                 cursor_field=cursor_field,
-            )
+            ):
+                yield record
 
-    def read_incremental(  # type: ignore  # ignoring typing for ConnectorStateManager because of circular dependencies
+    async def read_incremental(  # type: ignore  # ignoring typing for ConnectorStateManager because of circular dependencies
         self,
         cursor_field: Optional[List[str]],
         logger: logging.Logger,
@@ -176,7 +177,7 @@ class Stream(ABC):
             yield checkpoint
 
     @abstractmethod
-    def read_records(
+    async def read_records(
         self,
         sync_mode: SyncMode,
         cursor_field: Optional[List[str]] = None,

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/utils/stream_helper.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/utils/stream_helper.py
@@ -36,5 +36,5 @@ def get_first_record_for_slice(stream: Stream, stream_slice: Optional[Mapping[st
     """
     # We wrap the return output of read_records() because some implementations return types that are iterable,
     # but not iterators such as lists or tuples
-    records_for_slice = iter(stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice))
-    return next(records_for_slice)
+    records_for_slice = stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice)
+    return anext(records_for_slice)

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import asyncio
 import csv
 import ctypes
 import math
@@ -11,8 +12,10 @@ import urllib.parse
 import uuid
 from abc import ABC
 from contextlib import closing
+from threading import Thread
 from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Type, Union
 
+import aiohttp
 import pandas as pd
 import pendulum
 import requests  # type: ignore[import]
@@ -80,8 +83,8 @@ class SalesforceStream(HttpStream, ABC):
         properties_length = len(urllib.parse.quote(",".join(p for p in selected_properties)))
         return properties_length > self.max_properties_length
 
-    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
-        yield from response.json()["records"]
+    async def parse_response(self, response: aiohttp.ClientResponse, **kwargs) -> List[Mapping]:
+        return (await response.json())["records"]
 
     def get_json_schema(self) -> Mapping[str, Any]:
         if not self.schema:
@@ -125,8 +128,8 @@ class RestSalesforceStream(SalesforceStream):
             return next_token
         return f"/services/data/{self.sf_api.version}/queryAll"
 
-    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
-        response_data = response.json()
+    async def next_page_token(self, response: aiohttp.ClientResponse) -> Optional[Mapping[str, Any]]:
+        response_data = await response.json()
         next_token = response_data.get("nextRecordsUrl")
         return {"next_token": next_token} if next_token else None
 
@@ -191,14 +194,15 @@ class RestSalesforceStream(SalesforceStream):
             return None
         return min(non_exhausted_chunks, key=non_exhausted_chunks.get)
 
-    def _read_pages(
+    async def _read_pages(
         self,
         records_generator_fn: Callable[
-            [requests.PreparedRequest, requests.Response, Mapping[str, Any], Mapping[str, Any]], Iterable[StreamData]
+            [aiohttp.ClientRequest, aiohttp.ClientResponse, Mapping[str, Any], Mapping[str, Any]], Iterable[StreamData]
         ],
         stream_slice: Mapping[str, Any] = None,
         stream_state: Mapping[str, Any] = None,
-    ) -> Iterable[StreamData]:
+    ) -> None:
+        self._session = await self._ensure_session()  # TODO: move this into AbstractSource
         stream_state = stream_state or {}
         records_by_primary_key = {}
         property_chunks: Mapping[int, PropertyChunk] = {
@@ -211,15 +215,15 @@ class RestSalesforceStream(SalesforceStream):
                 break
 
             property_chunk = property_chunks[chunk_id]
-            request, response = self._fetch_next_page_for_chunk(
+            request, response = await self._fetch_next_page_for_chunk(
                 stream_slice, stream_state, property_chunk.next_page, property_chunk.properties
             )
 
             # When this is the first time we're getting a chunk's records, we set this to False to be used when deciding the next chunk
             if property_chunk.first_time:
                 property_chunk.first_time = False
-            property_chunk.next_page = self.next_page_token(response)
-            chunk_page_records = records_generator_fn(request, response, stream_state, stream_slice)
+            property_chunk.next_page = await self.next_page_token(response)
+            chunk_page_records = await records_generator_fn(request, response, stream_state, stream_slice)
             if not self.too_many_properties:
                 # this is the case when a stream has no primary key
                 # (it is allowed when properties length does not exceed the maximum value)
@@ -257,16 +261,13 @@ class RestSalesforceStream(SalesforceStream):
         if incomplete_record_ids:
             self.logger.warning(f"Inconsistent record(s) with primary keys {incomplete_record_ids} found. Skipping them.")
 
-        # Always return an empty generator just in case no records were ever yielded
-        yield from []
-
-    def _fetch_next_page_for_chunk(
+    async def _fetch_next_page_for_chunk(
         self,
         stream_slice: Mapping[str, Any] = None,
         stream_state: Mapping[str, Any] = None,
         next_page_token: Mapping[str, Any] = None,
         property_chunk: Mapping[str, Any] = None,
-    ) -> Tuple[requests.PreparedRequest, requests.Response]:
+    ) -> Tuple[aiohttp.ClientRequest, aiohttp.ClientResponse]:
         request_headers = self.request_headers(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
         request = self._create_prepared_request(
             path=self.path(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token),
@@ -278,7 +279,7 @@ class RestSalesforceStream(SalesforceStream):
             data=self.request_body_data(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token),
         )
         request_kwargs = self.request_kwargs(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
-        response = self._send_request(request, request_kwargs)
+        response = await self._send_request(request, request_kwargs)
         return request, response
 
 
@@ -293,22 +294,22 @@ class BulkSalesforceStream(SalesforceStream):
     transformer = TypeTransformer(TransformConfig.CustomSchemaNormalization | TransformConfig.DefaultSchemaNormalization)
 
     @default_backoff_handler(max_tries=5, factor=15)
-    def _send_http_request(self, method: str, url: str, json: dict = None, headers: dict = None, stream: bool = False):
+    async def _send_http_request(self, method: str, url: str, json: dict = None, headers: dict = None, stream=False) -> aiohttp.ClientResponse:
         headers = self.authenticator.get_auth_header() if not headers else headers | self.authenticator.get_auth_header()
-        response = self._session.request(method, url=url, headers=headers, json=json, stream=stream)
-        if response.status_code not in [200, 204]:
-            self.logger.error(f"error body: {response.text}, sobject options: {self.sobject_options}")
+        response = await self._session.request(method, url=url, headers=headers, json=json)
+        if response.status not in [200, 204]:
+            self.logger.error(f"error body: {await response.text()}, sobject options: {self.sobject_options}")
         response.raise_for_status()
         return response
 
-    def create_stream_job(self, query: str, url: str) -> Optional[str]:
+    async def create_stream_job(self, query: str, url: str) -> Optional[str]:
         """
         docs: https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/create_job.html
         """
         json = {"operation": "queryAll", "query": query, "contentType": "CSV", "columnDelimiter": "COMMA", "lineEnding": "LF"}
         try:
-            response = self._send_http_request("POST", url, json=json)
-            job_id: str = response.json()["id"]
+            response = await self._send_http_request("POST", url, json=json)
+            job_id: str = (await response.json())["id"]
             return job_id
         except exceptions.HTTPError as error:
             if error.response.status_code in [codes.FORBIDDEN, codes.BAD_REQUEST]:
@@ -365,7 +366,7 @@ class BulkSalesforceStream(SalesforceStream):
                 raise error
         return None
 
-    def wait_for_job(self, url: str) -> str:
+    async def wait_for_job(self, url: str) -> str:
         expiration_time: DateTime = pendulum.now().add(seconds=self.DEFAULT_WAIT_TIMEOUT_SECONDS)
         job_status = "InProgress"
         delay_timeout = 0.0
@@ -376,7 +377,7 @@ class BulkSalesforceStream(SalesforceStream):
         time.sleep(0.5)
         while pendulum.now() < expiration_time:
             try:
-                job_info = self._send_http_request("GET", url=url).json()
+                job_info = await (await self._send_http_request("GET", url=url)).json()
             except exceptions.HTTPError as error:
                 error_data = error.response.json()[0]
                 error_code = error_data.get("errorCode")
@@ -414,14 +415,14 @@ class BulkSalesforceStream(SalesforceStream):
         self.logger.warning(f"Not wait the {self.name} data for {self.DEFAULT_WAIT_TIMEOUT_SECONDS} seconds, data: {job_info}!!")
         return job_status
 
-    def execute_job(self, query: str, url: str) -> Tuple[Optional[str], Optional[str]]:
+    async def execute_job(self, query: str, url: str) -> Tuple[Optional[str], Optional[str]]:
         job_status = "Failed"
         for i in range(0, self.MAX_RETRY_NUMBER):
-            job_id = self.create_stream_job(query=query, url=url)
+            job_id = await self.create_stream_job(query=query, url=url)
             if not job_id:
                 return None, job_status
             job_full_url = f"{url}/{job_id}"
-            job_status = self.wait_for_job(url=job_full_url)
+            job_status = await self.wait_for_job(url=job_full_url)
             if job_status not in ["UploadComplete", "InProgress"]:
                 break
             self.logger.error(f"Waiting error. Try to run this job again {i + 1}/{self.MAX_RETRY_NUMBER}...")
@@ -429,7 +430,7 @@ class BulkSalesforceStream(SalesforceStream):
             job_status = "Aborted"
 
         if job_status in ["Aborted", "Failed"]:
-            self.delete_job(url=job_full_url)
+            await self.delete_job(url=job_full_url)
             return None, job_status
         return job_full_url, job_status
 
@@ -461,7 +462,7 @@ class BulkSalesforceStream(SalesforceStream):
 
         return self.encoding
 
-    def download_data(self, url: str, chunk_size: int = 1024) -> tuple[str, str, dict]:
+    async def download_data(self, url: str, chunk_size: int = 1024) -> tuple[str, str, dict]:
         """
         Retrieves binary data result from successfully `executed_job`, using chunks, to avoid local memory limitations.
         @ url: string - the url of the `executed_job`
@@ -470,12 +471,13 @@ class BulkSalesforceStream(SalesforceStream):
         """
         # set filepath for binary data from response
         tmp_file = str(uuid.uuid4())
-        with closing(self._send_http_request("GET", url, headers={"Accept-Encoding": "gzip"}, stream=True)) as response, open(
+        response = await self._send_http_request("GET", url, headers={"Accept-Encoding": "gzip"}, stream=True)
+        with open(
             tmp_file, "wb"
         ) as data_file:
             response_headers = response.headers
             response_encoding = self.get_response_encoding(response_headers)
-            for chunk in response.iter_content(chunk_size=chunk_size):
+            async for chunk in response.content.iter_chunked(chunk_size):
                 data_file.write(self.filter_null_bytes(chunk))
         # check the file exists
         if os.path.isfile(tmp_file):
@@ -511,8 +513,8 @@ class BulkSalesforceStream(SalesforceStream):
         self._send_http_request("PATCH", url=url, json=data)
         self.logger.warning("Broken job was aborted")
 
-    def delete_job(self, url: str):
-        self._send_http_request("DELETE", url=url)
+    async def delete_job(self, url: str):
+        await self._send_http_request("DELETE", url=url)
 
     @property
     def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
@@ -544,19 +546,20 @@ class BulkSalesforceStream(SalesforceStream):
 
         return {"q": query}
 
-    def read_records(
+    async def read_records(
         self,
         sync_mode: SyncMode,
         cursor_field: List[str] = None,
         stream_slice: Mapping[str, Any] = None,
         stream_state: Mapping[str, Any] = None,
     ) -> Iterable[Mapping[str, Any]]:
+        self._session = await self._ensure_session()  # TODO: move this into AbstractSource
         stream_state = stream_state or {}
         next_page_token = None
 
         params = self.request_params(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
         path = self.path(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
-        job_full_url, job_status = self.execute_job(query=params["q"], url=f"{self.url_base}{path}")
+        job_full_url, job_status = await self.execute_job(query=params["q"], url=f"{self.url_base}{path}")
         if not job_full_url:
             if job_status == "Failed":
                 # As rule as BULK logic returns unhandled error. For instance:
@@ -569,23 +572,24 @@ class BulkSalesforceStream(SalesforceStream):
                 if not stream_is_available:
                     self.logger.warning(f"Skipped syncing stream '{standard_instance.name}' because it was unavailable. Error: {error}")
                     return
-                yield from standard_instance.read_records(
+                for record in standard_instance.read_records(
                     sync_mode=sync_mode, cursor_field=cursor_field, stream_slice=stream_slice, stream_state=stream_state
-                )
+                ):
+                    yield record
                 return
             raise SalesforceException(f"Job for {self.name} stream using BULK API was failed.")
         salesforce_bulk_api_locator = None
         while True:
             req = PreparedRequest()
             req.prepare_url(f"{job_full_url}/results", {"locator": salesforce_bulk_api_locator})
-            tmp_file, response_encoding, response_headers = self.download_data(url=req.url)
+            tmp_file, response_encoding, response_headers = await self.download_data(url=req.url)
             for record in self.read_with_chunks(tmp_file, response_encoding):
                 yield record
 
             if response_headers.get("Sforce-Locator", "null") == "null":
                 break
             salesforce_bulk_api_locator = response_headers.get("Sforce-Locator")
-        self.delete_job(url=job_full_url)
+        await self.delete_job(url=job_full_url)
 
     def get_standard_instance(self) -> SalesforceStream:
         """Returns a instance of standard logic(non-BULK) with same settings"""


### PR DESCRIPTION
This POC shows changes to the CDK and to the Source Salesforce connector that will be required for integration of asyncio.

### Notes

#### Salesforce Connector Changes

Summary: added `async` and `await` annotations, some type updates, and updates to how we access things from the response object, which is now an `aiohttp` response. There's also some session-handling code in there that can and will be moved into the CDK code.

- The Salesforce connector has a couple of TODOs that will help minimize the changes. 
- This code change works for both the bulk and non-bulk Salesforce streams, in full refresh. There are likely other places where we could make use of asyncio (e.g. writing to a data file) but since they weren't necessary I haven't included them.
- This code works, but it isn't really suitable for performance testing against Salesforce because a) you'll eventually get rate limited, and b) there isn't enough data in our Sandbox account. If you want to play around with performance testing let me know and I'll give you a different branch an instructions on running a local server to send requests to.

#### CDK Changes

Summary: rewrite of much of `HttpStream` as well as calls to the `read`-related methods.

- All of this will be broken out into separate classes, instead of mixing async and sync code. E.g. there will be a separate AsyncHttpStream and helper functions, etc.
- I haven't fixed a lot of the type annotations in the CDK code.