### PR TITLE
fix precommit format to ignore new airbyte-ci versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: format-fix-all-on-push
         always_run: true
-        entry: airbyte-ci format fix all
+        entry: airbyte-ci --disable-update-check format fix all
         language: system
         name: Run airbyte-ci format fix on git push (~30s)
         pass_filenames: false


### PR DESCRIPTION
if there's a new version of airbyte-ci available, we fail the pre-push hook and force an update. For some reason, that doesn't even satisfy pre-push hooks on graphite. I really think it's an unnecessary check during hooks, and only adds friction