### PR TITLE
Ignore pipeline_reports in format

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
@@ -39,6 +39,7 @@ DEFAULT_FORMAT_IGNORE_LIST = [
     "airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/**",  # These files are generated and should not be formatted
     "**/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/**/invalid",  # This is a test directory with invalid and sometimes unformatted code
     "airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code",  # This is a test directory with badly formatted code
+    "airbyte-ci/connectors/pipelines/pipeline_reports",
 ]
 
 


### PR DESCRIPTION
## Problem
`airbyte-ci format fix all` failed with no modifications if you had pipeline reports on your machine.

## Quick Solution
Ignore that path

## Future Solution
We need to get better about copying repos to dagger.

We should be able to copy and adhere to .gitignore.

But thats a bigger fix