### PR TITLE
Use 'dev' sentry environment for airbyte-ci pipx installs in PRs

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -127,6 +127,8 @@ runs:
       with:
         python-version: "3.10"
         token: ${{ inputs.github_token }}
+      env:
+        SENTRY_ENVIRONMENT: "production"
 
     - name: Install ci-connector-ops package
       if: github.ref != 'refs/heads/master' && steps.changes.outputs.pipelines_any_changed == 'true'
@@ -135,6 +137,8 @@ runs:
         pip install pipx
         pipx ensurepath
         pipx install airbyte-ci/connectors/pipelines/
+      env:
+        SENTRY_ENVIRONMENT: "dev"
 
     - name: Run airbyte-ci
       shell: bash

--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -127,8 +127,6 @@ runs:
       with:
         python-version: "3.10"
         token: ${{ inputs.github_token }}
-      env:
-        SENTRY_ENVIRONMENT: "production"
 
     - name: Install ci-connector-ops package
       if: github.ref != 'refs/heads/master' && steps.changes.outputs.pipelines_any_changed == 'true'
@@ -137,8 +135,6 @@ runs:
         pip install pipx
         pipx ensurepath
         pipx install airbyte-ci/connectors/pipelines/
-      env:
-        SENTRY_ENVIRONMENT: "dev"
 
     - name: Run airbyte-ci
       shell: bash
@@ -161,6 +157,7 @@ runs:
         PRODUCTION: ${{ inputs.production }}
         PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         SENTRY_DSN: ${{ inputs.sentry_dsn }}
+        SENTRY_ENVIRONMENT: "dev" if (github.ref != 'refs/heads/master' && steps.changes.outputs.pipelines_any_changed == 'true') else "production"
         SLACK_WEBHOOK: ${{ inputs.slack_webhook_url }}
         SPEC_CACHE_BUCKET_NAME: ${{ inputs.spec_cache_bucket_name }}
         SPEC_CACHE_GCS_CREDENTIALS: ${{ inputs.spec_cache_gcs_credentials }}

--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -101,17 +101,15 @@ runs:
           pipelines:
             - 'airbyte-ci/connectors/pipelines/**'
 
-    - name: Determine whether to install Airbyte CI locally
+    - name: Determine how Airbyte CI should be installed
       shell: bash
       id: determine-install-mode
       run: |
         if [[ "${{ github.ref }}" != "refs/heads/master" ]] && [[ "${{ steps.changes.outputs.pipelines_any_changed }}" == "true" ]]; then
           echo "Making changes to Airbyte CI on a non-master branch. Airbyte-CI will be installed from source."
-          echo "SENTRY_ENVIRONMENT=dev" >> $GITHUB_ENV
-          echo "install-mode=local" >> $GITHUB_OUTPUT
+          echo "install-mode=dev" >> $GITHUB_OUTPUT
         else
-          echo "SENTRY_ENVIRONMENT=production" >> $GITHUB_ENV
-          echo "install-mode=binary" >> $GITHUB_OUTPUT
+          echo "install-mode=production" >> $GITHUB_OUTPUT
         fi
 
     - name: Docker login
@@ -127,7 +125,7 @@ runs:
 
     - name: Install airbyte-ci binary
       id: install-airbyte-ci
-      if: steps.determine-install-mode.outputs.install-mode == 'binary'
+      if: steps.determine-install-mode.outputs.install-mode == 'production'
       shell: bash
       run: |
         curl -sSL ${{ inputs.airbyte_ci_binary_url }} --output airbyte-ci-bin
@@ -136,13 +134,13 @@ runs:
 
     - name: Install Python 3.10
       uses: actions/setup-python@v4
-      if: steps.determine-install-mode.outputs.install-mode == 'local'
+      if: steps.determine-install-mode.outputs.install-mode == 'dev'
       with:
         python-version: "3.10"
         token: ${{ inputs.github_token }}
 
     - name: Install ci-connector-ops package
