### PR TITLE
Source Amazon Ads: add region to inputOAuthConfiguration

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
@@ -52,7 +52,7 @@ acceptance_tests:
     tests:
       - config_path: secrets/config.json
         backward_compatibility_tests_config:
-          disable_for_version: 2.3.1
+          disable_for_version: 3.4.3
   full_refresh:
     tests:
       - config_path: secrets/config.json
@@ -64,6 +64,6 @@ acceptance_tests:
     tests:
       - spec_path: integration_tests/spec.json
         backward_compatibility_tests_config:
-          disable_for_version: "3.2.0"
+          disable_for_version: 3.4.3
 connector_image: airbyte/source-amazon-ads:dev
 test_strictness_level: high

--- a/airbyte-integrations/connectors/source-amazon-ads/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-amazon-ads/integration_tests/spec.json
@@ -114,6 +114,16 @@
     "predicate_key": ["auth_type"],
     "predicate_value": "oauth2.0",
     "oauth_config_specification": {
+      "oauth_user_input_from_connector_config_specification": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "region": {
+            "type": "string",
+            "path_in_connector_config": ["region"]
+          }
+        }
+      },
       "complete_oauth_output_specification": {
         "type": "object",
         "additionalProperties": true,

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 4.0.0
+  dockerImageTag: 4.0.1
   dockerRepository: airbyte/source-amazon-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   githubIssueLabel: source-amazon-ads

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/spec.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/spec.yaml
@@ -129,6 +129,7 @@ advanced_auth:
   oauth_config_specification:
     oauth_user_input_from_connector_config_specification:
       type: object
+      additionalProperties: false
       properties:
         region:
           type: string

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/spec.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/spec.yaml
@@ -127,6 +127,13 @@ advanced_auth:
     - auth_type
   predicate_value: oauth2.0
   oauth_config_specification:
+    oauth_user_input_from_connector_config_specification:
+      type: object
+      properties:
+        region:
+          type: string
+          path_in_connector_config:
+            - region
     complete_oauth_output_specification:
       type: object
       additionalProperties: true

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -110,6 +110,7 @@ Information about expected report generation waiting time you may find [here](ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 4.0.1   | 2023-12-28 | [33833](https://github.com/airbytehq/airbyte/pull/33833) | Updated oauth spec to put region, so we can choose oauth consent url based on it                                |
 | 4.0.0   | 2023-12-28 | [33817](https://github.com/airbytehq/airbyte/pull/33817) | Fix schema for streams: `SponsoredBrandsAdGroups` and `SponsoredBrandsKeywords`                                 |
 | 3.4.2   | 2023-12-12 | [33361](https://github.com/airbytehq/airbyte/pull/33361) | Fix unexpected crash when handling error messages which don't have `requestId` field                            |
 | 3.4.1   | 2023-10-19 | [31599](https://github.com/airbytehq/airbyte/pull/31599) | Base image migration: remove Dockerfile and use the python-connector-base image                                 |


### PR DESCRIPTION
## What
*https://github.com/airbytehq/oncall/issues/3755*

## How
*Updated oauth configuration to put region to `inputOAuthConfiguration`*

