### PR TITLE
Change the run-ab-platform.sh script to support other shells than bash

### DIFF
--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -4,7 +4,7 @@ VERSION=0.50.38
 # Run away from anything even a little scary
 set -o nounset # -u exit if a variable is not set
 set -o errexit # -f exit for any command failure"
-set -u
+set +u
 
 # text color escape codes (please note \033 == \e but OSX doesn't respect the \e)
 blue_text='\033[94m'

--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -4,7 +4,6 @@ VERSION=0.50.38
 # Run away from anything even a little scary
 set -o nounset # -u exit if a variable is not set
 set -o errexit # -f exit for any command failure"
-set +u
 
 # text color escape codes (please note \033 == \e but OSX doesn't respect the \e)
 blue_text='\033[94m'

--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -12,7 +12,7 @@ red_text='\033[31m'
 default_text='\033[39m'
 
 # set -x/xtrace uses a Sony PS4 for more info
-PS4="$blue_text""${BASH_SOURCE}:${LINENO}: ""$default_text"
+PS4="$blue_text""${0}:${LINENO}: ""$default_text"
 
 ############################################################
 # Help                                                     #

--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -4,6 +4,7 @@ VERSION=0.50.38
 # Run away from anything even a little scary
 set -o nounset # -u exit if a variable is not set
 set -o errexit # -f exit for any command failure"
+set -u
 
 # text color escape codes (please note \033 == \e but OSX doesn't respect the \e)
 blue_text='\033[94m'


### PR DESCRIPTION
## What

This is small PR to remove the use of the bash specific variable `BASH_SOURCE` in the `run-ab-platform.sh` script in order to make it run on other shells than bash (tested on fish)

## How

After reading that [explanation](https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source) on Stackoverflow, I just changed the variable `${BASH_SOURCE}` to use `${0}`

Changing it allows to run the script on `fish` shell.

**Before:**

<img width="950" alt="Screenshot 2023-12-15 at 9 12 56 PM" src="https://github.com/airbytehq/airbyte/assets/958983/2f56515e-b710-4895-8b5b-ded63dd1d1c4">

**After:**

<img width="935" alt="Screenshot 2023-12-15 at 9 13 29 PM" src="https://github.com/airbytehq/airbyte/assets/958983/06856c62-7c0d-41f2-a281-39a994727aea">

