### PR TITLE
🐛 Source Convex: full_refresh stops after one page

### DIFF
--- a/airbyte-integrations/connectors/source-convex/Dockerfile
+++ b/airbyte-integrations/connectors/source-convex/Dockerfile
@@ -34,5 +34,5 @@ COPY source_convex ./source_convex
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.3.0
+LABEL io.airbyte.version=0.4.0
 LABEL io.airbyte.name=airbyte/source-convex

--- a/airbyte-integrations/connectors/source-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convex/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c332628c-f55c-4017-8222-378cfafda9b2
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.4.0
   dockerRepository: airbyte/source-convex
   githubIssueLabel: source-convex
   icon: convex.svg

--- a/airbyte-integrations/connectors/source-convex/source_convex/source.py
+++ b/airbyte-integrations/connectors/source-convex/source_convex/source.py
@@ -31,7 +31,7 @@ ConvexState = TypedDict(
     },
 )
 
-CONVEX_CLIENT_VERSION = "0.3.0"
+CONVEX_CLIENT_VERSION = "0.4.0"
 
 
 # Source

--- a/airbyte-integrations/connectors/source-convex/source_convex/source.py
+++ b/airbyte-integrations/connectors/source-convex/source_convex/source.py
@@ -153,7 +153,8 @@ class ConvexStream(HttpStream, IncrementalMixin):
         else:
             self._delta_cursor_value = resp_json["cursor"]
             self._delta_has_more = resp_json["hasMore"]
