### PR TITLE
use latest image for mssql

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/CloudDeploymentSslEnabledMssqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/CloudDeploymentSslEnabledMssqlSourceAcceptanceTest.java
@@ -14,7 +14,7 @@ public class CloudDeploymentSslEnabledMssqlSourceAcceptanceTest extends MssqlSou
 
   @Override
   protected void setupEnvironment(final TestDestinationEnv environment) {
-    final var container = new MsSQLContainerFactory().shared("mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04");
+    final var container = new MsSQLContainerFactory().shared("mcr.microsoft.com/mssql/server:2022-latest");
     testdb = new MsSQLTestDatabase(container);
     testdb = testdb
         .withConnectionProperty("encrypt", "true")

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/SslEnabledMssqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/SslEnabledMssqlSourceAcceptanceTest.java
@@ -19,7 +19,7 @@ public class SslEnabledMssqlSourceAcceptanceTest extends MssqlSourceAcceptanceTe
 
   @Override
   protected void setupEnvironment(final TestDestinationEnv environment) {
-    final var container = new MsSQLContainerFactory().shared("mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04");
+    final var container = new MsSQLContainerFactory().shared("mcr.microsoft.com/mssql/server:2022-latest");
     testdb = new MsSQLTestDatabase(container);
     testdb = testdb
         .withConnectionProperty("encrypt", "true")

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CloudDeploymentMssqlTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CloudDeploymentMssqlTest.java
@@ -25,7 +25,7 @@ public class CloudDeploymentMssqlTest {
 
   private MsSQLTestDatabase createTestDatabase(String... containerFactoryMethods) {
     final var container = new MsSQLContainerFactory().shared(
-        "mcr.microsoft.com/mssql/server:2022-RTM-CU2-ubuntu-20.04", containerFactoryMethods);
+        "mcr.microsoft.com/mssql/server:2022-latest", containerFactoryMethods);
     final var testdb = new MsSQLTestDatabase(container);
     return testdb
         .withConnectionProperty("encrypt", "true")


### PR DESCRIPTION
In a [previous change](https://github.com/airbytehq/airbyte/commit/dccd48a896405e6475405f62af3597948f1ac2de), we simplified our MSSQL images to only use latest, but I missed some places where we're still using strings. Here, we're bringing everything under latest. That should have the nice side effect to make CI a bit master, and less resource intensive