### PR TITLE
airbyte-ci: fix nightly build binary

### DIFF
--- a/.github/workflows/connectors_nightly_build.yml
+++ b/.github/workflows/connectors_nightly_build.yml
@@ -13,10 +13,6 @@ on:
       test-connectors-options:
         default: --concurrency=5 --support-level=certified
         required: true
-      airbyte-ci-binary-url:
-        description: "URL to airbyte-ci binary"
-        required: false
-        default: https://connectors.airbyte.com/airbyte-ci/releases/ubuntu/latest/airbyte-ci
 
 run-name: "Test connectors: ${{ inputs.test-connectors-options || 'nightly build for Certified connectors' }} - on ${{ inputs.runs-on || 'ci-runner-connector-nightly-xlarge-dagger-0-9-5' }}"
 
@@ -50,4 +46,3 @@ jobs:
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           subcommand: "connectors ${{ inputs.test-connectors-options || '--concurrency=8 --support-level=certified' }} test"
-          airbyte_ci_binary_url: ${{ github.event.inputs.airbyte-ci-binary-url }}


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Closes #34040

## How
The `airbyte-ci-binary-url` input was introduced as a workflow dispatch input  for manual testing purposes, without a default fallback on schedule. 
We can remove this input as:
* Nightly builds are meant to be scheduled, and not manually run
* They should run using the latest binary
* If we want to test an airbyte-ci change on this workflow the dev airbyte-ci version will be installed on the branch modifying airbyte-ci