### PR TITLE
airbyte-ci: make `airbyte-ci test` able to run any poetry run command

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -76,7 +76,7 @@ jobs:
           gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          subcommand: "test airbyte-ci/connectors/connector_ops"
+          subcommand: "test airbyte-ci/connectors/connector_ops --poetry-run-command='pytest tests'"
           airbyte_ci_binary_url: ${{ inputs.airbyte_ci_binary_url || 'https://connectors.airbyte.com/airbyte-ci/releases/ubuntu/latest/airbyte-ci' }}
           tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY }}
 
@@ -91,7 +91,7 @@ jobs:
           gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          subcommand: "test airbyte-ci/connectors/pipelines"
+          subcommand: "test airbyte-ci/connectors/pipelines --poetry-run-command='pytest tests'"
           airbyte_ci_binary_url: ${{ inputs.airbyte_ci_binary_url || 'https://connectors.airbyte.com/airbyte-ci/releases/ubuntu/latest/airbyte-ci' }}
           tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY }}
 
@@ -106,7 +106,7 @@ jobs:
           gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          subcommand: "test airbyte-ci/connectors/base_images"
+          subcommand: "test airbyte-ci/connectors/base_images --poetry-run-command='pytest tests'"
           airbyte_ci_binary_url: ${{ inputs.airbyte_ci_binary_url || 'https://connectors.airbyte.com/airbyte-ci/releases/ubuntu/latest/airbyte-ci' }}
           tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY }}
 
@@ -115,7 +115,7 @@ jobs:
         if: steps.changes.outputs.metadata_lib_any_changed == 'true'
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          subcommand: "test airbyte-ci/connectors/metadata_service/lib/"
+          subcommand: "test airbyte-ci/connectors/metadata_service/lib/ --poetry-run-command='pytest tests'"
           context: "pull_request"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -128,7 +128,7 @@ jobs:
         if: steps.changes.outputs.metadata_orchestrator_any_changed == 'true'
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          subcommand: "test airbyte-ci/connectors/metadata_service/orchestrator/"
+          subcommand: "test airbyte-ci/connectors/metadata_service/orchestrator/ --poetry-run-command='pytest tests'"
           context: "pull_request"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -506,17 +506,19 @@ This command runs the Python tests for a airbyte-ci poetry package.
 
 | Option             | Required | Default | Mapped environment variable | Description                                                                                      |
 | ------------------ | -------- | ------- | --------------------------- | ------------------------------------------------------------------------------------------------ |
-| `--test-directory` | False    | tests   |                             | The path to the directory on which pytest should discover tests, relative to the poetry package. |
+| `-c/--poetry-run-command` | True    | None   |                             | The command to run with `poetry run` |
 
 #### Example
 
-`airbyte-ci test airbyte-ci/connectors/pipelines --test-directory=tests`
-`airbyte-ci tests airbyte-integrations/bases/connector-acceptance-test --test-directory=unit_tests`
+`airbyte-ci test airbyte-ci/connectors/pipelines --poetry-run-command='pytest tests'`
+`airbyte-ci tests airbyte-integrations/bases/connector-acceptance-test--poetry-run-command='pytest tests/unit_tests'`
 
 ## Changelog
 
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 2.13.0  | [#33784](https://github.com/airbytehq/airbyte/pull/33784)  | Make `airbyte-ci test` able to run any poetry command                                               |
+| 2.12.0  | [#33313](https://github.com/airbytehq/airbyte/pull/33313)  | Add upgrade CDK command                                               |
 | 2.11.0  | [#32188](https://github.com/airbytehq/airbyte/pull/32188)  | Add -x option to connector test to allow for skipping steps                                               |
 | 2.10.12 | [#33419](https://github.com/airbytehq/airbyte/pull/33419)  | Make ClickPipelineContext handle dagger logging.                                                          |
 | 2.10.11 | [#33497](https://github.com/airbytehq/airbyte/pull/33497)  | Consider nested .gitignore rules in format.                                                               |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -511,7 +511,7 @@ This command runs the Python tests for a airbyte-ci poetry package.
 #### Example
 
 `airbyte-ci test airbyte-ci/connectors/pipelines --poetry-run-command='pytest tests'`
-`airbyte-ci tests airbyte-integrations/bases/connector-acceptance-test--poetry-run-command='pytest tests/unit_tests'`
+`airbyte-ci tests airbyte-integrations/bases/connector-acceptance-test --poetry-run-command='pytest tests/unit_tests'`
 
 ## Changelog
 

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -508,9 +508,13 @@ This command runs the Python tests for a airbyte-ci poetry package.
 | ------------------ | -------- | ------- | --------------------------- | ------------------------------------------------------------------------------------------------ |
 | `-c/--poetry-run-command` | True    | None   |                             | The command to run with `poetry run` |
 
-#### Example
+#### Examples
+You can pass multiple `-c/--poetry-run-command` options to run multiple commands.
 
-`airbyte-ci test airbyte-ci/connectors/pipelines --poetry-run-command='pytest tests'`
+E.G.: running `pytest` and `mypy`:
+`airbyte-ci test airbyte-ci/connectors/pipelines --poetry-run-command='pytest tests' --poetry-run-command='mypy pipelines'`
+
+E.G.: running `pytest` on a specific test folder:
 `airbyte-ci tests airbyte-integrations/bases/connector-acceptance-test --poetry-run-command='pytest tests/unit_tests'`
 
 ## Changelog

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.12.0"
+version = "2.13.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
Relates to #33719

The current `airbyte-ci test`  command is made to run tests on a poetry project.
It's currently only running a `pytest` command.
We have to change this command if we want to run other kind of commands to assess the health of the package (e.g. `mypy`) .

## How
* Add a `--poetry-run-command` options (mulitple) that will be run on the container where the poetry package is installed
* Make required changes to our workflow according to this interface change.

