### PR TITLE
airbyte-ci: target airbyte forks / clone

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -138,20 +138,21 @@ At this point you can run `airbyte-ci` commands.
 
 #### Options
 
-| Option                                         | Default value                   | Mapped environment variable   | Description                                                                                 |
-| ---------------------------------------------- | ------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
-| `--yes/--y`                                    | False                           |                               | Agrees to all prompts.                                                                      |
-| `--yes-auto-update`                            | False                           |                               | Agrees to the auto update prompts.                                                          |
-| `--enable-update-check/--disable-update-check` | True                            |                               | Turns on the update check feature                                                           |
-| `--enable-dagger-run/--disable-dagger-run`     | `--enable-dagger-run`           |                               | Disables the Dagger terminal UI.                                                            |
-| `--is-local/--is-ci`                           | `--is-local`                    |                               | Determines the environment in which the CLI runs: local environment or CI environment.      |
-| `--git-branch`                                 | The checked out git branch name | `CI_GIT_BRANCH`               | The git branch on which the pipelines will run.                                             |
-| `--git-revision`                               | The current branch head         | `CI_GIT_REVISION`             | The commit hash on which the pipelines will run.                                            |
-| `--diffed-branch`                              | `origin/master`                 |                               | Branch to which the git diff will happen to detect new or modified files.                   |
-| `--gha-workflow-run-id`                        |                                 |                               | GHA CI only - The run id of the GitHub action workflow                                      |
-| `--ci-context`                                 | `manual`                        |                               | The current CI context: `manual` for manual run, `pull_request`, `nightly_builds`, `master` |
-| `--pipeline-start-timestamp`                   | Current epoch time              | `CI_PIPELINE_START_TIMESTAMP` | Start time of the pipeline as epoch time. Used for pipeline run duration computation.       |
-| `--show-dagger-logs/--hide-dagger-logs`        | `--hide-dagger-logs`            |                               | Flag to show or hide the dagger logs.                                                       |
+| Option                                         | Default value                              | Mapped environment variable   | Description                                                                                 |
+| ---------------------------------------------- | ------------------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------- |
+| `--yes/--y`                                    | False                                      |                               | Agrees to all prompts.                                                                      |
+| `--yes-auto-update`                            | False                                      |                               | Agrees to the auto update prompts.                                                          |
+| `--enable-update-check/--disable-update-check` | True                                       |                               | Turns on the update check feature                                                           |
+| `--enable-dagger-run/--disable-dagger-run`     | `--enable-dagger-run`                      |                               | Disables the Dagger terminal UI.                                                            |
+| `--is-local/--is-ci`                           | `--is-local`                               |                               | Determines the environment in which the CLI runs: local environment or CI environment.      |
+| `--git-branch`                                 | The checked out git branch name            | `CI_GIT_BRANCH`               | The git branch on which the pipelines will run.                                             |
+| `--git-revision`                               | The current branch head                    | `CI_GIT_REVISION`             | The commit hash on which the pipelines will run.                                            |
+| `--diffed-branch`                              | `origin/master`                            |                               | Branch to which the git diff will happen to detect new or modified files.                   |
+| `--gha-workflow-run-id`                        |                                            |                               | GHA CI only - The run id of the GitHub action workflow                                      |
+| `--ci-context`                                 | `manual`                                   |                               | The current CI context: `manual` for manual run, `pull_request`, `nightly_builds`, `master` |
+| `--pipeline-start-timestamp`                   | Current epoch time                         | `CI_PIPELINE_START_TIMESTAMP` | Start time of the pipeline as epoch time. Used for pipeline run duration computation.       |
+| `--show-dagger-logs/--hide-dagger-logs`        | `--hide-dagger-logs`                       |                               | Flag to show or hide the dagger logs.                                                       |
+| `--target-repo-url`                            | `https://github.com/airbytehq/airbyte.git` |                               | Run airbyte-ci on a specific airbyte repo fork.                                             |
 
 
 ### <a id="connectors-command-subgroup"></a>`connectors` command subgroup
