### PR TITLE
CDK: Allow configuration of param injection method in OAuth Authenticator

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -36,6 +36,7 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
         refresh_request_body (Optional[Mapping[str, Any]]): The request body to send in the refresh request
         grant_type: The grant_type to request for access_token. If set to refresh_token, the refresh_token parameter has to be provided
         message_repository (MessageRepository): the message repository used to emit logs on HTTP requests
+        refresh_request_type: The request type to request for access_token
     """
 
     token_refresh_endpoint: Union[InterpolatedString, str]
@@ -54,6 +55,7 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
     refresh_request_body: Optional[Mapping[str, Any]] = None
     grant_type: Union[InterpolatedString, str] = "refresh_token"
     message_repository: MessageRepository = NoopMessageRepository()
+    refresh_request_type: Optional[str] = "body_data"
 
     def __post_init__(self, parameters: Mapping[str, Any]):
         self.token_refresh_endpoint = InterpolatedString.create(self.token_refresh_endpoint, parameters=parameters)
@@ -104,6 +106,9 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
 
     def get_token_expiry_date(self) -> pendulum.DateTime:
         return self._token_expiry_date
+
+    def get_refresh_request_type(self) -> str:
+        return self.refresh_request_type
 
     def set_token_expiry_date(self, value: Union[str, int]):
         self._token_expiry_date = self._parse_token_expiration_date(value)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -839,6 +839,12 @@ definitions:
             default: ["credentials", "token_expiry_date"]
             examples:
               - ["credentials", "token_expiry_date"]
+      refresh_request_type:
+        type: string
+        title: "Refresh Request Type"
+        description: "Set how to specify the parameters for receiving the access token"
+        enum: ["body_data", "body_json", "request_parameter"]
+        default: "body_data"
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -841,8 +841,8 @@ definitions:
               - ["credentials", "token_expiry_date"]
       refresh_request_type:
         type: string
-        title: "Refresh Request Type"
-        description: "Set how to specify the parameters for receiving the access token"
+        title: Refresh Request Type
+        description: Specifies how to inject the parameters for receiving the access token
         enum: ["body_data", "body_json", "request_parameter"]
         default: "body_data"
       $parameters:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -235,6 +235,12 @@ class RefreshTokenUpdater(BaseModel):
     )
 
 
+class RefreshRequestType(Enum):
+    body_data = 'body_data'
+    body_json = 'body_json'
+    request_parameter = 'request_parameter'
+
+
 class OAuthAuthenticator(BaseModel):
     type: Literal['OAuthAuthenticator']
     client_id: str = Field(
@@ -321,6 +327,11 @@ class OAuthAuthenticator(BaseModel):
         None,
         description='When the token updater is defined, new refresh tokens, access tokens and the access token expiry date are written back from the authentication response to the config object. This is important if the refresh token can only used once.',
         title='Token Updater',
+    )
+    refresh_request_type: Optional[RefreshRequestType] = Field(
+        'body_data',
+        description='Specifies how to inject the parameters for receiving the access token',
+        title='Refresh Request Type',
     )
     parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -235,12 +235,6 @@ class RefreshTokenUpdater(BaseModel):
     )
 
 
-class RefreshRequestType(Enum):
-    body_data = 'body_data'
-    body_json = 'body_json'
-    request_parameter = 'request_parameter'
-
-
 class OAuthAuthenticator(BaseModel):
     type: Literal['OAuthAuthenticator']
     client_id: str = Field(
@@ -327,11 +321,6 @@ class OAuthAuthenticator(BaseModel):
         None,
         description='When the token updater is defined, new refresh tokens, access tokens and the access token expiry date are written back from the authentication response to the config object. This is important if the refresh token can only used once.',
         title='Token Updater',
-    )
-    refresh_request_type: Optional[RefreshRequestType] = Field(
-        'body_data',
-        description='Specifies how to inject the parameters for receiving the access token',
-        title='Refresh Request Type',
     )
     parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -152,11 +152,7 @@ class AbstractOauth2Authenticator(AuthBase):
             return pendulum.now().add(seconds=int(float(value)))
 
     def get_refresh_request_data(self) -> Mapping[str, Any]:
-        request_type_mapping = dict(
-            request_parameter="params",
-            body_data="data",
-            body_json="json"
-        )
+        request_type_mapping = dict(request_parameter="params", body_data="data", body_json="json")
 
         request_type = self.get_refresh_request_type()
         if request_type not in request_type_mapping:

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -35,6 +35,7 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
         refresh_token_error_status_codes: Tuple[int, ...] = (),
         refresh_token_error_key: str = "",
         refresh_token_error_values: Tuple[str, ...] = (),
+        refresh_request_type: str = "body_data",
     ):
         self._token_refresh_endpoint = token_refresh_endpoint
         self._client_secret = client_secret
@@ -45,6 +46,7 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
         self._expires_in_name = expires_in_name
         self._refresh_request_body = refresh_request_body
         self._grant_type = grant_type
+        self._refresh_request_type = refresh_request_type
 
         self._token_expiry_date = token_expiry_date or pendulum.now().subtract(days=1)
         self._token_expiry_date_format = token_expiry_date_format
@@ -81,6 +83,9 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
 
     def get_token_expiry_date(self) -> pendulum.DateTime:
         return self._token_expiry_date
+
+    def get_refresh_request_type(self) -> str:
+        return self._refresh_request_type
 
     def set_token_expiry_date(self, value: Union[str, int]):
         self._token_expiry_date = self._parse_token_expiration_date(value)
@@ -133,6 +138,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
         refresh_token_error_status_codes: Tuple[int, ...] = (),
         refresh_token_error_key: str = "",
         refresh_token_error_values: Tuple[str, ...] = (),
+        refresh_request_type: str = "body_data",
     ):
         """
         Args:
@@ -180,6 +186,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
             refresh_token_error_status_codes=refresh_token_error_status_codes,
             refresh_token_error_key=refresh_token_error_key,
             refresh_token_error_values=refresh_token_error_values,
+            refresh_request_type=refresh_request_type,
         )
 
     def get_refresh_token_name(self) -> str:

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -416,6 +416,27 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
         )
         assert authenticator.refresh_access_token() == ("new_access_token", "42", "new_refresh_token")
 
+    @pytest.mark.parametrize(
+        "refresh_request_type, expected_request_type",
+        [
+            ("request_parameter", "params"),
+            ("body_data", "data"),
+            ("body_json", "json"),
+        ],
+        ids=["request_type_as_parameters", "request_type_as_body_data", "request_type_as_body_json"],
+    )
+    def test_get_refresh_request_data(self, refresh_request_type: str, expected_request_type: str):
+        oauth = Oauth2Authenticator(
+            token_refresh_endpoint=TestOauth2Authenticator.refresh_endpoint,
+            client_id=TestOauth2Authenticator.client_id,
+            client_secret=TestOauth2Authenticator.client_secret,
+            refresh_token=TestOauth2Authenticator.refresh_token,
+            refresh_request_type=refresh_request_type,
+        )
+        request_data = oauth.get_refresh_request_data()
+
+        assert list(request_data.keys())[0] == expected_request_type
+
 
 def mock_request(method, url, data):
     if url == "refresh_end":


### PR DESCRIPTION
## What
*Resolve https://github.com/airbytehq/airbyte/issues/27605.*

## How
*Add new parameter `refresh_request_type` for OAuth*

## Pre-merge Actions

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
