### PR TITLE
Concurrent CDK: fix state message ordering for incremental syncs

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/adapters.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/adapters.py
@@ -377,10 +377,15 @@ class StreamPartitionGenerator(PartitionGenerator):
         self._cursor = cursor
 
     def generate(self) -> Iterable[Partition]:
-        for s in self._stream.stream_slices(sync_mode=self._sync_mode, cursor_field=self._cursor_field, stream_state=self._state):
-            yield StreamPartition(
+        pending_partitions = []
+        for i, s in enumerate(
+                self._stream.stream_slices(sync_mode=self._sync_mode, cursor_field=self._cursor_field, stream_state=self._state)):
+            partition = StreamPartition(
                 self._stream, copy.deepcopy(s), self.message_repository, self._sync_mode, self._cursor_field, self._state, self._cursor
             )
+            pending_partitions.append(partition)
+        self._cursor.set_pending_partitions(pending_partitions)
+        yield from pending_partitions
 
 
 @deprecated("This class is experimental. Use at your own risk.")

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py
@@ -4,7 +4,7 @@
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, Any, List, MutableMapping, Optional
+from typing import TYPE_CHECKING, Any, Iterable, List, MutableMapping, Optional
 
 if TYPE_CHECKING:
     from airbyte_cdk.sources.streams.concurrent.cursor import CursorField
@@ -49,9 +49,7 @@ class AbstractStreamStateConverter(ABC):
         {
             "state_type": ConcurrencyCompatibleStateType.date_range.value,
             "metadata": { … },
-            "slices": [
-                {starts: 0, end: 1617030403, finished_processing: true}]
-        }
+            "low_water_mark": 1617030403
         """
         ...
 
@@ -66,19 +64,9 @@ class AbstractStreamStateConverter(ABC):
         ...
 
     @abstractmethod
-    def increment(self, timestamp: Any) -> Any:
+    def decrement(self, item: Any) -> Any:
         """
-        Increment a timestamp by a single unit.
-        """
-        ...
-
-    @abstractmethod
-    def merge_intervals(self, intervals: List[MutableMapping[str, Any]]) -> List[MutableMapping[str, Any]]:
-        """
-        Compute and return a list of merged intervals.
-
-        Intervals may be merged if the start time of the second interval is 1 unit or less (as defined by the
-        `increment` method) than the end time of the first interval.
+        Decrement an item by a single unit.
         """
         ...
 
@@ -92,4 +80,25 @@ class AbstractStreamStateConverter(ABC):
     @property
     @abstractmethod
     def zero_value(self) -> Any:
+        ...
+
+    @abstractmethod
+    def is_greater_than(self, item1: Any, item2: Any) -> bool:
+        """
+        Return True if the first item is greater than the second item.
+        """
+        ...
+
+    @abstractmethod
+    def min(self, *items: Iterable[Any]) -> Any:
+        """
+        Performs a comparison of the items and returns the min.
+        """
+        ...
+
+    @abstractmethod
+    def max(self, *items: Iterable[Any]) -> Any:
+        """
+        Performs a comparison of the items and returns the max.
+        """
         ...


### PR DESCRIPTION
This modifies how we were handling state messages due to a concurrency-related issue.

Note: the CCDK is not used for incremental syncs in production, so this hasn't actually caused any sync-related issues yet.

### Problem
Previously we were tracking partitions on the state object as an internal version of the state; when a partition was complete, we would perform a merge operation to consolidate the list of partitions that we'd synced, and then convert it to the current state message format for the connector before emitting the state by taking the maximum value of the minimum partition synced as the "low water mark".

The issue was that partitions were being processed before all partitions had been generated. [This line](https://github.com/airbytehq/airbyte/blob/b2902083910b904ee60bf4583b2221e2c1783253/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/cursor.py#L113) in particular was causing us to continuously overwrite the list of partitions with an empty list. 

The effect of that was that the `merge_partitions` method did not ever have an accurate picture of what had previously been synced and so was emitting state messages from whatever partitions existed at the time, rather than the full set of partitions. These state messages were being emitted out-of-order with respect to each other, and also were inaccurately indicating that all prior records had been synced when that wasn't the case.

### Solution

The fix itself was to avoid letting any partitions be processed until all partitions have been generated for that stream. This will be a performance hit for connectors for which generating partitions involves I/O. There may be a workaround involving listing out the partitions that we're going to generate in a first step, telling the cursor what the partitions will be, and then actually fetching them, but I'm not sure that's possible in 100% of cases. A better but more complicated workaround would involve allowing partitions to be processed right away but only allowing them to be closed once they've all been generated. This could be controlled using a shared object that the threads can write to when they've started processing a partition.

As part of this PR I also cleaned up the state management. The `merge_partitions` algorithm was unnecessarily complicated and so I replaced it with an algorithm that's more efficient, in the implementation of `close_partition`. This also enables us to simplify the internal state format for concurrent + incremental.
Old:
```
slices: [
    {"start": 0, "end": 1},
    {"start": 1, "end": 2},
    ...
]
```
New:
```
"low_water_mark": 0
```