### PR TITLE
DV2 TypingDedupingTest: read container stdout in real time

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
@@ -835,8 +835,7 @@ public abstract class BaseTypingDedupingTest {
           final Thread t = Executors.defaultThreadFactory().newThread(r);
           t.setDaemon(true);
           return t;
-        }
-    );
+        });
     messageHandler.submit(() -> {
       while (!destination.isFinished()) {
         // attemptRead isn't threadsafe, we read stdout fully here.

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
@@ -603,14 +603,12 @@ public abstract class BaseTypingDedupingTest {
     for (int i = 0; i < 100_000; i++) {
       pushMessages(messages2, sync2);
     }
-    // This will dump sync1's entire stdout to our stdout
     endSync(sync1);
     // Write some more messages to the second sync. It should not be affected by the first sync's
     // shutdown.
     for (int i = 0; i < 100_000; i++) {
       pushMessages(messages2, sync2);
     }
-    // And this will dump sync2's entire stdout to our stdout
     endSync(sync2);
 
     // For simplicity, don't verify the raw table. Assume that if the final table is correct, then

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
@@ -839,6 +839,8 @@ public abstract class BaseTypingDedupingTest {
     );
     messageHandler.submit(() -> {
       while (!destination.isFinished()) {
+        // attemptRead isn't threadsafe, we read stdout fully here.
+        // i.e. we shouldn't call attemptRead anywhere else.
         destination.attemptRead();
       }
     });


### PR DESCRIPTION
discovered accidentally - if a connector container logs too much to stdout, it eventually gets blocked because the buffer fills up. Dump stdout in a background thread instead.

I could be convinced to pass the executor service / future through to the `endSync` method? but that seemed overkill