### PR TITLE
🎉 Source Twitter: add missing fields and add authors stream

### DIFF
--- a/airbyte-integrations/connectors/source-twitter/Dockerfile
+++ b/airbyte-integrations/connectors/source-twitter/Dockerfile
@@ -34,5 +34,5 @@ COPY source_twitter ./source_twitter
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-twitter

--- a/airbyte-integrations/connectors/source-twitter/Dockerfile
+++ b/airbyte-integrations/connectors/source-twitter/Dockerfile
@@ -34,5 +34,5 @@ COPY source_twitter ./source_twitter
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.2.0
 LABEL io.airbyte.name=airbyte/source-twitter

--- a/airbyte-integrations/connectors/source-twitter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twitter/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d7fd4f40-5e5a-4b8b-918f-a73077f8c131
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   dockerRepository: airbyte/source-twitter
   documentationUrl: https://docs.airbyte.com/integrations/sources/twitter
   githubIssueLabel: source-twitter

--- a/airbyte-integrations/connectors/source-twitter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twitter/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d7fd4f40-5e5a-4b8b-918f-a73077f8c131
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-twitter
   documentationUrl: https://docs.airbyte.com/integrations/sources/twitter
   githubIssueLabel: source-twitter

--- a/airbyte-integrations/connectors/source-twitter/source_twitter/manifest.yaml
+++ b/airbyte-integrations/connectors/source-twitter/source_twitter/manifest.yaml
@@ -13,7 +13,7 @@ definitions:
       api_token: "{{ config.api_key }}"
     request_parameters:
       query: "{{ config['query'] }}"
-      tweet.fields: "author_id,conversation_id,created_at,in_reply_to_user_id,lang"
+      tweet.fields: "attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,in_reply_to_user_id,lang,possibly_sensitive,referenced_tweets,reply_settings,source,withheld"
   retriever:
     record_selector:
       $ref: "#/definitions/selector"

--- a/airbyte-integrations/connectors/source-twitter/source_twitter/manifest.yaml
+++ b/airbyte-integrations/connectors/source-twitter/source_twitter/manifest.yaml
@@ -3,7 +3,8 @@ version: "0.29.0"
 definitions:
   selector:
     extractor:
-      field_path: ["data"]
+      field_path: []
+      # ["includes", "users"] [ "data" ]
   requester:
     url_base: "https://api.twitter.com/2/tweets"
     http_method: "GET"
@@ -14,6 +15,8 @@ definitions:
     request_parameters:
       query: "{{ config['query'] }}"
       tweet.fields: "attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,in_reply_to_user_id,lang,possibly_sensitive,referenced_tweets,reply_settings,source,withheld"
+      user.fields: "created_at,description,entities,id,location,name,pinned_tweet_id,profile_image_url,protected,public_metrics,url,username,verified,verified_type,withheld"
+      expansions: "author_id"
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
@@ -35,8 +38,6 @@ definitions:
       $ref: "#/definitions/requester"
 
   base_stream:
-    retriever:
-      $ref: "#/definitions/retriever"
     incremental_sync:
       type: DatetimeBasedCursor
       datetime_format: "%Y-%m-%dT%H:%M:%S.000Z"
@@ -62,10 +63,30 @@ definitions:
       path: "/search/recent"
       cursor_field: "created_at"
       primary_key: "id"
+    retriever:
+      $ref: "#/definitions/retriever"
+      record_selector:
+        extractor:
+          field_path: [ "data" ]
+
+  authors_stream:
+    $ref: "#/definitions/base_stream"
+    $parameters:
+      name: "authors"
+      path: "/search/recent"
+      cursor_field: "created_at"
+      primary_key: "id"
+    retriever:
+      $ref: "#/definitions/retriever"
+      record_selector:
+        extractor:
+          field_path: [ "includes", "users" ]
 
 streams:
   - "#/definitions/tweets_stream"
+  - "#/definitions/authors_stream"
 
 check:
   stream_names:
     - "tweets"
+    - "authors"

