### PR TITLE
Azure Blob Storage: Fix unstructured format

### DIFF
--- a/airbyte-integrations/connectors/source-azure-blob-storage/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/acceptance-test-config.yml
@@ -86,6 +86,8 @@ acceptance_tests:
         status: succeed
       - config_path: secrets/jsonl_newlines_config.json
         status: succeed
+      - config_path: secrets/unstructured_config.json
+        status: succeed
   discovery:
     tests:
       - config_path: secrets/config.json

--- a/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: fdaaba68-4875-4ed9-8fcd-4ae1e0a25093
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.3.1
   dockerRepository: airbyte/source-azure-blob-storage
   documentationUrl: https://docs.airbyte.com/integrations/sources/azure-blob-storage
   githubIssueLabel: source-azure-blob-storage

--- a/airbyte-integrations/connectors/source-azure-blob-storage/source_azure_blob_storage/stream_reader.py
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/source_azure_blob_storage/stream_reader.py
@@ -59,7 +59,6 @@ class SourceAzureBlobStorageStreamReader(AbstractFileBasedStreamReader):
                 if not globs or self.file_matches_globs(remote_file, globs):
                     yield remote_file
 
-    @contextmanager
     def open_file(self, file: RemoteFile, mode: FileReadMode, encoding: Optional[str], logger: logging.Logger) -> IOBase:
         try:
             result = open(
@@ -73,8 +72,4 @@ class SourceAzureBlobStorageStreamReader(AbstractFileBasedStreamReader):
                 f"We don't have access to {file.uri}. The file appears to have become unreachable during sync."
                 f"Check whether key {file.uri} exists in `{self.config.azure_blob_storage_container_name}` container and/or has proper ACL permissions"
             )
-        # see https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager for why we do this
-        try:
-            yield result
-        finally:
-            result.close()
+        return result

--- a/docs/integrations/sources/azure-blob-storage.md
+++ b/docs/integrations/sources/azure-blob-storage.md
@@ -193,6 +193,7 @@ To perform the text extraction from PDF and Docx files, the connector uses the [
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------|
+| 0.3.1   | 2024-01-10 | [34084](https://github.com/airbytehq/airbyte/pull/34084)  | Fix bug for running check with document file format          |
 | 0.3.0   | 2023-12-14 | [33411](https://github.com/airbytehq/airbyte/pull/33411)  | Bump CDK version to auto-set primary key for document file streams and support raw txt files         |
 | 0.2.5   | 2023-12-06 | [33187](https://github.com/airbytehq/airbyte/pull/33187) | Bump CDK version to hide source-defined primary key                             |
 | 0.2.4   | 2023-11-16 | [32608](https://github.com/airbytehq/airbyte/pull/32608) | Improve document file type parser                                               |


### PR DESCRIPTION
When picking the unstructured format in the azure blob storage connector, the connection check fails.

This happens because the check logic tries to `close` the IO handle it got from `open_file`, but the logic of the azure blob storage stream reader doesn't implement it:
https://github.com/airbytehq/airbyte/blob/f5ac5cfd8022dd8769fd6f8a0b9adc43e57c880d/airbyte-cdk/python/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py#L68

This PR fixes the issue by removing the explicit context manager - this is sufficient as the return value from `smart_open.open` implements the necessary context manager interface, so it can be used in a `with` statement.

This problem wasn't discovered during testing, because it doesn't happen during actual reads, only during connection checks. To guard against this, this PR adds an acceptance test to run a "check" on unstructured data as well.