-      if: steps.determine-install-mode.outputs.install-mode == 'local'
+      if: steps.determine-install-mode.outputs.install-mode == 'dev'
       shell: bash
       run: |
         pip install pipx
@@ -170,6 +168,7 @@ runs:
         PRODUCTION: ${{ inputs.production }}
         PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         SENTRY_DSN: ${{ inputs.sentry_dsn }}
+        SENTRY_ENVIRONMENT: ${{ steps.determine-install-mode.outputs.install-mode }}
         SLACK_WEBHOOK: ${{ inputs.slack_webhook_url }}
         SPEC_CACHE_BUCKET_NAME: ${{ inputs.spec_cache_bucket_name }}
         SPEC_CACHE_GCS_CREDENTIALS: ${{ inputs.spec_cache_gcs_credentials }}

--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -101,6 +101,19 @@ runs:
           pipelines:
             - 'airbyte-ci/connectors/pipelines/**'
 
+    - name: Determine whether to install Airbyte CI locally
+      shell: bash
+      id: determine-install-mode
+      run: |
+        if [[ "${{ github.ref }}" != "refs/heads/master" ]] && [[ "${{ steps.changes.outputs.pipelines_any_changed }}" == "true" ]]; then
+          echo "Making changes to Airbyte CI on a non-master branch. Airbyte-CI will be installed from source."
+          echo "SENTRY_ENVIRONMENT=dev" >> $GITHUB_ENV
+          echo "install-mode=local" >> $GITHUB_OUTPUT
+        else
+          echo "SENTRY_ENVIRONMENT=production" >> $GITHUB_ENV
+          echo "install-mode=binary" >> $GITHUB_OUTPUT
+        fi
+
     - name: Docker login
       uses: docker/login-action@v1
       with:
@@ -114,7 +127,7 @@ runs:
 
     - name: Install airbyte-ci binary
       id: install-airbyte-ci
-      if: github.ref == 'refs/heads/master' || steps.changes.outputs.pipelines_any_changed == 'false'
+      if: steps.determine-install-mode.outputs.install-mode == 'binary'
       shell: bash
       run: |
         curl -sSL ${{ inputs.airbyte_ci_binary_url }} --output airbyte-ci-bin
@@ -123,13 +136,13 @@ runs:
 
     - name: Install Python 3.10
       uses: actions/setup-python@v4
-      if: github.ref != 'refs/heads/master' && steps.changes.outputs.pipelines_any_changed == 'true'
+      if: steps.determine-install-mode.outputs.install-mode == 'local'
       with:
         python-version: "3.10"
         token: ${{ inputs.github_token }}
 
     - name: Install ci-connector-ops package
-      if: github.ref != 'refs/heads/master' && steps.changes.outputs.pipelines_any_changed == 'true'
+      if: steps.determine-install-mode.outputs.install-mode == 'local'
       shell: bash
       run: |
         pip install pipx
@@ -140,13 +153,6 @@ runs:
       shell: bash
       run: |
         export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-
-        if [[ "${{ github.ref }}" != "refs/heads/master" ]] && [[ "${{ steps.changes.outputs.pipelines_any_changed }}" == "true" ]]; then
-          export SENTRY_ENVIRONMENT="dev"
-        else
-          export SENTRY_ENVIRONMENT="production"
-        fi
-
         airbyte-ci --disable-dagger-run --is-ci --gha-workflow-run-id=${{ github.run_id }} ${{ inputs.subcommand }} ${{ inputs.options }}
       env:
         _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"

--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -140,6 +140,13 @@ runs:
       shell: bash
       run: |
         export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
+
+        if [[ "${{ github.ref }}" != "refs/heads/master" ]] && [[ "${{ steps.changes.outputs.pipelines_any_changed }}" == "true" ]]; then
+          export SENTRY_ENVIRONMENT="dev"
+        else
+          export SENTRY_ENVIRONMENT="production"
+        fi
+
         airbyte-ci --disable-dagger-run --is-ci --gha-workflow-run-id=${{ github.run_id }} ${{ inputs.subcommand }} ${{ inputs.options }}
       env:
         _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
