### PR TITLE
airbyte-ci: ClickPipelineContext handles dagger logging

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -502,7 +502,8 @@ This command runs the Python tests for a airbyte-ci poetry package.
 
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| 2.10.11 | [#33497](https://github.com/airbytehq/airbyte/pull/33497)  | Consider nested .gitignore rules in format.                                          |
+| 2.10.12 | [#33419](https://github.com/airbytehq/airbyte/pull/33419)  | Make ClickPipelineContext handle dagger logging.                                                          |
+| 2.10.11 | [#33497](https://github.com/airbytehq/airbyte/pull/33497)  | Consider nested .gitignore rules in format.                                                               |
 | 2.10.10 | [#33449](https://github.com/airbytehq/airbyte/pull/33449)  | Add generated metadata models to the default format ignore list.                                          |
 | 2.10.9  | [#33370](https://github.com/airbytehq/airbyte/pull/33370)  | Fix bug that broke airbyte-ci test                                                                        |
 | 2.10.8  | [#33249](https://github.com/airbytehq/airbyte/pull/33249)  | Exclude git ignored files from formatting.                                                                |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/format_command.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/format_command.py
@@ -121,16 +121,8 @@ class FormatCommand(click.Command):
         Returns:
             Any: The result of running the command
         """
-        dagger_logs_file_descriptor, dagger_logs_temp_file_path = tempfile.mkstemp(
-            dir="/tmp", prefix=f"format_{self.formatter.value}_dagger_logs_", suffix=".log"
-        )
-        # Create a FileIO object from the file descriptor
-        dagger_logs = io.FileIO(dagger_logs_file_descriptor, "w+")
-        self.logger.info(f"Running {self.formatter.value} formatter. Logging dagger output to {dagger_logs_temp_file_path}")
 
-        dagger_client = await click_pipeline_context.get_dagger_client(
-            pipeline_name=f"Format {self.formatter.value}", log_output=dagger_logs
-        )
+        dagger_client = await click_pipeline_context.get_dagger_client(pipeline_name=f"Format {self.formatter.value}")
         dir_to_format = self.get_dir_to_format(dagger_client)
 
         container = self.get_format_container_fn(dagger_client, dir_to_format)

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.10.11"
+version = "2.10.12"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_models/test_click_pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_models/test_click_pipeline_context.py
@@ -15,6 +15,8 @@ async def test_get_dagger_client_singleton(dagger_connection):
         pass
 
     ctx = click.Context(cli)
+    ctx.obj = {"foo": "bar"}
+    ctx.params = {"baz": "qux"}
 
     async with ctx.scope():
         click_pipeline_context = ClickPipelineContext()


### PR DESCRIPTION
## What
`ClickPipelineContext` users rely on the `get_dagger_client` method to get the dagger client as a singleton.
We originally exposed a `log_output` parameter to this method, but as it returns a singleton dagger client, the passed `log_output` is not taken into account if the singleton already exists.

## How
The `get_dagger_client` defines the log output path according to the `show_dagger_logs` params.
If `show_dagger_logs` is true: show the logs in the stdout, otherwise log to a file.

Next:
* Remove the `show_dagger_logs` param/options and always log to a file
* Users can see the dagger logs if they're using a `dagger run` wrapped command
* Broaden the use of `ClickPipelineContext` to have a consistent logging management implementation