### PR TITLE
airbyte-ci: consider .prettierignore rule on js formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output
+**/pnpm-lock.yaml

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -521,6 +521,7 @@ E.G.: running `pytest` on a specific test folder:
 
 | Version | PR                                                         | Description                                                                                                       |
 | ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 3.1.0  | [#33975](https://github.com/airbytehq/airbyte/pull/33975)  | Consider `.prettierignore` and `.prettierc` in JS formatter. |
 | 3.0.0  | [#33582](https://github.com/airbytehq/airbyte/pull/33582)  | Upgrade to Dagger 0.9.5 |
 | 2.14.3  | [#33964](https://github.com/airbytehq/airbyte/pull/33964)  | Reintroduce mypy with fixes for AssertionError on publish and missing report URL on connector test commit status. |
 | 2.14.2  | [#33954](https://github.com/airbytehq/airbyte/pull/33954)  | Revert mypy changes                                                                                               |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
@@ -32,7 +32,6 @@ DEFAULT_FORMAT_IGNORE_LIST = [
     "**/dbt-project-template-tidb",
     "**/dbt-project-template",
     "**/node_modules",
-    "**/pnpm-lock.yaml",  # This file is generated and should not be formatted
     "**/normalization_test_output",
     "**/source-amplitude/unit_tests/api_data/zipped.json",  # Zipped file presents as non-UTF-8 making spotless sad
     "**/tools/git_hooks/tests/test_spec_linter.py",
@@ -64,4 +63,5 @@ WARM_UP_INCLUSIONS = {
     ],
     Formatter.PYTHON: ["pyproject.toml", "poetry.lock"],
     Formatter.LICENSE: [LICENSE_FILE_NAME],
+    Formatter.JS: [".prettierrc", ".prettierignore"],
 }

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
@@ -100,9 +100,11 @@ def format_java_container(dagger_client: dagger.Client, java_code: dagger.Direct
 
 def format_js_container(dagger_client: dagger.Client, js_code: dagger.Directory, prettier_version: str = "3.0.3") -> dagger.Container:
     """Create a Node container with prettier installed with mounted code to format and a cache volume."""
+    warmup_dir = dagger_client.host().directory(".", include=WARM_UP_INCLUSIONS[Formatter.JS], exclude=DEFAULT_FORMAT_IGNORE_LIST)
     return build_container(
         dagger_client,
         base_image=NODE_IMAGE,
+        warmup_dir=warmup_dir,
         dir_to_format=js_code,
         install_commands=[f"npm install -g npm@10.1.0 prettier@{prettier_version}"],
         cache_volume=dagger_client.cache_volume(cache_keys.get_prettier_cache_key(prettier_version)),

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "3.0.0"
+version = "3.1.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
When calling `airbyte-ci format js` we  use prettier as our JS formatter on the repo. But we did not mount the prettierignore and prettierc files to the prettier container.
The benefit of use `prettierignore` to manage these rules is that we don't have to change `airbyte-ci` code to change the formatting rules.
