### PR TITLE
🐛 Source Chargebee: Removes bypass for incremental acceptance tests

### DIFF
--- a/airbyte-integrations/connectors/source-chargebee/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-chargebee/acceptance-test-config.yml
@@ -49,22 +49,12 @@ acceptance_tests:
           extra_records: yes
         fail_on_extra_columns: false
   incremental:
-    # tests:
-    # - config_path: "secrets/config.json"
-    #   timeout_seconds: 2400
-    #   configured_catalog_path: "integration_tests/configured_catalog.json"
-    #   future_state:
-    #     future_state_path: "integration_tests/future_state.json"
-    #     missing_streams:
-    #     - name: attached_item
-    #       bypass_reason: "This stream is Full-Refresh only"
-    #     - name: contact
-    #       bypass_reason: "This stream is Full-Refresh only"
-    #     - name: quote_line_group
-    #       bypass_reason: "This stream is Full-Refresh only"
-    bypass_reason: >
-      "Incrremental tests are disabled until CAT works with cursor data-types directly,
-      relatated slack thread: https://airbyte-globallogic.slack.com/archives/C02U9R3AF37/p1690810513681859"
+    tests:
+    - config_path: "secrets/config.json"
+      timeout_seconds: 2400
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/future_state.json"
   full_refresh:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-chargebee/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-chargebee/acceptance-test-config.yml
@@ -50,11 +50,11 @@ acceptance_tests:
         fail_on_extra_columns: false
   incremental:
     tests:
-    - config_path: "secrets/config.json"
-      timeout_seconds: 2400
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      future_state:
-        future_state_path: "integration_tests/future_state.json"
+      - config_path: "secrets/config.json"
+        timeout_seconds: 2400
+        configured_catalog_path: "integration_tests/configured_catalog.json"
+        future_state:
+          future_state_path: "integration_tests/future_state.json"
   full_refresh:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-chargebee/integration_tests/future_state.json
+++ b/airbyte-integrations/connectors/source-chargebee/integration_tests/future_state.json
@@ -107,6 +107,27 @@
   {
     "type": "STREAM",
     "stream": {
+      "stream_state": { "occurred_at": 2147483647 },
+      "stream_descriptor": { "name": "contact" }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_state": { "occurred_at": 2147483647 },
+      "stream_descriptor": { "name": "quote_line_group" }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_state": { "occurred_at": 2147483647 },
+      "stream_descriptor": { "name": "attached_item" }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
       "stream_state": { "updated_at": 2147483647 },
       "stream_descriptor": { "name": "transaction" }
     }


### PR DESCRIPTION
## What
* Removes blanket bypass of incremental connector acceptance tests
* Adds additional streams to `future_state.json` for incremental tests

## How
* Removed blanket bypass (`bypass_reason`)
* Added `contact`, `quote_line_group`, and `attached_item` streams to `future_state.json`