### PR TITLE
🐛 Source Google Ads: Disable raising error for not enabled accounts

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/cli/ensure_repo_root.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/ensure_repo_root.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
 import logging
 import os
 from pathlib import Path

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: 3.2.0
+  dockerImageTag: 3.2.1
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   githubIssueLabel: source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -236,7 +236,6 @@ class CustomerClient(GoogleAdsStream):
     Customer Client stream: https://developers.google.com/google-ads/api/fields/v15/customer_client
     """
 
-    CATCH_CUSTOMER_NOT_ENABLED_ERROR = False
     primary_key = ["customer_client.id"]
 
     def __init__(self, customer_status_filter: List[str], **kwargs):

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_errors.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_errors.py
@@ -34,15 +34,6 @@ params = [
         ["CUSTOMER_NOT_FOUND"],
         "Failed to access the customer '123'. Ensure the customer is linked to your manager account or check your permissions to access this customer account.",
     ),
-    (
-        ["CUSTOMER_NOT_ENABLED"],
-        (
-            "The customer account '123' hasn't finished signup or has been deactivated. "
-            "Sign in to the Google Ads UI to verify its status. "
-            "For reactivating deactivated accounts, refer to: "
-            "https://support.google.com/google-ads/answer/2375392."
-        ),
-    ),
     (["QUERY_ERROR"], "Incorrect custom query. Error in query: unexpected end of query."),
     (
         ["RESOURCE_EXHAUSTED"],

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -280,6 +280,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version  | Date       | Pull Request                                             | Subject                                                                                                                                                |
 |:---------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `3.2.1`  | 2024-01-12 | [34200](https://github.com/airbytehq/airbyte/pull/34200) | Disable raising error for not enabled accounts                                                                                                         |
 | `3.2.0`  | 2024-01-09 | [33707](https://github.com/airbytehq/airbyte/pull/33707) | Add possibility to sync all connected accounts                                                                                                         |
 | `3.1.0`  | 2024-01-09 | [33603](https://github.com/airbytehq/airbyte/pull/33603) | Fix two issues in the custom queries: automatic addition of `segments.date` in the query; incorrect field type for `DATE` fields.                      |
 | `3.0.2`  | 2024-01-08 | [33494](https://github.com/airbytehq/airbyte/pull/33494) | Add handling for 401 error while parsing response. Add `metrics.cost_micros` field to Ad Group stream.                                                 |


### PR DESCRIPTION
## What
Following the 3.2.0 update, users with access to non-enabled accounts began encountering failures due to an error. To resolve this issue, I have disabled the exception that was being raised for this specific error scenario. Resolves: https://github.com/airbytehq/oncall/issues/3943

