### PR TITLE
Unpin Airbyte CDK version in connector templates

### DIFF
--- a/airbyte-integrations/connector-templates/source-python-http-api/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python-http-api/setup.py.hbs
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.2",
+    "airbyte-cdk",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connector-templates/source-python/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/setup.py.hbs
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.2",
+    "airbyte-cdk",
 ]
 
 TEST_REQUIREMENTS = [


### PR DESCRIPTION
This PR unpins the Airbyte Python CDK version that is used in the connectors made with `source-python` and `source-python-http-api` templates. As of right now, that installs `0.58.7`.