### PR TITLE
pin pendulum dependency for poetry2setup

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
@@ -4353,4 +4353,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8c6fa8dc9750af9e32ac39bfb45a960721098d735bd81f5baf8134921127f16d"
+content-hash = "8740e04661a4f3926650d1e905870688781b697a13851ab923817b705b7812fc"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -30,6 +30,7 @@ sentry-sdk = "^1.28.1"
 semver = "^3.0.1"
 python-dateutil = "^2.8.2"
 humanize = "^4.7.0"
+pendulum = "<3.0.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Our auto-deploy failed because of pendulum issues in our code - this wasn't noticed because when deploying locally, the versions from poetry.lock are used. We have to pin the version of pendulum specifically because when we use `poetry2setup`, it will pull the latest applicable versions according to `pyproject.toml` - it doesn't actually use the poetry locked versions :(

This has already been deployed manually to ensure it fixed the issue. This is expected to auto-deploy a no-op change.