### PR TITLE
AbstractJdbcSource and AbstractJdbcDestination now inherit from JdbcConnector

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/integrations/JdbcConnector.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/java/io/airbyte/cdk/integrations/JdbcConnector.java
@@ -18,6 +18,16 @@ public abstract class JdbcConnector extends BaseConnector {
   public static final String CONNECT_TIMEOUT_KEY = "connectTimeout";
   public static final Duration CONNECT_TIMEOUT_DEFAULT = Duration.ofSeconds(60);
 
+  protected final String driverClass;
+
+  protected JdbcConnector(String driverClass) {
+    this.driverClass = driverClass;
+  }
+
+  protected Duration getConnectionTimeout(final Map<String, String> connectionProperties) {
+    return getConnectionTimeout(connectionProperties, driverClass);
+  }
+
   /**
    * Retrieves connectionTimeout value from connection properties in millis, default minimum timeout
    * is 60 seconds since Hikari default of 30 seconds is not enough for acceptance tests. In the case

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/AbstractJdbcDestination.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/java/io/airbyte/cdk/integrations/destination/jdbc/AbstractJdbcDestination.java
@@ -11,7 +11,6 @@ import io.airbyte.cdk.db.factory.DataSourceFactory;
 import io.airbyte.cdk.db.jdbc.DefaultJdbcDatabase;
 import io.airbyte.cdk.db.jdbc.JdbcDatabase;
 import io.airbyte.cdk.db.jdbc.JdbcUtils;
-import io.airbyte.cdk.integrations.BaseConnector;
 import io.airbyte.cdk.integrations.JdbcConnector;
 import io.airbyte.cdk.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.cdk.integrations.base.AirbyteTraceMessageUtility;
@@ -51,7 +50,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class AbstractJdbcDestination extends BaseConnector implements Destination {
+public abstract class AbstractJdbcDestination extends JdbcConnector implements Destination {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJdbcDestination.class);
 
@@ -59,7 +58,6 @@ public abstract class AbstractJdbcDestination extends BaseConnector implements D
 
   public static final String DISABLE_TYPE_DEDUPE = "disable_type_dedupe";
 
-  private final String driverClass;
   private final NamingConventionTransformer namingResolver;
   private final SqlOperations sqlOperations;
 
@@ -74,7 +72,7 @@ public abstract class AbstractJdbcDestination extends BaseConnector implements D
   public AbstractJdbcDestination(final String driverClass,
                                  final NamingConventionTransformer namingResolver,
                                  final SqlOperations sqlOperations) {
-    this.driverClass = driverClass;
+    super(driverClass);
     this.namingResolver = namingResolver;
     this.sqlOperations = sqlOperations;
   }
@@ -198,7 +196,7 @@ public abstract class AbstractJdbcDestination extends BaseConnector implements D
         driverClass,
         jdbcConfig.get(JdbcUtils.JDBC_URL_KEY).asText(),
         connectionProperties,
-        JdbcConnector.getConnectionTimeout(connectionProperties, driverClass));
+        getConnectionTimeout(connectionProperties));
   }
 
   protected JdbcDatabase getDatabase(final DataSource dataSource) {

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/jdbc/AbstractJdbcSource.java
@@ -40,7 +40,6 @@ import io.airbyte.cdk.db.jdbc.JdbcDatabase;
 import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.cdk.db.jdbc.StreamingJdbcDatabase;
 import io.airbyte.cdk.db.jdbc.streaming.JdbcStreamingQueryConfig;
-import io.airbyte.cdk.integrations.JdbcConnector;
 import io.airbyte.cdk.integrations.base.Source;
 import io.airbyte.cdk.integrations.source.jdbc.dto.JdbcPrivilegeDto;
 import io.airbyte.cdk.integrations.source.relationaldb.AbstractDbSource;
@@ -90,7 +89,6 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJdbcSource.class);
 
-  protected final String driverClass;
   protected final Supplier<JdbcStreamingQueryConfig> streamingQueryConfigProvider;
   protected final JdbcCompatibleSourceOperations<Datatype> sourceOperations;
 
@@ -100,7 +98,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
   public AbstractJdbcSource(final String driverClass,
                             final Supplier<JdbcStreamingQueryConfig> streamingQueryConfigProvider,
                             final JdbcCompatibleSourceOperations<Datatype> sourceOperations) {
-    this.driverClass = driverClass;
+    super(driverClass);
     this.streamingQueryConfigProvider = streamingQueryConfigProvider;
     this.sourceOperations = sourceOperations;
   }
@@ -437,7 +435,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
         driverClass,
         jdbcConfig.get(JdbcUtils.JDBC_URL_KEY).asText(),
         connectionProperties,
-        JdbcConnector.getConnectionTimeout(connectionProperties, driverClass));
+        getConnectionTimeout(connectionProperties));
     // Record the data source so that it can be closed.
     dataSources.add(dataSource);
 

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/relationaldb/AbstractDbSource.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/relationaldb/AbstractDbSource.java
@@ -13,7 +13,7 @@ import datadog.trace.api.Trace;
 import io.airbyte.cdk.db.AbstractDatabase;
 import io.airbyte.cdk.db.IncrementalUtils;
 import io.airbyte.cdk.db.jdbc.JdbcDatabase;
-import io.airbyte.cdk.integrations.BaseConnector;
+import io.airbyte.cdk.integrations.JdbcConnector;
 import io.airbyte.cdk.integrations.base.AirbyteTraceMessageUtility;
 import io.airbyte.cdk.integrations.base.Source;
 import io.airbyte.cdk.integrations.source.relationaldb.InvalidCursorInfoUtil.InvalidCursorInfo;
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
  * source of both non-relational and relational type
  */
 public abstract class AbstractDbSource<DataType, Database extends AbstractDatabase> extends
-    BaseConnector implements Source, AutoCloseable {
+    JdbcConnector implements Source, AutoCloseable {
 
   public static final String CHECK_TRACE_OPERATION_NAME = "check-operation";
   public static final String DISCOVER_TRACE_OPERATION_NAME = "discover-operation";
@@ -79,6 +79,10 @@ public abstract class AbstractDbSource<DataType, Database extends AbstractDataba
 
   // TODO: Remove when the flag is not use anymore
   protected FeatureFlags featureFlags = new EnvVariableFeatureFlags();
+
+  protected AbstractDbSource(String driverClassName) {
+    super(driverClassName);
+  }
 
   @VisibleForTesting
   public void setFeatureFlags(FeatureFlags featureFlags) {

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/java/io/airbyte/cdk/integrations/source/relationaldb/AbstractDbSourceTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/java/io/airbyte/cdk/integrations/source/relationaldb/AbstractDbSourceTest.java
@@ -5,8 +5,9 @@
 package io.airbyte.cdk.integrations.source.relationaldb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.withSettings;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.cdk.integrations.source.relationaldb.state.StateGeneratorUtils;
@@ -34,7 +35,7 @@ public class AbstractDbSourceTest {
 
   @Test
   void testDeserializationOfLegacyState() throws IOException {
-    final AbstractDbSource dbSource = spy(AbstractDbSource.class);
+    final AbstractDbSource dbSource = mock(AbstractDbSource.class, withSettings().useConstructor("").defaultAnswer(CALLS_REAL_METHODS));
     final JsonNode config = mock(JsonNode.class);
 
     final String legacyStateJson = MoreResources.readResource("states/legacy.json");
@@ -49,7 +50,7 @@ public class AbstractDbSourceTest {
   @Test
   void testDeserializationOfGlobalState() throws IOException {
     environmentVariables.set(EnvVariableFeatureFlags.USE_STREAM_CAPABLE_STATE, "true");
-    final AbstractDbSource dbSource = spy(AbstractDbSource.class);
+    final AbstractDbSource dbSource = mock(AbstractDbSource.class, withSettings().useConstructor("").defaultAnswer(CALLS_REAL_METHODS));
     final JsonNode config = mock(JsonNode.class);
 
     final String globalStateJson = MoreResources.readResource("states/global.json");
@@ -64,7 +65,7 @@ public class AbstractDbSourceTest {
   @Test
   void testDeserializationOfStreamState() throws IOException {
     environmentVariables.set(EnvVariableFeatureFlags.USE_STREAM_CAPABLE_STATE, "true");
-    final AbstractDbSource dbSource = spy(AbstractDbSource.class);
+    final AbstractDbSource dbSource = mock(AbstractDbSource.class, withSettings().useConstructor("").defaultAnswer(CALLS_REAL_METHODS));
     final JsonNode config = mock(JsonNode.class);
 
     final String streamStateJson = MoreResources.readResource("states/per_stream.json");
@@ -78,7 +79,7 @@ public class AbstractDbSourceTest {
 
   @Test
   void testDeserializationOfNullState() throws IOException {
-    final AbstractDbSource dbSource = spy(AbstractDbSource.class);
+    final AbstractDbSource dbSource = mock(AbstractDbSource.class, withSettings().useConstructor("").defaultAnswer(CALLS_REAL_METHODS));
     final JsonNode config = mock(JsonNode.class);
 
     final List<AirbyteStateMessage> result = StateGeneratorUtils.deserializeInitialState(null, false, dbSource.getSupportedStateType(config));


### PR DESCRIPTION
This is introducing a new layer of inheritance between AbstractJdbcDestination and AbstractDbSource on one side and BaseConnector on the other. That allows us to expose an overridable getConnectionTimeout, and to share the driverClass with the parent as well. Should have no functional change