### PR TITLE
airbyte-ci: connector test steps can take extra parameters from CLI

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -521,6 +521,7 @@ E.G.: running `pytest` on a specific test folder:
 
 | Version | PR                                                         | Description                                                                                                       |
 | ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 3.2.0  | [#34050](https://github.com/airbytehq/airbyte/pull/34050)  | Connector test steps can take extra parameters |
 | 3.1.3   | [#34136](https://github.com/airbytehq/airbyte/pull/34136)  | Fix issue where dagger excludes were not being properly applied |
 | 3.1.2   | [#33972](https://github.com/airbytehq/airbyte/pull/33972)  | Remove secrets scrubbing hack for --is-local and other small tweaks. |
 | 3.1.1   | [#33979](https://github.com/airbytehq/airbyte/pull/33979)  | Fix AssertionError on report existence again |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -264,10 +264,23 @@ flowchart TD
 | `--fail-fast`       | False    | False         | Abort after any tests fail, rather than continuing to run additional tests. Use this setting to confirm a known bug is fixed (or not), or when you only require a pass/fail result.                      |
 | `--code-tests-only` | True     | False         | Skip any tests not directly related to code updates. For instance, metadata checks, version bump checks, changelog verification, etc. Use this setting to help focus on code quality during development. |
 | `--concurrent-cat`  | False    | False         | Make CAT tests run concurrently using pytest-xdist. Be careful about source or destination API rate limits.                                                                                              |
+| `--<step-id>.<extra-parameter>=<extra-parameter-value>`  | True    |          | You can pass extra parameters for specific test steps. More details in the extra parameters section below                                                                                              |
 
 Note:
 
 - The above options are implemented for Java connectors but may not be available for Python connectors. If an option is not supported, the pipeline will not fail but instead the 'default' behavior will be executed.
+
+#### Extra parameters
+You can pass extra parameters to the following steps:
+* `unit` 
+* `integration` 
+* `acceptance` 
+
+This allows you to override the default parameters of these steps. 
+For example, you can only run the `test_read` test of the acceptance test suite with:
+`airbyte-ci connectors --name=source-pokeapi test --acceptance.-k=test_read`
+Here the `-k` parameter is passed to the pytest command running acceptance tests.
+Please keep in mind that the extra parameters are not validated by the CLI: if you pass an invalid parameter, you'll face a late failure during the pipeline execution.
 
 ### <a id="connectors-build-command"></a>`connectors build` command
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
@@ -19,8 +19,8 @@ from pipelines.airbyte_ci.connectors.reports import ConnectorReport
 from pipelines.consts import BUILD_PLATFORMS
 from pipelines.dagger.actions import secrets
 from pipelines.helpers.connectors.modifed import ConnectorWithModifiedFiles
+from pipelines.helpers.execution.run_steps import RunStepOptions
 from pipelines.helpers.github import update_commit_status_check
-from pipelines.helpers.run_steps import RunStepOptions
 from pipelines.helpers.slack import send_message_to_webhook
 from pipelines.helpers.utils import METADATA_FILE_NAME
 from pipelines.models.contexts.pipeline_context import PipelineContext

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/pipeline.py
@@ -3,6 +3,10 @@
 #
 """This module groups factory like functions to dispatch tests steps according to the connector under test language."""
 
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
 
 import anyio
 from connector_ops.utils import ConnectorLanguage  # type: ignore
@@ -12,7 +16,11 @@ from pipelines.airbyte_ci.connectors.reports import ConnectorReport
 from pipelines.airbyte_ci.connectors.test.steps import java_connectors, python_connectors
 from pipelines.airbyte_ci.connectors.test.steps.common import QaChecks, VersionFollowsSemverCheck, VersionIncrementCheck
 from pipelines.airbyte_ci.metadata.pipeline import MetadataValidation
-from pipelines.helpers.run_steps import STEP_TREE, StepToRun, run_steps
+from pipelines.helpers.execution.run_steps import StepToRun, run_steps
+
+if TYPE_CHECKING:
+
+    from pipelines.helpers.execution.run_steps import STEP_TREE
 
 LANGUAGE_MAPPING = {
     "get_test_steps": {
@@ -23,6 +31,11 @@ LANGUAGE_MAPPING = {
 }
 
 
+EXTRA_PARAMS_PATTERN = re.compile(r"^--([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_-][a-zA-Z0-9_-]*)=([^=]+)$")
+EXTRA_PARAMS_PATTERN_FOR_FLAG = re.compile(r"^--([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_-][a-zA-Z0-9_-]*)$")
+EXTRA_PARAMS_PATTERN_ERROR_MESSAGE = "The extra params must be structured as --<step_id>.<param_name>=<param_value>"
+
+
 def get_test_steps(context: ConnectorContext) -> STEP_TREE:
     """Get all the tests steps according to the connector language.
 
@@ -30,7 +43,7 @@ def get_test_steps(context: ConnectorContext) -> STEP_TREE:
         context (ConnectorContext): The current connector context.
 
     Returns:
-        List[StepResult]: The list of tests steps.
+        STEP_TREE: The list of tests steps.
     """
     if _get_test_steps := LANGUAGE_MAPPING["get_test_steps"].get(context.connector.language):
         return _get_test_steps(context)
@@ -43,11 +56,12 @@ async def run_connector_test_pipeline(context: ConnectorContext, semaphore: anyi
     """
     Compute the steps to run for a connector test pipeline.
     """
+    all_steps_to_run: STEP_TREE = []
 
-    steps_to_run = get_test_steps(context)
+    all_steps_to_run += get_test_steps(context)
 
     if not context.code_tests_only:
-        steps_to_run += [
+        static_analysis_steps_to_run = [
             [
                 StepToRun(id=CONNECTOR_TEST_STEP_ID.METADATA_VALIDATION, step=MetadataValidation(context)),
                 StepToRun(id=CONNECTOR_TEST_STEP_ID.VERSION_FOLLOW_CHECK, step=VersionFollowsSemverCheck(context)),
@@ -55,11 +69,12 @@ async def run_connector_test_pipeline(context: ConnectorContext, semaphore: anyi
                 StepToRun(id=CONNECTOR_TEST_STEP_ID.QA_CHECKS, step=QaChecks(context)),
             ]
         ]
+        all_steps_to_run += static_analysis_steps_to_run
 
     async with semaphore:
         async with context:
             result_dict = await run_steps(
-                runnables=steps_to_run,
+                runnables=all_steps_to_run,
                 options=context.run_step_options,
             )
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/pipeline.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
 import anyio
@@ -29,11 +28,6 @@ LANGUAGE_MAPPING = {
         ConnectorLanguage.JAVA: java_connectors.get_test_steps,
     },
 }
-
-
-EXTRA_PARAMS_PATTERN = re.compile(r"^--([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_-][a-zA-Z0-9_-]*)=([^=]+)$")
-EXTRA_PARAMS_PATTERN_FOR_FLAG = re.compile(r"^--([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_-][a-zA-Z0-9_-]*)$")
-EXTRA_PARAMS_PATTERN_ERROR_MESSAGE = "The extra params must be structured as --<step_id>.<param_name>=<param_value>"
 
 
 def get_test_steps(context: ConnectorContext) -> STEP_TREE:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/java_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/java_connectors.py
@@ -23,7 +23,7 @@ from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.dagger.actions.system import docker
 from pipelines.helpers.run_steps import StepToRun
 from pipelines.helpers.utils import export_container_to_tarball
-from pipelines.models.steps import StepResult, StepStatus
+from pipelines.models.steps import STEP_PARAMS, StepResult, StepStatus
 
 if TYPE_CHECKING:
     from typing import Callable, Dict, List, Optional
@@ -35,9 +35,15 @@ class IntegrationTests(GradleTask):
     """A step to run integrations tests for Java connectors using the integrationTestJava Gradle task."""
 
     title = "Java Connector Integration Tests"
-    gradle_task_name = "integrationTestJava -x buildConnectorImage -x assemble"
+    gradle_task_name = "integrationTestJava"
     mount_connector_secrets = True
     bind_to_docker_host = True
+
+    @property
+    def default_params(self) -> STEP_PARAMS:
+        return super().default_params | {
+            "-x": ["buildConnectorImage", "assemble"],  # Exclude the buildConnectorImage and assemble tasks
+        }
 
     async def _load_normalization_image(self, normalization_tar_file: File) -> None:
         normalization_image_tag = f"{self.context.connector.normalization_repository}:dev"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/java_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/java_connectors.py
@@ -21,14 +21,14 @@ from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests
 from pipelines.airbyte_ci.steps.gradle import GradleTask
 from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.dagger.actions.system import docker
-from pipelines.helpers.run_steps import StepToRun
+from pipelines.helpers.execution.run_steps import StepToRun
 from pipelines.helpers.utils import export_container_to_tarball
 from pipelines.models.steps import STEP_PARAMS, StepResult, StepStatus
 
 if TYPE_CHECKING:
     from typing import Callable, Dict, List, Optional
 
-    from pipelines.helpers.run_steps import RESULTS_DICT, STEP_TREE
+    from pipelines.helpers.execution.run_steps import RESULTS_DICT, STEP_TREE
 
 
 class IntegrationTests(GradleTask):

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
@@ -16,7 +16,7 @@ from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests, CheckBaseImageIsUsed
 from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.dagger.actions import secrets
-from pipelines.helpers.run_steps import STEP_TREE, StepToRun
+from pipelines.helpers.execution.run_steps import STEP_TREE, StepToRun
 from pipelines.models.steps import STEP_PARAMS, Step, StepResult
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -13,7 +13,7 @@ from pipelines.airbyte_ci.steps.poetry import PoetryRunStep
 from pipelines.consts import DOCS_DIRECTORY_ROOT_PATH, INTERNAL_TOOL_PATHS
 from pipelines.dagger.actions.python.common import with_pip_packages
 from pipelines.dagger.containers.python import with_python_base
-from pipelines.helpers.run_steps import STEP_TREE, StepToRun, run_steps
+from pipelines.helpers.execution.run_steps import STEP_TREE, StepToRun, run_steps
 from pipelines.helpers.utils import DAGGER_CONFIG, get_secret_host_variable
 from pipelines.models.reports import Report
 from pipelines.models.steps import MountPath, Step, StepResult

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
@@ -11,7 +11,7 @@ from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.consts import AMAZONCORRETTO_IMAGE
 from pipelines.dagger.actions import secrets
 from pipelines.helpers.utils import sh_dash_c
-from pipelines.models.steps import Step, StepResult
+from pipelines.models.steps import STEP_PARAMS, Step, StepResult
 
 
 class GradleTask(Step, ABC):
@@ -27,14 +27,20 @@ class GradleTask(Step, ABC):
 
     context: ConnectorContext
 
-    DEFAULT_GRADLE_TASK_OPTIONS = ("--no-daemon", "--no-watch-fs", "--scan", "--build-cache", "--console=plain")
     LOCAL_MAVEN_REPOSITORY_PATH = "/root/.m2"
     GRADLE_DEP_CACHE_PATH = "/root/gradle-cache"
     GRADLE_HOME_PATH = "/root/.gradle"
-
+    STATIC_GRADLE_TASK_OPTIONS = ("--no-daemon", "--no-watch-fs", "--scan", "--build-cache", "--console=plain")
     gradle_task_name: ClassVar[str]
     bind_to_docker_host: ClassVar[bool] = False
     mount_connector_secrets: ClassVar[bool] = False
+    accept_extra_params = True
+
+    @property
+    def default_params(self) -> STEP_PARAMS:
+        return super().default_params | {
+            "-Ds3BuildCachePrefix": [self.context.connector.technical_name],  # Set the S3 build cache prefix.
+        }
 
     @property
     def dependency_cache_volume(self) -> CacheVolume:
@@ -56,7 +62,7 @@ class GradleTask(Step, ABC):
         ]
 
     def _get_gradle_command(self, task: str, *args: Any) -> str:
-        return f"./gradlew {' '.join(self.DEFAULT_GRADLE_TASK_OPTIONS + args)} {task}"
+        return f"./gradlew {' '.join(self.STATIC_GRADLE_TASK_OPTIONS + args)} {task}"
 
     async def _run(self, *args: Any, **kwargs: Any) -> StepResult:
         include = [
@@ -191,7 +197,7 @@ class GradleTask(Step, ABC):
                     # Warm the gradle cache.
                     f"(rsync -a --stats --mkpath {self.GRADLE_DEP_CACHE_PATH}/ {self.GRADLE_HOME_PATH} || true)",
                     # Run the gradle task.
-                    self._get_gradle_command(connector_task, f"-Ds3BuildCachePrefix={self.context.connector.technical_name}"),
+                    self._get_gradle_command(connector_task, *self.params_as_cli_options),
                 ]
             )
         )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
@@ -30,7 +30,7 @@ class GradleTask(Step, ABC):
     LOCAL_MAVEN_REPOSITORY_PATH = "/root/.m2"
     GRADLE_DEP_CACHE_PATH = "/root/gradle-cache"
     GRADLE_HOME_PATH = "/root/.gradle"
-    STATIC_GRADLE_TASK_OPTIONS = ("--no-daemon", "--no-watch-fs", "--scan", "--build-cache", "--console=plain")
+    STATIC_GRADLE_TASK_OPTIONS = ("--no-daemon", "--no-watch-fs")
     gradle_task_name: ClassVar[str]
     bind_to_docker_host: ClassVar[bool] = False
     mount_connector_secrets: ClassVar[bool] = False
@@ -40,6 +40,9 @@ class GradleTask(Step, ABC):
     def default_params(self) -> STEP_PARAMS:
         return super().default_params | {
             "-Ds3BuildCachePrefix": [self.context.connector.technical_name],  # Set the S3 build cache prefix.
+            "--build-cache": [],  # Enable the gradle build cache.
+            "--scan": [],  # Enable the gradle build scan.
+            "--console": ["plain"],  # Disable the gradle rich console.
         }
 
     @property

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/execution/argument_parsing.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/execution/argument_parsing.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import asyncclick as click
+
+if TYPE_CHECKING:
+    from enum import Enum
+    from typing import Callable, Dict, Tuple, Type
+
+    from pipelines.models.steps import STEP_PARAMS
+
+# Pattern  for extra param options: --<step_id>.<option_name>=<option_value>
+EXTRA_PARAM_PATTERN_FOR_OPTION = re.compile(r"^--([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_-][a-zA-Z0-9_-]*)=([^=]+)$")
+# Pattern  for extra param flag: --<step_id>.<option_name>
+EXTRA_PARAM_PATTERN_FOR_FLAG = re.compile(r"^--([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_-][a-zA-Z0-9_-]*)$")
+EXTRA_PARAM_PATTERN_ERROR_MESSAGE = "The extra flags must be structured as --<step_id>.<flag_name> for flags or --<step_id>.<option_name>=<option_value> for options. You can use - or -- for option/flag names."
+
+
+def build_extra_params_mapping(SupportedStepIds: Type[Enum]) -> Callable:
+    def callback(ctx: click.Context, argument: click.core.Argument, raw_extra_params: Tuple[str]) -> Dict[str, STEP_PARAMS]:
+        """Build a mapping of step id to extra params.
+        Validate the extra params and raise a ValueError if they are invalid.
+        Validation rules:
+        - The extra params must be structured as --<step_id>.<param_name>=<param_value> for options or --<step_id>.<param_name> for flags.
+        - The step id must be one of the existing step ids.
+
+
+        Args:
+            ctx (click.Context): The click context.
+            argument (click.core.Argument): The click argument.
+            raw_extra_params (Tuple[str]): The extra params provided by the user.
+        Raises:
+            ValueError: Raised if the extra params format is invalid.
+            ValueError: Raised if the step id in the extra params is not one of the unique steps to run.
+
+        Returns:
+            Dict[Literal, STEP_PARAMS]: The mapping of step id to extra params.
+        """
+        extra_params_mapping: Dict[str, STEP_PARAMS] = {}
+        for param in raw_extra_params:
+            is_flag = "=" not in param
+            pattern = EXTRA_PARAM_PATTERN_FOR_FLAG if is_flag else EXTRA_PARAM_PATTERN_FOR_OPTION
+            matches = pattern.match(param)
+            if not matches:
+                raise ValueError(f"Invalid parameter {param}. {EXTRA_PARAM_PATTERN_ERROR_MESSAGE}")
+            if is_flag:
+                step_name, param_name = matches.groups()
+                param_value = None
+            else:
+                step_name, param_name, param_value = matches.groups()
+            try:
+                step_id = SupportedStepIds(step_name).value
+            except ValueError:
+                raise ValueError(f"Invalid step name {step_name}, it must be one of {[step_id.value for step_id in SupportedStepIds]}")
+
+            extra_params_mapping.setdefault(step_id, {}).setdefault(param_name, [])
+            # param_value is None if the param is a flag
+            if param_value is not None:
+                extra_params_mapping[step_id][param_name].append(param_value)
+        return extra_params_mapping
+
+    return callback

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
@@ -18,9 +18,9 @@ from dagger import Client, Directory, File, GitRepository, Secret, Service
 from github import PullRequest
 from pipelines.airbyte_ci.connectors.reports import ConnectorReport
 from pipelines.consts import CIContext, ContextState
+from pipelines.helpers.execution.run_steps import RunStepOptions
 from pipelines.helpers.gcs import sanitize_gcs_credentials
 from pipelines.helpers.github import update_commit_status_check
-from pipelines.helpers.run_steps import RunStepOptions
 from pipelines.helpers.slack import send_message_to_webhook
 from pipelines.helpers.utils import AIRBYTE_REPO_URL
 from pipelines.models.reports import Report

--- a/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
@@ -174,9 +174,10 @@ class Step(ABC):
 
     @extra_params.setter
     def extra_params(self, value: STEP_PARAMS) -> None:
-        if not self.accept_extra_params:
+        if value and not self.accept_extra_params:
             raise ValueError(f"{self.__class__.__name__} does not accept extra params.")
         self._extra_params = value
+        self.logger.info(f"Will run with the following parameters: {self.params}")
 
     @property
     def default_params(self) -> STEP_PARAMS:

--- a/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
@@ -185,7 +185,7 @@ class Step(ABC):
 
     @property
     def params(self) -> STEP_PARAMS:
-        return self.extra_params | self.default_params
+        return self.default_params | self.extra_params
 
     @property
     def params_as_cli_options(self) -> List[str]:

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "3.1.3"
+version = "3.2.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_gradle.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_gradle.py
@@ -18,6 +18,7 @@ pytestmark = [
 class TestGradleTask:
     class DummyStep(gradle.GradleTask):
         gradle_task_name = "dummyTask"
+        title = "Dummy Step"
 
         async def _run(self) -> steps.StepResult:
             return steps.StepResult(self, steps.StepStatus.SUCCESS)
@@ -35,3 +36,21 @@ class TestGradleTask:
     async def test_build_include(self, test_context):
         step = self.DummyStep(test_context)
         assert step.build_include
+
+    def test_params(self, test_context):
+        step = self.DummyStep(test_context)
+        assert set(step.params_as_cli_options) == {
+            f"-Ds3BuildCachePrefix={test_context.connector.technical_name}",
+            "--build-cache",
+            "--scan",
+            "--console=plain",
+        }
+        step.extra_params = {"-x": ["dummyTask", "dummyTask2"], "--console": ["rich"]}
+        assert set(step.params_as_cli_options) == {
+            f"-Ds3BuildCachePrefix={test_context.connector.technical_name}",
+            "--build-cache",
+            "--scan",
+            "--console=rich",
+            "-x=dummyTask",
+            "-x=dummyTask2",
+        }

--- a/airbyte-ci/connectors/pipelines/tests/test_helpers/test_execution/test_argument_parsing.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_helpers/test_execution/test_argument_parsing.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+import enum
+import time
+
+import anyio
+import pytest
+from pipelines.helpers.execution import argument_parsing
+
+
+class SupportedStepIds(enum.Enum):
+    STEP1 = "step1"
+    STEP2 = "step2"
+    STEP3 = "step3"
+
+
+def test_build_extra_params_mapping(mocker):
+    ctx = mocker.Mock()
+    argument = mocker.Mock()
+
+    raw_extra_params = (
+        "--step1.param1=value1",
+        "--step2.param2=value2",
+        "--step3.param3=value3",
+        "--step1.param4",
+    )
+
+    result = argument_parsing.build_extra_params_mapping(SupportedStepIds)(ctx, argument, raw_extra_params)
+
+    expected_result = {
+        SupportedStepIds.STEP1.value: {"param1": ["value1"], "param4": []},
+        SupportedStepIds.STEP2.value: {"param2": ["value2"]},
+        SupportedStepIds.STEP3.value: {"param3": ["value3"]},
+    }
+
+    assert result == expected_result

--- a/airbyte-ci/connectors/pipelines/tests/test_helpers/test_execution/test_run_steps.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_helpers/test_execution/test_run_steps.py
@@ -346,3 +346,16 @@ async def test_run_steps_throws_on_invalid_args(invalid_args):
 
     with pytest.raises(TypeError):
         await run_steps(steps)
+
+
+@pytest.mark.anyio
+async def test_run_steps_with_params():
+    steps = [StepToRun(id="step1", step=TestStep(test_context))]
+    options = RunStepOptions(fail_fast=True, step_params={"step1": {"--param1": ["value1"]}})
+    TestStep.accept_extra_params = False
+    with pytest.raises(ValueError):
+        await run_steps(steps, options=options)
+    assert steps[0].step.params_as_cli_options == []
+    TestStep.accept_extra_params = True
+    await run_steps(steps, options=options)
+    assert steps[0].step.params_as_cli_options == ["--param1=value1"]

--- a/airbyte-ci/connectors/pipelines/tests/test_helpers/test_run_steps.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_helpers/test_run_steps.py
@@ -4,7 +4,7 @@ import time
 
 import anyio
 import pytest
-from pipelines.helpers.run_steps import InvalidStepConfiguration, RunStepOptions, StepToRun, run_steps
+from pipelines.helpers.execution.run_steps import InvalidStepConfiguration, RunStepOptions, StepToRun, run_steps
 from pipelines.models.contexts.pipeline_context import PipelineContext
 from pipelines.models.steps import Step, StepResult, StepStatus
 

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_common.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_common.py
@@ -241,6 +241,12 @@ class TestAcceptanceTests:
             fourth_date_result = await cat_container.stdout()
             assert fourth_date_result != third_date_result
 
+    async def test_params(self, dagger_client, mocker, test_context_ci, test_input_dir):
+        acceptance_test_step = self.get_patched_acceptance_test_step(dagger_client, mocker, test_context_ci, test_input_dir)
+        assert set(acceptance_test_step.params_as_cli_options) == {"-ra", "--disable-warnings", "--durations=3"}
+        acceptance_test_step.extra_params = {"--durations": ["5"], "--collect-only": []}
+        assert set(acceptance_test_step.params_as_cli_options) == {"-ra", "--disable-warnings", "--durations=5", "--collect-only"}
+
 
 class TestCheckBaseImageIsUsed:
     @pytest.fixture

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
@@ -97,3 +97,11 @@ class TestUnitTests:
             context_for_connector_with_poetry.connector.technical_name in pip_freeze_output
         ), "The connector should be installed in the test environment."
         assert "pytest" in pip_freeze_output, "The pytest package should be installed in the test environment."
+
+    def test_params(self, context_for_certified_connector_with_setup):
+        step = UnitTests(context_for_certified_connector_with_setup)
+        assert step.params_as_cli_options == [
+            "-s",
+            f"--cov={context_for_certified_connector_with_setup.connector.technical_name.replace('-', '_')}",
+            f"--cov-fail-under={step.MINIMUM_COVERAGE_FOR_CERTIFIED_CONNECTORS}",
+        ]


### PR DESCRIPTION
## What
Closes #24061

This PR is used to merge all the PR from the stack to create a new minor version of airbyte-ci in which users can pass extra parameters to connector test steps from the CLI
