### PR TITLE
CDK - add stop_condition to Paginator

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -999,6 +999,18 @@ definitions:
           - "$ref": "#/definitions/CustomPaginationStrategy"
           - "$ref": "#/definitions/OffsetIncrement"
           - "$ref": "#/definitions/PageIncrement"
+      stop_condition:
+        title: Stop Condition
+        description: Template string evaluating when to stop paginating.
+        type: string
+        interpolation_context:
+          - config
+          - headers
+          - last_records
+          - response
+        examples:
+          - "{{ response.data.has_more is false }}"
+          - "{{ 'next' not in headers['link'] }}"
       decoder:
         title: Decoder
         description: Component decoding the response so records can be extracted.

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/interpolated_boolean.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/interpolated_boolean.py
@@ -28,7 +28,7 @@ class InterpolatedBoolean:
         self._interpolation = JinjaInterpolation()
         self._parameters = parameters
 
-    def eval(self, config: Config, **additional_parameters):
+    def eval(self, config: Config, **additional_parameters) -> bool:
         """
         Interpolates the predicate condition string using the config and other optional arguments passed as parameter.
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/interpolated_boolean.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/interpolated_boolean.py
@@ -23,12 +23,13 @@ class InterpolatedBoolean:
     condition: str
     parameters: InitVar[Mapping[str, Any]]
 
-    def __post_init__(self, parameters: Mapping[str, Any]):
+    def __post_init__(self, parameters: Mapping[str, Any]) -> None:
         self._default = "False"
-        self._interpolation = JinjaInterpolation()
+        # Call to untyped function "JinjaInterpolation" in typed context
+        self._interpolation: JinjaInterpolation = JinjaInterpolation()  # type: ignore[no-untyped-call]
         self._parameters = parameters
 
-    def eval(self, config: Config, **additional_parameters) -> bool:
+    def eval(self, config: Config, **additional_parameters: Any) -> bool:
         """
         Interpolates the predicate condition string using the config and other optional arguments passed as parameter.
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -950,6 +950,15 @@ class DefaultPaginator(BaseModel):
         description='Strategy defining how records are paginated.',
         title='Pagination Strategy',
     )
+    stop_condition: Optional[str] = Field(
+        None,
+        description='Template string evaluating when to stop paginating.',
+        examples=[
+            '{{ response.data.has_more is false }}',
+            "{{ 'next' not in headers['link'] }}",
+        ],
+        title='Stop Condition',
+    )
     decoder: Optional[JsonDecoder] = Field(
         None,
         description='Component decoding the response so records can be extracted.',

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -318,7 +318,8 @@ class ModelToComponentFactory:
         )
         if model.request_authentication.type == "Bearer":
             return ModelToComponentFactory.create_bearer_authenticator(
-                BearerAuthenticatorModel(type="BearerAuthenticator", api_token=""),
+                # Missing named argument "$parameters" for "BearerAuthenticator"
+                BearerAuthenticatorModel(type="BearerAuthenticator", api_token=""),  # type: ignore[call-arg]
                 config,
                 token_provider=token_provider,  # type: ignore # $parameters defaults to None
             )

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -105,6 +105,7 @@ from airbyte_cdk.sources.declarative.requesters.paginators.strategies import (
     PageIncrement,
     StopConditionPaginationStrategyDecorator,
 )
+from airbyte_cdk.sources.declarative.requesters.paginators.strategies.stop_condition import InterpolatedStopCondition
 from airbyte_cdk.sources.declarative.requesters.request_option import RequestOptionType
 from airbyte_cdk.sources.declarative.requesters.request_options import InterpolatedRequestOptionsProvider
 from airbyte_cdk.sources.declarative.requesters.request_path import RequestPath
@@ -376,7 +377,6 @@ class ModelToComponentFactory:
             cursor_value=model.cursor_value,
             decoder=decoder,
             page_size=model.page_size,
-            stop_condition=model.stop_condition,
             config=config,
             parameters=model.parameters or {},
         )
@@ -665,7 +665,24 @@ class ModelToComponentFactory:
             self._create_component_from_model(model=model.page_token_option, config=config) if model.page_token_option else None
         )
         pagination_strategy = self._create_component_from_model(model=model.pagination_strategy, config=config)
