### PR TITLE
add connectionTimeout parameter to DslContextFactory.create

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/db/factory/DSLContextFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/db/factory/DSLContextFactory.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.db.factory;
 
+import java.time.Duration;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.jooq.DSLContext;
@@ -62,9 +63,10 @@ public class DSLContextFactory {
                                   final String driverClassName,
                                   final String jdbcConnectionString,
                                   final SQLDialect dialect,
-                                  final Map<String, String> connectionProperties) {
+                                  final Map<String, String> connectionProperties,
+                                  final Duration connectionTimeout) {
     return DSL.using(DataSourceFactory.create(username, password, driverClassName, jdbcConnectionString, connectionProperties,
-        DataSourceFactory.getConnectionTimeout(connectionProperties, driverClassName)), dialect);
+        connectionTimeout), dialect);
   }
 
 }

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/db/factory/DSLContextFactoryTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/db/factory/DSLContextFactoryTest.java
@@ -51,7 +51,8 @@ class DSLContextFactoryTest extends CommonFactoryTest {
         container.getDriverClassName(),
         container.getJdbcUrl(),
         dialect,
-        connectionProperties);
+        connectionProperties,
+        DataSourceFactory.CONNECT_TIMEOUT_DEFAULT);
     assertNotNull(dslContext);
     assertEquals(dialect, dslContext.configuration().dialect());
   }


### PR DESCRIPTION
This is essentially removing a caller to `DataSourceFactory.getConnectionTimeout`. Should have no functional change