### PR TITLE
limit memory for MSSQL containers

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLContainerFactory.java
+++ b/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLContainerFactory.java
@@ -13,7 +13,10 @@ public class MsSQLContainerFactory implements ContainerFactory<MSSQLServerContai
 
   @Override
   public MSSQLServerContainer<?> createNewContainer(DockerImageName imageName) {
-    return new MSSQLServerContainer<>(imageName.asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server")).acceptLicense();
+    MSSQLServerContainer container =
+        new MSSQLServerContainer<>(imageName.asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server")).acceptLicense();
+    container.addEnv("MSSQL_MEMORY_LIMIT_MB", "384");
+    return container;
   }
 
   @Override


### PR DESCRIPTION
on my M2 laptop, sometimes tests fail due to timeouts or some random process getting killed (either a container, or the gradle cache inside dagger). After investigation, I realized that we were running up to 6 different containers with MSSQL db, with each taking upwards of 2GB of RAM (real, not virtual). So I'm now limiting the individual MSSQL instances to 256MB. That helps with swapping too