### PR TITLE
airbyte-ci: disable update check in the pre-push hook for formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: format-fix-all-on-push
         always_run: true
-        entry: airbyte-ci format fix all
+        entry: airbyte-ci --disable-update-check format fix all
         language: system
         name: Run airbyte-ci format fix on git push (~30s)
         pass_filenames: false


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
We don't want to force folks to auto-update airbyte CI if they're using the pre-push hook.

## How
Pass the `--disable-update-check` to the pre-push hook.