### PR TITLE
🐛 Source Instagram: remove metrics from video feed

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 3.0.0
+  dockerImageTag: 3.0.1
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
@@ -413,6 +413,8 @@ class MediaInsights(Media):
         """Get insights for specific media"""
         if item.get("media_product_type") == "REELS":
             metrics = self.REELS_METRICS
+        elif item.get("media_type") == "VIDEO" and item.get("media_product_type") == "FEED":
+            metrics = ['impressions', 'reach', 'saved', 'video_views', 'video_views']
         elif item.get("media_type") == "VIDEO":
             metrics = self.MEDIA_METRICS + ["video_views"]
         elif item.get("media_type") == "CAROUSEL_ALBUM":

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
@@ -414,7 +414,7 @@ class MediaInsights(Media):
         if item.get("media_product_type") == "REELS":
             metrics = self.REELS_METRICS
         elif item.get("media_type") == "VIDEO" and item.get("media_product_type") == "FEED":
-            metrics = ['impressions', 'reach', 'saved', 'video_views', 'video_views']
+            metrics = ["impressions", "reach", "saved", "video_views", "video_views"]
         elif item.get("media_type") == "VIDEO":
             metrics = self.MEDIA_METRICS + ["video_views"]
         elif item.get("media_type") == "CAROUSEL_ALBUM":

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -113,6 +113,7 @@ Instagram limits the number of requests that can be made at a time. See Facebook
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
+| 3.0.1   | 2024-01-08 | [33989](https://github.com/airbytehq/airbyte/pull/33989) | Remove metrics from video feed                                                                                            |
 | 3.0.0   | 2024-01-05 | [33930](https://github.com/airbytehq/airbyte/pull/33930) | Upgrade to API v18.0                                                                                                      |
 | 2.0.1   | 2024-01-03 | [33889](https://github.com/airbytehq/airbyte/pull/33889) | Change requested metrics for stream `media_insights`                                                                      |
 | 2.0.0   | 2023-11-17 | [32500](https://github.com/airbytehq/airbyte/pull/32500) | Add primary keys for UserLifetimeInsights and UserInsights; add airbyte_type to timestamp fields                          |


### PR DESCRIPTION
## What
The metrics requested for "media_product_type" == "FEED and "media_type" == "VIDEO" are crashing syncs. The error is `(#100) Incompatible metric (total_interactions) with the media`

## How
Excluding total_interactions`, `impressions`, `likes` and `comments`

## 🚨 User Impact 🚨
We should hopefully see sync with video reel working again
