### PR TITLE
java CDK: add debug logging of executed SQL in TestDatabase

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/TestDatabase.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/TestDatabase.java
@@ -165,10 +165,13 @@ abstract public class TestDatabase<C extends JdbcDatabaseContainer<?>, T extends
     return new Database(getDslContext());
   }
 
-  protected void execSQL(Stream<String> sql) {
+  protected void execSQL(final Stream<String> sql) {
     try {
       getDatabase().query(ctx -> {
-        sql.forEach(ctx::execute);
+        sql.forEach(statement -> {
+          LOGGER.debug("{}", statement);
+          ctx.execute(statement);
+        });
         return null;
       });
     } catch (SQLException e) {


### PR DESCRIPTION
This is just a small QoL improvement. It doesn't need its own CDK release and can wait until the next one.