### PR TITLE
[airbyte-cdk] Initial and Incremental Stream State definitions for Cursor-based and CDC syncs

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -163,7 +163,8 @@ MavenLocal debugging steps:
 ### Java CDK
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
-| :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.11.0  | 2023-12-21 | [\#33606](https://github.com/airbytehq/airbyte/pull/33606) | Add updated Initial and Incremental Stream State definitions for DB Sources                                                                                    |
 | 0.10.1  | 2023-12-21 | [\#33723](https://github.com/airbytehq/airbyte/pull/33723) | Make memory-manager log message less scary                                                                                                                     |
 | 0.10.0  | 2023-12-20 | [\#33704](https://github.com/airbytehq/airbyte/pull/33704) | JdbcDestinationHandler now properly implements `getInitialRawTableState`; reenable SqlGenerator test                                                           |
 | 0.9.0   | 2023-12-18 | [\#33124](https://github.com/airbytehq/airbyte/pull/33124) | Make Schema Creation Separate from Table Creation, exclude the T&D module from the CDK                                                                         |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.10.1
+version=0.11.0

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/resources/db_models/internal_models.yaml
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/resources/db_models/internal_models.yaml
@@ -12,11 +12,12 @@ properties:
     "$ref": "#/definitions/CursorBasedStatus"
 definitions:
   StateType:
-    description: Enum to define the sync mode of state.
+    description: Enum to define the sync mode of stream state.
     type: string
     enum:
       - cursor_based
       - ordered_column
+      - cdc
   CursorBasedStatus:
     type: object
     extends:

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/resources/db_models/internal_models.yaml
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/resources/db_models/internal_models.yaml
@@ -1,13 +1,13 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-title: Mssql Models
+title: DbSource Models
 type: object
-description: Mssql Models
+description: DbSource Models
 properties:
   state_type:
     "$ref": "#/definitions/StateType"
-  primary_key_state:
-    "$ref": "#/definitions/PrimaryKeyLoadStatus"
+  ordered_column_state:
+    "$ref": "#/definitions/OrderedColumnLoadStatus"
   cursor_based_state:
     "$ref": "#/definitions/CursorBasedStatus"
 definitions:
@@ -16,7 +16,7 @@ definitions:
     type: string
     enum:
       - cursor_based
-      - primary_key
+      - ordered_column
   CursorBasedStatus:
     type: object
     extends:
@@ -28,7 +28,7 @@ definitions:
       version:
         description: Version of state.
         type: integer
-  PrimaryKeyLoadStatus:
+  OrderedColumnLoadStatus:
     type: object
     properties:
       version:
@@ -36,13 +36,13 @@ definitions:
         type: integer
       state_type:
         "$ref": "#/definitions/StateType"
-      pk_name:
-        description: primary key name
+      ordered_col:
+        description: ordered column name
         type: string
-      pk_val:
-        description: primary key watermark
+      ordered_col_val:
+        description: ordered column high watermark
         type: string
       incremental_state:
-        description: State to switch to after completion of primary key initial sync
+        description: State to switch to after completion of the ordered column initial sync
         type: object
         existingJavaType: com.fasterxml.jackson.databind.JsonNode

--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -1,6 +1,9 @@
+import org.jsonschema2pojo.SourceType
+
 plugins {
     id 'application'
     id 'airbyte-java-connector'
+    id 'org.jsonschema2pojo' version '1.2.1'
 }
 
 airbyteJavaConnector {
@@ -14,7 +17,6 @@ configurations.all {
         force libs.jooq
     }
 }
-
 
 
 application {
@@ -36,4 +38,18 @@ dependencies {
 
     testImplementation libs.testcontainers.mssqlserver
     testFixturesImplementation libs.testcontainers.mssqlserver
+}
+
+jsonSchema2Pojo {
+    sourceType = SourceType.YAMLSCHEMA
+    source = files("${sourceSets.main.output.resourcesDir}/internal_models")
+    targetDirectory = new File(project.buildDir, 'generated/src/gen/java/')
+    removeOldOutput = true
+
+    targetPackage = 'io.airbyte.integrations.source.mssql.internal.models'
+
+    useLongIntegers = true
+    generateBuilders = true
+    includeConstructors = false
+    includeSetters = true
 }

--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -6,7 +6,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.7.7'
     features = ['db-sources']
-    useLocalCdk = true
+    useLocalCdk = false
 }
 
 configurations.all {

--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -1,15 +1,12 @@
-import org.jsonschema2pojo.SourceType
-
 plugins {
     id 'application'
     id 'airbyte-java-connector'
-    id 'org.jsonschema2pojo' version '1.2.1'
 }
 
 airbyteJavaConnector {
     cdkVersionRequired = '0.7.7'
     features = ['db-sources']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 configurations.all {
@@ -38,18 +35,4 @@ dependencies {
 
     testImplementation libs.testcontainers.mssqlserver
     testFixturesImplementation libs.testcontainers.mssqlserver
-}
-
-jsonSchema2Pojo {
-    sourceType = SourceType.YAMLSCHEMA
-    source = files("${sourceSets.main.output.resourcesDir}/internal_models")
-    targetDirectory = new File(project.buildDir, 'generated/src/gen/java/')
-    removeOldOutput = true
-
-    targetPackage = 'io.airbyte.integrations.source.mssql.internal.models'
-
-    useLongIntegers = true
-    generateBuilders = true
-    includeConstructors = false
-    includeSetters = true
 }

--- a/airbyte-integrations/connectors/source-mssql/src/main/resources/internal_models/internal_models.yaml
+++ b/airbyte-integrations/connectors/source-mssql/src/main/resources/internal_models/internal_models.yaml
@@ -1,0 +1,48 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+title: Mssql Models
+type: object
+description: Mssql Models
+properties:
+  state_type:
+    "$ref": "#/definitions/StateType"
+  primary_key_state:
+    "$ref": "#/definitions/PrimaryKeyLoadStatus"
+  cursor_based_state:
+    "$ref": "#/definitions/CursorBasedStatus"
+definitions:
+  StateType:
+    description: Enum to define the sync mode of state.
+    type: string
+    enum:
+      - cursor_based
+      - primary_key
+  CursorBasedStatus:
+    type: object
+    extends:
+      type: object
+      existingJavaType: "io.airbyte.cdk.integrations.source.relationaldb.models.DbStreamState"
+    properties:
+      state_type:
+        "$ref": "#/definitions/StateType"
+      version:
+        description: Version of state.
+        type: integer
+  PrimaryKeyLoadStatus:
+    type: object
+    properties:
+      version:
+        description: Version of state.
+        type: integer
+      state_type:
+        "$ref": "#/definitions/StateType"
+      pk_name:
+        description: primary key name
+        type: string
+      pk_val:
+        description: primary key watermark
+        type: string
+      incremental_state:
+        description: State to switch to after completion of primary key initial sync
+        type: object
+        existingJavaType: com.fasterxml.jackson.databind.JsonNode


### PR DESCRIPTION
***Description:***  As part of the efforts to enable initial read via Primary Key,  a new state definition needs to be created and the current default `DbStreamState` needs to be expanded to include new fields to support initial sync checkpointing and enable resumability for CDC and Cursor-based. 

The new generated classes will be available in the cdk module and will be accessible within any connector.

*NOTE*: This PR is effectively a no-op since no connectors is relying on these newly generated classes yet. This is a prep for the upcoming source-mssql checkpointing work.

Refer to [tech spec](https://docs.google.com/document/d/1kX-NhwQdinKQXKdgcazxvDpDzi-KOrQuXpXCFf9lMjA/edit) for more context and full definitions