### PR TITLE
airbyte-ci: fix nightly build workflow

### DIFF
--- a/.github/workflows/connectors_nightly_build.yml
+++ b/.github/workflows/connectors_nightly_build.yml
@@ -37,6 +37,7 @@ jobs:
   test_connectors:
     name: "Test connectors: ${{ inputs.test-connectors-options || 'nightly build for Certified connectors' }}"
     timeout-minutes: 720 # 12 hours
+    needs: get_ci_runner
     runs-on: ${{ needs.get_ci_runner.outputs.runner_name }}
     steps:
       - name: Checkout Airbyte


### PR DESCRIPTION

## What
The forgotten `needs` field on the main job declare in the nightly build workflow made it impossible to schedule as the runs-on field depends on the output of the needed job.
