### PR TITLE
airbyte-ci: fix assertion error on report existence

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -521,6 +521,7 @@ E.G.: running `pytest` on a specific test folder:
 
 | Version | PR                                                         | Description                                                                                                       |
 | ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 3.1.1  | [#33979](https://github.com/airbytehq/airbyte/pull/33979)  | Fix AssertionError on report existence again |
 | 3.1.0   | [#33994](https://github.com/airbytehq/airbyte/pull/33994)  | Log more context information in CI. |
 | 3.0.2   | [#33987](https://github.com/airbytehq/airbyte/pull/33987)  | Fix type checking issue when running --help |
 | 3.0.1   | [#33981](https://github.com/airbytehq/airbyte/pull/33981)  | Fix issues with deploying dagster, pin pendulum version in dagster-cli install |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
@@ -120,6 +120,7 @@ class PublishConnectorContext(ConnectorContext):
             message += "🔴"
         message += f" {self.state.value['description']}\n"
         if self.state is ContextState.SUCCESSFUL:
+            assert self.report is not None, "Report should be set when state is successful"
             message += f"⏲️ Run duration: {format_duration(self.report.run_duration)}\n"
         if self.state is ContextState.FAILURE:
             message += "\ncc. <!subteam^S0407GYHW4E>"  # @dev-connector-ops

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -164,6 +164,8 @@ async def run_metadata_orchestrator_deploy_pipeline(
     pipeline_start_timestamp: Optional[int],
     ci_context: Optional[str],
 ) -> bool:
+    success: bool = False
+
     metadata_pipeline_context = PipelineContext(
         pipeline_name="Metadata Service Orchestrator Unit Test Pipeline",
         is_local=is_local,
@@ -175,7 +177,6 @@ async def run_metadata_orchestrator_deploy_pipeline(
         pipeline_start_timestamp=pipeline_start_timestamp,
         ci_context=ci_context,
     )
-
     async with dagger.Connection(DAGGER_CONFIG) as dagger_client:
         metadata_pipeline_context.dagger_client = dagger_client.pipeline(metadata_pipeline_context.pipeline_name)
 
@@ -196,9 +197,11 @@ async def run_metadata_orchestrator_deploy_pipeline(
                 ],
             ]
             steps_results = await run_steps(steps)
-            metadata_pipeline_context.report = Report(
+            report = Report(
                 pipeline_context=metadata_pipeline_context,
                 steps_results=list(steps_results.values()),
                 name="METADATA ORCHESTRATOR DEPLOY RESULTS",
             )
-    return metadata_pipeline_context.report.success
+            metadata_pipeline_context.report = report
+            success = report.success
+    return success

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
@@ -149,8 +149,7 @@ class PipelineContext:
         return self.dagger_client.git(AIRBYTE_REPO_URL, keep_git_dir=True)
 
     @property
-    def report(self) -> Report | ConnectorReport:
-        assert self._report is not None, "The report was not set on this PipelineContext."
+    def report(self) -> Report | ConnectorReport | None:
         return self._report
 
     @report.setter

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "3.1.0"
+version = "3.1.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
The report attribute is sometime accessed on the pipeline context before it's set, so it can be `None`.
