### PR TITLE
Skip if no enabled version

### DIFF
--- a/airbyte-ci/connectors/ci_credentials/ci_credentials/secrets_manager.py
+++ b/airbyte-ci/connectors/ci_credentials/ci_credentials/secrets_manager.py
@@ -117,6 +117,9 @@ class SecretsManager:
                 enabled_versions = [version["name"] for version in versions_data["versions"] if version["state"] == "ENABLED"]
                 if len(enabled_versions) > 1:
                     self.logger.critical(f"{log_name} should have one enabled version at the same time!!!")
+                if not enabled_versions:
+                    self.logger.warning(f"{log_name} doesn't have enabled versions for {secret_name}")
+                    continue
                 enabled_version = enabled_versions[0]
                 secret_url = f"https://secretmanager.googleapis.com/v1/{enabled_version}:access"
                 secret_data = self.api.get(secret_url)


### PR DESCRIPTION
## Overview
I had wanted to disable some secrets entirely.

But was unable to as `ci_credentials` would still try and run as though it would always have an active version

This is a quick fix to unblock