### PR TITLE
move getConnectionTimeout from DataSourceFactory to a new JdbcConnector class

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/db/factory/DataSourceFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/db/factory/DataSourceFactory.java
@@ -4,17 +4,12 @@
 
 package io.airbyte.cdk.db.factory;
 
-import static org.postgresql.PGProperty.CONNECT_TIMEOUT;
-
 import com.google.common.base.Preconditions;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import java.io.Closeable;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.Map;
-import java.util.Optional;
 import javax.sql.DataSource;
 
 /**
@@ -23,9 +18,6 @@ import javax.sql.DataSource;
  * application framework to manage the creation and injection of {@link DataSource} objects.
  */
 public class DataSourceFactory {
-
-  public static final String CONNECT_TIMEOUT_KEY = "connectTimeout";
-  public static final Duration CONNECT_TIMEOUT_DEFAULT = Duration.ofSeconds(60);
 
   /**
    * Constructs a new {@link DataSource} using the provided configuration.
@@ -170,49 +162,6 @@ public class DataSourceFactory {
         closeable.close();
       }
     }
-  }
-
-  /**
-   * Retrieves connectionTimeout value from connection properties in millis, default minimum timeout
-   * is 60 seconds since Hikari default of 30 seconds is not enough for acceptance tests. In the case
-   * the value is 0, pass the value along as Hikari and Postgres use default max value for 0 timeout
-   * value.
-   *
-   * NOTE: Postgres timeout is measured in seconds:
-   * https://jdbc.postgresql.org/documentation/head/connect.html
-   *
-   * @param connectionProperties custom jdbc_url_parameters containing information on connection
-   *        properties
-   * @param driverClassName name of the JDBC driver
-   * @return DataSourceBuilder class used to create dynamic fields for DataSource
-   */
-  public static Duration getConnectionTimeout(final Map<String, String> connectionProperties, String driverClassName) {
-    final Optional<Duration> parsedConnectionTimeout = switch (DatabaseDriver.findByDriverClassName(driverClassName)) {
-      case POSTGRESQL -> maybeParseDuration(connectionProperties.get(CONNECT_TIMEOUT.getName()), ChronoUnit.SECONDS)
-          .or(() -> maybeParseDuration(CONNECT_TIMEOUT.getDefaultValue(), ChronoUnit.SECONDS));
-      case MYSQL -> maybeParseDuration(connectionProperties.get("connectTimeout"), ChronoUnit.MILLIS);
-      case MSSQLSERVER -> maybeParseDuration(connectionProperties.get("loginTimeout"), ChronoUnit.SECONDS);
-      default -> maybeParseDuration(connectionProperties.get(CONNECT_TIMEOUT_KEY), ChronoUnit.SECONDS)
-          // Enforce minimum timeout duration for unspecified data sources.
-          .filter(d -> d.compareTo(CONNECT_TIMEOUT_DEFAULT) >= 0);
-    };
-    return parsedConnectionTimeout.orElse(CONNECT_TIMEOUT_DEFAULT);
-  }
-
-  private static Optional<Duration> maybeParseDuration(final String stringValue, TemporalUnit unit) {
-    if (stringValue == null) {
-      return Optional.empty();
-    }
-    final long number;
-    try {
-      number = Long.parseLong(stringValue);
-    } catch (NumberFormatException __) {
-      return Optional.empty();
-    }
-    if (number < 0) {
-      return Optional.empty();
-    }
-    return Optional.of(Duration.of(number, unit));
   }
 
   /**

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/integrations/JdbcConnector.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/integrations/JdbcConnector.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.integrations;
+
+import static org.postgresql.PGProperty.CONNECT_TIMEOUT;
+
+import io.airbyte.cdk.db.factory.DatabaseDriver;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class JdbcConnector extends BaseConnector {
+
+  public static final String CONNECT_TIMEOUT_KEY = "connectTimeout";
+  public static final Duration CONNECT_TIMEOUT_DEFAULT = Duration.ofSeconds(60);
+
+  /**
+   * Retrieves connectionTimeout value from connection properties in millis, default minimum timeout
+   * is 60 seconds since Hikari default of 30 seconds is not enough for acceptance tests. In the case
+   * the value is 0, pass the value along as Hikari and Postgres use default max value for 0 timeout
+   * value.
+   *
+   * NOTE: Postgres timeout is measured in seconds:
+   * https://jdbc.postgresql.org/documentation/head/connect.html
+   *
+   * @param connectionProperties custom jdbc_url_parameters containing information on connection
+   *        properties
+   * @param driverClassName name of the JDBC driver
+   * @return DataSourceBuilder class used to create dynamic fields for DataSource
+   */
+  public static Duration getConnectionTimeout(final Map<String, String> connectionProperties, String driverClassName) {
+    final Optional<Duration> parsedConnectionTimeout = switch (DatabaseDriver.findByDriverClassName(driverClassName)) {
+      case POSTGRESQL -> maybeParseDuration(connectionProperties.get(CONNECT_TIMEOUT.getName()), ChronoUnit.SECONDS)
+          .or(() -> maybeParseDuration(CONNECT_TIMEOUT.getDefaultValue(), ChronoUnit.SECONDS));
+      case MYSQL -> maybeParseDuration(connectionProperties.get("connectTimeout"), ChronoUnit.MILLIS);
+      case MSSQLSERVER -> maybeParseDuration(connectionProperties.get("loginTimeout"), ChronoUnit.SECONDS);
+      default -> maybeParseDuration(connectionProperties.get(CONNECT_TIMEOUT_KEY), ChronoUnit.SECONDS)
+          // Enforce minimum timeout duration for unspecified data sources.
+          .filter(d -> d.compareTo(CONNECT_TIMEOUT_DEFAULT) >= 0);
+    };
+    return parsedConnectionTimeout.orElse(CONNECT_TIMEOUT_DEFAULT);
+  }
+
+  private static Optional<Duration> maybeParseDuration(final String stringValue, TemporalUnit unit) {
+    if (stringValue == null) {
+      return Optional.empty();
+    }
+    final long number;
+    try {
+      number = Long.parseLong(stringValue);
+    } catch (NumberFormatException __) {
+      return Optional.empty();
+    }
+    if (number < 0) {
+      return Optional.empty();
+    }
+    return Optional.of(Duration.of(number, unit));
+  }
+
+}

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/db/factory/DSLContextFactoryTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/db/factory/DSLContextFactoryTest.java
@@ -7,6 +7,7 @@ package io.airbyte.cdk.db.factory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import io.airbyte.cdk.integrations.JdbcConnector;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.jooq.DSLContext;
@@ -52,7 +53,7 @@ class DSLContextFactoryTest extends CommonFactoryTest {
         container.getJdbcUrl(),
         dialect,
         connectionProperties,
-        DataSourceFactory.CONNECT_TIMEOUT_DEFAULT);
+        JdbcConnector.CONNECT_TIMEOUT_DEFAULT);
     assertNotNull(dslContext);
     assertEquals(dialect, dslContext.configuration().dialect());
   }

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/db/factory/DataSourceFactoryTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/db/factory/DataSourceFactoryTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.zaxxer.hikari.HikariDataSource;
+import io.airbyte.cdk.integrations.JdbcConnector;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Assertions;
@@ -55,7 +56,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
         driverClassName,
         jdbcUrl,
         connectionProperties,
