### PR TITLE
🐛 Source Shopify: Add very low load on Shopify rate limiter

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/source_shopify/utils.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/utils.py
@@ -140,7 +140,7 @@ class ShopifyRateLimiter:
     Define timings for RateLimits. Adjust timings if needed.
 
     :: on_unknown_load = 1.0 sec - Shopify recommended time to hold between each API call.
-    :: on_very_low_load = 0.0 sec - when the bucket is empty, don't hold, because each api call can already take more than 200 miliseconds.
+    :: on_very_low_load = 0.0 sec - when the bucket is empty, don't hold, because current api call processing can already take longer than Shopify's leak rate.
     :: on_low_load = 0.2 sec (200 miliseconds) - ideal ratio between hold time and api call, also the standard hold time between each API call.
     :: on_mid_load = 1.5 sec - great timing to retrieve another 15% of request capacity while having mid_load.
     :: on_high_load = 5.0 sec - ideally we should wait 2.0 sec while having high_load, but we hold 5 sec to retrieve up to 80% of request capacity.

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_control_rate_limit.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_control_rate_limit.py
@@ -44,6 +44,20 @@ def test_rest_api_with_unknown_load(requests_mock):
     assert limiter.on_unknown_load == actual_sleep_time
 
 
+def test_rest_api_with_very_low_load(requests_mock):
+    """
+    Test simulates very low load 2/40 points of rate limit.
+    """
+    test_response_header = {"X-Shopify-Shop-Api-Call-Limit": "1/40"}
+
+    requests_mock.get("https://test.myshopify.com/", headers=test_response_header)
+    test_response = requests.get("https://test.myshopify.com/")
+
+    actual_sleep_time = limiter.get_rest_api_wait_time(test_response, threshold=TEST_THRESHOLD, rate_limit_header=TEST_RATE_LIMIT_HEADER)
+
+    assert limiter.on_very_low_load == actual_sleep_time
+
+
 def test_rest_api_with_low_load(requests_mock):
     """
     Test simulates low load 10/40 points of rate limit.
@@ -96,6 +110,21 @@ def test_graphql_api_with_unknown_load(requests_mock):
     actual_sleep_time = limiter.get_graphql_api_wait_time(test_response, threshold=TEST_THRESHOLD)
 
     assert limiter.on_unknown_load == actual_sleep_time
+
+
+def test_graphql_api_with_low_load(requests_mock):
+    """
+    Test simulates very low load (2000-1800)/2000=0.1 points of rate limit.
+    """
+
+    api_response = get_graphql_api_response(maximum_available=2000, currently_available=1800)
+    requests_mock.get("https://test.myshopify.com/", json=api_response)
+    test_response = requests.get("https://test.myshopify.com/")
+
+    actual_sleep_time = limiter.get_graphql_api_wait_time(test_response, threshold=TEST_THRESHOLD)
+
+    assert limiter.on_very_low_load == actual_sleep_time
+
 
 
 def test_graphql_api_with_low_load(requests_mock):

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_control_rate_limit.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_control_rate_limit.py
@@ -112,7 +112,7 @@ def test_graphql_api_with_unknown_load(requests_mock):
     assert limiter.on_unknown_load == actual_sleep_time
 
 
-def test_graphql_api_with_low_load(requests_mock):
+def test_graphql_api_with_very_low_load(requests_mock):
     """
     Test simulates very low load (2000-1800)/2000=0.1 points of rate limit.
     """


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*
It addresses this open issue: https://github.com/airbytehq/airbyte/issues/32818

Speeds up number of requests per second where unnecessarily slow. There was always a hold (wait_time) between each API call even when the bucket is emptied much faster than it is being filled. When the bucket is (almost) empty, there is no need to wait between each API call. 

Before
<img width="493" alt="image" src="https://github.com/airbytehq/airbyte/assets/133117116/5071cb97-1025-4b9f-9f96-3c59e81ff193">
After
<img width="499" alt="image" src="https://github.com/airbytehq/airbyte/assets/133117116/a73c6545-9554-4f78-89cd-360fd9f6d8fe">



## How
*Describe the solution*
I added another option in the Shopify rate limiter. Before, the fastest option was a hold of 200 miliseconds between API calls. This was when the bucket was less than half full. 

Now this is true only when the bucket is between 25% and 50% full. When bucket is less than 25% full, it should not hold (wait_time is 0 miliseconds) between the API calls. 

For Shopify Plus users this means that most of the time, there won't be any unnecessary hold, because each API call processeing by this connector already takes more time (cca 200 miliseconds/request) than Shopify is able to process (50 miliseconds/request). For all the other users, they might see a slight speed improvement, but the existing rate limiter will still cover existing loads with conservative holds, so this change should not introduce new limit errors.

## Recommended reading order
1. `source_shopify/utils.py`
2. `source-shopify/unit_tests/test_control_rate_limit.py`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*
No breaking changes. 
End user will see a slight performance improvement at per entity API requests, up to 2x.

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***
Patch (Syncs will be faster)

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*



<summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added

### Airbyter
If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).