### PR TITLE
airbyte-lib: Add pip_url option and enforce source versions in a more consistent manner

### DIFF
--- a/airbyte-lib/airbyte_lib/factories.py
+++ b/airbyte-lib/airbyte_lib/factories.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from airbyte_lib.cache import InMemoryCache
-from airbyte_lib.executor import PathExecutor, VenvExecutor
+from airbyte_lib.executor import Executor, PathExecutor, VenvExecutor
 from airbyte_lib.registry import get_connector_metadata
 from airbyte_lib.source import Source
 
@@ -15,20 +15,41 @@ def get_in_memory_cache():
 
 def get_connector(
     name: str,
-    version: str = "latest",
-    config: Optional[Dict[str, Any]] = None,
+    version: str | None = None,
+    pip_url: str | None = None,
+    config: dict[str, Any] | None = None,
     use_local_install: bool = False,
     install_if_missing: bool = False,
 ):
     """
     Get a connector by name and version.
     :param name: connector name
-    :param version: connector version - if not provided, the most recent version will be used
-    :param config: connector config - if not provided, you need to set it later via the set_config method
+    :param version: connector version - if not provided, the currently installed version will be used. If no version is installed, the latest available version will be used.
+    :param pip_url: connector pip URL - if not provided, the pip url will be inferred from the connector name.
+    :param config: connector config - if not provided, you need to set it later via the set_config method.
     :param use_local_install: whether to use a virtual environment to run the connector. If True, the connector is expected to be available on the path (e.g. installed via pip). If False, the connector will be installed automatically in a virtual environment.
     :param install_if_missing: whether to install the connector if it is not available locally. This parameter is ignored if use_local_install is True.
     """
     metadata = get_connector_metadata(name)
+    if use_local_install:
+        if pip_url:
+            raise ValueError("Param 'pip_url' is not supported when 'use_local_install' is True")
+        if version:
+            raise ValueError("Param 'version' is not supported when 'use_local_install' is True")
+        executor: Executor = PathExecutor(
+            metadata=metadata,
+            target_version=version,
+        )
+
+    else:
+        executor = VenvExecutor(
+            metadata=metadata,
+            target_version=version,
+            install_if_missing=install_if_missing,
+            pip_url=pip_url,
+        )
     return Source(
-        PathExecutor(metadata, version) if use_local_install else VenvExecutor(metadata, version, install_if_missing), name, config
+        executor=executor,
+        name=name,
+        config=config,
     )

--- a/airbyte-lib/airbyte_lib/factories.py
+++ b/airbyte-lib/airbyte_lib/factories.py
@@ -24,7 +24,7 @@ def get_connector(
     """
     Get a connector by name and version.
     :param name: connector name
-    :param version: connector version - if not provided, the currently installed version will be used. If no version is installed, the latest available version will be used.
+    :param version: connector version - if not provided, the currently installed version will be used. If no version is installed, the latest available version will be used. The version can also be set to "latest" to force the use of the latest available version.
     :param pip_url: connector pip URL - if not provided, the pip url will be inferred from the connector name.
     :param config: connector config - if not provided, you need to set it later via the set_config method.
     :param use_local_install: whether to use a virtual environment to run the connector. If True, the connector is expected to be available on the path (e.g. installed via pip). If False, the connector will be installed automatically in a virtual environment.


### PR DESCRIPTION
This PR does two things:
* Add source install via `pip_url` from https://github.com/airbytehq/airbyte/pull/33878/files
* Enforce versions only if the version was explicitly stated when initializing the source:
  * If the user does not specify the version, the latest version is installed if there is no installation already, otherwise whatever installed version is available will be used
  * If the user specifies "latest" as their target version, the latest version of the connector is looked up via the registry and enforced (initalization fails if the latest version can't be installed)
  * If the user specifies a specific version, this version is enforced (initalization fails if the latest version can't be installed)