### PR TITLE
🐛 Destination Iceberg: do not restrict S3 regions

### DIFF
--- a/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: df65a8f3-9908-451b-aa9b-445462803560
-  dockerImageTag: 0.1.5
+  dockerImageTag: 0.1.6
   dockerRepository: airbyte/destination-iceberg
   githubIssueLabel: destination-iceberg
   license: MIT

--- a/airbyte-integrations/connectors/destination-iceberg/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-iceberg/src/main/resources/spec.json
@@ -212,8 +212,7 @@
                 "type": "string",
                 "default": "",
                 "description": "The region of the S3 bucket. See <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions\">here</a> for all region codes.",
-                "enum": [
-                  "",
+                "examples": [
                   "af-south-1",
                   "ap-east-1",
                   "ap-northeast-1",


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

One cannot use an object storage of another cloud provider than AWS because the S3 region configuration field is limited to AWS regions. In my case I would like to set `fr-par` as S3 region, which corresponds to Paris region at Scaleway.

It solves https://github.com/airbytehq/airbyte/issues/34216.

## How

Do not restrict S3 region in Iceberg destination connector, instead provide all AWS regions as examples

## 🚨 User Impact 🚨

No negative impact, just the ability to use non AWS cloud provider for object storage.

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
