### PR TITLE
fix none type parquet and support jakarta region

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -5,7 +5,7 @@ data:
   dockerImageTag: 0.5.6
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
-  icon: s3.svg
+  icon: icon.svg
   license: ELv2
   name: S3
   registries:

--- a/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
@@ -66,6 +66,7 @@
           "ap-northeast-3",
           "ap-southeast-1",
           "ap-southeast-2",
+          "ap-southeast-3",
           "ca-central-1",
           "cn-north-1",
           "cn-northwest-1",

--- a/airbyte-integrations/connectors/source-s3/.dockerignore
+++ b/airbyte-integrations/connectors/source-s3/.dockerignore
@@ -5,3 +5,4 @@
 !source_s3
 !setup.py
 !secrets
+!.venv/lib/python3.10/site-packages/airbyte_cdk/sources/file_based/file_types/parquet_parser.py

--- a/airbyte-integrations/connectors/source-s3/Dockerfile
+++ b/airbyte-integrations/connectors/source-s3/Dockerfile
@@ -1,0 +1,11 @@
+FROM airbyte/python-connector-base:1.2.0
+
+COPY . ./airbyte/integration_code
+RUN pip install ./airbyte/integration_code
+
+COPY .venv/lib/python3.10/site-packages/airbyte_cdk/sources/file_based/file_types/parquet_parser.py /usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
+
+# The entrypoint and default env vars are already set in the base image
+ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -14,7 +14,7 @@ data:
   dockerRepository: airbyte/source-s3
   documentationUrl: https://docs.airbyte.com/integrations/sources/s3
   githubIssueLabel: source-s3
-  icon: s3.svg
+  icon: icon.svg
   license: ELv2
   name: S3
   registries:

--- a/airbyte-integrations/connectors/source-s3/source_s3/source.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/source.py
@@ -46,7 +46,13 @@ class SourceS3Spec(SourceFilesAbstractSpec, BaseModel):
             "folders/files which you don't need to replicate.",
             order=3,
         )
-
+        bucket_region_name: Optional[str] = Field(
+            default="",
+            title="Region",
+            description="S3 Region, Leave empty to use default",
+            examples=["ap-southeast-1"],
+            order=6,
+        )
         endpoint: str = Field("", description="Endpoint to an S3 compatible service. Leave empty to use AWS.", order=4)
         start_date: Optional[str] = Field(
             title="Start Date",

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
@@ -40,6 +40,14 @@ class Config(AbstractFileBasedSpec):
         order=3,
     )
 
+    bucket_region_name: Optional[str] = Field(
+        default="",
+        title="Region",
+        description="S3 Region, Leave empty to use default",
+        examples=["ap-southeast-1"],
+        order=5,
+    )
+
     endpoint: Optional[str] = Field(
         default="",
         title="Endpoint",

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/legacy_config_transformer.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/legacy_config_transformer.py
@@ -42,6 +42,8 @@ class LegacyConfigTransformer:
             transformed_config["aws_access_key_id"] = legacy_config.provider.aws_access_key_id
         if legacy_config.provider.aws_secret_access_key:
             transformed_config["aws_secret_access_key"] = legacy_config.provider.aws_secret_access_key
+        if legacy_config.provider.bucket_region_name:
+            transformed_config["bucket_region_name"] = legacy_config.provider.bucket_region_name
         if legacy_config.provider.endpoint:
             transformed_config["endpoint"] = legacy_config.provider.endpoint
         if legacy_config.user_schema and legacy_config.user_schema != "{}":

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
@@ -56,6 +56,7 @@ class SourceS3StreamReader(AbstractFileBasedStreamReader):
                 "s3",
                 aws_access_key_id=self.config.aws_access_key_id,
                 aws_secret_access_key=self.config.aws_secret_access_key,
+                region_name=self.config.bucket_region_name,
                 **client_kv_args,
             )
         return self._s3_client


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Source S3:
- Support for specifying bucket region when boto not detect automatically
- Fixing parquet parse error when converting map values

Destination S3:
- Support `ap-southeast-3` region


## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
