### PR TITLE
airbyte-ci: accept extra options on `connectors test` and pass these to test steps

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
@@ -19,8 +19,8 @@ from pipelines.airbyte_ci.connectors.reports import ConnectorReport
 from pipelines.consts import BUILD_PLATFORMS
 from pipelines.dagger.actions import secrets
 from pipelines.helpers.connectors.modifed import ConnectorWithModifiedFiles
+from pipelines.helpers.execution.run_steps import RunStepOptions
 from pipelines.helpers.github import update_commit_status_check
-from pipelines.helpers.run_steps import RunStepOptions
 from pipelines.helpers.slack import send_message_to_webhook
 from pipelines.helpers.utils import METADATA_FILE_NAME
 from pipelines.models.contexts.pipeline_context import PipelineContext

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/pipeline.py
@@ -3,6 +3,10 @@
 #
 """This module groups factory like functions to dispatch tests steps according to the connector under test language."""
 
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
 
 import anyio
 from connector_ops.utils import ConnectorLanguage  # type: ignore
@@ -12,7 +16,11 @@ from pipelines.airbyte_ci.connectors.reports import ConnectorReport
 from pipelines.airbyte_ci.connectors.test.steps import java_connectors, python_connectors
 from pipelines.airbyte_ci.connectors.test.steps.common import QaChecks, VersionFollowsSemverCheck, VersionIncrementCheck
 from pipelines.airbyte_ci.metadata.pipeline import MetadataValidation
