### PR TITLE
update CDK to 0.2.3 for all connectors that only have 0.2.0

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/build.gradle
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: b4c5d105-31fd-4817-96b6-cb923bfc04cb
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   dockerRepository: airbyte/destination-azure-blob-storage
   githubIssueLabel: destination-azure-blob-storage
   icon: azureblobstorage.svg

--- a/airbyte-integrations/connectors/destination-cassandra/build.gradle
+++ b/airbyte-integrations/connectors/destination-cassandra/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 707456df-6f4f-4ced-b5c6-03f73bcad1c5
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   dockerRepository: airbyte/destination-cassandra
   githubIssueLabel: destination-cassandra
   icon: cassandra.svg

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 0.2.5
+  dockerImageTag: 0.2.6
   dockerRepository: airbyte/destination-clickhouse-strict-encrypt
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 0.2.5
+  dockerImageTag: 0.2.6
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-csv/build.gradle
+++ b/airbyte-integrations/connectors/destination-csv/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-csv/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-csv/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 8be1cf83-fde1-477f-a4ad-318d23c9f3c6
-  dockerImageTag: 1.0.0
+  dockerImageTag: 1.0.1
   dockerRepository: airbyte/destination-csv
   githubIssueLabel: destination-csv
   icon: file-csv.svg

--- a/airbyte-integrations/connectors/destination-databricks/build.gradle
+++ b/airbyte-integrations/connectors/destination-databricks/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-databricks/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databricks/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 072d5540-f236-4294-ba7c-ade8fd918496
-  dockerImageTag: 1.1.1
+  dockerImageTag: 1.1.2
   dockerRepository: airbyte/destination-databricks
   githubIssueLabel: destination-databricks
   icon: databricks.svg

--- a/airbyte-integrations/connectors/destination-dev-null/build.gradle
+++ b/airbyte-integrations/connectors/destination-dev-null/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.3.1
   dockerRepository: airbyte/destination-dev-null
   githubIssueLabel: destination-dev-null
   icon: airbyte.svg

--- a/airbyte-integrations/connectors/destination-doris/build.gradle
+++ b/airbyte-integrations/connectors/destination-doris/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-doris/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-doris/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 05c161bf-ca73-4d48-b524-d392be417002
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/destination-doris
   githubIssueLabel: destination-doris
   icon: apachedoris.svg

--- a/airbyte-integrations/connectors/destination-dynamodb/build.gradle
+++ b/airbyte-integrations/connectors/destination-dynamodb/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 8ccd8909-4e99-4141-b48d-4984b70b2d89
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.9
   dockerRepository: airbyte/destination-dynamodb
   githubIssueLabel: destination-dynamodb
   icon: dynamodb.svg

--- a/airbyte-integrations/connectors/destination-e2e-test/build.gradle
+++ b/airbyte-integrations/connectors/destination-e2e-test/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: unknown
   connectorType: destination
   definitionId: 2eb65e87-983a-4fd7-b3e3-9d9dc6eb8537
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.3.1
   dockerRepository: airbyte/destination-e2e-test
   githubIssueLabel: destination-e2e-test
   icon: airbyte.svg

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: 68f351a7-2745-4bef-ad7f-996b8e51bb8c
-  dockerImageTag: 0.1.6
+  dockerImageTag: 0.1.7
   dockerRepository: airbyte/destination-elasticsearch-strict-encrypt
   githubIssueLabel: destination-elasticsearch
   icon: elasticsearch.svg

--- a/airbyte-integrations/connectors/destination-elasticsearch/build.gradle
+++ b/airbyte-integrations/connectors/destination-elasticsearch/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: 68f351a7-2745-4bef-ad7f-996b8e51bb8c
-  dockerImageTag: 0.1.6
+  dockerImageTag: 0.1.7
   dockerRepository: airbyte/destination-elasticsearch
   githubIssueLabel: destination-elasticsearch
   icon: elasticsearch.svg

--- a/airbyte-integrations/connectors/destination-exasol/build.gradle
+++ b/airbyte-integrations/connectors/destination-exasol/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-exasol/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-exasol/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: bb6071d9-6f34-4766-bec2-d1d4ed81a653
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   dockerRepository: airbyte/destination-exasol
   githubIssueLabel: destination-exasol
   license: MIT

--- a/airbyte-integrations/connectors/destination-gcs/build.gradle
+++ b/airbyte-integrations/connectors/destination-gcs/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: ca8f6566-e555-4b40-943a-545bf123117a
-  dockerImageTag: 0.4.4
+  dockerImageTag: 0.4.5
   dockerRepository: airbyte/destination-gcs
   githubIssueLabel: destination-gcs
   icon: googlecloudstorage.svg

--- a/airbyte-integrations/connectors/destination-iceberg/build.gradle
+++ b/airbyte-integrations/connectors/destination-iceberg/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: df65a8f3-9908-451b-aa9b-445462803560
-  dockerImageTag: 0.1.5
+  dockerImageTag: 0.1.6
   dockerRepository: airbyte/destination-iceberg
   githubIssueLabel: destination-iceberg
   license: MIT