--- a/airbyte-integrations/connectors/source-twitter/source_twitter/schemas/authors.json
+++ b/airbyte-integrations/connectors/source-twitter/source_twitter/schemas/authors.json
@@ -2,28 +2,16 @@
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "type" : "object",
   "properties" : {
-    "attachments" : {
-      "type" : [
-        "null",
-        "object"
-      ]
-    },
-    "author_id" : {
+    "id" : {
       "type" : [
         "null",
         "string"
       ]
     },
-    "context_annotations" : {
+    "public_metrics" : {
       "type" : [
         "null",
         "object"
-      ]
-    },
-    "conversation_id" : {
-      "type" : [
-        "null",
-        "string"
       ]
     },
     "created_at" : {
@@ -33,20 +21,53 @@
       ],
       "format" : "date-time"
     },
-    "edit_controls" : {
+    "name" : {
+      "type" : [
+        "null",
+        "string"
+      ]
+    },
+    "location" : {
       "type" : [
         "null",
         "object"
       ]
     },
-    "edit_history_tweet_ids" : {
+    "pinned_tweet_id" : {
       "type" : [
         "null",
-        "array"
-      ],
-      "items" : {
-        "type" : "string"
-      }
+        "string"
+      ]
+    },
+    "profile_image_url" : {
+      "type" : [
+        "null",
+        "string"
+      ]
+    },
+    "username" : {
+      "type" : [
+        "null",
+        "object"
+      ]
+    },
+    "verified_type" : {
+      "type" : [
+        "null",
+        "object"
+      ]
+    },
+    "verified" : {
+      "type" : [
+        "null",
+        "object"
+      ]
+    },
+    "url" : {
+      "type" : [
+        "null",
+        "object"
+      ]
     },
     "entities" : {
       "type" : [
@@ -54,70 +75,16 @@
         "object"
       ]
     },
-    "geo" : {
+    "description" : {
       "type" : [
         "null",
         "string"
       ]
     },
-    "id" : {
+    "protected" : {
       "type" : [
         "null",
         "string"
-      ]
-    },
-    "in_reply_to_user_id" : {
-      "type" : [
-        "null",
-        "string"
-      ]
-    },
-    "lang" : {
-      "type" : [
-        "null",
-        "string"
-      ]
-    },
-    "possibly_sensitive" : {
-      "type" : [
-        "null",
-        "string"
-      ]
-    },
-    "referenced_tweets" : {
-      "type" : [
-        "null",
-        "array"
-      ]
-    },
-    "reply_settings" : {
-      "type" : [
-        "null",
-        "string"
-      ]
-    },
-    "source" : {
-      "type" : [
-        "null",
-        "string"
-      ]
-    },
-    "text" : {
-      "type" : [
-        "null",
-        "string"
-      ]
-    },
-    "withheld" : {
-      "type" : [
-        "null",
-        "object"
-      ]
-    },
-    "users" : {
-      "type" : [
-        "null",
-        "object"
       ]
     }
   }

--- a/airbyte-integrations/connectors/source-twitter/source_twitter/schemas/authors.json
+++ b/airbyte-integrations/connectors/source-twitter/source_twitter/schemas/authors.json
@@ -1,6 +1,7 @@
 {
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "type" : "object",
+  "additionalProperties": true,
   "properties" : {
     "id" : {
       "type" : [
@@ -12,7 +13,40 @@
       "type" : [
         "null",
         "object"
-      ]
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "tweet_count": {
+          "type" : [
+            "null",
+            "integer"
+          ]
+        },
+        "like_count": {
+          "type" : [
+            "null",
+            "integer"
+          ]
+        },
+        "following_count": {
+          "type" : [
+            "null",
+            "integer"
+          ]
+        },
+        "listed_count": {
+          "type" : [
+            "null",
+            "integer"
+          ]
+        },
+        "followers_count": {
+          "type" : [
+            "null",
+            "integer"
+          ]
+        }
+      }
     },
     "created_at" : {
       "type" : [
@@ -30,7 +64,7 @@
     "location" : {
       "type" : [
         "null",
-        "object"
+        "string"
       ]
     },
     "pinned_tweet_id" : {
@@ -48,32 +82,34 @@
     "username" : {
       "type" : [
         "null",
-        "object"
+        "string"
       ]
     },
     "verified_type" : {
       "type" : [
         "null",
-        "object"
+        "string"
       ]
     },
     "verified" : {
       "type" : [
         "null",
-        "object"
+        "boolean"
       ]
     },
     "url" : {
       "type" : [
         "null",
-        "object"
+        "string"
       ]
     },
     "entities" : {
       "type" : [
         "null",
         "object"
-      ]
+      ],
+      "additionalProperties": true,
+      "properties": {}
     },
     "description" : {
       "type" : [

--- a/airbyte-integrations/connectors/source-twitter/source_twitter/schemas/tweets.json
+++ b/airbyte-integrations/connectors/source-twitter/source_twitter/schemas/tweets.json
@@ -2,33 +2,63 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "edit_history_tweet_ids": {
-      "type": ["null", "array"],
-      "items": {
-        "type": "string"
-      }
+    "attachments": {
+      "type": ["null", "object"]
     },
-    "id": {
+    "author_id": {
       "type": ["null", "string"]
     },
-    "text": {
+    "context_annotations": {
+      "type": ["null", "object"]
+    },
+    "conversation_id": {
       "type": ["null", "string"]
     },
     "created_at": {
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "lang": {
+    "edit_controls": {
+      "type": ["null", "object"]
+    },
+    "edit_history_tweet_ids": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "entities": {
+      "type": ["null", "object"]
+    },
+    "geo": {
       "type": ["null", "string"]
     },
-    "author_id": {
-      "type": ["null", "string"]
-    },
-    "conversation_id": {
+    "id": {
       "type": ["null", "string"]
     },
     "in_reply_to_user_id": {
       "type": ["null", "string"]
+    },
+    "lang": {
+      "type": ["null", "string"]
+    },
+    "possibly_sensitive": {
+      "type": ["null", "string"]
+    },
+    "referenced_tweets": {
+      "type": ["null", "array"]
+    },
+    "reply_settings": {
+      "type": ["null", "string"]
+    },
+    "source": {
+      "type": ["null", "string"]
+    },
+    "text": {
+      "type": ["null", "string"]
+    },
+    "withheld": {
+      "type": ["null", "object"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-twitter/source_twitter/schemas/tweets.json
+++ b/airbyte-integrations/connectors/source-twitter/source_twitter/schemas/tweets.json
@@ -1,12 +1,15 @@
 {
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "type" : "object",
+  "additionalProperties": true,
   "properties" : {
     "attachments" : {
       "type" : [
         "null",
         "object"
-      ]
+      ],
+      "additionalProperties": true,
+      "properties": {}
     },
     "author_id" : {
       "type" : [
@@ -18,7 +21,9 @@
       "type" : [
         "null",
         "object"
-      ]
+      ],
+      "additionalProperties": true,
+      "properties": {}
     },
     "conversation_id" : {
       "type" : [
@@ -37,22 +42,23 @@
       "type" : [
         "null",
         "object"
-      ]
+      ],
+      "additionalProperties": true,
+      "properties": {}
     },
     "edit_history_tweet_ids" : {
-      "type" : [
-        "null",
-        "array"
-      ],
+      "type": ["null", "array"],
       "items" : {
-        "type" : "string"
+        "type" : ["null", "string"]
       }
     },
     "entities" : {
       "type" : [
         "null",
         "object"
-      ]
+      ],
+      "additionalProperties": true,
+      "properties": {}
     },
     "geo" : {
       "type" : [
@@ -85,10 +91,25 @@
       ]
     },
     "referenced_tweets" : {
-      "type" : [
-        "null",
-        "array"
-      ]
+      "type": ["null", "array"],
+      "items" : {
+        "type" : ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "id" : {
+            "type" : [
+              "null",
+              "string"
+            ]
+          },
+          "type" : {
+            "type" : [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
     },
     "reply_settings" : {
       "type" : [
@@ -112,13 +133,17 @@
       "type" : [
         "null",
         "object"
-      ]
+      ],
+      "additionalProperties": true,
+      "properties": {}
     },
     "users" : {
       "type" : [
         "null",
         "object"
-      ]
+      ],
+      "additionalProperties": true,
+      "properties": {}
     }
   }
 }

--- a/docs/integrations/sources/twitter.md
+++ b/docs/integrations/sources/twitter.md
@@ -38,7 +38,7 @@ Rate limiting is mentioned in the API [documentation](https://developer.twitter.
 
 | Version | Date       | Pull Request                                             | Subject                                           |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------|
-| 0.1.3   | 2023-07-26 | [28736](https://github.com/airbytehq/airbyte/pull/28736) | add all available fields                                               |
+| 0.2.0   | 2023-07-26 | [33343](https://github.com/airbytehq/airbyte/pull/33343) | add all available fields                                               |
 | 0.1.2   | 2023-03-06 | [23749](https://github.com/airbytehq/airbyte/pull/23749) | Spec and docs are improved for beta certification |
 | 0.1.1   | 2023-03-03 | [23661](https://github.com/airbytehq/airbyte/pull/23661) | Incremental added for the "tweets" stream         |
 | 0.1.0   | 2022-11-01 | [18883](https://github.com/airbytehq/airbyte/pull/18858) | 🎉 New Source: Twitter                            |

--- a/docs/integrations/sources/twitter.md
+++ b/docs/integrations/sources/twitter.md
@@ -38,6 +38,7 @@ Rate limiting is mentioned in the API [documentation](https://developer.twitter.
 
 | Version | Date       | Pull Request                                             | Subject                                           |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------|
+| 0.1.3   | 2023-07-26 | [28736](https://github.com/airbytehq/airbyte/pull/28736) | add all available fields                                               |
 | 0.1.2   | 2023-03-06 | [23749](https://github.com/airbytehq/airbyte/pull/23749) | Spec and docs are improved for beta certification |
 | 0.1.1   | 2023-03-03 | [23661](https://github.com/airbytehq/airbyte/pull/23661) | Incremental added for the "tweets" stream         |
 | 0.1.0   | 2022-11-01 | [18883](https://github.com/airbytehq/airbyte/pull/18858) | 🎉 New Source: Twitter                            |


### PR DESCRIPTION
## What
*Retrieve all available fields from the search tweets API

## How
*In the previous version only mandatory fields (id, text...) were configured in the manifest in this version several fields have been added as entities, attachments, reply_settings.
