### PR TITLE
airbyte-ci: `Steps` can receive extra parameters

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/java_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/java_connectors.py
@@ -23,7 +23,7 @@ from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.dagger.actions.system import docker
 from pipelines.helpers.run_steps import StepToRun
 from pipelines.helpers.utils import export_container_to_tarball
-from pipelines.models.steps import StepResult, StepStatus
+from pipelines.models.steps import STEP_PARAMS, StepResult, StepStatus
 
 if TYPE_CHECKING:
     from typing import Callable, Dict, List, Optional
@@ -35,9 +35,15 @@ class IntegrationTests(GradleTask):
     """A step to run integrations tests for Java connectors using the integrationTestJava Gradle task."""
 
     title = "Java Connector Integration Tests"
-    gradle_task_name = "integrationTestJava -x buildConnectorImage -x assemble"
+    gradle_task_name = "integrationTestJava"
     mount_connector_secrets = True
     bind_to_docker_host = True
+
+    @property
+    def default_params(self) -> STEP_PARAMS:
+        return super().default_params | {
+            "-x": ["buildConnectorImage", "assemble"],  # Exclude the buildConnectorImage and assemble tasks
+        }
 
     async def _load_normalization_image(self, normalization_tar_file: File) -> None:
         normalization_image_tag = f"{self.context.connector.normalization_repository}:dev"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
@@ -11,7 +11,7 @@ from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.consts import AMAZONCORRETTO_IMAGE
 from pipelines.dagger.actions import secrets
 from pipelines.helpers.utils import sh_dash_c
-from pipelines.models.steps import Step, StepResult
+from pipelines.models.steps import STEP_PARAMS, Step, StepResult
 
 
 class GradleTask(Step, ABC):
@@ -27,14 +27,20 @@ class GradleTask(Step, ABC):
 
     context: ConnectorContext
 
-    DEFAULT_GRADLE_TASK_OPTIONS = ("--no-daemon", "--no-watch-fs", "--scan", "--build-cache", "--console=plain")
     LOCAL_MAVEN_REPOSITORY_PATH = "/root/.m2"
     GRADLE_DEP_CACHE_PATH = "/root/gradle-cache"
     GRADLE_HOME_PATH = "/root/.gradle"
-
+    STATIC_GRADLE_TASK_OPTIONS = ("--no-daemon", "--no-watch-fs", "--scan", "--build-cache", "--console=plain")
     gradle_task_name: ClassVar[str]
     bind_to_docker_host: ClassVar[bool] = False
     mount_connector_secrets: ClassVar[bool] = False
+    accept_extra_params = True
+
+    @property
+    def default_params(self) -> STEP_PARAMS:
+        return super().default_params | {
+            "-Ds3BuildCachePrefix": [self.context.connector.technical_name],  # Set the S3 build cache prefix.
+        }
 
     @property
     def dependency_cache_volume(self) -> CacheVolume:
@@ -56,7 +62,7 @@ class GradleTask(Step, ABC):
         ]
 
     def _get_gradle_command(self, task: str, *args: Any) -> str:
-        return f"./gradlew {' '.join(self.DEFAULT_GRADLE_TASK_OPTIONS + args)} {task}"
+        return f"./gradlew {' '.join(self.STATIC_GRADLE_TASK_OPTIONS + args)} {task}"
 
     async def _run(self, *args: Any, **kwargs: Any) -> StepResult:
         include = [
@@ -191,7 +197,7 @@ class GradleTask(Step, ABC):
                     # Warm the gradle cache.
                     f"(rsync -a --stats --mkpath {self.GRADLE_DEP_CACHE_PATH}/ {self.GRADLE_HOME_PATH} || true)",
                     # Run the gradle task.
-                    self._get_gradle_command(connector_task, f"-Ds3BuildCachePrefix={self.context.connector.technical_name}"),
+                    self._get_gradle_command(connector_task, *self.params_as_cli_options),
                 ]
             )
         )


### PR DESCRIPTION
## What
Relates to https://github.com/airbytehq/airbyte/issues/24061

We want `Step` subclasses to:
* Expose default parameters 
*  Accept extra parameters
* Merge default and extra parameters in a list of options that will be passed to the final `with_exec` of the `run` method.

 
## How
* Create new properties on the abstract `Step` class: `default_params`, `extra_params`, `params` (merging default and extra params), `params_as_cli_options` (building a CLI compatible list of options from the params property).
* Declare `default_params` for Python Unit and Integration tests, Java integration tests, AcceptanceTests
* Adapt `Step` subclasses  `_run` method to use the `params_as_cli_options` property.

## Impact
None: no Step is yet called with extra params. This will come in downstream PRs in the stack?
