### PR TITLE
Use only required resources for sensor

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -140,7 +140,7 @@ RESOURCES = {
 }
 
 SENSORS = [
-    registry_updated_sensor(job=generate_registry_reports, resources_def=RESOURCES),
+    registry_updated_sensor(job=generate_registry_reports, resources_def=REGISTRY_RESOURCE_TREE),
     new_gcs_blobs_sensor(
         job=generate_oss_registry,
         resources_def=REGISTRY_ENTRY_RESOURCE_TREE,


### PR DESCRIPTION
The sensor is timing out - the current hypothesis is that the resource tree provided to the sensor is too large. Using only the required resource tree instead of all resources should help.

Fixes half of https://github.com/airbytehq/airbyte/issues/34024