-        DataSourceFactory.getConnectionTimeout(connectionProperties, driverClassName));
+        JdbcConnector.getConnectionTimeout(connectionProperties, driverClassName));
     assertNotNull(dataSource);
     assertEquals(HikariDataSource.class, dataSource.getClass());
     assertEquals(61000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
@@ -71,7 +72,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
         driverClassName,
         jdbcUrl,
         connectionProperties,
-        DataSourceFactory.getConnectionTimeout(connectionProperties, driverClassName));
+        JdbcConnector.getConnectionTimeout(connectionProperties, driverClassName));
     assertNotNull(dataSource);
     assertEquals(HikariDataSource.class, dataSource.getClass());
     assertEquals(30000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
@@ -89,7 +90,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
           mySQLContainer.getDriverClassName(),
           mySQLContainer.getJdbcUrl(),
           connectionProperties,
-          DataSourceFactory.getConnectionTimeout(connectionProperties, mySQLContainer.getDriverClassName()));
+          JdbcConnector.getConnectionTimeout(connectionProperties, mySQLContainer.getDriverClassName()));
       assertNotNull(dataSource);
       assertEquals(HikariDataSource.class, dataSource.getClass());
       assertEquals(5000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
@@ -106,7 +107,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
         driverClassName,
         jdbcUrl,
         connectionProperties,
-        DataSourceFactory.getConnectionTimeout(connectionProperties, driverClassName));
+        JdbcConnector.getConnectionTimeout(connectionProperties, driverClassName));
     assertNotNull(dataSource);
     assertEquals(HikariDataSource.class, dataSource.getClass());
     assertEquals(Integer.MAX_VALUE, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
@@ -121,7 +122,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
         driverClassName,
         jdbcUrl,
         connectionProperties,
-        DataSourceFactory.getConnectionTimeout(connectionProperties, driverClassName));
+        JdbcConnector.getConnectionTimeout(connectionProperties, driverClassName));
     assertNotNull(dataSource);
     assertEquals(HikariDataSource.class, dataSource.getClass());
     assertEquals(10000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
@@ -138,7 +139,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
           mySQLContainer.getDriverClassName(),
           mySQLContainer.getJdbcUrl(),
           connectionProperties,
-          DataSourceFactory.getConnectionTimeout(connectionProperties, mySQLContainer.getDriverClassName()));
+          JdbcConnector.getConnectionTimeout(connectionProperties, mySQLContainer.getDriverClassName()));
       assertNotNull(dataSource);
       assertEquals(HikariDataSource.class, dataSource.getClass());
       assertEquals(60000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
@@ -164,7 +165,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
         driverClassName,
         jdbcUrl,
         connectionProperties,
-        DataSourceFactory.getConnectionTimeout(connectionProperties, driverClassName));
+        JdbcConnector.getConnectionTimeout(connectionProperties, driverClassName));
     assertNotNull(dataSource);
     assertEquals(HikariDataSource.class, dataSource.getClass());
     assertEquals(10, ((HikariDataSource) dataSource).getHikariConfigMXBean().getMaximumPoolSize());

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/AbstractJdbcDestination.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/AbstractJdbcDestination.java
@@ -12,6 +12,7 @@ import io.airbyte.cdk.db.jdbc.DefaultJdbcDatabase;
 import io.airbyte.cdk.db.jdbc.JdbcDatabase;
 import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.cdk.integrations.BaseConnector;
