### PR TITLE
Destination bigquery: restrict test concurrency

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/gradle.properties
+++ b/airbyte-integrations/connectors/destination-bigquery/gradle.properties
@@ -1,1 +1,1 @@
-testExecutionConcurrency=-1
+testExecutionConcurrency=5

--- a/airbyte-integrations/connectors/destination-bigquery/gradle.properties
+++ b/airbyte-integrations/connectors/destination-bigquery/gradle.properties
@@ -1,1 +1,1 @@
-testExecutionConcurrency=5
+testExecutionConcurrency=3


### PR DESCRIPTION
(ignore for now, I just want to trigger CI a few times)

I've only managed to repro various transient test failures when running the full test suite - running individual tests has been super reliable. I also haven't found any explicit interference between tests - they're reliably using different namespaces, etc. so... maybe bigquery itself is having issues when we run several concurrent syncs to the same project?

failures I've seen:
* T+D being skipped (even though the test logs indicate that T+D was executed successfully)
* raw tables not being populated (even though the sync terminated with exit code 0)
* `dumpFinalRecords` returning fewer records than the expected records, but those records are present in bigquery when I query manually