### PR TITLE
Fix cdk unit test

### DIFF
--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -71,7 +71,7 @@ setup(
         "isodate~=0.6.1",
         "jsonschema~=3.2.0",
         "jsonref~=0.2",
-        "pendulum",
+        "pendulum<3.0.0",
         "genson==1.2.2",
         "pydantic>=1.10.8,<2.0.0",
         "pyrate-limiter~=3.1.0",


### PR DESCRIPTION
Pendulum got updated to 3.0: https://pypi.org/project/pendulum/#history

As we don't pin the version, this caused some errors. This is setting it to lower than 3.0, but we should upgrade in time