### PR TITLE
ignore generated files in format

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -502,7 +502,8 @@ This command runs the Python tests for a airbyte-ci poetry package.
 
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| 2.10.9  | [#33370](https://github.com/airbytehq/airbyte/pull/33370)  | Fix bug that broke airbyte-ci test
+| 2.10.10 | [#33449](https://github.com/airbytehq/airbyte/pull/33449)  | Add generated metadata models to the default format ignore list.                                          |
+| 2.10.9  | [#33370](https://github.com/airbytehq/airbyte/pull/33370)  | Fix bug that broke airbyte-ci test                                                                        |
 | 2.10.8  | [#33249](https://github.com/airbytehq/airbyte/pull/33249)  | Exclude git ignored files from formatting.                                                                |
 | 2.10.7  | [#33248](https://github.com/airbytehq/airbyte/pull/33248)  | Fix bug which broke airbyte-ci connectors tests when optional DockerHub credentials env vars are not set. |
 | 2.10.6  | [#33170](https://github.com/airbytehq/airbyte/pull/33170)  | Remove Dagger logs from console output of `format`.                                                       |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
@@ -20,7 +20,6 @@ DEFAULT_FORMAT_IGNORE_LIST = [
     "**/.tox",
     "**/.venv",
     "**/*.egg-info",
-    "**/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/**/invalid",  # These are deliberately invalid and unformattable.
     "**/build",
     "**/charts",  # Helm charts often have injected template strings that will fail general linting. Helm linting is done separately.
     "**/dbt_test_config",
@@ -37,6 +36,8 @@ DEFAULT_FORMAT_IGNORE_LIST = [
     "**/source-amplitude/unit_tests/api_data/zipped.json",  # Zipped file presents as non-UTF-8 making spotless sad
     "**/tools/git_hooks/tests/test_spec_linter.py",
     "airbyte-cdk/python/airbyte_cdk/sources/declarative/models/**",  # These files are generated and should not be formatted
+    "airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/**",  # These files are generated and should not be formatted
+    "**/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/**/invalid",  # This is a test directory with invalid and sometimes unformatted code
     "airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code",  # This is a test directory with badly formatted code
 ]
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.10.9"
+version = "2.10.10"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
Addressing this comment: https://github.com/airbytehq/airbyte/pull/33111#discussion_r1425160942

We need to update the ignore list and then regenerate the files separately to keep CI happy because we're running the latest binary in CI.