### PR TITLE
Add S3 IAM roles + ALB ingress definition

### DIFF
--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -291,14 +291,12 @@ metadata:
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-x:xxxxxxxxx:certificate/xxxxxxxxx-xxxxx-xxxx-xxxx-xxxxxxxxxxx
     # Sets the idle timeout value for the ALB.
     alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=30
-    # [Optional] Custom SSL policy for security settings and protocols. If not provided, a default will be used.
-    alb.ingress.kubernetes.io/ssl-policy:
-    # [Optional] Specifies the VPC subnets and security groups for the ALB
-    alb.ingress.kubernetes.io/subnets: 'subnet-12345, subnet-67890'
-    alb.ingress.kubernetes.io/security-groups: 'sg-12345678'
+    # [If Applicable] Specifies the VPC subnets and security groups for the ALB
+    # alb.ingress.kubernetes.io/subnets: '' e.g. 'subnet-12345, subnet-67890'
+    # alb.ingress.kubernetes.io/security-groups: <SECURITY_GROUP>
 spec:
   rules:
-  - host: enterprise-demo.airbyte.com
+  - host: <WEBAPP_URL> e.g. enterprise-demo.airbyte.com
     http:
       paths:
       - backend:
@@ -317,9 +315,13 @@ spec:
         pathType: Prefix
 ```
 
+The ALB controller will use a `ServiceAccount` that requires the [following IAM policy](https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json) to be attached.
+
 </TabItem>
 </Tabs>
 </details>
+
+Once this is complete, ensure that the value of the `webapp-url` field in your `airbyte.yml` is configured to match the ingress URL.
 
 You may configure ingress using a load balancer or an API Gateway. We do not currently support most service meshes (such as Istio). If you are having networking issues after fully deploying Airbyte, please verify that firewalls or lacking permissions are not interfering with pod-pod communication. Please also verify that deployed pods have the right permissions to make requests to your external database.
 

--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -279,7 +279,7 @@ If you are intending on using Amazon Application Load Balancer (ALB) for ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: enterprise-demo
+  name: <INGRESS_NAME>
   annotations:
     # Specifies that the Ingress should use an AWS ALB.
     kubernetes.io/ingress.class: "alb"
@@ -305,7 +305,7 @@ spec:
           service:
             name: airbyte-pro-airbyte-webapp-svc 
             port:
-              number: 8080
+              number: 80
         path: /
         pathType: Prefix
       - backend:

--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -281,15 +281,21 @@ kind: Ingress
 metadata:
   name: enterprise-demo
   annotations:
+    # Specifies that the Ingress should use an AWS ALB.
     kubernetes.io/ingress.class: "alb"
+    # Redirects HTTP traffic to HTTPS.
     ingress.kubernetes.io/ssl-redirect: "true"
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    # Creates an internal ALB, which is only accessible within your VPC or through a VPN.
+    alb.ingress.kubernetes.io/scheme: internal
+    # Specifies the ARN of the SSL certificate managed by AWS ACM, essential for HTTPS.
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-x:xxxxxxxxx:certificate/xxxxxxxxx-xxxxx-xxxx-xxxx-xxxxxxxxxxx
+    # Sets the idle timeout value for the ALB.
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=30
+    # [Optional] Custom SSL policy for security settings and protocols. If not provided, a default will be used.
+    alb.ingress.kubernetes.io/ssl-policy:
+    # [Optional] Specifies the VPC subnets and security groups for the ALB
     alb.ingress.kubernetes.io/subnets: 'subnet-12345, subnet-67890'
     alb.ingress.kubernetes.io/security-groups: 'sg-12345678'
-    alb.ingress.kubernetes.io/healthcheck-path: /healthz
-    alb.ingress.kubernetes.io/success-codes: '200-499'
 spec:
   rules:
   - host: enterprise-demo.airbyte.com


### PR DESCRIPTION
Adds:
* New step on S3 IAM roles.
* New section including a skeleton for ALB ingress definition
* Clarifying that default external Airbyte DB security config doesn't require more than user/password
* Clarifying that you need to change `ingress` field in `airbyte.yml`