### PR TITLE
🐛Source Google Analytics: add incorrect custom reports config handling

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.2.0
+  dockerImageTag: 2.2.1
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -22,7 +22,13 @@ from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.utils import AirbyteTracedException
 from requests import HTTPError
 from source_google_analytics_data_api import utils
-from source_google_analytics_data_api.utils import DATE_FORMAT, WRONG_DIMENSIONS, WRONG_JSON_SYNTAX, WRONG_METRICS
+from source_google_analytics_data_api.utils import (
+    DATE_FORMAT,
+    WRONG_CUSTOM_REPORT_CONFIG,
+    WRONG_DIMENSIONS,
+    WRONG_JSON_SYNTAX,
+    WRONG_METRICS,
+)
 
 from .api_quota import GoogleAnalyticsApiQuota
 from .utils import (
@@ -37,8 +43,8 @@ from .utils import (
     transform_json,
 )
 
-# set the quota handler globaly since limitations are the same for all streams
-# the initial values should be saved once and tracked for each stream, inclusivelly.
+# set the quota handler globally since limitations are the same for all streams
+# the initial values should be saved once and tracked for each stream, inclusively.
 GoogleAnalyticsQuotaHandler: GoogleAnalyticsApiQuota = GoogleAnalyticsApiQuota()
 
 LOOKBACK_WINDOW = datetime.timedelta(days=2)
@@ -520,8 +526,14 @@ class SourceGoogleAnalyticsDataApi(AbstractSource):
 
                 report_stream = self.instantiate_report_class(report, False, _config, page_size=100)
                 # check if custom_report dimensions + metrics can be combined and report generated
-                stream_slice = next(report_stream.stream_slices(sync_mode=SyncMode.full_refresh))
-                next(report_stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice), None)
+                try:
+                    stream_slice = next(report_stream.stream_slices(sync_mode=SyncMode.full_refresh))
+                    next(report_stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice), None)
+                except HTTPError as e:
+                    error_response = ""
+                    if e.response.status_code == HTTPStatus.BAD_REQUEST:
+                        error_response = e.response.json().get("error", {}).get("message", "")
+                    return False, WRONG_CUSTOM_REPORT_CONFIG.format(report=report["name"], error_response=error_response)
 
             return True, None
 

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/utils.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/utils.py
@@ -71,6 +71,7 @@ WRONG_DIMENSIONS = "The custom report {report_name} entered contains invalid dim
 WRONG_METRICS = "The custom report {report_name} entered contains invalid metrics: {fields}. Validate your custom query with the GA 4 Query Explorer (https://ga-dev-tools.google/ga4/query-explorer/)."
 WRONG_PIVOTS = "The custom report {report_name} entered contains invalid pivots: {fields}. Ensure the pivot follow the syntax described in the docs (https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/Pivot)."
 API_LIMIT_PER_HOUR = "Your API key has reached its limit for the hour. Wait until the quota refreshes in an hour to retry."
+WRONG_CUSTOM_REPORT_CONFIG = "Please check configuration for custom report {report}. {error_response}"
 
 
 def datetime_to_secs(dt: datetime.datetime) -> int:

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -264,6 +264,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------|
+| 2.2.1   | 2024-01-18 | [34352](https://github.com/airbytehq/airbyte/pull/34352) | Add incorrect custom reports config handling                                    |
 | 2.2.0   | 2024-01-10 | [34176](https://github.com/airbytehq/airbyte/pull/34176) | Add a report option keepEmptyRows                                               |
 | 2.1.1   | 2024-01-08 | [34018](https://github.com/airbytehq/airbyte/pull/34018) | prepare for airbyte-lib                                                         |
 | 2.1.0   | 2023-12-28 | [33802](https://github.com/airbytehq/airbyte/pull/33802) | Add `CohortSpec` to custom report in specification                              |


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/oncall/issues/4030

## How
Add handling of HTTP error `400` in `check_connection` which occurs when a custom report config is incorrect

## Recommended reading order
1. `source.py`

## 🚨 User Impact 🚨
No breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
