### PR TITLE
[mitigation] pin airbyte ci version in master run

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -42,6 +42,9 @@ jobs:
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           tailscale_auth_key: ${{ secrets.TAILSCALE_AUTH_KEY }}
           subcommand: "format check all"
+          # Pin to a specific version of airbyte-ci to avoid transient failures
+          # Mentioned in issue https://github.com/airbytehq/airbyte/issues/34041
+          airbyte_ci_binary_url: https://connectors.airbyte.com/airbyte-ci/releases/ubuntu/2.14.1/airbyte-ci
 
       - name: Run airbyte-ci format check [PULL REQUEST]
         id: airbyte_ci_format_check_all_pr


### PR DESCRIPTION
Format is not running on master - it is failing and returning success. 

This is because the pinned mitigation version is not set as it is for workflow dispatch and pull request setups. 

The step fails on master at the moment, with [this error](https://airbytehq.sentry.io/issues/4831824596/events/02bee9de10c04151904b87c97a95d5ca/?alert_rule_id=14570850&alert_type=issue&environment=production&notification_uuid=bd9ff481-1986-4fb9-b096-fac00fb7183e&project=4505596642983936&referrer=next-event) that sounds about right (as we are trying to run dagger 0.9.x code on a 0.6.x runner)

The action returns success - not sure why. 

Note that this same error appears on PRs touching airbyte-ci since we install the latest airbyte-ci on the branch - issue for that [here](https://github.com/airbytehq/airbyte/issues/34076). 