### PR TITLE
CDK: Fix unit test

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -234,7 +234,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
             new_token_expiry_date = self.get_new_token_expiry_date(access_token_expires_in, self._token_expiry_date_format)
             self.access_token = new_access_token
             self.set_refresh_token(new_refresh_token)
-            self.set_token_expiry_date(new_token_expiry_date)
+            self.set_token_expiry_date(new_token_expiry_date.to_iso8601_string())
             # FIXME emit_configuration_as_airbyte_control_message as been deprecated in favor of package airbyte_cdk.sources.message
             #  Usually, a class shouldn't care about the implementation details but to keep backward compatibility where we print the
             #  message directly in the console, this is needed

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -322,9 +322,9 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
     @pytest.mark.parametrize(
         "test_name, expires_in_value, expiry_date_format, expected_expiry_date",
         [
-            ("number_of_seconds", 42, None, "2022-12-31T00:00:42+00:00"),
-            ("string_of_seconds", "42", None, "2022-12-31T00:00:42+00:00"),
-            ("date_format", "2023-04-04", "YYYY-MM-DD", "2023-04-04T00:00:00+00:00"),
+            ("number_of_seconds", 42, None, "2022-12-31T00:00:42Z"),
+            ("string_of_seconds", "42", None, "2022-12-31T00:00:42Z"),
+            ("date_format", "2023-04-04", "YYYY-MM-DD", "2023-04-04T00:00:00Z"),
         ],
     )
     def test_given_no_message_repository_get_access_token(
@@ -376,7 +376,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
         assert emitted_message.control.type == OrchestratorType.CONNECTOR_CONFIG
         assert emitted_message.control.connectorConfig.config["credentials"]["access_token"] == "new_access_token"
         assert emitted_message.control.connectorConfig.config["credentials"]["refresh_token"] == "new_refresh_token"
-        assert emitted_message.control.connectorConfig.config["credentials"]["token_expiry_date"] == "2023-04-04T00:00:00+00:00"
+        assert emitted_message.control.connectorConfig.config["credentials"]["token_expiry_date"] == "2023-04-04T00:00:00Z"
         assert emitted_message.control.connectorConfig.config["credentials"]["client_id"] == "my_client_id"
         assert emitted_message.control.connectorConfig.config["credentials"]["client_secret"] == "my_client_secret"
 


### PR DESCRIPTION
This PR fixes the CDK oauth authenticator unit tests.

To make the code more robust in the future, it's calling `to_iso8601_string` on the pendulum object instead of relying on the implicit string conversion which changed recently: https://github.com/sdispater/pendulum/commit/071bf633