--- a/airbyte-integrations/connectors/destination-kafka/build.gradle
+++ b/airbyte-integrations/connectors/destination-kafka/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kafka/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 9f760101-60ae-462f-9ee6-b7a9dafd454d
-  dockerImageTag: 0.1.10
+  dockerImageTag: 0.1.11
   dockerRepository: airbyte/destination-kafka
   githubIssueLabel: destination-kafka
   icon: kafka.svg

--- a/airbyte-integrations/connectors/destination-keen/build.gradle
+++ b/airbyte-integrations/connectors/destination-keen/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-keen/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-keen/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: 81740ce8-d764-4ea7-94df-16bb41de36ae
-  dockerImageTag: 0.2.4
+  dockerImageTag: 0.2.5
   dockerRepository: airbyte/destination-keen
   githubIssueLabel: destination-keen
   icon: chargify.svg

--- a/airbyte-integrations/connectors/destination-kinesis/build.gradle
+++ b/airbyte-integrations/connectors/destination-kinesis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-kinesis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kinesis/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: 6d1d66d4-26ab-4602-8d32-f85894b04955
-  dockerImageTag: 0.1.5
+  dockerImageTag: 0.1.6
   dockerRepository: airbyte/destination-kinesis
   githubIssueLabel: destination-kinesis
   icon: kinesis.svg

--- a/airbyte-integrations/connectors/destination-local-json/build.gradle
+++ b/airbyte-integrations/connectors/destination-local-json/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-local-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-local-json/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: a625d593-bba5-4a1c-a53d-2d246268a816
-  dockerImageTag: 0.2.11
+  dockerImageTag: 0.2.12
   dockerRepository: airbyte/destination-local-json
   githubIssueLabel: destination-local-json
   icon: file-json.svg

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/build.gradle
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 294a4790-429b-40ae-9516-49826b9702e1
-  dockerImageTag: 0.1.7
+  dockerImageTag: 0.1.8
   dockerRepository: airbyte/destination-mariadb-columnstore
   githubIssueLabel: destination-mariadb-columnstore
   icon: mariadb.svg

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 8b746512-8c2e-6ac1-4adc-b59faafd473c
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/destination-mongodb-strict-encrypt
   githubIssueLabel: destination-mongodb
   icon: mongodb.svg

--- a/airbyte-integrations/connectors/destination-mongodb/build.gradle
+++ b/airbyte-integrations/connectors/destination-mongodb/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 8b746512-8c2e-6ac1-4adc-b59faafd473c
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/destination-mongodb
   githubIssueLabel: destination-mongodb
   icon: mongodb.svg

--- a/airbyte-integrations/connectors/destination-mqtt/build.gradle
+++ b/airbyte-integrations/connectors/destination-mqtt/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-mqtt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mqtt/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: message_queue
   connectorType: destination
   definitionId: f3802bc4-5406-4752-9e8d-01e504ca8194
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.1.4
   dockerRepository: airbyte/destination-mqtt
   githubIssueLabel: destination-mqtt
   icon: mqtt.svg

