### PR TITLE
Airbyte-ci: Ensure we set the working directory earlier

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -521,6 +521,7 @@ E.G.: running `pytest` on a specific test folder:
 
 | Version | PR                                                         | Description                                                                                                       |
 | ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 3.1.3   | [#34136](https://github.com/airbytehq/airbyte/pull/34136)  | Fix issue where dagger excludes were not being properly applied |
 | 3.1.2   | [#33972](https://github.com/airbytehq/airbyte/pull/33972)  | Remove secrets scrubbing hack for --is-local and other small tweaks. |
 | 3.1.1   | [#33979](https://github.com/airbytehq/airbyte/pull/33979)  | Fix AssertionError on report existence again |
 | 3.1.0   | [#33994](https://github.com/airbytehq/airbyte/pull/33994)  | Log more context information in CI. |

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/ensure_repo_root.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/ensure_repo_root.py
@@ -1,0 +1,57 @@
+import logging
+import os
+from pathlib import Path
+
+import git
+
+
+def _validate_airbyte_repo(repo: git.Repo) -> bool:
+    """Check if any of the remotes are the airbyte repo."""
+    expected_repo_name = "airbytehq/airbyte"
+    for remote in repo.remotes:
+        if expected_repo_name in remote.url:
+            return True
+
+    warning_message = f"""
+    ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+
+    It looks like you are not running this command from the airbyte repo ({expected_repo_name}).
+
+    If this command is run from outside the airbyte repo, it will not work properly.
+
+    Please run this command your local airbyte project.
+
+    ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+    """
+
+    logging.warning(warning_message)
+
+    return False
+
+
+def get_airbyte_repo() -> git.Repo:
+    """Get the airbyte repo."""
+    repo = git.Repo(search_parent_directories=True)
+    _validate_airbyte_repo(repo)
+    return repo
+
+
+def get_airbyte_repo_path_with_fallback() -> Path:
+    """Get the path to the airbyte repo."""
+    try:
+        repo_path = get_airbyte_repo().working_tree_dir
+        if repo_path is not None:
+            return Path(str(get_airbyte_repo().working_tree_dir))
+    except git.exc.InvalidGitRepositoryError:
+        pass
+    logging.warning("Could not find the airbyte repo, falling back to the current working directory.")
+    path = Path.cwd()
+    logging.warning(f"Using {path} as the airbyte repo path.")
+    return path
+
+
+def set_working_directory_to_root() -> None:
+    """Set the working directory to the root of the airbyte repo."""
+    working_dir = get_airbyte_repo_path_with_fallback()
+    logging.info(f"Setting working directory to {working_dir}")
+    os.chdir(working_dir)

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "3.1.2"
+version = "3.1.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## Problem
Globs we use for exclude were being evaluated before the working directory was set.

Leading to files that should be excluded appearing in dagger containers if the `airbyte-ci` commmand was not run from root

## Quick Solution
Hoist the function call higher

closes #34070 