-        if cursor_used_for_stop_condition:
+        if model.stop_condition:
+            pagination_strategy = StopConditionPaginationStrategyDecorator(
+                pagination_strategy,
+                InterpolatedStopCondition(
+                    condition=model.stop_condition, decoder=decoder, parameters=model.parameters, config=config,
+                ),
+            )
+        elif isinstance(model.pagination_strategy, CursorPaginationModel) and model.pagination_strategy.stop_condition:
+            pagination_strategy = StopConditionPaginationStrategyDecorator(
+                pagination_strategy,
+                InterpolatedStopCondition(
+                    condition=model.pagination_strategy.stop_condition,
+                    decoder=decoder,
+                    parameters=model.pagination_strategy.parameters,
+                    config=config,
+                ),
+            )
+        elif cursor_used_for_stop_condition:
             pagination_strategy = StopConditionPaginationStrategyDecorator(
                 pagination_strategy, CursorStopCondition(cursor_used_for_stop_condition)
             )

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -669,7 +669,10 @@ class ModelToComponentFactory:
             pagination_strategy = StopConditionPaginationStrategyDecorator(
                 pagination_strategy,
                 InterpolatedStopCondition(
-                    condition=model.stop_condition, decoder=decoder, parameters=model.parameters, config=config,
+                    condition=model.stop_condition,
+                    decoder=decoder,
+                    parameters=model.parameters,
+                    config=config,
                 ),
             )
         elif isinstance(model.pagination_strategy, CursorPaginationModel) and model.pagination_strategy.stop_condition:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -671,7 +671,7 @@ class ModelToComponentFactory:
                 InterpolatedStopCondition(
                     condition=model.stop_condition,
                     decoder=decoder,
-                    parameters=model.parameters,
+                    parameters=model.parameters or {},
                     config=config,
                 ),
             )
@@ -681,7 +681,7 @@ class ModelToComponentFactory:
                 InterpolatedStopCondition(
                     condition=model.pagination_strategy.stop_condition,
                     decoder=decoder,
-                    parameters=model.pagination_strategy.parameters,
+                    parameters=model.pagination_strategy.parameters or {},
                     config=config,
                 ),
             )

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
@@ -8,7 +8,6 @@ from typing import Any, List, Mapping, Optional, Union
 import requests
 from airbyte_cdk.sources.declarative.decoders.decoder import Decoder
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
-from airbyte_cdk.sources.declarative.interpolation.interpolated_boolean import InterpolatedBoolean
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.pagination_strategy import PaginationStrategy
 from airbyte_cdk.sources.declarative.types import Config
@@ -23,7 +22,6 @@ class CursorPaginationStrategy(PaginationStrategy):
         page_size (Optional[int]): the number of records to request
         cursor_value (Union[InterpolatedString, str]): template string evaluating to the cursor value
         config (Config): connection config
-        stop_condition (Optional[InterpolatedBoolean]): template string evaluating when to stop paginating
         decoder (Decoder): decoder to decode the response
     """
 
@@ -31,14 +29,11 @@ class CursorPaginationStrategy(PaginationStrategy):
     config: Config
     parameters: InitVar[Mapping[str, Any]]
     page_size: Optional[int] = None
-    stop_condition: Optional[Union[InterpolatedBoolean, str]] = None
     decoder: Decoder = JsonDecoder(parameters={})
 
     def __post_init__(self, parameters: Mapping[str, Any]):
         if isinstance(self.cursor_value, str):
             self.cursor_value = InterpolatedString.create(self.cursor_value, parameters=parameters)
-        if isinstance(self.stop_condition, str):
-            self.stop_condition = InterpolatedBoolean(condition=self.stop_condition, parameters=parameters)
 
     @property
     def initial_token(self) -> Optional[Any]:
@@ -52,10 +47,6 @@ class CursorPaginationStrategy(PaginationStrategy):
         headers = response.headers
         headers["link"] = response.links
 
-        if self.stop_condition:
-            should_stop = self.stop_condition.eval(self.config, response=decoded_response, headers=headers, last_records=last_records)
-            if should_stop:
-                return None
         token = self.cursor_value.eval(config=self.config, last_records=last_records, response=decoded_response, headers=headers)
         return token if token else None
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/stop_condition.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/stop_condition.py
@@ -3,31 +3,56 @@
 #
 
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union, Mapping
 
 import requests
+
+from airbyte_cdk.sources.declarative.decoders import Decoder, JsonDecoder
 from airbyte_cdk.sources.declarative.incremental import Cursor
+from airbyte_cdk.sources.declarative.interpolation import InterpolatedBoolean
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.pagination_strategy import PaginationStrategy
-from airbyte_cdk.sources.declarative.types import Record
+from airbyte_cdk.sources.declarative.types import Config, Record
 
 
 class PaginationStopCondition(ABC):
     @abstractmethod
-    def is_met(self, record: Record) -> bool:
+    def is_met(self, response: requests.Response, last_records: List[Record]) -> bool:
         """