+import io.airbyte.cdk.integrations.JdbcConnector;
 import io.airbyte.cdk.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.cdk.integrations.base.AirbyteTraceMessageUtility;
 import io.airbyte.cdk.integrations.base.Destination;
@@ -197,7 +198,7 @@ public abstract class AbstractJdbcDestination extends BaseConnector implements D
         driverClass,
         jdbcConfig.get(JdbcUtils.JDBC_URL_KEY).asText(),
         connectionProperties,
-        DataSourceFactory.getConnectionTimeout(connectionProperties, driverClass));
+        JdbcConnector.getConnectionTimeout(connectionProperties, driverClass));
   }
 
   protected JdbcDatabase getDatabase(final DataSource dataSource) {

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/jdbc/AbstractJdbcSource.java
@@ -40,6 +40,7 @@ import io.airbyte.cdk.db.jdbc.JdbcDatabase;
 import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.cdk.db.jdbc.StreamingJdbcDatabase;
 import io.airbyte.cdk.db.jdbc.streaming.JdbcStreamingQueryConfig;
+import io.airbyte.cdk.integrations.JdbcConnector;
 import io.airbyte.cdk.integrations.base.Source;
 import io.airbyte.cdk.integrations.source.jdbc.dto.JdbcPrivilegeDto;
 import io.airbyte.cdk.integrations.source.relationaldb.AbstractDbSource;
@@ -436,7 +437,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
         driverClass,
         jdbcConfig.get(JdbcUtils.JDBC_URL_KEY).asText(),
         connectionProperties,
-        DataSourceFactory.getConnectionTimeout(connectionProperties, driverClass));
+        JdbcConnector.getConnectionTimeout(connectionProperties, driverClass));
     // Record the data source so that it can be closed.
     dataSources.add(dataSource);
 

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/TestDatabase.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/TestDatabase.java
@@ -12,6 +12,7 @@ import io.airbyte.cdk.db.factory.DSLContextFactory;
 import io.airbyte.cdk.db.factory.DataSourceFactory;
 import io.airbyte.cdk.db.factory.DatabaseDriver;
 import io.airbyte.cdk.db.jdbc.JdbcUtils;
+import io.airbyte.cdk.integrations.JdbcConnector;
 import io.airbyte.cdk.integrations.util.HostPortResolver;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.string.Strings;
@@ -103,7 +104,7 @@ abstract public class TestDatabase<C extends JdbcDatabaseContainer<?>, T extends
         getDatabaseDriver().getDriverClassName(),
         getJdbcUrl(),
         connectionProperties,
-        DataSourceFactory.getConnectionTimeout(connectionProperties, getDatabaseDriver().getDriverClassName()));
+        JdbcConnector.getConnectionTimeout(connectionProperties, getDatabaseDriver().getDriverClassName()));
     this.dslContext = DSLContextFactory.create(dataSource, getSqlDialect());
     return self();
   }


### PR DESCRIPTION
A couple of methods are moved to a new class, to prepare for the next step. Should have no functional change