@@ -547,6 +548,7 @@ E.G.: running `pytest` on a specific test folder:
 
 | Version | PR                                                         | Description                                                                                                       |
 | ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 3.6.0   | [#34350](https://github.com/airbytehq/airbyte/pull/34350)  | Add a `--target-repo-url` option to the main command.                                                             |
 | 3.5.1   | [#34321](https://github.com/airbytehq/airbyte/pull/34321)  | Upgrade to Dagger 0.9.6 .                                                                                         |
 | 3.5.0   | [#33313](https://github.com/airbytehq/airbyte/pull/33313)  | Pass extra params after Gradle tasks.                                                                             |
 | 3.4.2   | [#34301](https://github.com/airbytehq/airbyte/pull/34301)  | Pass extra params after Gradle tasks.                                                                             |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/commands.py
@@ -48,6 +48,7 @@ async def build(ctx: click.Context, use_host_gradle_dist_tar: bool, build_archit
             pipeline_name=f"Build connector {connector.technical_name}",
             connector=connector,
             is_local=ctx.obj["is_local"],
+            target_repo=ctx.obj["target_repo"],
             git_branch=ctx.obj["git_branch"],
             git_revision=ctx.obj["git_revision"],
             ci_report_bucket=ctx.obj["ci_report_bucket_name"],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/commands.py
@@ -27,6 +27,7 @@ async def bump_version(
             pipeline_name=f"Upgrade base image versions of connector {connector.technical_name}",
             connector=connector,
             is_local=ctx.obj["is_local"],
+            target_repo=ctx.obj["target_repo"],
             git_branch=ctx.obj["git_branch"],
             git_revision=ctx.obj["git_revision"],
             ci_report_bucket=ctx.obj["ci_report_bucket_name"],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
     from pathlib import Path as NativePath
     from typing import Dict, FrozenSet, List, Optional, Sequence
 
+    from pipelines.models.repo import Repo
+
 
 class ConnectorContext(PipelineContext):
     """The connector context is used to store configuration for a specific connector pipeline run."""
@@ -40,6 +42,7 @@ class ConnectorContext(PipelineContext):
         pipeline_name: str,
         connector: ConnectorWithModifiedFiles,
         is_local: bool,
+        target_repo: Repo,
         git_branch: str,
         git_revision: str,
         report_output_prefix: str,
@@ -120,6 +123,7 @@ class ConnectorContext(PipelineContext):
         super().__init__(
             pipeline_name=pipeline_name,
             is_local=is_local,
+            target_repo=target_repo,
             git_branch=git_branch,
             git_revision=git_revision,
             report_output_prefix=report_output_prefix,

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_base_image/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_base_image/commands.py
@@ -29,6 +29,7 @@ async def migrate_to_base_image(
             pipeline_name=f"Upgrade base image versions of connector {connector.technical_name}",
             connector=connector,
             is_local=ctx.obj["is_local"],
+            target_repo=ctx.obj["target_repo"],
             git_branch=ctx.obj["git_branch"],
             git_revision=ctx.obj["git_revision"],
             ci_report_bucket=ctx.obj["ci_report_bucket_name"],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/commands.py
@@ -98,6 +98,7 @@ async def publish(
                 ci_report_bucket=ctx.obj["ci_report_bucket_name"],
                 report_output_prefix=ctx.obj["report_output_prefix"],
                 is_local=ctx.obj["is_local"],
+                target_repo=ctx.obj["target_repo"],
                 git_branch=ctx.obj["git_branch"],
                 git_revision=ctx.obj["git_revision"],
                 gha_workflow_run_url=ctx.obj.get("gha_workflow_run_url"),

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
@@ -4,7 +4,9 @@
 
 """Module declaring context related classes."""
 
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
 
 import asyncclick as click
 from dagger import Secret
@@ -14,6 +16,9 @@ from pipelines.consts import ContextState
 from pipelines.helpers.connectors.modifed import ConnectorWithModifiedFiles
 from pipelines.helpers.gcs import sanitize_gcs_credentials
 from pipelines.helpers.utils import format_duration
+
+if TYPE_CHECKING:
+    from pipelines.models.repo import Repo
 
 
 class PublishConnectorContext(ConnectorContext):
@@ -35,6 +40,7 @@ class PublishConnectorContext(ConnectorContext):
         ci_report_bucket: str,
         report_output_prefix: str,
         is_local: bool,
+        target_repo: Repo,
         git_branch: str,
         git_revision: str,
         gha_workflow_run_url: Optional[str] = None,
@@ -64,6 +70,7 @@ class PublishConnectorContext(ConnectorContext):
             report_output_prefix=report_output_prefix,
             ci_report_bucket=ci_report_bucket,
             is_local=is_local,
+            target_repo=target_repo,
             git_branch=git_branch,
             git_revision=git_revision,
             gha_workflow_run_url=gha_workflow_run_url,

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
@@ -110,6 +110,7 @@ async def test(
             pipeline_name=f"Testing connector {connector.technical_name}",
             connector=connector,
             is_local=ctx.obj["is_local"],
+            target_repo=ctx.obj["target_repo"],
             git_branch=ctx.obj["git_branch"],
             git_revision=ctx.obj["git_revision"],
             ci_report_bucket=ctx.obj["ci_report_bucket_name"],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/upgrade_base_image/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/upgrade_base_image/commands.py
@@ -23,6 +23,7 @@ async def upgrade_base_image(ctx: click.Context, set_if_not_exists: bool, docker
             pipeline_name=f"Upgrade base image versions of connector {connector.technical_name}",
             connector=connector,
             is_local=ctx.obj["is_local"],
+            target_repo=ctx.obj["target_repo"],
             git_branch=ctx.obj["git_branch"],
             git_revision=ctx.obj["git_revision"],
             ci_report_bucket=ctx.obj["ci_report_bucket_name"],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/upgrade_cdk/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/upgrade_cdk/commands.py
@@ -35,6 +35,7 @@ async def bump_version(
             pipeline_name=f"Upgrade CDK version of connector {connector.technical_name}",
             connector=connector,
             is_local=ctx.obj["is_local"],
+            target_repo=ctx.obj["target_repo"],
             git_branch=ctx.obj["git_branch"],
             git_revision=ctx.obj["git_revision"],
             ci_report_bucket=ctx.obj["ci_report_bucket_name"],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/commands.py
@@ -30,6 +30,7 @@ async def deploy_orchestrator(ctx: click.Context) -> None:
 
     await run_metadata_orchestrator_deploy_pipeline(
         ctx.obj["is_local"],
+        ctx.obj["target_repo"],
         ctx.obj["git_branch"],
         ctx.obj["git_revision"],
         ctx.obj["report_output_prefix"],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -1,9 +1,10 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
+from __future__ import annotations
 
 import uuid
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import dagger
 from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
@@ -18,6 +19,8 @@ from pipelines.helpers.utils import DAGGER_CONFIG, get_secret_host_variable
 from pipelines.models.reports import Report
 from pipelines.models.steps import MountPath, Step, StepResult
 
+if TYPE_CHECKING:
+    from pipelines.models.repo import Repo
 # STEPS
 
 
@@ -154,6 +157,7 @@ class TestOrchestrator(PoetryRunStep):
 
 async def run_metadata_orchestrator_deploy_pipeline(
     is_local: bool,
+    target_repo: Repo,
     git_branch: str,
     git_revision: str,
     report_output_prefix: str,
@@ -167,6 +171,7 @@ async def run_metadata_orchestrator_deploy_pipeline(
     metadata_pipeline_context = PipelineContext(
         pipeline_name="Metadata Service Orchestrator Unit Test Pipeline",
         is_local=is_local,
+        target_repo=target_repo,
         git_branch=git_branch,
         git_revision=git_revision,
         report_output_prefix=report_output_prefix,

--- a/airbyte-ci/connectors/pipelines/pipelines/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/consts.py
@@ -60,6 +60,7 @@ POETRY_CACHE_VOLUME_NAME = "poetry_cache"
 POETRY_CACHE_PATH = "/root/.cache/pypoetry"
 STORAGE_DRIVER = "fuse-overlayfs"
 TAILSCALE_AUTH_KEY = os.getenv("TAILSCALE_AUTH_KEY")
+AIRBYTE_REPO_URL = "https://github.com/airbytehq/airbyte.git"
 
 
 class CIContext(str, Enum):

--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/containers/git.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/containers/git.py
@@ -1,13 +1,18 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
 
 from dagger import Client, Container
-from pipelines.helpers.utils import AIRBYTE_REPO_URL
+
+if TYPE_CHECKING:
+    from pipelines.models.repo import Repo
 
 
 async def checked_out_git_container(
     dagger_client: Client,
+    repo: Repo,
     current_git_branch: str,
     current_git_revision: str,
     diffed_branch: Optional[str] = None,
@@ -31,7 +36,7 @@ async def checked_out_git_container(
                 "--track",
                 diffed_branch if diffed_branch is not None else current_git_branch,
                 "origin",
-                AIRBYTE_REPO_URL,
+                repo.url,
             ]
         )
         .with_exec(["checkout", "-t", f"origin/{current_git_branch}"])

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
     from pipelines.airbyte_ci.connectors.context import ConnectorContext
 
 DAGGER_CONFIG = Config(log_output=sys.stderr)
-AIRBYTE_REPO_URL = "https://github.com/airbytehq/airbyte.git"
 METADATA_FILE_NAME = "metadata.yaml"
 METADATA_ICON_FILE_NAME = "icon.svg"
 DIFF_FILTER = "MADRT"  # Modified, Added, Deleted, Renamed, Type changed

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
@@ -22,7 +22,7 @@ from pipelines.helpers.execution.run_steps import RunStepOptions
 from pipelines.helpers.gcs import sanitize_gcs_credentials
 from pipelines.helpers.github import update_commit_status_check
 from pipelines.helpers.slack import send_message_to_webhook
-from pipelines.helpers.utils import AIRBYTE_REPO_URL
+from pipelines.models.repo import Repo
 from pipelines.models.reports import Report
 
 if TYPE_CHECKING:
@@ -62,6 +62,7 @@ class PipelineContext:
         self,
         pipeline_name: str,
         is_local: bool,
+        target_repo: Repo,
         git_branch: str,
         git_revision: str,
         report_output_prefix: str,
@@ -99,6 +100,7 @@ class PipelineContext:
         """
         self.pipeline_name = pipeline_name
         self.is_local = is_local
+        self.target_repo = target_repo
         self.git_branch = git_branch
         self.git_revision = git_revision
         self.report_output_prefix = report_output_prefix
@@ -146,7 +148,7 @@ class PipelineContext:
 
     @property
     def repo(self) -> GitRepository:
-        return self.dagger_client.git(AIRBYTE_REPO_URL, keep_git_dir=True)
+        return self.dagger_client.git(self.target_repo.url, keep_git_dir=True)
 
     @property
     def report(self) -> Report | ConnectorReport | None:
@@ -175,6 +177,7 @@ class PipelineContext:
             target_url = self.report.html_report_url
 
         return {
+            "repo_name": self.target_repo.name,
             "sha": self.git_revision,
             "state": self.state.value["github_state"],
             "target_url": target_url,

--- a/airbyte-ci/connectors/pipelines/pipelines/models/repo.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/repo.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Type
+from urllib.parse import urlparse
+
+
+class SupportedHosts(Enum):
+    GITHUB = "github.com"
+
+
+@dataclass
+class Repo:
+    name: str
+    host: str
+
+    @property
+    def url(self) -> str:
+        return f"https://{self.host}/{self.name}.git"
+
+    @classmethod
+    def from_url(cls: Type[Repo], repo_url: str) -> Repo:
+        parsed_url = urlparse(repo_url)
+        host = parsed_url.netloc
+        if SupportedHosts(host) is SupportedHosts.GITHUB:
+            repo_name = cls.get_github_repo_name(parsed_url.path)
+            return Repo(name=repo_name, host=host)
+        raise NotImplementedError("Only GitHub is supported for now")
+
+    @classmethod
+    def get_github_repo_name(cls: Type[Repo], url_path: str) -> str:
+        # Remove leading slash and trailing .git
+        return url_path[1:].split(".")[0]
+
+    def __post_init__(self) -> None:
+        # Validate the host is supported
+        SupportedHosts(self.host)
+
+    def __str__(self) -> str:
+        return self.url

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "3.5.1"
+version = "3.6.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/conftest.py
+++ b/airbyte-ci/connectors/pipelines/tests/conftest.py
@@ -13,7 +13,9 @@ import git
 import pytest
 import requests
 from connector_ops.utils import Connector
+from pipelines.consts import AIRBYTE_REPO_URL
 from pipelines.helpers import utils
+from pipelines.models.repo import Repo
 from tests.utils import ALL_CONNECTORS
 
 
@@ -81,3 +83,8 @@ def all_connectors() -> List[Connector]:
 @pytest.fixture(scope="session")
 def current_platform():
     return dagger.Platform(f"linux/{platform.machine()}")
+
+
+@pytest.fixture(scope="session")
+def target_repo():
+    return Repo.from_url(AIRBYTE_REPO_URL)

--- a/airbyte-ci/connectors/pipelines/tests/test_actions/test_environments.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_actions/test_environments.py
@@ -12,7 +12,7 @@ pytestmark = [
 
 
 @pytest.fixture
-def connector_context(dagger_client):
+def connector_context(dagger_client, target_repo):
     context = ConnectorContext(
         pipeline_name="test",
         connector="source-faker",
@@ -20,6 +20,7 @@ def connector_context(dagger_client):
         git_revision="test",
         report_output_prefix="test",
         is_local=True,
+        target_repo=target_repo,
         use_remote_secrets=True,
     )
     context.dagger_client = dagger_client

--- a/airbyte-ci/connectors/pipelines/tests/test_build_image/test_python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_build_image/test_python_connectors.py
@@ -51,7 +51,7 @@ class TestBuildConnectorImage:
 
     @pytest.fixture
     def test_context_with_real_connector_using_base_image(
-        self, connector_with_base_image_no_build_customization, dagger_client, current_platform
+        self, connector_with_base_image_no_build_customization, dagger_client, current_platform, target_repo
     ):
         context = ConnectorContext(
             pipeline_name="test build",
@@ -60,6 +60,7 @@ class TestBuildConnectorImage:
             git_revision="test",
             report_output_prefix="test",
             is_local=True,
+            target_repo=target_repo,
             use_remote_secrets=True,
             targeted_platforms=[current_platform],
         )
@@ -68,7 +69,7 @@ class TestBuildConnectorImage:
 
     @pytest.fixture
     def test_context_with_real_connector_using_base_image_with_build_customization(
-        self, connector_with_base_image_with_build_customization, dagger_client, current_platform
+        self, connector_with_base_image_with_build_customization, dagger_client, current_platform, target_repo
     ):
         context = ConnectorContext(
             pipeline_name="test build",
@@ -77,6 +78,7 @@ class TestBuildConnectorImage:
             git_revision="test",
             report_output_prefix="test",
             is_local=True,
+            target_repo=target_repo,
             use_remote_secrets=True,
             targeted_platforms=[current_platform],
         )
@@ -91,7 +93,7 @@ class TestBuildConnectorImage:
         pytest.skip("No connector without a connectorBuildOptions.baseImage metadata found")
 
     @pytest.fixture
-    def test_context_with_real_connector_without_base_image(self, connector_without_base_image, dagger_client, current_platform):
+    def test_context_with_real_connector_without_base_image(self, connector_without_base_image, dagger_client, current_platform, target_repo):
         context = ConnectorContext(
             pipeline_name="test build",
             connector=connector_without_base_image,
@@ -99,6 +101,7 @@ class TestBuildConnectorImage:
             git_revision="test",
             report_output_prefix="test",
             is_local=True,
+            target_repo=target_repo,
             use_remote_secrets=True,
             targeted_platforms=[current_platform],
         )

--- a/airbyte-ci/connectors/pipelines/tests/test_dagger/test_actions/test_python/test_common.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_dagger/test_actions/test_python/test_common.py
@@ -33,7 +33,7 @@ def python_connector_with_setup_not_latest_cdk(all_connectors):
 
 
 @pytest.fixture(scope="module")
-def context_with_setup(dagger_client, python_connector_with_setup_not_latest_cdk):
+def context_with_setup(dagger_client, python_connector_with_setup_not_latest_cdk, target_repo):
     context = ConnectorContext(
         pipeline_name="test python common",
         connector=python_connector_with_setup_not_latest_cdk,
@@ -41,6 +41,7 @@ def context_with_setup(dagger_client, python_connector_with_setup_not_latest_cdk
         git_revision="test",
         report_output_prefix="test",
         is_local=True,
+        target_repo=target_repo,
         use_remote_secrets=False,
     )
     context.dagger_client = dagger_client

--- a/airbyte-ci/connectors/pipelines/tests/test_helpers/test_execution/test_run_steps.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_helpers/test_execution/test_run_steps.py
@@ -4,11 +4,20 @@ import time
 
 import anyio
 import pytest
+from pipelines.consts import AIRBYTE_REPO_URL
 from pipelines.helpers.execution.run_steps import InvalidStepConfiguration, RunStepOptions, StepToRun, run_steps
 from pipelines.models.contexts.pipeline_context import PipelineContext
+from pipelines.models.repo import Repo
 from pipelines.models.steps import Step, StepResult, StepStatus
 
-test_context = PipelineContext(pipeline_name="test", is_local=True, git_branch="test", git_revision="test", report_output_prefix="test")
+test_context = PipelineContext(
+    pipeline_name="test",
+    is_local=True,
+    target_repo=Repo.from_url(AIRBYTE_REPO_URL),
+    git_branch="test",
+    git_revision="test",
+    report_output_prefix="test",
+)
 
 
 class TestStep(Step):

--- a/airbyte-ci/connectors/pipelines/tests/test_steps/test_simple_docker_step.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_steps/test_simple_docker_step.py
@@ -16,10 +16,11 @@ pytestmark = [
 
 
 @pytest.fixture
-def context(dagger_client):
+def context(dagger_client, target_repo):
     context = PipelineContext(
         pipeline_name="test",
         is_local=True,
+        target_repo=target_repo,
         git_branch="test",
         git_revision="test",
         report_output_prefix="test",

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_common.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_common.py
@@ -40,7 +40,7 @@ class TestAcceptanceTests:
         return container.with_new_file("/stupid_bash_script.sh", contents=f"echo {stdout}; echo {stderr} >&2; exit {exit_code}")
 
     @pytest.fixture
-    def test_context_ci(self, current_platform, dagger_client):
+    def test_context_ci(self, current_platform, dagger_client, target_repo):
         context = ConnectorContext(
             pipeline_name="test",
             connector=ConnectorWithModifiedFiles("source-faker", frozenset()),
@@ -48,6 +48,7 @@ class TestAcceptanceTests:
             git_revision="test",
             report_output_prefix="test",
             is_local=False,
+            target_repo=target_repo,
             use_remote_secrets=True,
             targeted_platforms=[current_platform],
         )

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
@@ -28,7 +28,9 @@ class TestUnitTests:
         pytest.skip("No certified connector with setup.py found.")
 
     @pytest.fixture
-    def context_for_certified_connector_with_setup(self, mocker, certified_connector_with_setup, dagger_client, current_platform):
+    def context_for_certified_connector_with_setup(
+        self, mocker, certified_connector_with_setup, dagger_client, current_platform, target_repo
+    ):
         context = ConnectorContext(
             pipeline_name="test unit tests",
             connector=certified_connector_with_setup,
@@ -36,6 +38,7 @@ class TestUnitTests:
             git_revision="test",
             report_output_prefix="test",
             is_local=True,
+            target_repo=target_repo,
             use_remote_secrets=True,
             targeted_platforms=[current_platform],
         )
@@ -49,7 +52,7 @@ class TestUnitTests:
         return result.output_artifact[current_platform]
 
     @pytest.fixture
-    def context_for_connector_with_poetry(self, mocker, connector_with_poetry, dagger_client, current_platform):
+    def context_for_connector_with_poetry(self, mocker, connector_with_poetry, dagger_client, current_platform, target_repo):
         context = ConnectorContext(
             pipeline_name="test unit tests",
             connector=connector_with_poetry,
@@ -57,6 +60,7 @@ class TestUnitTests:
             git_revision="test",
             report_output_prefix="test",
             is_local=True,
+            target_repo=target_repo,
             use_remote_secrets=True,
             targeted_platforms=[current_platform],
         )

--- a/airbyte-ci/connectors/pipelines/tests/test_upgrade_cdk.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_upgrade_cdk.py
@@ -46,7 +46,7 @@ setup(
 
 
 @pytest.fixture
-def connector_context(sample_connector, dagger_client, current_platform):
+def connector_context(sample_connector, dagger_client, current_platform, target_repo):
     context = ConnectorContext(
         pipeline_name="test",
         connector=sample_connector,
@@ -54,6 +54,7 @@ def connector_context(sample_connector, dagger_client, current_platform):
         git_revision="test",
         report_output_prefix="test",
         is_local=True,
+        target_repo=target_repo,
         use_remote_secrets=True,
         targeted_platforms=[current_platform],
     )


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Relates to #34346
We want airbyte-ci to be able to run a forks / private airbyte copy.
This PR adds an option to `airbyte-ci` to target a specific repo (whose structure has to match the existing `airbyte` repo structure).



## How
* Add `airbyte-ci --target-repo-url` option
* Pass a `Repo` object around where metadata about the repo is required.

# TODO
* Handle SSH authentication to clone private repos

## Manual testing
- [x] [`airbyte-ci connector test`](https://github.com/airbytehq/airbyte/actions/runs/7571369493)
- [x] [`airbyte-ci connector publish`](https://github.com/airbytehq/airbyte/actions/runs/7571376331)
- [ ] [`airbyte-ci test`](https://github.com/airbytehq/airbyte/actions/runs/7571741946/job/20619957053?pr=34350) (unit tests are currently failing, I'm on it)
- [x] [`airbyte-ci format`](https://github.com/airbytehq/airbyte/actions/runs/7571361739)

