### PR TITLE
airbyte-ci: consider nested .gitignore files in format

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -502,6 +502,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 2.10.11 | [#33497](https://github.com/airbytehq/airbyte/pull/33497)  | Consider nested .gitignore rules in format.                                          |
 | 2.10.10 | [#33449](https://github.com/airbytehq/airbyte/pull/33449)  | Add generated metadata models to the default format ignore list.                                          |
 | 2.10.9  | [#33370](https://github.com/airbytehq/airbyte/pull/33370)  | Fix bug that broke airbyte-ci test                                                                        |
 | 2.10.8  | [#33249](https://github.com/airbytehq/airbyte/pull/33249)  | Exclude git ignored files from formatting.                                                                |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/format_command.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/format_command.py
@@ -76,7 +76,7 @@ class FormatCommand(click.Command):
             message = f"{message}."
         return message
 
-    def get_dir_to_format(self, dagger_client) -> Directory:
+    def get_dir_to_format(self, dagger_client) -> dagger.Directory:
         """Get a directory with all the source code to format according to the file_filter.
         We mount the the files to format in a git container and remove all gitignored files.
         It ensures we're not formatting files that are gitignored.
@@ -89,7 +89,7 @@ class FormatCommand(click.Command):
         """
         # Load a directory from the host with all the files to format according to the file_filter and the .gitignore files
         dir_to_format = dagger_client.host().directory(
-            self.LOCAL_REPO_PATH, include=self.file_filter + [".gitignore"], exclude=DEFAULT_FORMAT_IGNORE_LIST
+            self.LOCAL_REPO_PATH, include=self.file_filter + ["**/.gitignore"], exclude=DEFAULT_FORMAT_IGNORE_LIST
         )
 
         return (

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.10.10"
+version = "2.10.11"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
A missing wildcard in the `.gitignore` path match made `format` not consider git ignore rules of nested .gitignore files.
