### PR TITLE
[ISSUE #32871] enable debug logs for integration tests

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte-cdk/python/airbyte_cdk/test/entrypoint_wrapper.py
@@ -136,6 +136,7 @@ def read(
                     make_file(tmp_directory_path / "state.json", state),
                 ]
             )
+        args.append("--debug")
         source_entrypoint = AirbyteEntrypoint(source)
         parsed_args = source_entrypoint.parse_args(args)
 


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/33348 which helps for debugging for sources that prints the HTTP requests that are performed

## How
Adding the `--debug` argument to the command
