### PR TITLE
cat-test: fix CI command

### DIFF
--- a/.github/workflows/cat-tests.yml
+++ b/.github/workflows/cat-tests.yml
@@ -31,5 +31,5 @@ jobs:
           gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          subcommand: "test airbyte-integrations/bases/connector-acceptance-test --test-directory=unit_tests"
+          subcommand: "test airbyte-integrations/bases/connector-acceptance-test --poetry-run-command='pytest unit_tests'"
           tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY }}


### PR DESCRIPTION


## What
Interface of `airbyte-ci test` has changed, we need to adapt the workflow to use the new `--poetry-run-command` option to run the CAT test suite in the CI.