@@ -157,7 +164,6 @@ runs:
         PRODUCTION: ${{ inputs.production }}
         PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         SENTRY_DSN: ${{ inputs.sentry_dsn }}
-        SENTRY_ENVIRONMENT: "dev" if (github.ref != 'refs/heads/master' && steps.changes.outputs.pipelines_any_changed == 'true') else "production"
         SLACK_WEBHOOK: ${{ inputs.slack_webhook_url }}
         SPEC_CACHE_BUCKET_NAME: ${{ inputs.spec_cache_bucket_name }}
         SPEC_CACHE_GCS_CREDENTIALS: ${{ inputs.spec_cache_gcs_credentials }}

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -521,6 +521,7 @@ E.G.: running `pytest` on a specific test folder:
 
 | Version | PR                                                         | Description                                                                                               |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 2.13.1  | [#33920](https://github.com/airbytehq/airbyte/pull/33920)  | Report different sentry environments
 | 2.13.0  | [#33784](https://github.com/airbytehq/airbyte/pull/33784)  | Make `airbyte-ci test` able to run any poetry command                                               |
 | 2.12.0  | [#33313](https://github.com/airbytehq/airbyte/pull/33313)  | Add upgrade CDK command                                               |
 | 2.11.0  | [#32188](https://github.com/airbytehq/airbyte/pull/32188)  | Add -x option to connector test to allow for skipping steps                                               |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/commands.py
@@ -31,6 +31,7 @@ async def run_poetry_command(container: dagger.Container, command: str) -> Tuple
         Tuple[str, str]: The stdout and stderr of the command.
     """
     container = container.with_exec(["poetry", "run", *command.split(" ")])
+    raise Exception("Test exception")
     return await container.stdout(), await container.stderr()
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/commands.py
@@ -31,7 +31,7 @@ async def run_poetry_command(container: dagger.Container, command: str) -> Tuple
         Tuple[str, str]: The stdout and stderr of the command.
     """
     container = container.with_exec(["poetry", "run", *command.split(" ")])
-    raise Exception("Test exception")
+    raise Exception("An oh so different test exception")
     return await container.stdout(), await container.stderr()
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/commands.py
@@ -31,7 +31,6 @@ async def run_poetry_command(container: dagger.Container, command: str) -> Tuple
         Tuple[str, str]: The stdout and stderr of the command.
     """
     container = container.with_exec(["poetry", "run", *command.split(" ")])
-    raise Exception("An oh so different test exception")
     return await container.stdout(), await container.stderr()
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py
@@ -13,6 +13,7 @@ def initialize():
     if "SENTRY_DSN" in os.environ:
         sentry_sdk.init(
             dsn=os.environ.get("SENTRY_DSN"),
+            environment = os.environ.get("SENTRY_ENVIRONMENT") or "production",
             before_send=before_send,
             release=f"pipelines@{importlib.metadata.version('pipelines')}",
         )

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/sentry_utils.py
@@ -13,7 +13,7 @@ def initialize():
     if "SENTRY_DSN" in os.environ:
         sentry_sdk.init(
             dsn=os.environ.get("SENTRY_DSN"),
-            environment = os.environ.get("SENTRY_ENVIRONMENT") or "production",
+            environment=os.environ.get("SENTRY_ENVIRONMENT") or "production",
             before_send=before_send,
             release=f"pipelines@{importlib.metadata.version('pipelines')}",
         )

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "2.13.0"
+version = "2.13.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
Use different sentry environments based on how we install Airbyte CI in PRs so that we can configure our alerting and sort our open issues on sentry. 

After changing our slack alerts (still not sure why we have 2 different ones) explicitly to alert for the `production` environment (which is what all of our issues are being sent to currently), a [new dev alert](https://airbytehq.sentry.io/issues/?environment=dev&project=4505596642983936&referrer=sidebar&statsPeriod=14d) was not posted to slack. 

Closes #33892 