### PR TITLE
Fix metadata service steps

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -521,6 +521,7 @@ E.G.: running `pytest` on a specific test folder:
 
 | Version | PR                                                         | Description                                                                                                       |
 | ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 3.0.1  | [#33981](https://github.com/airbytehq/airbyte/pull/33981)  | Fix issues with deploying dagster, pin pendulum version in dagster-cli install |
 | 3.0.0  | [#33582](https://github.com/airbytehq/airbyte/pull/33582)  | Upgrade to Dagger 0.9.5 |
 | 2.14.3  | [#33964](https://github.com/airbytehq/airbyte/pull/33964)  | Reintroduce mypy with fixes for AssertionError on publish and missing report URL on connector test commit status. |
 | 2.14.2  | [#33954](https://github.com/airbytehq/airbyte/pull/33954)  | Revert mypy changes                                                                                               |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -179,15 +179,15 @@ async def run_metadata_orchestrator_deploy_pipeline(
 
         async with metadata_pipeline_context:
             steps: STEP_TREE = [
-                StepToRun(
+                [StepToRun(
                     id=CONNECTOR_TEST_STEP_ID.TEST_ORCHESTRATOR,
                     step=TestOrchestrator(context=metadata_pipeline_context),
-                ),
-                StepToRun(
+                )],
+                [StepToRun(
                     id=CONNECTOR_TEST_STEP_ID.DEPLOY_ORCHESTRATOR,
                     step=DeployOrchestrator(context=metadata_pipeline_context),
                     depends_on=[CONNECTOR_TEST_STEP_ID.TEST_ORCHESTRATOR],
-                ),
+                )],
             ]
             steps_results = await run_steps(steps)
             metadata_pipeline_context.report = Report(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -123,7 +123,9 @@ class DeployOrchestrator(Step):
         # mount metadata_service/lib and metadata_service/orchestrator
         parent_dir = self.context.get_repo_dir("airbyte-ci/connectors/metadata_service")
         python_base = with_python_base(self.context, "3.9")
-        python_with_dependencies = with_pip_packages(python_base, ["dagster-cloud==1.2.6", "pydantic==1.10.6", "poetry2setup==1.1.0", "pendulum==2.1.2"])
+        python_with_dependencies = with_pip_packages(
+            python_base, ["dagster-cloud==1.2.6", "pydantic==1.10.6", "poetry2setup==1.1.0", "pendulum==2.1.2"]
+        )
         dagster_cloud_api_token_secret: dagger.Secret = get_secret_host_variable(
             self.context.dagger_client, "DAGSTER_CLOUD_METADATA_API_TOKEN"
         )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -123,7 +123,7 @@ class DeployOrchestrator(Step):
         # mount metadata_service/lib and metadata_service/orchestrator
         parent_dir = self.context.get_repo_dir("airbyte-ci/connectors/metadata_service")
         python_base = with_python_base(self.context, "3.9")
-        python_with_dependencies = with_pip_packages(python_base, ["dagster-cloud==1.2.6", "pydantic==1.10.6", "poetry2setup==1.1.0"])
+        python_with_dependencies = with_pip_packages(python_base, ["dagster-cloud==1.2.6", "pydantic==1.10.6", "poetry2setup==1.1.0", "pendulum==2.1.2"])
         dagster_cloud_api_token_secret: dagger.Secret = get_secret_host_variable(
             self.context.dagger_client, "DAGSTER_CLOUD_METADATA_API_TOKEN"
         )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -179,15 +179,19 @@ async def run_metadata_orchestrator_deploy_pipeline(
 
         async with metadata_pipeline_context:
             steps: STEP_TREE = [
-                [StepToRun(
-                    id=CONNECTOR_TEST_STEP_ID.TEST_ORCHESTRATOR,
-                    step=TestOrchestrator(context=metadata_pipeline_context),
-                )],
-                [StepToRun(
-                    id=CONNECTOR_TEST_STEP_ID.DEPLOY_ORCHESTRATOR,
-                    step=DeployOrchestrator(context=metadata_pipeline_context),
-                    depends_on=[CONNECTOR_TEST_STEP_ID.TEST_ORCHESTRATOR],
-                )],
+                [
+                    StepToRun(
+                        id=CONNECTOR_TEST_STEP_ID.TEST_ORCHESTRATOR,
+                        step=TestOrchestrator(context=metadata_pipeline_context),
+                    )
+                ],
+                [
+                    StepToRun(
+                        id=CONNECTOR_TEST_STEP_ID.DEPLOY_ORCHESTRATOR,
+                        step=DeployOrchestrator(context=metadata_pipeline_context),
+                        depends_on=[CONNECTOR_TEST_STEP_ID.TEST_ORCHESTRATOR],
+                    )
+                ],
             ]
             steps_results = await run_steps(steps)
             metadata_pipeline_context.report = Report(

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
@@ -303,14 +303,15 @@ class PipelineContext:
         Returns:
             bool: Whether the teardown operation ran successfully.
         """
-        self.state = self.determine_final_state(self.report, exception_value)
-        self.stopped_at = datetime.utcnow()
-
         if exception_value:
             self.logger.error("An error was handled by the Pipeline", exc_info=True)
+
         if self.report is None:
             self.logger.error("No test report was provided. This is probably due to an upstream error")
             self.report = Report(self, steps_results=[])
+
+        self.state = self.determine_final_state(self.report, exception_value)
+        self.stopped_at = datetime.utcnow()
 
         self.report.print()
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "3.0.0"
+version = "3.0.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## Problem
We use arrays to denote concurrency

e.g.
```
steps = [
  [1a, 1b, 1c],
  [2a, 2b, 2c],
  ]
```

and the orchestrator deploy steps were defined concurrently when they needed to be sequential.

## Solution
1. Update to use the array
2. Throw a better error message
3. Add tests
4. Open discussion on if we should use something more explicit than an array structure