-        Given a condition is met, the pagination will stop
+        Given a condition is met, the pagination will stop.
+        Receives the same arguments as next_page_token
 
-        :param record: a record used to evaluate the condition
+        :param response: the last response from the API
+        :param last_records: the last records extracted
         """
-        raise NotImplementedError()
 
 
 class CursorStopCondition(PaginationStopCondition):
     def __init__(self, cursor: Cursor):
         self._cursor = cursor
 
-    def is_met(self, record: Record) -> bool:
-        return not self._cursor.should_be_synced(record)
+    def is_met(self, response: requests.Response, last_records: List[Record]) -> bool:
+        return any(not self._cursor.should_be_synced(record) for record in reversed(last_records))
+
+
+class InterpolatedStopCondition(PaginationStopCondition):
+    def __init__(self, condition: Union[InterpolatedBoolean, str], decoder: Decoder, parameters: Mapping[str, Any], config: Config):
+        self._decoder = decoder or JsonDecoder(parameters={})
+        self._config = config
+
+        if isinstance(condition, str):
+            self._condition = InterpolatedBoolean(condition=condition, parameters=parameters)
+        else:
+            self._condition = condition
+
+    def is_met(self, response: requests.Response, last_records: List[Record]) -> bool:
+        decoded_response = self._decoder.decode(response)
+
+        # The default way that link is presented in requests.Response is a string of various links (last, next, etc). This
+        # is not indexable or useful for parsing the cursor, so we replace it with the link dictionary from response.links
+        headers = response.headers
+        headers["link"] = response.links
+
+        return self._condition.eval(self._config, response=decoded_response, headers=response.headers, last_records=last_records)
 
 
 class StopConditionPaginationStrategyDecorator(PaginationStrategy):
@@ -38,7 +63,7 @@ class StopConditionPaginationStrategyDecorator(PaginationStrategy):
     def next_page_token(self, response: requests.Response, last_records: List[Record]) -> Optional[Any]:
         # We evaluate in reverse order because the assumption is that most of the APIs using data feed structure will return records in
         # descending order. In terms of performance/memory, we return the records lazily
-        if last_records and any(self._stop_condition.is_met(record) for record in reversed(last_records)):
+        if self._stop_condition.is_met(response, last_records):
             return None
         return self._delegate.next_page_token(response, last_records)
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/stop_condition.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/stop_condition.py
@@ -3,10 +3,9 @@
 #
 
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional, Union, Mapping
+from typing import Any, List, Mapping, Optional, Union
 
 import requests
-
 from airbyte_cdk.sources.declarative.decoders import Decoder, JsonDecoder
 from airbyte_cdk.sources.declarative.incremental import Cursor
 from airbyte_cdk.sources.declarative.interpolation import InterpolatedBoolean

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/stop_condition.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/stop_condition.py
@@ -49,7 +49,8 @@ class InterpolatedStopCondition(PaginationStopCondition):
         # The default way that link is presented in requests.Response is a string of various links (last, next, etc). This
         # is not indexable or useful for parsing the cursor, so we replace it with the link dictionary from response.links
         headers = response.headers
-        headers["link"] = response.links
+        # Incompatible types in assignment (expression has type "dict[Any, Any]", target has type "str")  [assignment]
+        headers["link"] = response.links  # type: ignore[assignment]
 
         return self._condition.eval(self._config, response=decoded_response, headers=response.headers, last_records=last_records)
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_cursor_pagination_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_cursor_pagination_strategy.py
@@ -7,39 +7,34 @@ import json
 import pytest
 import requests
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
-from airbyte_cdk.sources.declarative.interpolation.interpolated_boolean import InterpolatedBoolean
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.cursor_pagination_strategy import CursorPaginationStrategy
 
 
 @pytest.mark.parametrize(
-    "test_name, template_string, stop_condition, expected_token, page_size",
+    "test_name, template_string, expected_token, page_size",
     [
-        ("test_static_token", "token", None, "token", None),
-        ("test_static_token_with_page_size", "token", None, "token", 5),
-        ("test_token_from_config", "{{ config.config_key }}", None, "config_value", None),
-        ("test_token_from_last_record", "{{ last_records[-1].id }}", None, 1, None),
-        ("test_token_from_response", "{{ response._metadata.content }}", None, "content_value", None),
-        ("test_token_from_parameters", "{{ parameters.key }}", None, "value", None),
-        ("test_token_not_found", "{{ response.invalid_key }}", None, None, None),
-        ("test_static_token_with_stop_condition_false", "token", InterpolatedBoolean("{{False}}", parameters={}), "token", None),
-        ("test_static_token_with_stop_condition_true", "token", InterpolatedBoolean("{{True}}", parameters={}), None, None),
+        ("test_static_token", "token", "token", None),
+        ("test_static_token_with_page_size", "token", "token", 5),
+        ("test_token_from_config", "{{ config.config_key }}", "config_value", None),
+        ("test_token_from_last_record", "{{ last_records[-1].id }}", 1, None),
+        ("test_token_from_response", "{{ response._metadata.content }}", "content_value", None),
+        ("test_token_from_parameters", "{{ parameters.key }}", "value", None),
+        ("test_token_not_found", "{{ response.invalid_key }}", None, None),
         (
             "test_token_from_header",
             "{{ headers.next }}",
-            InterpolatedBoolean("{{ not headers.has_more }}", parameters={}),
             "ready_to_go",
             None,
         ),
         (
             "test_token_from_response_header_links",
             "{{ headers.link.next.url }}",
-            InterpolatedBoolean("{{ not headers.link.next.url }}", parameters={}),
             "https://adventure.io/api/v1/records?page=2&per_page=100",
             None,
         ),
     ],
 )
-def test_cursor_pagination_strategy(test_name, template_string, stop_condition, expected_token, page_size):
+def test_cursor_pagination_strategy(test_name, template_string, expected_token, page_size):
     decoder = JsonDecoder(parameters={})
     config = {"config_key": "config_value"}
     parameters = {"key": "value"}
@@ -47,7 +42,6 @@ def test_cursor_pagination_strategy(test_name, template_string, stop_condition, 
         page_size=page_size,
         cursor_value=template_string,
         config=config,
-        stop_condition=stop_condition,
         decoder=decoder,
         parameters=parameters,
     )

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
@@ -21,12 +21,11 @@ from airbyte_cdk.sources.declarative.requesters.request_path import RequestPath
 
 
 @pytest.mark.parametrize(
-    "test_name, page_token_request_option, stop_condition, expected_updated_path, expected_request_params, expected_headers, expected_body_data, expected_body_json, last_records, expected_next_page_token, limit",
+    "test_name, page_token_request_option, expected_updated_path, expected_request_params, expected_headers, expected_body_data, expected_body_json, last_records, expected_next_page_token, limit",
     [
         (
             "test_default_paginator_path",
             RequestPath(parameters={}),
-            None,
             "/next_url",
             {"limit": 2},
             {},
@@ -40,7 +39,6 @@ from airbyte_cdk.sources.declarative.requesters.request_path import RequestPath
             "test_default_paginator_request_param",
             RequestOption(inject_into=RequestOptionType.request_parameter, field_name="from", parameters={}),
             None,
-            None,
             {"limit": 2, "from": "https://airbyte.io/next_url"},
             {},
             {},
@@ -50,22 +48,8 @@ from airbyte_cdk.sources.declarative.requesters.request_path import RequestPath
             2,
         ),
         (
-            "test_default_paginator_no_token",
-            RequestOption(inject_into=RequestOptionType.request_parameter, field_name="from", parameters={}),
-            InterpolatedBoolean(condition="{{True}}", parameters={}),
-            None,
-            {"limit": 2},
-            {},
-            {},
-            {},
-            [{"id": 0}, {"id": 1}],
-            None,
-            2,
-        ),
-        (
             "test_default_paginator_cursor_header",
             RequestOption(inject_into=RequestOptionType.header, field_name="from", parameters={}),
-            None,
             None,
             {"limit": 2},
             {"from": "https://airbyte.io/next_url"},
@@ -79,7 +63,6 @@ from airbyte_cdk.sources.declarative.requesters.request_path import RequestPath
             "test_default_paginator_cursor_body_data",
             RequestOption(inject_into=RequestOptionType.body_data, field_name="from", parameters={}),
             None,
-            None,
             {"limit": 2},
             {},
             {"from": "https://airbyte.io/next_url"},
@@ -91,7 +74,6 @@ from airbyte_cdk.sources.declarative.requesters.request_path import RequestPath
         (
             "test_default_paginator_cursor_body_json",
             RequestOption(inject_into=RequestOptionType.body_json, field_name="from", parameters={}),
-            None,
             None,
             {"limit": 2},
             {},
@@ -106,7 +88,6 @@ from airbyte_cdk.sources.declarative.requesters.request_path import RequestPath
 def test_default_paginator_with_cursor(
     test_name,
     page_token_request_option,
-    stop_condition,
     expected_updated_path,
     expected_request_params,
     expected_headers,
@@ -124,7 +105,6 @@ def test_default_paginator_with_cursor(
     strategy = CursorPaginationStrategy(
         page_size=limit,
         cursor_value=cursor_value,
-        stop_condition=stop_condition,
         decoder=JsonDecoder(parameters={}),
         config=config,
         parameters=parameters,

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
-from airbyte_cdk.sources.declarative.interpolation.interpolated_boolean import InterpolatedBoolean
 from airbyte_cdk.sources.declarative.requesters.paginators.default_paginator import (
     DefaultPaginator,
     PaginatorTestReadDecorator,

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_stop_condition.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_stop_condition.py
@@ -4,15 +4,19 @@
 
 from unittest.mock import Mock
 
+import pytest
+from airbyte_cdk.sources.declarative.decoders import JsonDecoder
 from airbyte_cdk.sources.declarative.incremental import Cursor
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.pagination_strategy import PaginationStrategy
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.stop_condition import (
     CursorStopCondition,
+    InterpolatedStopCondition,
     PaginationStopCondition,
     StopConditionPaginationStrategyDecorator,
 )
 from airbyte_cdk.sources.declarative.types import Record
 from pytest import fixture
+from requests.models import Response
 
 ANY_RECORD = Mock()
 NO_RECORDS = []
@@ -92,3 +96,28 @@ def test_when_get_page_size_then_delegate(mocked_pagination_strategy, mocked_sto
 
     assert page_size == mocked_pagination_strategy.get_page_size.return_value
     mocked_pagination_strategy.get_page_size.assert_called_once_with()
+
+
+def make_response(**kwargs):
+    response = Response()
+    for k, v in kwargs.items():
+        setattr(response, k, v)
+    return response
+
+
+@pytest.mark.parametrize(
+    "test_name,condition,response,last_records,expected_result",
+    [
+        ("empty", "", make_response(), [ANY_RECORD], False),
+        ("true_const", "{{ True }}", make_response(), [ANY_RECORD], True),
+        ("false_const", "{{ False }}", make_response(), [ANY_RECORD], False),
+        ("response_headers_false", "{{ headers['stop'] }}", make_response(headers={"stop": False}), [ANY_RECORD], False),
+        ("response_headers_true", "{{ headers['stop'] }}", make_response(headers={"stop": True}), [ANY_RECORD], True),
+        ("response_body_false", "{{ 'records' not in response }}", make_response(_content=b'{"records": []}'), [ANY_RECORD], False),
+        ("response_body_true", "{{ 'records' not in response }}", make_response(_content=b'{}'), [ANY_RECORD], True),
+        ("last_records", "{{ last_records[0] }}", make_response(), [ANY_RECORD], True),
+    ],
+)
+def test_interpolated_with_const(test_name, condition, response, last_records, expected_result):
+    condition = InterpolatedStopCondition(condition=condition, decoder=JsonDecoder(parameters={}), parameters={}, config={})
+    assert condition.is_met(response=response, last_records=last_records) == expected_result

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_stop_condition.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_stop_condition.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from unittest.mock import Mock, call
+from unittest.mock import Mock
 
 from airbyte_cdk.sources.declarative.incremental import Cursor
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.pagination_strategy import PaginationStrategy


### PR DESCRIPTION
## What
solves #28226 

## How
extending StopCondition
adding stop_condition on Paginator level
move stop_condition logic of CursorPaginator into StopCondition keeping the same interface in manifest for backward compatibility.

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
