### PR TITLE
Fix connector doc headers

### DIFF
--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -45,7 +45,7 @@ export const HeaderDecoration = ({
     </dl>
 
     <div className={styles.header}>
-      <img src={iconUrl} alt="" class={styles.connectorIcon} />
+      <img src={iconUrl} alt="" className={styles.connectorIcon} />
       <h1 id={originalId}>{originalTitle}</h1>
     </div>
   </>;

--- a/docusaurus/src/remark/docsHeaderDecoration.js
+++ b/docusaurus/src/remark/docsHeaderDecoration.js
@@ -39,11 +39,14 @@ const plugin = () => {
 
     if (!registryEntry) return;
 
+    let firstHeading = true;
+
     visit(ast, "heading", (node) => {
-      if (node.depth === 1 && node.children.length === 1) {
+      if (firstHeading && node.depth === 1 && node.children.length === 1) {
         const originalTitle = node.children[0].value;
         const originalId = node.data.hProperties.id;
 
+        firstHeading = false;
         node.children = [];
         node.type = "mdxJsxFlowElement";
         node.name = "HeaderDecoration";


### PR DESCRIPTION
Only show the connector icon (and header decorator) for the first h1 in the docs. Currently it's rendered for every, which can be seen e.g. on the Kafka docs: https://docs.airbyte.com/integrations/sources/kafka#kafka

Also fix a small JSX issue, where we still set `class` instead of `className`.