### PR TITLE
Source Faker: Add support for PyPi and AirbyteLib entrypoints

### DIFF
--- a/.devcontainer/java-connectors-generic/devcontainer.json
+++ b/.devcontainer/java-connectors-generic/devcontainer.json
@@ -1,6 +1,6 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 {
-  "name": "Connector Development DevContainer (Generic)",
+  "name": "Java Development DevContainer (Generic)",
 
   "image": "mcr.microsoft.com/devcontainers/java:0-17",
   "features": {

--- a/.devcontainer/python-connectors-generic/devcontainer.json
+++ b/.devcontainer/python-connectors-generic/devcontainer.json
@@ -49,8 +49,8 @@
   // Mark the root directory as 'safe' for git.
   "initializeCommand": "git config --add safe.directory /workspaces/airbyte",
 
-  // Optionally run commands post-create.
-  // "postCreateCommand": "",
+  // Setup airbyte-ci on the container:
+  "postCreateCommand": "make tools.airbyte-ci-dev.install",
 
   "containerEnv": {
     // Deterministic Poetry virtual env location: `./.venv`

--- a/.devcontainer/python-connectors-generic/devcontainer.json
+++ b/.devcontainer/python-connectors-generic/devcontainer.json
@@ -1,65 +1,65 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 {
-    "name": "Python Development DevContainer (Generic)",
+  "name": "Python Development DevContainer (Generic)",
 
-    "image": "mcr.microsoft.com/devcontainers/python:0-3.10",
-    "features": {
-      "ghcr.io/devcontainers/features/docker-in-docker": {},
-      "ghcr.io/devcontainers/features/python:1": {
-        "installGradle": true,
-        "version": "3.10",
-        "installTools": true
-      },
-      "ghcr.io/devcontainers-contrib/features/poetry:2": {}
+  "image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker": {},
+    "ghcr.io/devcontainers/features/python:1": {
+      "installGradle": true,
+      "version": "3.10",
+      "installTools": true
     },
+    "ghcr.io/devcontainers-contrib/features/poetry:2": {}
+  },
 
-    // Deterministic order reduces cache busting
-    "overrideFeatureInstallOrder": [
-      "ghcr.io/devcontainers/features/docker-in-docker",
-      "ghcr.io/devcontainers/features/python",
-      "ghcr.io/devcontainers-contrib/features/poetry"
-    ],
+  // Deterministic order reduces cache busting
+  "overrideFeatureInstallOrder": [
+    "ghcr.io/devcontainers/features/docker-in-docker",
+    "ghcr.io/devcontainers/features/python",
+    "ghcr.io/devcontainers-contrib/features/poetry"
+  ],
 
-    // Configure tool-specific properties.
-    "customizations": {
-      "vscode": {
-        "extensions": [
-            // Python extensions:
-            "charliermarsh.ruff",
-            "matangover.mypy",
-            "ms-python.python",
-            "ms-python.vscode-pylance",
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // Python extensions:
+        "charliermarsh.ruff",
+        "matangover.mypy",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
 
-            // Toml support
-            "tamasfe.even-better-toml",
+        // Toml support
+        "tamasfe.even-better-toml",
 
-            // Yaml and JSON Schema support:
-            "redhat.vscode-yaml",
+        // Yaml and JSON Schema support:
+        "redhat.vscode-yaml",
 
-            // Contributing:
-            "GitHub.vscode-pull-request-github"
-        ],
-        "settings": {
-          "extensions.ignoreRecommendations": true,
-          "git.openRepositoryInParentFolders": "always"
-        }
+        // Contributing:
+        "GitHub.vscode-pull-request-github"
+      ],
+      "settings": {
+        "extensions.ignoreRecommendations": true,
+        "git.openRepositoryInParentFolders": "always"
       }
-    },
-
-    // Mark the root directory as 'safe' for git.
-    "initializeCommand": "git config --add safe.directory /workspaces/airbyte",
-
-    // Optionally run commands post-create.
-    // "postCreateCommand": "",
-
-    "containerEnv": {
-      // Deterministic Poetry virtual env location: `./.venv`
-      "POETRY_VIRTUALENVS_IN_PROJECT": "true"
     }
+  },
 
-    // Override to change the directory that the IDE opens by default:
-    // "workspaceFolder": "/workspaces/airbyte"
+  // Mark the root directory as 'safe' for git.
+  "initializeCommand": "git config --add safe.directory /workspaces/airbyte",
 
-    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-    // "remoteUser": "root"
+  // Optionally run commands post-create.
+  // "postCreateCommand": "",
+
+  "containerEnv": {
+    // Deterministic Poetry virtual env location: `./.venv`
+    "POETRY_VIRTUALENVS_IN_PROJECT": "true"
   }
+
+  // Override to change the directory that the IDE opens by default:
+  // "workspaceFolder": "/workspaces/airbyte"
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.devcontainer/python-connectors-generic/devcontainer.json
+++ b/.devcontainer/python-connectors-generic/devcontainer.json
@@ -2,7 +2,7 @@
 {
     "name": "Python Development DevContainer (Generic)",
 
-    "image": "mcr.microsoft.com/devcontainers/python:0-17",
+    "image": "mcr.microsoft.com/devcontainers/python:0-3.10",
     "features": {
       "ghcr.io/devcontainers/features/docker-in-docker": {},
       "ghcr.io/devcontainers/features/python:1": {

--- a/.devcontainer/python-connectors-generic/devcontainer.json
+++ b/.devcontainer/python-connectors-generic/devcontainer.json
@@ -1,0 +1,65 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+{
+    "name": "Python Development DevContainer (Generic)",
+
+    "image": "mcr.microsoft.com/devcontainers/python:0-17",
+    "features": {
+      "ghcr.io/devcontainers/features/docker-in-docker": {},
+      "ghcr.io/devcontainers/features/python:1": {
+        "installGradle": true,
+        "version": "3.10",
+        "installTools": true
+      },
+      "ghcr.io/devcontainers-contrib/features/poetry:2": {}
+    },
+
+    // Deterministic order reduces cache busting
+    "overrideFeatureInstallOrder": [
+      "ghcr.io/devcontainers/features/docker-in-docker",
+      "ghcr.io/devcontainers/features/python",
+      "ghcr.io/devcontainers-contrib/features/poetry"
+    ],
+
+    // Configure tool-specific properties.
+    "customizations": {
+      "vscode": {
+        "extensions": [
+            // Python extensions:
+            "charliermarsh.ruff",
+            "matangover.mypy",
+            "ms-python.python",
+            "ms-python.vscode-pylance",
+
+            // Toml support
+            "tamasfe.even-better-toml",
+
+            // Yaml and JSON Schema support:
+            "redhat.vscode-yaml",
+
+            // Contributing:
+            "GitHub.vscode-pull-request-github"
+        ],
+        "settings": {
+          "extensions.ignoreRecommendations": true,
+          "git.openRepositoryInParentFolders": "always"
+        }
+      }
+    },
+
+    // Mark the root directory as 'safe' for git.
+    "initializeCommand": "git config --add safe.directory /workspaces/airbyte",
+
+    // Optionally run commands post-create.
+    // "postCreateCommand": "",
+
+    "containerEnv": {
+      // Deterministic Poetry virtual env location: `./.venv`
+      "POETRY_VIRTUALENVS_IN_PROJECT": "true"
+    }
+
+    // Override to change the directory that the IDE opens by default:
+    // "workspaceFolder": "/workspaces/airbyte"
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+  }

--- a/airbyte-integrations/connectors/source-faker/Dockerfile
+++ b/airbyte-integrations/connectors/source-faker/Dockerfile
@@ -34,5 +34,5 @@ COPY source_faker ./source_faker
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=5.0.0
+LABEL io.airbyte.version=5.0.1
 LABEL io.airbyte.name=airbyte/source-faker

--- a/airbyte-integrations/connectors/source-faker/main.py
+++ b/airbyte-integrations/connectors/source-faker/main.py
@@ -3,11 +3,7 @@
 #
 
 
-import sys
-
-from airbyte_cdk.entrypoint import launch
-from source_faker import SourceFaker
+from source_faker.run import run
 
 if __name__ == "__main__":
-    source = SourceFaker()
-    launch(source, sys.argv[1:])
+    run()

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 5.0.0
+  dockerImageTag: 5.0.1
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   githubIssueLabel: source-faker

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -42,6 +42,10 @@ data:
       - products
       - purchases
   supportLevel: community
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-faker
   tags:
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-faker/setup.py
+++ b/airbyte-integrations/connectors/source-faker/setup.py
@@ -24,4 +24,10 @@ setup(
     extras_require={
         "tests": TEST_REQUIREMENTS,
     },
+    # register console entry points
+    entry_points={
+        "console_scripts": [
+            "source-faker=source_faker.run:run",
+        ],
+    },
 )

--- a/airbyte-integrations/connectors/source-faker/source_faker/run.py
+++ b/airbyte-integrations/connectors/source-faker/source_faker/run.py
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+
+import sys
+
+from airbyte_cdk.entrypoint import launch
+
+from source_faker import SourceFaker
+
+
+def run():
+    source = SourceFaker()
+    launch(source, sys.argv[1:])
+
+
+if __name__ == "__main__":
+    run()

--- a/airbyte-integrations/connectors/source-faker/source_faker/run.py
+++ b/airbyte-integrations/connectors/source-faker/source_faker/run.py
@@ -6,7 +6,6 @@
 import sys
 
 from airbyte_cdk.entrypoint import launch
-
 from source_faker import SourceFaker
 
 

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -96,6 +96,7 @@ None!
 
 | Version | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:--------|:-----------|:----------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 5.0.1   | 2023-01-08 | [34033](https://github.com/airbytehq/airbyte/pull/34033)                                                              | Add standard entrypoints for usage with AirbyteLib                                                      |
 | 5.0.0   | 2023-08-08 | [29213](https://github.com/airbytehq/airbyte/pull/29213)                                                              | Change all `*id` fields and `products.year` to be integer                                                       |
 | 4.0.0   | 2023-07-19 | [28485](https://github.com/airbytehq/airbyte/pull/28485)                                                              | Bump to test publication                                                                                        |
 | 3.0.2   | 2023-07-07 | [27807](https://github.com/airbytehq/airbyte/pull/28060)                                                              | Bump to test publication                                                                                        |


### PR DESCRIPTION
This adds compatibility with AirbyteLib.

Includes PyPi declaration as defined in:

- https://github.com/airbytehq/airbyte/pull/33529

This PR replaces the related changes in:

- https://github.com/airbytehq/airbyte/pull/33878

This PR also includes a generic Python DevContainer, which can be used for testing in Codespaces. I'm happy to remove it though and move to a different PR if anyone has an objection. I confirmed I was able to run pytest from this decontainer, and that all tests are passing.