### PR TITLE
Unify lowcode tags

### DIFF
--- a/airbyte-integrations/connector-templates/source-configuration-based/metadata.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-configuration-based/metadata.yaml.hbs
@@ -26,5 +26,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/{{dashCase name}}
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-apify-dataset/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apify-dataset/metadata.yaml
@@ -29,5 +29,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/apify-dataset
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-appfollow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appfollow/metadata.yaml
@@ -20,7 +20,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/appfollow
   tags:
-    - language:lowcode
+    - language:low-code
   releases:
     breakingChanges:
       1.0.0:

--- a/airbyte-integrations/connectors/source-auth0/metadata.yaml
+++ b/airbyte-integrations/connectors/source-auth0/metadata.yaml
@@ -26,5 +26,5 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-babelforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-babelforce/metadata.yaml
@@ -20,7 +20,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/babelforce
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-chargify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargify/metadata.yaml
@@ -21,7 +21,7 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/chargify
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-clockify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clockify/metadata.yaml
@@ -21,7 +21,7 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/clockify
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-commercetools/metadata.yaml
+++ b/airbyte-integrations/connectors/source-commercetools/metadata.yaml
@@ -20,7 +20,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/commercetools
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-copper/metadata.yaml
+++ b/airbyte-integrations/connectors/source-copper/metadata.yaml
@@ -20,5 +20,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/copper
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/source-customer-io/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/customer-io
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dixa/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dixa/metadata.yaml
@@ -21,7 +21,7 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/dixa
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-dockerhub/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dockerhub/metadata.yaml
@@ -21,7 +21,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/dockerhub
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-drift/metadata.yaml
+++ b/airbyte-integrations/connectors/source-drift/metadata.yaml
@@ -21,7 +21,7 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/drift
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
@@ -22,5 +22,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/exchange-rates
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-fastbill/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fastbill/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/fastbill
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
@@ -17,7 +17,7 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshcaller
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-freshservice/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshservice/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshservice
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-glassfrog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-glassfrog/metadata.yaml
@@ -20,7 +20,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/glassfrog
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-harness/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harness/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/harness
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-hubplanner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubplanner/metadata.yaml
@@ -21,7 +21,7 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubplanner
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-insightly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-insightly/metadata.yaml
@@ -20,7 +20,7 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/insightly
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-lemlist/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lemlist/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/lemlist
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-nasa/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nasa/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/nasa
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-onesignal/metadata.yaml
+++ b/airbyte-integrations/connectors/source-onesignal/metadata.yaml
@@ -20,6 +20,6 @@ data:
   releaseDate: 2023-08-31
   releaseStage: alpha
   tags:
-    - language:lowcode
+    - language:low-code
   supportLevel: community
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/open-exchange-rates
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -20,5 +20,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/openweather
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-opsgenie/metadata.yaml
+++ b/airbyte-integrations/connectors/source-opsgenie/metadata.yaml
@@ -15,7 +15,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/opsgenie
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-orbit/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orbit/metadata.yaml
@@ -21,7 +21,7 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/orbit
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-pagerduty/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pagerduty/metadata.yaml
@@ -21,7 +21,7 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/pagerduty
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-persistiq/metadata.yaml
+++ b/airbyte-integrations/connectors/source-persistiq/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/persistiq
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
@@ -29,5 +29,5 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/pokeapi
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-public-apis/metadata.yaml
+++ b/airbyte-integrations/connectors/source-public-apis/metadata.yaml
@@ -23,5 +23,5 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-qonto/metadata.yaml
+++ b/airbyte-integrations/connectors/source-qonto/metadata.yaml
@@ -13,5 +13,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/qonto
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-qualaroo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-qualaroo/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/qualaroo
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-serpstat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-serpstat/metadata.yaml
@@ -18,5 +18,5 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/serpstat
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-shortio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shortio/metadata.yaml
@@ -23,7 +23,7 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/sources/shortio
   tags:
     - language:python
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-todoist/metadata.yaml
+++ b/airbyte-integrations/connectors/source-todoist/metadata.yaml
@@ -26,5 +26,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/todoist
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-visma-economic/metadata.yaml
+++ b/airbyte-integrations/connectors/source-visma-economic/metadata.yaml
@@ -21,5 +21,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/visma-economic
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-wrike/metadata.yaml
+++ b/airbyte-integrations/connectors/source-wrike/metadata.yaml
@@ -23,5 +23,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/wrike
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-younium/metadata.yaml
+++ b/airbyte-integrations/connectors/source-younium/metadata.yaml
@@ -23,5 +23,5 @@ data:
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/younium
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
@@ -19,7 +19,7 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-sell
   tags:
-    - language:lowcode
+    - language:low-code
   ab_internal:
     sl: 100
     ql: 100

--- a/airbyte-integrations/connectors/source-zenefits/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenefits/metadata.yaml
@@ -24,5 +24,5 @@ data:
     ql: 100
   supportLevel: community
   tags:
-    - language:lowcode
+    - language:low-code
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
We have `language:lowcode` and `language:low-code` tags - let's unify that.

As `low-code` was used more commonly I went for that.