### PR TITLE
add run method in run.py

### DIFF
--- a/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/run.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/run.py.hbs
@@ -8,6 +8,6 @@ import sys
 from airbyte_cdk.entrypoint import launch
 from .source import Source{{properCase name}}
 
-if __name__ == "__main__":
+def run():
     source = Source{{properCase name}}()
     launch(source, sys.argv[1:])


### PR DESCRIPTION
## what
 run.py
* add `run()` inside run.py
-> `airbyte-integrations/connector-templates/source-python/main.py.hbs`
```python
#
# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
#

from source_{{snakeCase name}}.run import run

if __name__ == "__main__":
    run()
```
NB: but `source_{{snakeCase name}}.run` has no run method

## How
* python3 main.py spec -> Now there have import issue. so this PR will solve this issue