-from pipelines.helpers.run_steps import STEP_TREE, StepToRun, run_steps
+from pipelines.helpers.execution.run_steps import StepToRun, run_steps
+
+if TYPE_CHECKING:
+
+    from pipelines.helpers.execution.run_steps import STEP_TREE
 
 LANGUAGE_MAPPING = {
     "get_test_steps": {
@@ -23,6 +31,11 @@ LANGUAGE_MAPPING = {
 }
 
 
+EXTRA_PARAMS_PATTERN = re.compile(r"^--([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_-][a-zA-Z0-9_-]*)=([^=]+)$")
+EXTRA_PARAMS_PATTERN_FOR_FLAG = re.compile(r"^--([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_-][a-zA-Z0-9_-]*)$")
+EXTRA_PARAMS_PATTERN_ERROR_MESSAGE = "The extra params must be structured as --<step_id>.<param_name>=<param_value>"
+
+
 def get_test_steps(context: ConnectorContext) -> STEP_TREE:
     """Get all the tests steps according to the connector language.
 
@@ -30,7 +43,7 @@ def get_test_steps(context: ConnectorContext) -> STEP_TREE:
         context (ConnectorContext): The current connector context.
 
     Returns:
-        List[StepResult]: The list of tests steps.
+        STEP_TREE: The list of tests steps.
     """
     if _get_test_steps := LANGUAGE_MAPPING["get_test_steps"].get(context.connector.language):
         return _get_test_steps(context)
@@ -43,11 +56,12 @@ async def run_connector_test_pipeline(context: ConnectorContext, semaphore: anyi
     """
     Compute the steps to run for a connector test pipeline.
     """
+    all_steps_to_run: STEP_TREE = []
 
-    steps_to_run = get_test_steps(context)
+    all_steps_to_run += get_test_steps(context)
 
     if not context.code_tests_only:
-        steps_to_run += [
+        static_analysis_steps_to_run = [
             [
                 StepToRun(id=CONNECTOR_TEST_STEP_ID.METADATA_VALIDATION, step=MetadataValidation(context)),
                 StepToRun(id=CONNECTOR_TEST_STEP_ID.VERSION_FOLLOW_CHECK, step=VersionFollowsSemverCheck(context)),
@@ -55,11 +69,12 @@ async def run_connector_test_pipeline(context: ConnectorContext, semaphore: anyi
                 StepToRun(id=CONNECTOR_TEST_STEP_ID.QA_CHECKS, step=QaChecks(context)),
             ]
         ]
+        all_steps_to_run += static_analysis_steps_to_run
 
     async with semaphore:
         async with context:
             result_dict = await run_steps(
-                runnables=steps_to_run,
+                runnables=all_steps_to_run,
                 options=context.run_step_options,
             )
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/java_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/java_connectors.py
@@ -21,14 +21,14 @@ from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests
 from pipelines.airbyte_ci.steps.gradle import GradleTask
 from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.dagger.actions.system import docker
-from pipelines.helpers.run_steps import StepToRun
+from pipelines.helpers.execution.run_steps import StepToRun
 from pipelines.helpers.utils import export_container_to_tarball
 from pipelines.models.steps import STEP_PARAMS, StepResult, StepStatus
 
 if TYPE_CHECKING:
     from typing import Callable, Dict, List, Optional
 
-    from pipelines.helpers.run_steps import RESULTS_DICT, STEP_TREE
+    from pipelines.helpers.execution.run_steps import RESULTS_DICT, STEP_TREE
 
 
 class IntegrationTests(GradleTask):

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
@@ -16,7 +16,7 @@ from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests, CheckBaseImageIsUsed
 from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.dagger.actions import secrets
-from pipelines.helpers.run_steps import STEP_TREE, StepToRun
+from pipelines.helpers.execution.run_steps import STEP_TREE, StepToRun
 from pipelines.models.steps import STEP_PARAMS, Step, StepResult
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -13,7 +13,7 @@ from pipelines.airbyte_ci.steps.poetry import PoetryRunStep
 from pipelines.consts import DOCS_DIRECTORY_ROOT_PATH, INTERNAL_TOOL_PATHS
 from pipelines.dagger.actions.python.common import with_pip_packages
 from pipelines.dagger.containers.python import with_python_base
-from pipelines.helpers.run_steps import STEP_TREE, StepToRun, run_steps
+from pipelines.helpers.execution.run_steps import STEP_TREE, StepToRun, run_steps
 from pipelines.helpers.utils import DAGGER_CONFIG, get_secret_host_variable
 from pipelines.models.reports import Report
 from pipelines.models.steps import MountPath, Step, StepResult

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
@@ -30,7 +30,7 @@ class GradleTask(Step, ABC):
     LOCAL_MAVEN_REPOSITORY_PATH = "/root/.m2"
     GRADLE_DEP_CACHE_PATH = "/root/gradle-cache"
     GRADLE_HOME_PATH = "/root/.gradle"
-    STATIC_GRADLE_TASK_OPTIONS = ("--no-daemon", "--no-watch-fs", "--scan", "--build-cache", "--console=plain")
+    STATIC_GRADLE_TASK_OPTIONS = ("--no-daemon", "--no-watch-fs")
     gradle_task_name: ClassVar[str]
     bind_to_docker_host: ClassVar[bool] = False
     mount_connector_secrets: ClassVar[bool] = False
@@ -40,6 +40,9 @@ class GradleTask(Step, ABC):
     def default_params(self) -> STEP_PARAMS:
         return super().default_params | {
             "-Ds3BuildCachePrefix": [self.context.connector.technical_name],  # Set the S3 build cache prefix.
+            "--build-cache": [],  # Enable the gradle build cache.
+            "--scan": [],  # Enable the gradle build scan.
+            "--console": ["plain"],  # Disable the gradle rich console.
         }
 
     @property

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/execution/argument_parsing.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/execution/argument_parsing.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import asyncclick as click
+
+if TYPE_CHECKING:
+    from enum import Enum
+    from typing import Callable, Dict, Tuple, Type
+
+    from pipelines.models.steps import STEP_PARAMS
+
+# Pattern  for extra param options: --<step_id>.<option_name>=<option_value>
+EXTRA_PARAM_PATTERN_FOR_OPTION = re.compile(r"^--([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_-][a-zA-Z0-9_-]*)=([^=]+)$")
+# Pattern  for extra param flag: --<step_id>.<option_name>
+EXTRA_PARAM_PATTERN_FOR_FLAG = re.compile(r"^--([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_-][a-zA-Z0-9_-]*)$")
+EXTRA_PARAM_PATTERN_ERROR_MESSAGE = "The extra flags must be structured as --<step_id>.<flag_name> for flags or --<step_id>.<option_name>=<option_value> for options. You can use - or -- for option/flag names."
+
+
+def build_extra_params_mapping(SupportedStepIds: Type[Enum]) -> Callable:
+    def callback(ctx: click.Context, argument: click.core.Argument, raw_extra_params: Tuple[str]) -> Dict[str, STEP_PARAMS]:
+        """Build a mapping of step id to extra params.
+        Validate the extra params and raise a ValueError if they are invalid.
+        Validation rules:
+        - The extra params must be structured as --<step_id>.<param_name>=<param_value> for options or --<step_id>.<param_name> for flags.
+        - The step id must be one of the existing step ids.
+
+
+        Args:
+            ctx (click.Context): The click context.
+            argument (click.core.Argument): The click argument.
+            raw_extra_params (Tuple[str]): The extra params provided by the user.
+        Raises:
+            ValueError: Raised if the extra params format is invalid.
+            ValueError: Raised if the step id in the extra params is not one of the unique steps to run.
+
+        Returns:
+            Dict[Literal, STEP_PARAMS]: The mapping of step id to extra params.
+        """
+        extra_params_mapping: Dict[str, STEP_PARAMS] = {}
+        for param in raw_extra_params:
+            is_flag = "=" not in param
+            pattern = EXTRA_PARAM_PATTERN_FOR_FLAG if is_flag else EXTRA_PARAM_PATTERN_FOR_OPTION
+            matches = pattern.match(param)
+            if not matches:
+                raise ValueError(f"Invalid parameter {param}. {EXTRA_PARAM_PATTERN_ERROR_MESSAGE}")
+            if is_flag:
+                step_name, param_name = matches.groups()
+                param_value = None
+            else:
+                step_name, param_name, param_value = matches.groups()
+            try:
+                step_id = SupportedStepIds(step_name).value
+            except ValueError:
+                raise ValueError(f"Invalid step name {step_name}, it must be one of {[step_id.value for step_id in SupportedStepIds]}")
+
+            extra_params_mapping.setdefault(step_id, {}).setdefault(param_name, [])
+            # param_value is None if the param is a flag
+            if param_value is not None:
+                extra_params_mapping[step_id][param_name].append(param_value)
+        return extra_params_mapping
+
+    return callback

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
@@ -18,9 +18,9 @@ from dagger import Client, Directory, File, GitRepository, Secret, Service
 from github import PullRequest
 from pipelines.airbyte_ci.connectors.reports import ConnectorReport
 from pipelines.consts import CIContext, ContextState
+from pipelines.helpers.execution.run_steps import RunStepOptions
 from pipelines.helpers.gcs import sanitize_gcs_credentials
 from pipelines.helpers.github import update_commit_status_check
-from pipelines.helpers.run_steps import RunStepOptions
 from pipelines.helpers.slack import send_message_to_webhook
 from pipelines.helpers.utils import AIRBYTE_REPO_URL
 from pipelines.models.reports import Report

--- a/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
@@ -174,9 +174,10 @@ class Step(ABC):
 
     @extra_params.setter
     def extra_params(self, value: STEP_PARAMS) -> None:
-        if not self.accept_extra_params:
+        if value and not self.accept_extra_params:
             raise ValueError(f"{self.__class__.__name__} does not accept extra params.")
         self._extra_params = value
+        self.logger.info(f"Will run with the following parameters: {self.params}")
 
     @property
     def default_params(self) -> STEP_PARAMS:

--- a/airbyte-ci/connectors/pipelines/tests/test_helpers/test_run_steps.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_helpers/test_run_steps.py
@@ -4,7 +4,7 @@ import time
 
 import anyio
 import pytest
-from pipelines.helpers.run_steps import InvalidStepConfiguration, RunStepOptions, StepToRun, run_steps
+from pipelines.helpers.execution.run_steps import InvalidStepConfiguration, RunStepOptions, StepToRun, run_steps
 from pipelines.models.contexts.pipeline_context import PipelineContext
 from pipelines.models.steps import Step, StepResult, StepStatus
 


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Relates to https://github.com/airbytehq/airbyte/issues/24061
In https://github.com/airbytehq/airbyte/pull/34049 I updated the `Step` class to receive extra parameters and use them.
In this PR  I'm updating the `connectors test` command to handle step specific extra parameters and pass them to the Step.

## How
1.  Add unprocessed arguments to the `test` comment to pass arbitrary options that we'll consider being extra parameters for steps
2. Parse and validate these extra parameters 
3. Pass them to the Steps.

E.G:
Passing a different option to python unit tests:
```
airbyte-ci --disable-dagger-run connectors --name=source-faker test --unit.--cov-fail-under=100
````

## Caveats / Limitation

* As some step id are mapped to different Step class we can't guarantee that an extra parameter will be correctly handled during step execution. Example: I run the  `test` command on a python and a java connectors with `--unit.cov-fail-under=100` option. The `cov-fail-under` option only exists in the python connector land (it's a pytest option) , so the gradle test for the java connector will likely fail as the command  with this specific option is invalid.

## TODO
Add unit tests in a different branch