### PR TITLE
Fix #28764: missing organisations data in zendesk support connector

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
-  dockerImageTag: 2.2.3
+  dockerImageTag: 2.2.4
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
   githubIssueLabel: source-zendesk-support

--- a/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/streams.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/streams.py
@@ -444,7 +444,7 @@ class Users(SourceZendeskIncrementalExportStream):
         return "incremental/users/cursor.json"
 
 
-class Organizations(SourceZendeskIncrementalExportStream):
+class Organizations(CursorPaginationZendeskSupportStream):
     """Organizations stream: https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/"""
 
     response_list_name: str = "organizations"


### PR DESCRIPTION
## What

Zendesk Support only extracts 100 records, because it only supports date-based pagination

## How

Changing the base class to CursorPaginationZendeskSupportStream fixes the issue

## 🚨 User Impact 🚨

Broken organisations stream (when more than 100 orgs) is now fixed.

## Note

currently this breaks tests on the organisations stream (even though the fixed connector works perfectly in production); I'm not knowledgeable enough to know how to fix them, assistance would be very welcome.