-        return cast(ConvexState, self.state) if self._delta_has_more else None
+        has_more = self._snapshot_has_more or self._delta_has_more
+        return cast(ConvexState, self.state) if has_more else None
 
     def path(
         self,

--- a/airbyte-integrations/connectors/source-convex/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-convex/unit_tests/test_streams.py
@@ -5,14 +5,16 @@
 from http import HTTPStatus
 from unittest.mock import MagicMock
 
+from airbyte_cdk.models import SyncMode
 import pytest
+import responses
+import requests
 from source_convex.source import ConvexStream
 
 
 @pytest.fixture
 def patch_base_class(mocker):
     # Mock abstract methods to enable instantiating abstract class
-    mocker.patch.object(ConvexStream, "path", "v0/example_endpoint")
     mocker.patch.object(ConvexStream, "primary_key", "test_primary_key")
     mocker.patch.object(ConvexStream, "__abstractmethods__", set())
 
@@ -60,6 +62,66 @@ def test_next_page_token(patch_base_class):
     stream.parse_response(resp, {})
     assert stream.next_page_token(resp) is None
     assert stream.state == {"snapshot_cursor": 1235, "snapshot_has_more": False, "delta_cursor": 7000}
+
+
+@responses.activate
+def test_read_records_full_refresh(patch_base_class):
+    stream = ConvexStream("http://mocked_base_url:8080", "accesskey", "json", "messages", None)
+    snapshot0_resp = {"values": [{"_id": "my_id", "field": "f", "_ts": 123}], "cursor": 1234, "snapshot": 5000, "hasMore": True}
+    responses.add(
+        responses.GET,
+        "http://mocked_base_url:8080/api/list_snapshot?tableName=messages&format=json",
+        json=snapshot0_resp,
+    )
+    snapshot1_resp = {"values": [{"_id": "an_id", "field": "b", "_ts": 100}], "cursor": 2345, "snapshot": 5000, "hasMore": True}
+    responses.add(
+        responses.GET,
+        "http://mocked_base_url:8080/api/list_snapshot?tableName=messages&format=json&cursor=1234&snapshot=5000",
+        json=snapshot1_resp,
+    )
+    snapshot2_resp = {"values": [{"_id": "a_id", "field": "x", "_ts": 300}], "cursor": 3456, "snapshot": 5000, "hasMore": False}
+    responses.add(
+        responses.GET,
+        "http://mocked_base_url:8080/api/list_snapshot?tableName=messages&format=json&cursor=2345&snapshot=5000",
+        json=snapshot2_resp,
+    )
+    records = list(stream.read_records(SyncMode.full_refresh))
+    assert len(records) == 3
+    assert [record["field"] for record in records] == ["f", "b", "x"]
+    assert stream.state == {"delta_cursor": 5000, "snapshot_cursor": 3456, "snapshot_has_more": False}
+
+
+@responses.activate
+def test_read_records_incremental(patch_base_class):
+    stream = ConvexStream("http://mocked_base_url:8080", "accesskey", "json", "messages", None)
+    snapshot0_resp = {"values": [{"_id": "my_id", "field": "f", "_ts": 123}], "cursor": 1234, "snapshot": 5000, "hasMore": True}
+    responses.add(
+        responses.GET,
+        "http://mocked_base_url:8080/api/list_snapshot?tableName=messages&format=json",
+        json=snapshot0_resp,
+    )
+    snapshot1_resp = {"values": [{"_id": "an_id", "field": "b", "_ts": 100}], "cursor": 2345, "snapshot": 5000, "hasMore": False}
+    responses.add(
+        responses.GET,
+        "http://mocked_base_url:8080/api/list_snapshot?tableName=messages&format=json&cursor=1234&snapshot=5000",
+        json=snapshot1_resp,
+    )
+    delta0_resp = {"values": [{"_id": "a_id", "field": "x", "_ts": 300}], "cursor": 6000, "hasMore": True}
+    responses.add(
+        responses.GET,
+        "http://mocked_base_url:8080/api/document_deltas?tableName=messages&format=json&cursor=5000",
+        json=delta0_resp,
+    )
+    delta1_resp = {"values": [{"_id": "a_id", "field": "x", "_ts": 400}], "cursor": 7000, "hasMore": False}
+    responses.add(
+        responses.GET,
+        "http://mocked_base_url:8080/api/document_deltas?tableName=messages&format=json&cursor=6000",
+        json=delta1_resp,
+    )
+    records = list(stream.read_records(SyncMode.incremental))
+    assert len(records) == 4
+    assert [record["field"] for record in records] == ["f", "b", "x", "x"]
+    assert stream.state == {"delta_cursor": 7000, "snapshot_cursor": 2345, "snapshot_has_more": False}
 
 
 def test_parse_response(patch_base_class):

--- a/airbyte-integrations/connectors/source-convex/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-convex/unit_tests/test_streams.py
@@ -5,10 +5,10 @@
 from http import HTTPStatus
 from unittest.mock import MagicMock
 
-from airbyte_cdk.models import SyncMode
 import pytest
-import responses
 import requests
+import responses
+from airbyte_cdk.models import SyncMode
 from source_convex.source import ConvexStream
 
 

--- a/airbyte-integrations/connectors/source-convex/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-convex/unit_tests/test_streams.py
@@ -137,7 +137,7 @@ def test_parse_response(patch_base_class):
 def test_request_headers(patch_base_class):
     stream = ConvexStream("murky-swan-635", "accesskey", "json", "messages", None)
     inputs = {"stream_slice": None, "stream_state": None, "next_page_token": None}
-    assert stream.request_headers(**inputs) == {"Convex-Client": "airbyte-export-0.3.0"}
+    assert stream.request_headers(**inputs) == {"Convex-Client": "airbyte-export-0.4.0"}
 
 
 def test_http_method(patch_base_class):

--- a/docs/integrations/sources/convex.md
+++ b/docs/integrations/sources/convex.md
@@ -70,9 +70,10 @@ In the Data tab, you should see the tables and a sample of the data that will be
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                                      |
-| :------ | :--------- | :------------------------------------------------------- | :------------------------------------------- |
-| 0.3.0   | 2023-09-28 | [30853](https://github.com/airbytehq/airbyte/pull/30853) | 🐛 Convex source switch to clean JSON format |
-| 0.2.0   | 2023-06-21 | [27226](https://github.com/airbytehq/airbyte/pull/27226) | 🐛 Convex source fix skipped records         |
-| 0.1.1   | 2023-03-06 | [23797](https://github.com/airbytehq/airbyte/pull/23797) | 🐛 Convex source connector error messages    |
-| 0.1.0   | 2022-10-24 | [18403](https://github.com/airbytehq/airbyte/pull/18403) | 🎉 New Source: Convex                        |
+| Version | Date       | Pull Request                                             | Subject                                                          |
+| :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------- |
+| 0.4.0   | 2023-12-13 | [33431](https://github.com/airbytehq/airbyte/pull/33431) | 🐛 Convex source fix bug where full_refresh stops after one page |
+| 0.3.0   | 2023-09-28 | [30853](https://github.com/airbytehq/airbyte/pull/30853) | 🐛 Convex source switch to clean JSON format                     |
+| 0.2.0   | 2023-06-21 | [27226](https://github.com/airbytehq/airbyte/pull/27226) | 🐛 Convex source fix skipped records                             |
+| 0.1.1   | 2023-03-06 | [23797](https://github.com/airbytehq/airbyte/pull/23797) | 🐛 Convex source connector error messages                        |
+| 0.1.0   | 2022-10-24 | [18403](https://github.com/airbytehq/airbyte/pull/18403) | 🎉 New Source: Convex                                            |


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*

The Convex source connector has a bug where SyncMode == full_refresh causes it to stop the sync after a single page of 128 results. This PR fixes the bug and adds tests.

*It helps to add screenshots if it affects the frontend.*

Before, note that only 128 documents are synced:
<img width="1397" alt="Screenshot 2023-12-12 at 9 12 43 PM" src="https://github.com/airbytehq/airbyte/assets/4319355/3bf2a4bb-9812-415f-b3a6-2e11e125eb5b">

After, note that 1773 records are synced, which is the total number of records in the source:
<img width="1260" alt="Screenshot 2023-12-13 at 11 15 40 AM" src="https://github.com/airbytehq/airbyte/assets/4319355/fd04fcdd-b132-4faf-8f83-c85e6b64e3e2">

## How
*Describe the solution*

The Convex source connector does two sets of pagination, in sequence:
1. the "snapshot" pagination syncs a snapshot of the data
2. the "delta" pagination syncs subsequent changes after the snapshot

Currently we stop the sync when the "delta" pagination is done. But this is a problem for full-refresh sync, which doesn't do the "delta" pagination at all, which means the "delta" pagination is marked as done before the "snapshot" pagination has completed.

The solution is we return a non-None `next_page_token` when //either// the "snapshot" or "delta" syncs have more data.

Also add unit tests that would have caught this case.

## Recommended reading order
1. `source_convex/source.py`
2. `source-convex/unit_tests/test_streams.py`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

The end result is that syncs that would previously have terminated early will now fully sync all data.
This only applies for users that are using full_refresh sync mode.

Therefore it is strongly recommended that users do a full sync after this change releases, to make sure their data fully syncs.
Up to reviewer whether this counts as a breaking change.


*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<strong>Updating a connector</strong>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added

<img width="1102" alt="Screenshot 2023-12-13 at 12 41 56 PM" src="https://github.com/airbytehq/airbyte/assets/4319355/e76c4d6f-1c02-4fad-8c81-313fcc402f9d">


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).