--- a/airbyte-integrations/connectors/destination-mssql-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-mssql-strict-encrypt/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = [
             'db-sources', // required for tests
             'db-destinations',

--- a/airbyte-integrations/connectors/destination-mssql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql-strict-encrypt/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/destination-mssql-strict-encrypt
   githubIssueLabel: destination-mssql
   icon: mssql.svg

--- a/airbyte-integrations/connectors/destination-mssql/build.gradle
+++ b/airbyte-integrations/connectors/destination-mssql/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = [
             'db-sources', // required for tests
             'db-destinations',

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/destination-mssql
   githubIssueLabel: destination-mssql
   icon: mssql.svg

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 3986776d-2319-4de9-8af8-db14c0996e72
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/destination-oracle-strict-encrypt
   githubIssueLabel: destination-oracle
   icon: oracle.svg

--- a/airbyte-integrations/connectors/destination-oracle/build.gradle
+++ b/airbyte-integrations/connectors/destination-oracle/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 3986776d-2319-4de9-8af8-db14c0996e72
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/destination-oracle
   githubIssueLabel: destination-oracle
   icon: oracle.svg

--- a/airbyte-integrations/connectors/destination-pubsub/build.gradle
+++ b/airbyte-integrations/connectors/destination-pubsub/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-pubsub/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pubsub/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: 356668e2-7e34-47f3-a3b0-67a8a481b692
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/destination-pubsub
   githubIssueLabel: destination-pubsub
   icon: googlepubsub.svg

--- a/airbyte-integrations/connectors/destination-pulsar/build.gradle
+++ b/airbyte-integrations/connectors/destination-pulsar/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 2340cbba-358e-11ec-8d3d-0242ac130203
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.1.4
   dockerRepository: airbyte/destination-pulsar
   githubIssueLabel: destination-pulsar
   icon: pulsar.svg

--- a/airbyte-integrations/connectors/destination-r2/build.gradle
+++ b/airbyte-integrations/connectors/destination-r2/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-r2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-r2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 0fb07be9-7c3b-4336-850d-5efc006152ee
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/destination-r2
   githubIssueLabel: destination-r2
   icon: cloudflare-r2.svg

--- a/airbyte-integrations/connectors/destination-redis/build.gradle
+++ b/airbyte-integrations/connectors/destination-redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-redis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redis/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: d4d3fef9-e319-45c2-881a-bd02ce44cc9f
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   dockerRepository: airbyte/destination-redis
   githubIssueLabel: destination-redis
   icon: redis.svg

--- a/airbyte-integrations/connectors/destination-redpanda/build.gradle
+++ b/airbyte-integrations/connectors/destination-redpanda/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-redpanda/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redpanda/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 825c5ee3-ed9a-4dd1-a2b6-79ed722f7b13
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/destination-redpanda
   githubIssueLabel: destination-redpanda
   icon: redpanda.svg

--- a/airbyte-integrations/connectors/destination-rockset/build.gradle
+++ b/airbyte-integrations/connectors/destination-rockset/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-rockset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rockset/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 2c9d93a7-9a17-4789-9de9-f46f0097eb70
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   dockerRepository: airbyte/destination-rockset
   githubIssueLabel: destination-rockset
   license: MIT

--- a/airbyte-integrations/connectors/destination-s3-glue/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-glue/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 471e5cab-8ed1-49f3-ba11-79c687784737
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.9
   dockerRepository: airbyte/destination-s3-glue
   githubIssueLabel: destination-s3-glue
   icon: s3-glue.svg

--- a/airbyte-integrations/connectors/destination-scylla/build.gradle
+++ b/airbyte-integrations/connectors/destination-scylla/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-scylla/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-scylla/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 3dc6f384-cd6b-4be3-ad16-a41450899bf0
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.1.4
   dockerRepository: airbyte/destination-scylla
   githubIssueLabel: destination-scylla
   icon: scylla.svg

--- a/airbyte-integrations/connectors/destination-selectdb/build.gradle
+++ b/airbyte-integrations/connectors/destination-selectdb/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-selectdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-selectdb/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   connectorType: destination
   definitionId: 50a559a7-6323-4e33-8aa0-51dfd9dfadac
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   connectorSubtype: database
   dockerRepository: airbyte/destination-selectdb
   githubIssueLabel: destination-selectdb

--- a/airbyte-integrations/connectors/destination-starburst-galaxy/build.gradle
+++ b/airbyte-integrations/connectors/destination-starburst-galaxy/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorType: destination
   connectorSubtype: file
   definitionId: 4528e960-6f7b-4412-8555-7e0097e1da17
-  dockerImageTag: 0.0.1
+  dockerImageTag: 0.0.2
   dockerRepository: airbyte/destination-starburst-galaxy
   githubIssueLabel: destination-starburst-galaxy
   icon: starburst-galaxy.svg

--- a/airbyte-integrations/connectors/destination-teradata/build.gradle
+++ b/airbyte-integrations/connectors/destination-teradata/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-teradata/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 58e6f9da-904e-11ed-a1eb-0242ac120002
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.1.4
   dockerRepository: airbyte/destination-teradata
   githubIssueLabel: destination-teradata
   icon: teradata.svg

--- a/airbyte-integrations/connectors/destination-tidb/build.gradle
+++ b/airbyte-integrations/connectors/destination-tidb/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-tidb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-tidb/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 06ec60c7-7468-45c0-91ac-174f6e1a788b
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   dockerRepository: airbyte/destination-tidb
   githubIssueLabel: destination-tidb
   icon: tidb.svg

--- a/airbyte-integrations/connectors/destination-vertica/build.gradle
+++ b/airbyte-integrations/connectors/destination-vertica/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-vertica/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-vertica/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ca81ee7c-3163-9678-af40-094cc31e5e42
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/destination-vertica
   githubIssueLabel: destination-vertica
   icon: vertica.svg

--- a/airbyte-integrations/connectors/destination-yugabytedb/build.gradle
+++ b/airbyte-integrations/connectors/destination-yugabytedb/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-yugabytedb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yugabytedb/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 2300fdcf-a532-419f-9f24-a014336e7966
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   dockerRepository: airbyte/destination-yugabytedb
   githubIssueLabel: destination-yugabytedb
   icon: yugabytedb.svg

--- a/airbyte-integrations/connectors/source-elasticsearch/build.gradle
+++ b/airbyte-integrations/connectors/source-elasticsearch/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-sources']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 7cf88806-25f5-4e1a-b422-b2fa9e1b0090
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   dockerRepository: airbyte/source-elasticsearch
   githubIssueLabel: source-elasticsearch
   icon: elasticsearch.svg

--- a/airbyte-integrations/connectors/source-kafka/build.gradle
+++ b/airbyte-integrations/connectors/source-kafka/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-sources']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/source-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kafka/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: d917a47b-8537-4d0d-8c10-36a9928d4265
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   dockerRepository: airbyte/source-kafka
   githubIssueLabel: source-kafka
   icon: kafka.svg

--- a/airbyte-integrations/connectors/source-sftp/build.gradle
+++ b/airbyte-integrations/connectors/source-sftp/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.2.3'
     features = ['db-sources']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/source-sftp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: a827c52e-791c-4135-a245-e233c5255199
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   dockerRepository: airbyte/source-sftp
   documentationUrl: https://docs.airbyte.com/integrations/sources/sftp
   githubIssueLabel: source-sftp

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -143,6 +143,7 @@ They will be like this in the output file:
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 | :------ | :--------- | :--------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.2.2    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.2.1   | 2023-09-13 | [\#30412](https://github.com/airbytehq/airbyte/pull/30412) | Switch noisy logging to debug                                                                                                                                   |
 | 0.2.0   | 2023-01-18 | [\#21467](https://github.com/airbytehq/airbyte/pull/21467) | Support spilling of objects exceeding configured size threshold                                                                                                 |
 | 0.1.6   | 2022-08-08 | [\#15318](https://github.com/airbytehq/airbyte/pull/15318) | Support per-stream state                                                                                                                                        |

--- a/docs/integrations/destinations/cassandra.md
+++ b/docs/integrations/destinations/cassandra.md
@@ -50,4 +50,5 @@ data from the connector.
 
 | Version | Date       | Pull Request                                             | Subject                                |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------- |
+| 0.1.5    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.4   | 2022-08-23 | [15894](https://github.com/airbytehq/airbyte/pull/15894) | Replace batch insert with async method |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -79,6 +79,7 @@ Therefore, Airbyte ClickHouse destination will create tables and schemas using t
 
 | Version | Date       | Pull Request                                               | Subject                                                                                       |
 | :------ | :--------- | :--------------------------------------------------------- | :-------------------------------------------------------------------------------------------- |
+| 0.2.6    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.2.5   | 2023-06-21 | [\#27555](https://github.com/airbytehq/airbyte/pull/27555) | Reduce image size                                                                             |
 | 0.2.4   | 2023-06-05 | [\#27036](https://github.com/airbytehq/airbyte/pull/27036) | Internal code change for future development (install normalization packages inside connector) |
 | 0.2.3   | 2023-04-04 | [\#24604](https://github.com/airbytehq/airbyte/pull/24604) | Support for destination checkpointing                                                         |

--- a/docs/integrations/destinations/csv.md
+++ b/docs/integrations/destinations/csv.md
@@ -75,6 +75,7 @@ Note: If you are running Airbyte on Windows with Docker backed by WSL2, you have
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 1.0.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 1.0.0   | 2022-12-20 | [17998](https://github.com/airbytehq/airbyte/pull/17998) | Breaking changes: non backwards compatible. Adds delimiter dropdown.            |
 | 0.2.10  | 2022-06-20 | [13932](https://github.com/airbytehq/airbyte/pull/13932) | Merging published connector changes                                             |
 | 0.2.9   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add ExitOnOutOfMemoryError to java connectors and bump versions                 |

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -345,6 +345,7 @@ Delta Lake tables are created. You may want to consult the tutorial on
 
 | Version | Date       | Pull Request                                                                                                        | Subject                                                                                                                  |
 | :------ | :--------- | :------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------------------- |
+| 1.1.2    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 1.1.1   | 2024-01-03 | [#33924](https://github.com/airbytehq/airbyte/pull/33924)                                                           | (incompatible with CDK, do not use) Add new ap-southeast-3 AWS region                                                    |
 | 1.1.0   | 2023-06-02 | [\#26942](https://github.com/airbytehq/airbyte/pull/26942)                                                          | Support schema evolution                                                                                                 |
 | 1.0.2   | 2023-04-20 | [\#25366](https://github.com/airbytehq/airbyte/pull/25366)                                                          | Fix default catalog to be `hive_metastore`                                                                               |

--- a/docs/integrations/destinations/doris.md
+++ b/docs/integrations/destinations/doris.md
@@ -57,4 +57,5 @@ You need to prepare tables that will be used to store synced data from Airbyte, 
 
 | Version | Date       | Pull Request                                             | Subject        |
 | :------ | :--------- | :------------------------------------------------------- | :------------- |
+| 0.1.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.0   | 2022-11-14 | [17884](https://github.com/airbytehq/airbyte/pull/17884) | Initial Commit |

--- a/docs/integrations/destinations/dynamodb.md
+++ b/docs/integrations/destinations/dynamodb.md
@@ -76,6 +76,7 @@ provision more capacity units in the DynamoDB console when there are performance
 
 | Version | Date       | Pull Request                                               | Subject                                                     |
 | :------ | :--------- | :--------------------------------------------------------- | :---------------------------------------------------------- |
+| 0.1.9    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.8   | 2024-01-03 | [#33924](https://github.com/airbytehq/airbyte/pull/33924)  | Add new ap-southeast-3 AWS region                           |
 | 0.1.7   | 2022-11-03 | [\#18672](https://github.com/airbytehq/airbyte/pull/18672) | Added strict-encrypt cloud runner                           |
 | 0.1.6   | 2022-11-01 | [\#18672](https://github.com/airbytehq/airbyte/pull/18672) | Enforce to use ssl connection                               |

--- a/docs/integrations/destinations/e2e-test.md
+++ b/docs/integrations/destinations/e2e-test.md
@@ -46,6 +46,7 @@ The OSS and Cloud variants have the same version number starting from version `0
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------| :------------------------------------------------------- |:----------------------------------------------------------|
+| 0.3.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.3.0   | 2023-05-08 | [25776](https://github.com/airbytehq/airbyte/pull/25776) | Standardize spec and change property field to non-keyword |
 | 0.2.4   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors    |
 | 0.2.3   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option              |

--- a/docs/integrations/destinations/elasticsearch.md
+++ b/docs/integrations/destinations/elasticsearch.md
@@ -94,6 +94,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.7    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.6 | 2022-10-26 | [18341](https://github.com/airbytehq/airbyte/pull/18341) | enforce ssl connection on cloud |
 | 0.1.5 | 2022-10-24 | [18177](https://github.com/airbytehq/airbyte/pull/18177) | add custom CA certificate processing |
 | 0.1.4 | 2022-10-14 | [17805](https://github.com/airbytehq/airbyte/pull/17805) | add SSH Tunneling |
@@ -101,4 +102,3 @@ Using this feature requires additional configuration, when creating the source. 
 | 0.1.2 | 2022-04-19 | [11752](https://github.com/airbytehq/airbyte/pull/11752) | Reduce batch size to 32Mb |
 | 0.1.1 | 2022-02-10 | [10256](https://github.com/airbytehq/airbyte/pull/1256) | Add ExitOnOutOfMemoryError connectors |
 | 0.1.0 | 2021-10-13 | [7005](https://github.com/airbytehq/airbyte/pull/7005) | Initial release. |
-

--- a/docs/integrations/destinations/exasol.md
+++ b/docs/integrations/destinations/exasol.md
@@ -69,5 +69,6 @@ You should now have all the requirements needed to configure Exasol as a destina
 
 | Version | Date       | Pull Request                                             | Subject                                   |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------- |
+| 0.1.2    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.1   | 2023-02-21 | [xxx](https://github.com/airbytehq/airbyte/pull/xxx)     | Fix the build                             |
 | 0.1.0   | 2023-01-?? | [21200](https://github.com/airbytehq/airbyte/pull/21200) | Initial version of the Exasol destination |

--- a/docs/integrations/destinations/gcs.md
+++ b/docs/integrations/destinations/gcs.md
@@ -237,6 +237,7 @@ Under the hood, an Airbyte data stream in Json schema is first converted to an A
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                    |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
+| 0.4.5    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.4.4   | 2023-07-14 | [#28345](https://github.com/airbytehq/airbyte/pull/28345)  | Increment patch to trigger a rebuild                                                                                       |
 | 0.4.3   | 2023-07-05 | [#27936](https://github.com/airbytehq/airbyte/pull/27936)  | Internal code update                                                                                                       |
 | 0.4.2   | 2023-06-30 | [#27891](https://github.com/airbytehq/airbyte/pull/27891)  | Internal code update                                                                                                       |

--- a/docs/integrations/destinations/iceberg.md
+++ b/docs/integrations/destinations/iceberg.md
@@ -61,6 +61,7 @@ specify the target size of compacted Iceberg data file.
 
 | Version | Date       | Pull Request                                              | Subject                                                    |
 | :------ | :--------- | :-------------------------------------------------------- | :--------------------------------------------------------- |
+| 0.1.6    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.5   | 2024-01-03 | [#33924](https://github.com/airbytehq/airbyte/pull/33924) | Add new ap-southeast-3 AWS region                          |
 | 0.1.4   | 2023-07-20 | [28506](https://github.com/airbytehq/airbyte/pull/28506)  | Support server-managed storage config                      |
 | 0.1.3   | 2023-07-12 | [28158](https://github.com/airbytehq/airbyte/pull/28158)  | Bump Iceberg library to 1.3.0 and add REST catalog support |

--- a/docs/integrations/destinations/kafka.md
+++ b/docs/integrations/destinations/kafka.md
@@ -102,6 +102,7 @@ _NOTE_: Some configurations for SSL are not available yet.
 
 | Version | Date       | Pull Request                                             | Subject                                                                       |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------- |
+| 0.1.11   | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.10  | 2022-08-04 | [15287](https://github.com/airbytehq/airbyte/pull/15287) | Update Kafka destination to use outputRecordCollector to properly store state |
 | 0.1.9   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors                        |
 | 0.1.7   | 2022-04-19 | [12134](https://github.com/airbytehq/airbyte/pull/12134) | Add PLAIN Auth                                                                |

--- a/docs/integrations/destinations/keen.md
+++ b/docs/integrations/destinations/keen.md
@@ -82,6 +82,7 @@ If you have any questions, please reach out to us at team@keen.io and we’ll be
 
 | Version | Date       | Pull Request                                             | Subject                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------- |
+| 0.2.5    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.2.4   | 2022-08-04 | [15291](https://github.com/airbytehq/airbyte/pull/15291) | Update Keen destination to use outputRecordCollector to properly store state |
 | 0.2.3   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors                       |
 | 0.2.1   | 2021-12-30 | [8809](https://github.com/airbytehq/airbyte/pull/8809)   | Update connector fields title/description                                    |

--- a/docs/integrations/destinations/kinesis.md
+++ b/docs/integrations/destinations/kinesis.md
@@ -48,4 +48,5 @@ The connector buffer size should also be tweaked according to your data size and
 
 | Version | Date       | Pull Request                                             | Subject                    |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------- |
+| 0.1.6    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.5   | 2022-09-22 | [16952](https://github.com/airbytehq/airbyte/pull/16952) | Add required config fields |

--- a/docs/integrations/destinations/local-json.md
+++ b/docs/integrations/destinations/local-json.md
@@ -75,4 +75,5 @@ Note: If you are running Airbyte on Windows with Docker backed by WSL2, you have
 
 | Version | Date       | Pull Request                                             | Subject                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------- |
+| 0.2.12   | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.2.11  | 2022-02-14 | [14641](https://github.com/airbytehq/airbyte/pull/14641) | Include lifecycle management |

--- a/docs/integrations/destinations/mariadb-columnstore.md
+++ b/docs/integrations/destinations/mariadb-columnstore.md
@@ -76,6 +76,7 @@ Using this feature requires additional configuration, when creating the destinat
 
 | Version | Date       | Pull Request                                             | Subject                                      |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------|
+| 0.1.8    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.7 | 2022-09-07 | [16391](https://github.com/airbytehq/airbyte/pull/16391) | Add custom JDBC parameters field |
 | 0.1.6 | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors |
 | 0.1.5   | 2022-05-17 | [12820](https://github.com/airbytehq/airbyte/pull/12820) | Improved 'check' operation performance |
@@ -84,4 +85,3 @@ Using this feature requires additional configuration, when creating the destinat
 | 0.1.2   | 2021-12-30 | [\#8809](https://github.com/airbytehq/airbyte/pull/8809) | Update connector fields title/description    |
 | 0.1.1   | 2021-12-01 | [\#8371](https://github.com/airbytehq/airbyte/pull/8371) | Fixed incorrect handling "\n" in ssh key.    |
 | 0.1.0   | 2021-11-15 | [\#7961](https://github.com/airbytehq/airbyte/pull/7961) | Added MariaDB ColumnStore destination.       |
-

--- a/docs/integrations/destinations/mongodb.md
+++ b/docs/integrations/destinations/mongodb.md
@@ -117,6 +117,7 @@ Collection names should begin with an underscore or a letter character, and cann
 
 | Version | Date       | Pull Request                                             | Subject                                                    |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------- |
+| 0.2.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.2.0   | 2023-06-27 | [27781](https://github.com/airbytehq/airbyte/pull/27781) | License Update: Elv2                                       |
 | 0.1.9   | 2022-11-08 | [18892](https://github.com/airbytehq/airbyte/pull/18892) | Adds check for TLS flag                                    |
 | 0.1.8   | 2022-10-26 | [18280](https://github.com/airbytehq/airbyte/pull/18280) | Adds SSH tunneling                                         |

--- a/docs/integrations/destinations/mqtt.md
+++ b/docs/integrations/destinations/mqtt.md
@@ -85,6 +85,7 @@ _NOTE_: MQTT version 5 is not supported yet.
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
+| 0.1.4    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.3   | 2022-09-02 | [16263](https://github.com/airbytehq/airbyte/pull/16263) | Marked password field in spec as airbyte_secret |
 | 0.1.2   | 2022-07-12 | [14648](https://github.com/airbytehq/airbyte/pull/14648) | Include lifecycle management                    |
 | 0.1.1   | 2022-05-24 | [13099](https://github.com/airbytehq/airbyte/pull/13099) | Fixed build's tests                             |

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -116,6 +116,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date       | Pull Request                                               | Subject                                                                                             |
 | :------ | :--------- | :--------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
+| 0.2.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.2.0   | 2023-06-27 | [\#27781](https://github.com/airbytehq/airbyte/pull/27781) | License Update: Elv2                                                                                |
 | 0.1.25  | 2023-06-21 | [\#27555](https://github.com/airbytehq/airbyte/pull/27555) | Reduce image size                                                                                   |
 | 0.1.24  | 2023-06-05 | [\#27034](https://github.com/airbytehq/airbyte/pull/27034) | Internal code change for future development (install normalization packages inside connector)       |

--- a/docs/integrations/destinations/oracle.md
+++ b/docs/integrations/destinations/oracle.md
@@ -92,6 +92,7 @@ Airbyte has the ability to connect to the Oracle source with 3 network connectiv
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                             |
 | :---------- | :--------- | :--------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
+| 0.2.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.2.0       | 2023-06-27 | [\#27781](https://github.com/airbytehq/airbyte/pull/27781) | License Update: Elv2                                                                                |
 | 0.1.19      | 2022-07-26 | [\#10719](https://github.com/airbytehq/airbyte/pull/)      | Destination Oracle: added custom JDBC parameters support.                                           |
 | 0.1.18      | 2022-07-14 | [\#14618](https://github.com/airbytehq/airbyte/pull/14618) | Removed additionalProperties: false from JDBC destination connectors                                |

--- a/docs/integrations/destinations/pubsub.md
+++ b/docs/integrations/destinations/pubsub.md
@@ -93,6 +93,7 @@ Once you've configured PubSub as a destination, delete the Service Account Key f
 
 | Version | Date              | Pull Request                                             | Subject                                                    |
 | :------ | :---------------- | :------------------------------------------------------- | :--------------------------------------------------------- |
+| 0.2.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.2.0   | August 16, 2022   | [15705](https://github.com/airbytehq/airbyte/pull/15705) | Add configuration for Batching and Ordering                |
 | 0.1.5   | 2022-06-17        | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors     |
 | 0.1.4   | February 21, 2022 | [\#9819](https://github.com/airbytehq/airbyte/pull/9819) | Upgrade version of google-cloud-pubsub                     |

--- a/docs/integrations/destinations/pulsar.md
+++ b/docs/integrations/destinations/pulsar.md
@@ -94,4 +94,5 @@ More info about this can be found in the [Pulsar producer configs documentation 
 
 | Version | Date       | Pull Request                                             | Subject                                                                        |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| 0.1.4    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.3   | 2022-08-05 | [15349](https://github.com/airbytehq/airbyte/pull/15349) | Update Pulsar destination to use outputRecordCollector to properly store state |

--- a/docs/integrations/destinations/r2.md
+++ b/docs/integrations/destinations/r2.md
@@ -284,4 +284,5 @@ Under the hood, an Airbyte data stream in JSON schema is first converted to an A
 
 | Version | Date       | Pull Request                                               | Subject          |
 | :------ | :--------- | :--------------------------------------------------------- | :--------------- |
+| 0.1.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.0   | 2022-09-25 | [\#15296](https://github.com/airbytehq/airbyte/pull/15296) | Initial release. |

--- a/docs/integrations/destinations/redis.md
+++ b/docs/integrations/destinations/redis.md
@@ -59,5 +59,6 @@ save snapshots periodically on disk.
 
 | Version | Date       | Pull Request                                               | Subject         |
 | :------ | :--------- | :--------------------------------------------------------- | :-------------- |
+| 0.1.5    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.4   | 2022-10-25 | [\#18358](https://github.com/airbytehq/airbyte/pull/18358) | TLS support     |
 | 0.1.3   | 2022-10-18 | [\#17951](https://github.com/airbytehq/airbyte/pull/17951) | Add SSH support |

--- a/docs/integrations/destinations/redpanda.md
+++ b/docs/integrations/destinations/redpanda.md
@@ -62,4 +62,5 @@ _NOTE_: Configurations for SSL are not available yet.
 
 | Version | Date       | Pull Request                                             | Subject        |
 | :------ | :--------- | :------------------------------------------------------- | :------------- |
+| 0.1.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.0   | 2022-08-05 | [18884](https://github.com/airbytehq/airbyte/pull/18884) | Initial commit |

--- a/docs/integrations/destinations/rockset.md
+++ b/docs/integrations/destinations/rockset.md
@@ -33,6 +33,7 @@
 
 | Version | Date       | Pull Request                                             | Subject                                                |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------- |
+| 0.1.5    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.4   | 2022-06-17 | [15395](https://github.com/airbytehq/airbyte/pull/15395) | Updated Destination Rockset to handle per-stream state |
 | 0.1.3   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors |
 | 0.1.2   | 2022-05-17 | [12820](https://github.com/airbytehq/airbyte/pull/12820) | Improved 'check' operation performance                 |

--- a/docs/integrations/destinations/s3-glue.md
+++ b/docs/integrations/destinations/s3-glue.md
@@ -300,6 +300,7 @@ the output filename will have an extra extension (GZIP: `.jsonl.gz`).
 
 | Version | Date       | Pull Request                                              | Subject                                                                                 |
 | :------ | :--------- | :-------------------------------------------------------- | :-------------------------------------------------------------------------------------- |
+| 0.1.9    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.8   | 2024-01-03 | [#33924](https://github.com/airbytehq/airbyte/pull/33924) | Add new ap-southeast-3 AWS region                                                       |
 | 0.1.7   | 2023-05-01 | [25724](https://github.com/airbytehq/airbyte/pull/25724)  | Fix decimal type creation syntax to avoid overflow                                      |
 | 0.1.6   | 2023-04-13 | [25178](https://github.com/airbytehq/airbyte/pull/25178)  | Fix decimal precision and scale to allow for a wider range of numeric values            |

--- a/docs/integrations/destinations/scylla.md
+++ b/docs/integrations/destinations/scylla.md
@@ -51,4 +51,5 @@ and handle any amount of data from the connector.
 
 | Version | Date       | Pull Request                                              | Subject                   |
 | :------ | :--------- | :-------------------------------------------------------- | :------------------------ |
+| 0.1.4    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.3   | 2022-08-10 | [153999](https://github.com/airbytehq/airbyte/pull/15399) | handling per-stream state |

--- a/docs/integrations/destinations/selectdb.md
+++ b/docs/integrations/destinations/selectdb.md
@@ -57,4 +57,5 @@ You need to prepare database that will be used to store synced data from Airbyte
 
 | Version | Date       | Pull Request                                               | Subject                              |
 | :------ | :--------- | :--------------------------------------------------------- | :----------------------------------- |
+| 0.1.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.0   | 2023-04-03 | [\#20881](https://github.com/airbytehq/airbyte/pull/20881) | Initial release SelectDB Destination |

--- a/docs/integrations/destinations/starburst-galaxy.md
+++ b/docs/integrations/destinations/starburst-galaxy.md
@@ -98,4 +98,5 @@ Learn more about [Starburst Galaxy Iceberg type mapping](https://docs.starburst.
 
 | Version | Date       | Pull Request                                               | Subject                 |
 | :------ | :--------- | :--------------------------------------------------------- | :---------------------- |
+| 0.0.2    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.0.1   | 2023-03-28 | [\#24620](https://github.com/airbytehq/airbyte/pull/24620) | Initial public release. |

--- a/docs/integrations/destinations/teradata.md
+++ b/docs/integrations/destinations/teradata.md
@@ -86,6 +86,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                    | Subject                          |
 | :------ | :--------- | :---------------------------------------------- | :------------------------------- |
+| 0.1.4    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.3   | 2023-08-17 | https://github.com/airbytehq/airbyte/pull/30740 | Enable custom DBT transformation |
 | 0.1.2   | 2023-08-09 | https://github.com/airbytehq/airbyte/pull/29174 | Small internal refactor          |
 | 0.1.1   | 2023-03-03 | https://github.com/airbytehq/airbyte/pull/21760 | Added SSL support                |

--- a/docs/integrations/destinations/tidb.md
+++ b/docs/integrations/destinations/tidb.md
@@ -99,6 +99,7 @@ Using this feature requires additional configuration, when creating the destinat
 
 | Version | Date       | Pull Request                                               | Subject                                                                                       |
 | :------ | :--------- | :--------------------------------------------------------- | :-------------------------------------------------------------------------------------------- |
+| 0.1.5    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.4   | 2023-06-21 | [\#27555](https://github.com/airbytehq/airbyte/pull/27555) | Reduce image size                                                                             |
 | 0.1.3   | 2023-06-05 | [\#27025](https://github.com/airbytehq/airbyte/pull/27025) | Internal code change for future development (install normalization packages inside connector) |
 | 0.1.2   | 2023-05-23 | [\#19109](https://github.com/airbytehq/airbyte/pull/19109) | Enabled Append Dedub mode                                                                     |

--- a/docs/integrations/destinations/vertica.md
+++ b/docs/integrations/destinations/vertica.md
@@ -160,4 +160,5 @@ Each stream will be mapped to a separate table in Vertica. Each table will conta
 
 | Version | Date       | Pull Request                                               | Subject                 |
 | :------ | :--------- | :--------------------------------------------------------- | :---------------------- |
+| 0.1.1    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.0   | 2023-05-29 | [\#25682](https://github.com/airbytehq/airbyte/pull/25682) | Add Vertica Destination |

--- a/docs/integrations/destinations/yugabytedb.md
+++ b/docs/integrations/destinations/yugabytedb.md
@@ -56,5 +56,6 @@ For each major cloud provider we support, also add a follow-along guide for sett
 
 | Version | Date       | Pull Request                                                  | Subject                 |
 |:--------|:-----------|:--------------------------------------------------------------|:------------------------|
+| 0.1.2    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.1   | 2023-03-17 | [#24180](https://github.com/airbytehq/airbyte/pull/24180)     | Fix field order |
 | 0.1.0   | 2022-10-28 | [#18039](https://github.com/airbytehq/airbyte/pull/18039)     | New Destination YugabyteDB |

--- a/docs/integrations/sources/elasticsearch.md
+++ b/docs/integrations/sources/elasticsearch.md
@@ -84,5 +84,6 @@ all values in the array must be of the same data type. Hence, every field can be
 
 | Version | Date       | Pull Request                                             | Subject         |
 | :------ | :--------- | :------------------------------------------------------- | :-------------- |
+| 0.1.2    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | `0.1.1` | 2022-12-02 | [18118](https://github.com/airbytehq/airbyte/pull/18118) | Avoid too_long_frame_exception |
 | `0.1.0` | 2022-07-12 | [14118](https://github.com/airbytehq/airbyte/pull/14118) | Initial Release |

--- a/docs/integrations/sources/kafka.md
+++ b/docs/integrations/sources/kafka.md
@@ -50,6 +50,7 @@ The Kafka source connector supports the following [sync modes](https://docs.airb
 
 | Version | Date       | Pull Request                                           | Subject                                   |
 | :------ | :--------  | :------------------------------------------------------| :---------------------------------------- |
+| 0.2.4    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.2.3 | 2022-12-06 | [19587](https://github.com/airbytehq/airbyte/pull/19587) | Fix missing data before consumer is closed |
 | 0.2.2 | 2022-11-04 | [18648](https://github.com/airbytehq/airbyte/pull/18648) | Add missing record_count increment for JSON|
 | 0.2.1 | 2022-11-04 | This version was the same as 0.2.0 and was committed so using 0.2.2 next to keep versions in order|

--- a/docs/integrations/sources/sftp.md
+++ b/docs/integrations/sources/sftp.md
@@ -108,5 +108,6 @@ More formats \(e.g. Apache Avro\) will be supported in the future.
 
 | Version | Date       | Pull Request                                             | Subject                                                |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------- |
+| 0.1.3    | 2024-01-17 | [34235](https://github.com/airbytehq/airbyte/pull/34235) | bump CDK to 0.2.3 |
 | 0.1.2   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors |
 | 0.1.0   | 2021-24-05 |                                                          | Initial version                                        |


### PR DESCRIPTION
all connectors that are currently pointing to java CDK 0.2.0 also use CDK 0.2.0 instead of 0.4.0, which really makes it hard to debug in intelliJ. While we need a longer term fix to avoid different connectors messing with intelliJ debugging, this is a good-enough short-term workaround