### PR TITLE
🚨🚨 Source Stripe: Rename cursor from `updated` to `_ab_source_record_last_modified`

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e094cb9a-26de-4645-8761-65c0c425d1de
-  dockerImageTag: 5.2.0
+  dockerImageTag: 6.0.0
   dockerRepository: airbyte/source-stripe
   documentationUrl: https://docs.airbyte.com/integrations/sources/stripe
   githubIssueLabel: source-stripe

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/application_fees.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/application_fees.json
@@ -31,7 +31,7 @@
     "created": {
       "type": ["null", "number"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "currency": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/application_fees_refunds.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/application_fees_refunds.json
@@ -19,7 +19,7 @@
     "created": {
       "type": ["null", "number"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "currency": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/authorizations.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/authorizations.json
@@ -36,7 +36,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "currency": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/bank_accounts.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/bank_accounts.json
@@ -44,7 +44,7 @@
     "status": {
       "type": ["null", "string"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "is_deleted": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/charges.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/charges.json
@@ -348,7 +348,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "order": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/checkout_sessions.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/checkout_sessions.json
@@ -214,7 +214,7 @@
       }
     },
     "url": { "type": ["null", "string"] },
-    "updated": { "type": ["null", "integer"] },
+    "_ab_source_record_last_modified": { "type": ["null", "integer"] },
     "created": { "type": ["null", "integer"] },
     "currency_conversion": {
       "type": ["null", "object"],

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/coupons.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/coupons.json
@@ -47,7 +47,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "percent_off": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/credit_notes.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/credit_notes.json
@@ -18,7 +18,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "currency": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/disputes.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/disputes.json
@@ -27,7 +27,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "currency": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/early_fraud_warnings.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/early_fraud_warnings.json
@@ -19,7 +19,7 @@
     "created": {
       "type": ["null", "number"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "fraud_type": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_bank_accounts.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_bank_accounts.json
@@ -44,7 +44,7 @@
     "account": {
       "type": ["string", "null"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "is_deleted": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_cards.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_cards.json
@@ -74,7 +74,7 @@
     "account": {
       "type": ["string", "null"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "is_deleted": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoice_items.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoice_items.json
@@ -120,7 +120,7 @@
     "date": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "object": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoices.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoices.json
@@ -4,7 +4,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "next_payment_attempt": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/payouts.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/payouts.json
@@ -22,7 +22,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "amount_reversed": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/persons.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/persons.json
@@ -75,7 +75,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "dob": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/plans.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/plans.json
@@ -36,7 +36,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "statement_description": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/prices.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/prices.json
@@ -19,7 +19,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "currency": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/products.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/products.json
@@ -76,7 +76,7 @@
     "unit_label": {
       "type": ["null", "string"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "url": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/promotion_codes.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/promotion_codes.json
@@ -43,7 +43,7 @@
     "object": { "type": ["null", "string"] },
     "active": { "type": ["null", "boolean"] },
     "created": { "type": ["null", "integer"] },
-    "updated": { "type": ["null", "integer"] },
+    "_ab_source_record_last_modified": { "type": ["null", "integer"] },
     "customer": { "type": ["null", "string"] },
     "expires_at": { "type": ["null", "integer"] },
     "livemode": { "type": ["null", "boolean"] },

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/refunds.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/refunds.json
@@ -19,9 +19,6 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
-      "type": ["null", "integer"]
-    },
     "currency": {
       "type": ["null", "string"]
     },

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/reviews.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/reviews.json
@@ -15,7 +15,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "id": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/setup_attempts.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/setup_attempts.json
@@ -329,9 +329,6 @@
             "created": {
               "type": ["null", "integer"]
             },
-            "updated": {
-              "type": ["null", "integer"]
-            },
             "customer": {
               "type": ["null", "string"]
             },

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/subscription_schedule.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/subscription_schedule.json
@@ -21,7 +21,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "current_phase": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/subscriptions.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/subscriptions.json
@@ -239,7 +239,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "ended_at": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/top_ups.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/top_ups.json
@@ -31,7 +31,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "destination_balance": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/transactions.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/transactions.json
@@ -29,7 +29,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "currency": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/transfers.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/transfers.json
@@ -42,7 +42,7 @@
     "created": {
       "type": ["null", "integer"]
     },
-    "updated": {
+    "_ab_source_record_last_modified": {
       "type": ["null", "integer"]
     },
     "amount_reversed": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -338,7 +338,7 @@ class UpdatedCursorIncrementalStripeStream(StripeStream):
     def __init__(
         self,
         *args,
-        cursor_field: str = "updated",
+        cursor_field: str = "_ab_source_record_last_modified",
         legacy_cursor_field: Optional[str] = "created",
         event_types: Optional[List[str]] = None,
         record_extractor: Optional[IRecordExtractor] = None,
@@ -438,7 +438,7 @@ class IncrementalStripeStream(StripeStream):
     def __init__(
         self,
         *args,
-        cursor_field: str = "updated",
+        cursor_field: str = "_ab_source_record_last_modified",
         legacy_cursor_field: Optional[str] = "created",
         event_types: Optional[List[str]] = None,
         **kwargs,
@@ -727,7 +727,7 @@ class UpdatedCursorIncrementalStripeLazySubStream(StripeStream, ABC):
         self,
         parent: StripeStream,
         *args,
-        cursor_field: str = "updated",
+        cursor_field: str = "_ab_source_record_last_modified",
         legacy_cursor_field: Optional[str] = "created",
         event_types: Optional[List[str]] = None,
         sub_items_attr: Optional[str] = None,

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/config.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/config.py
@@ -9,7 +9,7 @@ class ConfigBuilder:
         self._config: Dict[str, Any] = {
             "client_secret": "ConfigBuilder default client secret",
             "account_id": "ConfigBuilder default account id",
-            "start_date": "2020-05-01T00:00:00Z"
+            "start_date": "2020-05-01T00:00:00Z",
         }
 
     def with_account_id(self, account_id: str) -> "ConfigBuilder":
@@ -21,7 +21,7 @@ class ConfigBuilder:
         return self
 
     def with_start_date(self, start_datetime: datetime) -> "ConfigBuilder":
-        self._config["start_date"] = start_datetime.isoformat()[:-13]+"Z"
+        self._config["start_date"] = start_datetime.isoformat()[:-13] + "Z"
         return self
 
     def with_lookback_window_in_days(self, number_of_days: int) -> "ConfigBuilder":

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_application_fees.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_application_fees.py
@@ -69,11 +69,7 @@ def _an_event() -> RecordBuilder:
 
 
 def _events_response() -> HttpResponseBuilder:
-    return create_response_builder(
-        find_template("events", __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
-    )
+    return create_response_builder(find_template("events", __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy())
 
 
 def _an_application_fee() -> RecordBuilder:
@@ -87,31 +83,25 @@ def _an_application_fee() -> RecordBuilder:
 
 def _application_fees_response() -> HttpResponseBuilder:
     return create_response_builder(
-        find_template(_ENDPOINT_TEMPLATE_NAME, __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        find_template(_ENDPOINT_TEMPLATE_NAME, __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy()
     )
 
 
 def _given_application_fees_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
         StripeRequestBuilder.application_fees_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _application_fees_response().build()
+        _application_fees_response().build(),
     )
 
 
 def _given_events_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _events_response().build()
+        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _events_response().build()
     )
 
 
 def _read(
-    config_builder: ConfigBuilder,
-    sync_mode: SyncMode,
-    state: Optional[Dict[str, Any]] = None,
-    expecting_exception: bool = False
+    config_builder: ConfigBuilder, sync_mode: SyncMode, state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = _catalog(sync_mode)
     config = config_builder.build()
@@ -120,7 +110,6 @@ def _read(
 
 @freezegun.freeze_time(_NOW.isoformat())
 class FullRefreshTest(TestCase):
-
     @HttpMocker()
     def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -138,10 +127,18 @@ class FullRefreshTest(TestCase):
         _given_events_availability_check(http_mocker)
         http_mocker.get(
             _application_fees_request().with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
-            _application_fees_response().with_pagination().with_record(_an_application_fee().with_id("last_record_id_from_first_page")).build(),
+            _application_fees_response()
+            .with_pagination()
+            .with_record(_an_application_fee().with_id("last_record_id_from_first_page"))
+            .build(),
         )
         http_mocker.get(
-            _application_fees_request().with_starting_after("last_record_id_from_first_page").with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
+            _application_fees_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(_A_START_DATE)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _application_fees_response().with_record(_an_application_fee()).with_record(_an_application_fee()).build(),
         )
 
@@ -185,7 +182,11 @@ class FullRefreshTest(TestCase):
             _application_fees_response().build(),
         )
         http_mocker.get(
-            _application_fees_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).build(),
+            _application_fees_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _application_fees_response().build(),
         )
 
@@ -249,7 +250,7 @@ class FullRefreshTest(TestCase):
         events_requests = StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build()
         http_mocker.get(
             events_requests,
-            _events_response().build()  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
+            _events_response().build(),  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
         )
         http_mocker.get(
             _application_fees_request().with_any_query_params().build(),
@@ -266,7 +267,6 @@ class FullRefreshTest(TestCase):
 
 @freezegun.freeze_time(_NOW.isoformat())
 class IncrementalTest(TestCase):
-
     @HttpMocker()
     def test_given_no_state_when_read_then_use_application_fees_endpoint(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -287,10 +287,15 @@ class IncrementalTest(TestCase):
         _given_application_fees_availability_check(http_mocker)
         _given_events_availability_check(http_mocker)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                _an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _an_application_fee().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_record(_an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _an_application_fee().build()))
+            .build(),
         )
 
         output = self._read(
@@ -306,16 +311,26 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         state_datetime = _NOW - timedelta(days=5)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_pagination().with_record(
-                _an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _an_application_fee().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_pagination()
+            .with_record(_an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _an_application_fee().build()))
+            .build(),
         )
         http_mocker.get(
-            _events_request().with_starting_after("last_record_id_from_first_page").with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                self._an_application_fee_event()
-            ).build(),
+            _events_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response().with_record(self._an_application_fee_event()).build(),
         )
 
         output = self._read(
@@ -332,13 +347,25 @@ class IncrementalTest(TestCase):
         slice_datetime = state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES + slice_range
 
         _given_application_fees_availability_check(http_mocker)
-        _given_events_availability_check(http_mocker)  # the availability check does not consider the state so we need to define a generic availability check
+        _given_events_availability_check(
+            http_mocker
+        )  # the availability check does not consider the state so we need to define a generic availability check
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(slice_datetime).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_application_fee_event()).build(),
         )
         http_mocker.get(
-            _events_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_application_fee_event()).with_record(self._an_application_fee_event()).build(),
         )
 
@@ -350,7 +377,9 @@ class IncrementalTest(TestCase):
         assert len(output.records) == 3
 
     @HttpMocker()
-    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(self, http_mocker: HttpMocker) -> None:
+    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(
+        self, http_mocker: HttpMocker
+    ) -> None:
         # this seems odd as we would miss some data between start_date and events_lower_boundary. In that case, we should hit the
         # application fees endpoint
         _given_application_fees_availability_check(http_mocker)
@@ -358,7 +387,12 @@ class IncrementalTest(TestCase):
         state_value = _NOW - timedelta(days=39)
         events_lower_boundary = _NOW - timedelta(days=30)
         http_mocker.get(
-            _events_request().with_created_gte(events_lower_boundary).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(events_lower_boundary)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_application_fee_event()).build(),
         )
 

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_authorizations.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_authorizations.py
@@ -69,11 +69,7 @@ def _an_event() -> RecordBuilder:
 
 
 def _events_response() -> HttpResponseBuilder:
-    return create_response_builder(
-        find_template("events", __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
-    )
+    return create_response_builder(find_template("events", __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy())
 
 
 def _an_authorization() -> RecordBuilder:
@@ -87,31 +83,25 @@ def _an_authorization() -> RecordBuilder:
 
 def _authorizations_response() -> HttpResponseBuilder:
     return create_response_builder(
-        find_template(_ENDPOINT_TEMPLATE_NAME, __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        find_template(_ENDPOINT_TEMPLATE_NAME, __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy()
     )
 
 
 def _given_authorizations_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
         StripeRequestBuilder.issuing_authorizations_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _authorizations_response().build()
+        _authorizations_response().build(),
     )
 
 
 def _given_events_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _events_response().build()
+        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _events_response().build()
     )
 
 
 def _read(
-    config_builder: ConfigBuilder,
-    sync_mode: SyncMode,
-    state: Optional[Dict[str, Any]] = None,
-    expecting_exception: bool = False
+    config_builder: ConfigBuilder, sync_mode: SyncMode, state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = _catalog(sync_mode)
     config = config_builder.build()
@@ -120,7 +110,6 @@ def _read(
 
 @freezegun.freeze_time(_NOW.isoformat())
 class FullRefreshTest(TestCase):
-
     @HttpMocker()
     def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -141,7 +130,12 @@ class FullRefreshTest(TestCase):
             _authorizations_response().with_pagination().with_record(_an_authorization().with_id("last_record_id_from_first_page")).build(),
         )
         http_mocker.get(
-            _authorizations_request().with_starting_after("last_record_id_from_first_page").with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
+            _authorizations_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(_A_START_DATE)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _authorizations_response().with_record(_an_authorization()).with_record(_an_authorization()).build(),
         )
 
@@ -185,7 +179,11 @@ class FullRefreshTest(TestCase):
             _authorizations_response().build(),
         )
         http_mocker.get(
-            _authorizations_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).build(),
+            _authorizations_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _authorizations_response().build(),
         )
 
@@ -249,7 +247,7 @@ class FullRefreshTest(TestCase):
         events_requests = StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build()
         http_mocker.get(
             events_requests,
-            _events_response().build()  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
+            _events_response().build(),  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
         )
         http_mocker.get(
             _authorizations_request().with_any_query_params().build(),
@@ -266,7 +264,6 @@ class FullRefreshTest(TestCase):
 
 @freezegun.freeze_time(_NOW.isoformat())
 class IncrementalTest(TestCase):
-
     @HttpMocker()
     def test_given_no_state_when_read_then_use_authorizations_endpoint(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -287,10 +284,15 @@ class IncrementalTest(TestCase):
         _given_authorizations_availability_check(http_mocker)
         _given_events_availability_check(http_mocker)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                _an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _an_authorization().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_record(_an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _an_authorization().build()))
+            .build(),
         )
 
         output = self._read(
@@ -306,13 +308,25 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         state_datetime = _NOW - timedelta(days=5)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_pagination().with_record(
-                _an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _an_authorization().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_pagination()
+            .with_record(_an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _an_authorization().build()))
+            .build(),
         )
         http_mocker.get(
-            _events_request().with_starting_after("last_record_id_from_first_page").with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_authorization_event()).build(),
         )
 
@@ -330,13 +344,25 @@ class IncrementalTest(TestCase):
         slice_datetime = state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES + slice_range
 
         _given_authorizations_availability_check(http_mocker)
-        _given_events_availability_check(http_mocker)  # the availability check does not consider the state so we need to define a generic availability check
+        _given_events_availability_check(
+            http_mocker
+        )  # the availability check does not consider the state so we need to define a generic availability check
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(slice_datetime).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_authorization_event()).build(),
         )
         http_mocker.get(
-            _events_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_authorization_event()).with_record(self._an_authorization_event()).build(),
         )
 
@@ -348,7 +374,9 @@ class IncrementalTest(TestCase):
         assert len(output.records) == 3
 
     @HttpMocker()
-    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(self, http_mocker: HttpMocker) -> None:
+    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(
+        self, http_mocker: HttpMocker
+    ) -> None:
         # this seems odd as we would miss some data between start_date and events_lower_boundary. In that case, we should hit the
         # authorizations endpoint
         _given_authorizations_availability_check(http_mocker)
@@ -356,7 +384,12 @@ class IncrementalTest(TestCase):
         state_value = _NOW - timedelta(days=39)
         events_lower_boundary = _NOW - timedelta(days=30)
         http_mocker.get(
-            _events_request().with_created_gte(events_lower_boundary).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(events_lower_boundary)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_authorization_event()).build(),
         )
 

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_bank_accounts.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_bank_accounts.py
@@ -80,11 +80,7 @@ def _an_event() -> RecordBuilder:
 
 
 def _events_response() -> HttpResponseBuilder:
-    return create_response_builder(
-        find_template("events", __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
-    )
+    return create_response_builder(find_template("events", __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy())
 
 
 def _a_customer() -> RecordBuilder:
@@ -98,9 +94,7 @@ def _a_customer() -> RecordBuilder:
 
 def _customers_response() -> HttpResponseBuilder:
     return create_response_builder(
-        find_template(_CUSTOMERS_TEMPLATE_NAME, __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        find_template(_CUSTOMERS_TEMPLATE_NAME, __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy()
     )
 
 
@@ -114,23 +108,22 @@ def _a_bank_account() -> RecordBuilder:
 
 def _bank_accounts_response() -> HttpResponseBuilder:
     return create_response_builder(
-        find_template(_BANK_ACCOUNTS_TEMPLATE_NAME, __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        find_template(_BANK_ACCOUNTS_TEMPLATE_NAME, __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy()
     )
 
 
 def _given_customers_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
         StripeRequestBuilder.customers_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _customers_response().with_record(_a_customer()).build()  # there needs to be a record in the parent stream for the child to be available
+        _customers_response()
+        .with_record(_a_customer())
+        .build(),  # there needs to be a record in the parent stream for the child to be available
     )
 
 
 def _given_events_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _events_response().build()
+        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _events_response().build()
     )
 
 
@@ -139,10 +132,7 @@ def _as_dict(response_builder: HttpResponseBuilder) -> Dict[str, Any]:
 
 
 def _read(
-    config_builder: ConfigBuilder,
-    sync_mode: SyncMode,
-    state: Optional[Dict[str, Any]] = None,
-    expecting_exception: bool = False
+    config_builder: ConfigBuilder, sync_mode: SyncMode, state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = _catalog(sync_mode)
     config = config_builder.build()
@@ -163,20 +153,12 @@ class FullRefreshTest(TestCase):
             _customers_request().with_expands(_EXPANDS).with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
             _customers_response()
             .with_record(
-                _a_customer()
-                .with_field(
-                    _SOURCES_FIELD,
-                    _as_dict(
-                        _bank_accounts_response()
-                        .with_record(_a_bank_account())
-                        .with_record(_a_bank_account())
-                    )
+                _a_customer().with_field(
+                    _SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account()).with_record(_a_bank_account()))
                 )
             )
-            .with_record(
-                _a_customer()
-                .with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account())))
-            ).build(),
+            .with_record(_a_customer().with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account()))))
+            .build(),
         )
 
         output = self._read(_config().with_start_date(_A_START_DATE))
@@ -189,16 +171,8 @@ class FullRefreshTest(TestCase):
         http_mocker.get(
             _customers_request().with_expands(_EXPANDS).with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
             _customers_response()
-            .with_record(
-                _a_customer()
-                .with_field(
-                    _SOURCES_FIELD,
-                    _as_dict(
-                        _bank_accounts_response()
-                        .with_record(_NOT_A_BANK_ACCOUNT)
-                    )
-                )
-            ).build(),
+            .with_record(_a_customer().with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_NOT_A_BANK_ACCOUNT))))
+            .build(),
         )
 
         output = self._read(_config().with_start_date(_A_START_DATE))
@@ -216,13 +190,10 @@ class FullRefreshTest(TestCase):
                 .with_id("parent_id")
                 .with_field(
                     _SOURCES_FIELD,
-                    _as_dict(
-                        _bank_accounts_response()
-                        .with_pagination()
-                        .with_record(_a_bank_account().with_id("latest_bank_account_id"))
-                    )
+                    _as_dict(_bank_accounts_response().with_pagination().with_record(_a_bank_account().with_id("latest_bank_account_id"))),
                 )
-            ).build(),
+            )
+            .build(),
         )
         http_mocker.get(
             # we do not use slice boundaries here because:
@@ -247,28 +218,21 @@ class FullRefreshTest(TestCase):
             .with_record(
                 _a_customer()
                 .with_id("parent_id")
-                .with_field(
-                    _SOURCES_FIELD,
-                    _as_dict(
-                        _bank_accounts_response()
-                        .with_record(_a_bank_account())
-                    )
-                )
-            ).build(),
+                .with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account())))
+            )
+            .build(),
         )
         http_mocker.get(
-            _customers_request().with_expands(_EXPANDS).with_starting_after("parent_id").with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
+            _customers_request()
+            .with_expands(_EXPANDS)
+            .with_starting_after("parent_id")
+            .with_created_gte(_A_START_DATE)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _customers_response()
-            .with_record(
-                _a_customer()
-                .with_field(
-                    _SOURCES_FIELD,
-                    _as_dict(
-                        _bank_accounts_response()
-                        .with_record(_a_bank_account())
-                    )
-                )
-            ).build(),
+            .with_record(_a_customer().with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account()))))
+            .build(),
         )
 
         output = self._read(_config().with_start_date(_A_START_DATE))
@@ -295,18 +259,26 @@ class FullRefreshTest(TestCase):
 
         _given_events_availability_check(http_mocker)
         http_mocker.get(
-            _customers_request().with_expands(_EXPANDS).with_created_gte(start_date).with_created_lte(slice_datetime).with_limit(100).build(),
-            _customers_response().with_record(
-                _a_customer()
-                .with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account())))
-            ).build(),
+            _customers_request()
+            .with_expands(_EXPANDS)
+            .with_created_gte(start_date)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .build(),
+            _customers_response()
+            .with_record(_a_customer().with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account()))))
+            .build(),
         )
         http_mocker.get(
-            _customers_request().with_expands(_EXPANDS).with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).build(),
-            _customers_response().with_record(
-                _a_customer()
-                .with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account())))
-            ).build(),
+            _customers_request()
+            .with_expands(_EXPANDS)
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
+            _customers_response()
+            .with_record(_a_customer().with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account()))))
+            .build(),
         )
 
         output = self._read(_config().with_start_date(start_date).with_slice_range_in_days(slice_range.days))
@@ -325,22 +297,25 @@ class FullRefreshTest(TestCase):
         _given_events_availability_check(http_mocker)
         http_mocker.get(
             StripeRequestBuilder.customers_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-            _customers_response().build()
+            _customers_response().build(),
         )  # catching subsequent slicing request that we don't really care for this test
         http_mocker.get(
-            _customers_request().with_expands(_EXPANDS).with_created_gte(start_date).with_created_lte(slice_datetime).with_limit(100).build(),
-            _customers_response().with_record(
+            _customers_request()
+            .with_expands(_EXPANDS)
+            .with_created_gte(start_date)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .build(),
+            _customers_response()
+            .with_record(
                 _a_customer()
                 .with_id("parent_id")
                 .with_field(
                     _SOURCES_FIELD,
-                    _as_dict(
-                        _bank_accounts_response()
-                        .with_pagination()
-                        .with_record(_a_bank_account().with_id("latest_bank_account_id"))
-                    )
+                    _as_dict(_bank_accounts_response().with_pagination().with_record(_a_bank_account().with_id("latest_bank_account_id"))),
                 )
-            ).build(),
+            )
+            .build(),
         )
         http_mocker.get(
             # slice range is not applied here
@@ -370,16 +345,8 @@ class FullRefreshTest(TestCase):
         http_mocker.get(
             _customers_request().with_expands(_EXPANDS).with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
             _customers_response()
-            .with_record(
-                _a_customer()
-                .with_field(
-                    _SOURCES_FIELD,
-                    _as_dict(
-                        _bank_accounts_response()
-                        .with_record(_a_bank_account())
-                    )
-                )
-            ).build(),
+            .with_record(_a_customer().with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account()))))
+            .build(),
         )
 
         output = self._read(_config().with_start_date(_A_START_DATE))
@@ -402,13 +369,9 @@ class FullRefreshTest(TestCase):
             _customers_request().with_any_query_params().build(),
             [
                 a_response_with_status(429),
-                _customers_response().with_record(_a_customer().with_field(
-                    _SOURCES_FIELD,
-                    _as_dict(
-                        _bank_accounts_response()
-                        .with_record(_a_bank_account())
-                    )
-                )).build(),
+                _customers_response()
+                .with_record(_a_customer().with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account()))))
+                .build(),
             ],
         )
         output = self._read(_config().with_start_date(_A_START_DATE))
@@ -430,7 +393,6 @@ class FullRefreshTest(TestCase):
 
 @freezegun.freeze_time(_NOW.isoformat())
 class IncrementalTest(TestCase):
-
     @HttpMocker()
     def test_given_no_state_and_successful_sync_when_read_then_set_state_to_now(self, http_mocker: HttpMocker) -> None:
         # If stripe takes some time to ingest the data, we should recommend to use a lookback window when syncing the bank_accounts stream
@@ -438,10 +400,9 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         http_mocker.get(
             _customers_request().with_expands(_EXPANDS).with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
-            _customers_response().with_record(
-                _a_customer()
-                .with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account())))
-            ).build(),
+            _customers_response()
+            .with_record(_a_customer().with_field(_SOURCES_FIELD, _as_dict(_bank_accounts_response().with_record(_a_bank_account()))))
+            .build(),
         )
 
         output = self._read(_config().with_start_date(_A_START_DATE), _NO_STATE)
@@ -457,10 +418,15 @@ class IncrementalTest(TestCase):
         _given_customers_availability_check(http_mocker)
         _given_events_availability_check(http_mocker)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                _an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _a_bank_account().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_record(_an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _a_bank_account().build()))
+            .build(),
         )
 
         output = self._read(
@@ -476,13 +442,25 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         state_datetime = _NOW - timedelta(days=5)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_pagination().with_record(
-                _an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _a_bank_account().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_pagination()
+            .with_record(_an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _a_bank_account().build()))
+            .build(),
         )
         http_mocker.get(
-            _events_request().with_starting_after("last_record_id_from_first_page").with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_bank_account_event()).build(),
         )
 
@@ -500,13 +478,25 @@ class IncrementalTest(TestCase):
         slice_datetime = state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES + slice_range
 
         _given_customers_availability_check(http_mocker)
-        _given_events_availability_check(http_mocker)  # the availability check does not consider the state so we need to define a generic availability check
+        _given_events_availability_check(
+            http_mocker
+        )  # the availability check does not consider the state so we need to define a generic availability check
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(slice_datetime).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_bank_account_event()).build(),
         )
         http_mocker.get(
-            _events_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_bank_account_event()).with_record(self._a_bank_account_event()).build(),
         )
 
@@ -518,7 +508,9 @@ class IncrementalTest(TestCase):
         assert len(output.records) == 3
 
     @HttpMocker()
-    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(self, http_mocker: HttpMocker) -> None:
+    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(
+        self, http_mocker: HttpMocker
+    ) -> None:
         # this seems odd as we would miss some data between start_date and events_lower_boundary. In that case, we should hit the
         # customer endpoint
         _given_customers_availability_check(http_mocker)
@@ -526,7 +518,12 @@ class IncrementalTest(TestCase):
         state_value = _NOW - timedelta(days=39)
         events_lower_boundary = _NOW - timedelta(days=30)
         http_mocker.get(
-            _events_request().with_created_gte(events_lower_boundary).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(events_lower_boundary)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_bank_account_event()).build(),
         )
 
@@ -543,10 +540,13 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         state_datetime = _NOW - timedelta(days=5)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                _an_event().with_field(_DATA_FIELD, _NOT_A_BANK_ACCOUNT.build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response().with_record(_an_event().with_field(_DATA_FIELD, _NOT_A_BANK_ACCOUNT.build())).build(),
         )
 
         output = self._read(

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_cards.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_cards.py
@@ -69,11 +69,7 @@ def _an_event() -> RecordBuilder:
 
 
 def _events_response() -> HttpResponseBuilder:
-    return create_response_builder(
-        find_template("events", __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
-    )
+    return create_response_builder(find_template("events", __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy())
 
 
 def _a_card() -> RecordBuilder:
@@ -87,31 +83,24 @@ def _a_card() -> RecordBuilder:
 
 def _cards_response() -> HttpResponseBuilder:
     return create_response_builder(
-        find_template(_ENDPOINT_TEMPLATE_NAME, __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        find_template(_ENDPOINT_TEMPLATE_NAME, __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy()
     )
 
 
 def _given_cards_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.issuing_cards_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _cards_response().build()
+        StripeRequestBuilder.issuing_cards_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _cards_response().build()
     )
 
 
 def _given_events_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _events_response().build()
+        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _events_response().build()
     )
 
 
 def _read(
-    config_builder: ConfigBuilder,
-    sync_mode: SyncMode,
-    state: Optional[Dict[str, Any]] = None,
-    expecting_exception: bool = False
+    config_builder: ConfigBuilder, sync_mode: SyncMode, state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = _catalog(sync_mode)
     config = config_builder.build()
@@ -120,7 +109,6 @@ def _read(
 
 @freezegun.freeze_time(_NOW.isoformat())
 class FullRefreshTest(TestCase):
-
     @HttpMocker()
     def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -141,7 +129,12 @@ class FullRefreshTest(TestCase):
             _cards_response().with_pagination().with_record(_a_card().with_id("last_record_id_from_first_page")).build(),
         )
         http_mocker.get(
-            _cards_request().with_starting_after("last_record_id_from_first_page").with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
+            _cards_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(_A_START_DATE)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _cards_response().with_record(_a_card()).with_record(_a_card()).build(),
         )
 
@@ -185,7 +178,11 @@ class FullRefreshTest(TestCase):
             _cards_response().build(),
         )
         http_mocker.get(
-            _cards_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).build(),
+            _cards_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _cards_response().build(),
         )
 
@@ -249,7 +246,7 @@ class FullRefreshTest(TestCase):
         events_requests = StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build()
         http_mocker.get(
             events_requests,
-            _events_response().build()  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
+            _events_response().build(),  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
         )
         http_mocker.get(
             _cards_request().with_any_query_params().build(),
@@ -266,7 +263,6 @@ class FullRefreshTest(TestCase):
 
 @freezegun.freeze_time(_NOW.isoformat())
 class IncrementalTest(TestCase):
-
     @HttpMocker()
     def test_given_no_state_when_read_then_use_cards_endpoint(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -287,10 +283,13 @@ class IncrementalTest(TestCase):
         _given_cards_availability_check(http_mocker)
         _given_events_availability_check(http_mocker)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                _an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _a_card().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response().with_record(_an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _a_card().build())).build(),
         )
 
         output = self._read(
@@ -306,13 +305,25 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         state_datetime = _NOW - timedelta(days=5)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_pagination().with_record(
-                _an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _a_card().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_pagination()
+            .with_record(_an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _a_card().build()))
+            .build(),
         )
         http_mocker.get(
-            _events_request().with_starting_after("last_record_id_from_first_page").with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_card_event()).build(),
         )
 
@@ -330,13 +341,25 @@ class IncrementalTest(TestCase):
         slice_datetime = state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES + slice_range
 
         _given_cards_availability_check(http_mocker)
-        _given_events_availability_check(http_mocker)  # the availability check does not consider the state so we need to define a generic availability check
+        _given_events_availability_check(
+            http_mocker
+        )  # the availability check does not consider the state so we need to define a generic availability check
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(slice_datetime).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_card_event()).build(),
         )
         http_mocker.get(
-            _events_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_card_event()).with_record(self._a_card_event()).build(),
         )
 
@@ -348,7 +371,9 @@ class IncrementalTest(TestCase):
         assert len(output.records) == 3
 
     @HttpMocker()
-    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(self, http_mocker: HttpMocker) -> None:
+    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(
+        self, http_mocker: HttpMocker
+    ) -> None:
         # this seems odd as we would miss some data between start_date and events_lower_boundary. In that case, we should hit the
         # cards endpoint
         _given_cards_availability_check(http_mocker)
@@ -356,7 +381,12 @@ class IncrementalTest(TestCase):
         state_value = _NOW - timedelta(days=39)
         events_lower_boundary = _NOW - timedelta(days=30)
         http_mocker.get(
-            _events_request().with_created_gte(events_lower_boundary).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(events_lower_boundary)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_card_event()).build(),
         )
 

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_external_account_bank_accounts.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_external_account_bank_accounts.py
@@ -70,11 +70,7 @@ def _an_event() -> RecordBuilder:
 
 
 def _events_response() -> HttpResponseBuilder:
-    return create_response_builder(
-        find_template("events", __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
-    )
+    return create_response_builder(find_template("events", __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy())
 
 
 def _an_external_bank_account() -> RecordBuilder:
@@ -87,31 +83,25 @@ def _an_external_bank_account() -> RecordBuilder:
 
 def _external_bank_accounts_response() -> HttpResponseBuilder:
     return create_response_builder(
-        find_template(_ENDPOINT_TEMPLATE_NAME, __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        find_template(_ENDPOINT_TEMPLATE_NAME, __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy()
     )
 
 
 def _given_external_accounts_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
         StripeRequestBuilder.external_accounts_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _external_bank_accounts_response().build()
+        _external_bank_accounts_response().build(),
     )
 
 
 def _given_events_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _events_response().build()
+        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _events_response().build()
     )
 
 
 def _read(
-    config_builder: ConfigBuilder,
-    sync_mode: SyncMode,
-    state: Optional[Dict[str, Any]] = None,
-    expecting_exception: bool = False
+    config_builder: ConfigBuilder, sync_mode: SyncMode, state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = _catalog(sync_mode)
     config = config_builder.build()
@@ -120,7 +110,6 @@ def _read(
 
 @freezegun.freeze_time(_NOW.isoformat())
 class FullRefreshTest(TestCase):
-
     @HttpMocker()
     def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -138,7 +127,10 @@ class FullRefreshTest(TestCase):
         _given_events_availability_check(http_mocker)
         http_mocker.get(
             _external_accounts_request().with_object(_OBJECT).with_limit(100).build(),
-            _external_bank_accounts_response().with_pagination().with_record(_an_external_bank_account().with_id("last_record_id_from_first_page")).build(),
+            _external_bank_accounts_response()
+            .with_pagination()
+            .with_record(_an_external_bank_account().with_id("last_record_id_from_first_page"))
+            .build(),
         )
         http_mocker.get(
             _external_accounts_request().with_starting_after("last_record_id_from_first_page").with_object(_OBJECT).with_limit(100).build(),
@@ -217,7 +209,7 @@ class FullRefreshTest(TestCase):
         events_requests = StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build()
         http_mocker.get(
             events_requests,
-            _events_response().build()  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
+            _events_response().build(),  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
         )
         http_mocker.get(
             _external_accounts_request().with_any_query_params().build(),
@@ -234,7 +226,6 @@ class FullRefreshTest(TestCase):
 
 @freezegun.freeze_time(_NOW.isoformat())
 class IncrementalTest(TestCase):
-
     @HttpMocker()
     def test_given_no_state_when_read_then_use_external_accounts_endpoint(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -254,10 +245,15 @@ class IncrementalTest(TestCase):
         _given_external_accounts_availability_check(http_mocker)
         _given_events_availability_check(http_mocker)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                _an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _an_external_bank_account().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_record(_an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _an_external_bank_account().build()))
+            .build(),
         )
 
         output = self._read(
@@ -275,9 +271,7 @@ class IncrementalTest(TestCase):
         _given_external_accounts_availability_check(http_mocker)
         http_mocker.get(
             StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-            _events_response().with_record(
-                _an_event().with_field(_DATA_FIELD, {"object": "not a bank account"})
-            ).build(),
+            _events_response().with_record(_an_event().with_field(_DATA_FIELD, {"object": "not a bank account"})).build(),
         )
 
         output = self._read(
@@ -293,13 +287,25 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         state_datetime = _NOW - timedelta(days=5)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_pagination().with_record(
-                _an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _an_external_bank_account().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_pagination()
+            .with_record(_an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _an_external_bank_account().build()))
+            .build(),
         )
         http_mocker.get(
-            _events_request().with_starting_after("last_record_id_from_first_page").with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_external_account_event()).build(),
         )
 
@@ -317,13 +323,25 @@ class IncrementalTest(TestCase):
         slice_datetime = state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES + slice_range
 
         _given_external_accounts_availability_check(http_mocker)
-        _given_events_availability_check(http_mocker)  # the availability check does not consider the state so we need to define a generic availability check
+        _given_events_availability_check(
+            http_mocker
+        )  # the availability check does not consider the state so we need to define a generic availability check
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(slice_datetime).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_external_account_event()).build(),
         )
         http_mocker.get(
-            _events_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_external_account_event()).with_record(self._an_external_account_event()).build(),
         )
 
@@ -335,7 +353,9 @@ class IncrementalTest(TestCase):
         assert len(output.records) == 3
 
     @HttpMocker()
-    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(self, http_mocker: HttpMocker) -> None:
+    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(
+        self, http_mocker: HttpMocker
+    ) -> None:
         # this seems odd as we would miss some data between start_date and events_lower_boundary. In that case, we should hit the
         # external_accounts endpoint
         _given_external_accounts_availability_check(http_mocker)
@@ -343,7 +363,12 @@ class IncrementalTest(TestCase):
         state_value = _NOW - timedelta(days=39)
         events_lower_boundary = _NOW - timedelta(days=30)
         http_mocker.get(
-            _events_request().with_created_gte(events_lower_boundary).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(events_lower_boundary)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_external_account_event()).build(),
         )
 

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_external_account_cards.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_external_account_cards.py
@@ -70,11 +70,7 @@ def _an_event() -> RecordBuilder:
 
 
 def _events_response() -> HttpResponseBuilder:
-    return create_response_builder(
-        find_template("events", __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
-    )
+    return create_response_builder(find_template("events", __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy())
 
 
 def _an_external_account_card() -> RecordBuilder:
@@ -92,31 +88,25 @@ def _external_accounts_card_response() -> HttpResponseBuilder:
      tests, we will leave it as is for now.
     """
     return create_response_builder(
-        find_template(_ENDPOINT_TEMPLATE_NAME, __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        find_template(_ENDPOINT_TEMPLATE_NAME, __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy()
     )
 
 
 def _given_external_accounts_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
         StripeRequestBuilder.external_accounts_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _external_accounts_card_response().build()
+        _external_accounts_card_response().build(),
     )
 
 
 def _given_events_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _events_response().build()
+        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _events_response().build()
     )
 
 
 def _read(
-    config_builder: ConfigBuilder,
-    sync_mode: SyncMode,
-    state: Optional[Dict[str, Any]] = None,
-    expecting_exception: bool = False
+    config_builder: ConfigBuilder, sync_mode: SyncMode, state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = _catalog(sync_mode)
     config = config_builder.build()
@@ -125,7 +115,6 @@ def _read(
 
 @freezegun.freeze_time(_NOW.isoformat())
 class FullRefreshTest(TestCase):
-
     @HttpMocker()
     def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -143,7 +132,10 @@ class FullRefreshTest(TestCase):
         _given_events_availability_check(http_mocker)
         http_mocker.get(
             _external_accounts_request().with_object(_OBJECT).with_limit(100).build(),
-            _external_accounts_card_response().with_pagination().with_record(_an_external_account_card().with_id("last_record_id_from_first_page")).build(),
+            _external_accounts_card_response()
+            .with_pagination()
+            .with_record(_an_external_account_card().with_id("last_record_id_from_first_page"))
+            .build(),
         )
         http_mocker.get(
             _external_accounts_request().with_starting_after("last_record_id_from_first_page").with_object(_OBJECT).with_limit(100).build(),
@@ -222,7 +214,7 @@ class FullRefreshTest(TestCase):
         events_requests = StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build()
         http_mocker.get(
             events_requests,
-            _events_response().build()  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
+            _events_response().build(),  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
         )
         http_mocker.get(
             _external_accounts_request().with_any_query_params().build(),
@@ -239,7 +231,6 @@ class FullRefreshTest(TestCase):
 
 @freezegun.freeze_time(_NOW.isoformat())
 class IncrementalTest(TestCase):
-
     @HttpMocker()
     def test_given_no_state_when_read_then_use_external_accounts_endpoint(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -259,10 +250,15 @@ class IncrementalTest(TestCase):
         _given_external_accounts_availability_check(http_mocker)
         _given_events_availability_check(http_mocker)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                _an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _an_external_account_card().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_record(_an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _an_external_account_card().build()))
+            .build(),
         )
 
         output = self._read(
@@ -280,9 +276,7 @@ class IncrementalTest(TestCase):
         _given_external_accounts_availability_check(http_mocker)
         http_mocker.get(
             StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-            _events_response().with_record(
-                _an_event().with_field(_DATA_FIELD, {"object": "not a card"})
-            ).build(),
+            _events_response().with_record(_an_event().with_field(_DATA_FIELD, {"object": "not a card"})).build(),
         )
 
         output = self._read(
@@ -298,13 +292,25 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         state_datetime = _NOW - timedelta(days=5)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_pagination().with_record(
-                _an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _an_external_account_card().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_pagination()
+            .with_record(_an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _an_external_account_card().build()))
+            .build(),
         )
         http_mocker.get(
-            _events_request().with_starting_after("last_record_id_from_first_page").with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_external_account_event()).build(),
         )
 
@@ -322,13 +328,25 @@ class IncrementalTest(TestCase):
         slice_datetime = state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES + slice_range
 
         _given_external_accounts_availability_check(http_mocker)
-        _given_events_availability_check(http_mocker)  # the availability check does not consider the state so we need to define a generic availability check
+        _given_events_availability_check(
+            http_mocker
+        )  # the availability check does not consider the state so we need to define a generic availability check
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(slice_datetime).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_external_account_event()).build(),
         )
         http_mocker.get(
-            _events_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_external_account_event()).with_record(self._an_external_account_event()).build(),
         )
 
@@ -340,7 +358,9 @@ class IncrementalTest(TestCase):
         assert len(output.records) == 3
 
     @HttpMocker()
-    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(self, http_mocker: HttpMocker) -> None:
+    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(
+        self, http_mocker: HttpMocker
+    ) -> None:
         # this seems odd as we would miss some data between start_date and events_lower_boundary. In that case, we should hit the
         # external_accounts endpoint
         _given_external_accounts_availability_check(http_mocker)
@@ -348,7 +368,12 @@ class IncrementalTest(TestCase):
         state_value = _NOW - timedelta(days=39)
         events_lower_boundary = _NOW - timedelta(days=30)
         http_mocker.get(
-            _events_request().with_created_gte(events_lower_boundary).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(events_lower_boundary)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._an_external_account_event()).build(),
         )
 

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_payment_methods.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_payment_methods.py
@@ -74,11 +74,7 @@ def _an_event() -> RecordBuilder:
 
 
 def _events_response() -> HttpResponseBuilder:
-    return create_response_builder(
-        find_template("events", __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
-    )
+    return create_response_builder(find_template("events", __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy())
 
 
 def _a_payment_method() -> RecordBuilder:
@@ -92,31 +88,25 @@ def _a_payment_method() -> RecordBuilder:
 
 def _payment_methods_response() -> HttpResponseBuilder:
     return create_response_builder(
-        find_template(_ENDPOINT_TEMPLATE_NAME, __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        find_template(_ENDPOINT_TEMPLATE_NAME, __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy()
     )
 
 
 def _given_payment_methods_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
         StripeRequestBuilder.payment_methods_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _payment_methods_response().build()
+        _payment_methods_response().build(),
     )
 
 
 def _given_events_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _events_response().build()
+        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _events_response().build()
     )
 
 
 def _read(
-    config_builder: ConfigBuilder,
-    sync_mode: SyncMode,
-    state: Optional[Dict[str, Any]] = None,
-    expecting_exception: bool = False
+    config_builder: ConfigBuilder, sync_mode: SyncMode, state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = _catalog(sync_mode)
     config = config_builder.build()
@@ -125,7 +115,6 @@ def _read(
 
 @freezegun.freeze_time(_NOW.isoformat())
 class FullRefreshTest(TestCase):
-
     @HttpMocker()
     def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -143,7 +132,10 @@ class FullRefreshTest(TestCase):
         _given_events_availability_check(http_mocker)
         http_mocker.get(
             _payment_methods_request().with_limit(100).build(),
-            _payment_methods_response().with_pagination().with_record(_a_payment_method().with_id("last_record_id_from_first_page")).build(),
+            _payment_methods_response()
+            .with_pagination()
+            .with_record(_a_payment_method().with_id("last_record_id_from_first_page"))
+            .build(),
         )
         http_mocker.get(
             _payment_methods_request().with_starting_after("last_record_id_from_first_page").with_limit(100).build(),
@@ -222,7 +214,7 @@ class FullRefreshTest(TestCase):
         events_requests = StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build()
         http_mocker.get(
             events_requests,
-            _events_response().build()  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
+            _events_response().build(),  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
         )
         http_mocker.get(
             _payment_methods_request().with_any_query_params().build(),
@@ -239,7 +231,6 @@ class FullRefreshTest(TestCase):
 
 @freezegun.freeze_time(_NOW.isoformat())
 class IncrementalTest(TestCase):
-
     @HttpMocker()
     def test_given_no_state_when_read_then_use_payment_methods_endpoint(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -260,10 +251,15 @@ class IncrementalTest(TestCase):
         _given_payment_methods_availability_check(http_mocker)
         _given_events_availability_check(http_mocker)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                _an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _a_payment_method().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_record(_an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _a_payment_method().build()))
+            .build(),
         )
 
         output = self._read(
@@ -279,13 +275,25 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         state_datetime = _NOW - timedelta(days=5)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_pagination().with_record(
-                _an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _a_payment_method().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_pagination()
+            .with_record(_an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _a_payment_method().build()))
+            .build(),
         )
         http_mocker.get(
-            _events_request().with_starting_after("last_record_id_from_first_page").with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_payment_method_event()).build(),
         )
 
@@ -303,13 +311,25 @@ class IncrementalTest(TestCase):
         slice_datetime = state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES + slice_range
 
         _given_payment_methods_availability_check(http_mocker)
-        _given_events_availability_check(http_mocker)  # the availability check does not consider the state so we need to define a generic availability check
+        _given_events_availability_check(
+            http_mocker
+        )  # the availability check does not consider the state so we need to define a generic availability check
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(slice_datetime).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_payment_method_event()).build(),
         )
         http_mocker.get(
-            _events_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_payment_method_event()).with_record(self._a_payment_method_event()).build(),
         )
 
@@ -321,7 +341,9 @@ class IncrementalTest(TestCase):
         assert len(output.records) == 3
 
     @HttpMocker()
-    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(self, http_mocker: HttpMocker) -> None:
+    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(
+        self, http_mocker: HttpMocker
+    ) -> None:
         # this seems odd as we would miss some data between start_date and events_lower_boundary. In that case, we should hit the
         # payment_methods endpoint
         _given_payment_methods_availability_check(http_mocker)
@@ -329,7 +351,12 @@ class IncrementalTest(TestCase):
         state_value = _NOW - timedelta(days=39)
         events_lower_boundary = _NOW - timedelta(days=30)
         http_mocker.get(
-            _events_request().with_created_gte(events_lower_boundary).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(events_lower_boundary)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_payment_method_event()).build(),
         )
 

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_persons.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_persons.py
@@ -61,16 +61,13 @@ def _create_response() -> HttpResponseBuilder:
     return create_response_builder(
         response_template=find_template("accounts", __file__),
         records_path=FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        pagination_strategy=StripePaginationStrategy(),
     )
 
 
 def _create_record(resource: str) -> RecordBuilder:
     return create_record_builder(
-        find_template(resource, __file__),
-        FieldPath("data"),
-        record_id_path=FieldPath("id"),
-        record_cursor_path=FieldPath("created")
+        find_template(resource, __file__), FieldPath("data"), record_id_path=FieldPath("id"), record_cursor_path=FieldPath("created")
     )
 
 
@@ -83,18 +80,19 @@ def _create_persons_event_record(event_type: str) -> RecordBuilder:
     )
 
     person_record = create_record_builder(
-        find_template("persons", __file__),
-        FieldPath("data"),
-        record_id_path=FieldPath("id"),
-        record_cursor_path=FieldPath("created")
+        find_template("persons", __file__), FieldPath("data"), record_id_path=FieldPath("id"), record_cursor_path=FieldPath("created")
     )
 
     return event_record.with_field(NestedPath(["data", "object"]), person_record.build()).with_field(NestedPath(["type"]), event_type)
 
 
 def emits_successful_sync_status_messages(status_messages: List[AirbyteStreamStatus]) -> bool:
-    return (len(status_messages) == 3 and status_messages[0] == AirbyteStreamStatus.STARTED
-            and status_messages[1] == AirbyteStreamStatus.RUNNING and status_messages[2] == AirbyteStreamStatus.COMPLETE)
+    return (
+        len(status_messages) == 3
+        and status_messages[0] == AirbyteStreamStatus.STARTED
+        and status_messages[1] == AirbyteStreamStatus.RUNNING
+        and status_messages[2] == AirbyteStreamStatus.COMPLETE
+    )
 
 
 @freezegun.freeze_time(_NOW.isoformat())
@@ -112,7 +110,12 @@ class PersonsTest(TestCase):
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_record("events")).with_record(record=_create_record("events")).build(),
         )
 
@@ -144,8 +147,12 @@ class PersonsTest(TestCase):
 
         # The persons stream makes a final call to events endpoint
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_record("events")).with_record(record=_create_record("events")).build(),
         )
 
@@ -166,20 +173,27 @@ class PersonsTest(TestCase):
         # Persons stream first page request
         http_mocker.get(
             _create_persons_request().with_limit(100).build(),
-            _create_response().with_record(record=_create_record("persons")).with_record(record=_create_record("persons").with_id("last_page_record_id")).with_pagination().build(),
+            _create_response()
+            .with_record(record=_create_record("persons"))
+            .with_record(record=_create_record("persons").with_id("last_page_record_id"))
+            .with_pagination()
+            .build(),
         )
 
         # Persons stream second page request
         http_mocker.get(
             _create_persons_request().with_limit(100).with_starting_after("last_page_record_id").build(),
-            _create_response().with_record(record=_create_record("persons")).with_record(
-                record=_create_record("persons")).build(),
+            _create_response().with_record(record=_create_record("persons")).with_record(record=_create_record("persons")).build(),
         )
 
         # The persons stream makes a final call to events endpoint
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_record("events")).with_record(record=_create_record("events")).build(),
         )
 
@@ -295,13 +309,25 @@ class PersonsTest(TestCase):
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(["person.created", "person.updated", "person.deleted"]).build(),
-            _create_response().with_record(record=_create_persons_event_record(event_type="person.created")).with_record(record=_create_persons_event_record(event_type="person.created")).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
+            _create_response()
+            .with_record(record=_create_persons_event_record(event_type="person.created"))
+            .with_record(record=_create_persons_event_record(event_type="person.created"))
+            .build(),
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(cursor_datetime).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(cursor_datetime)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_persons_event_record(event_type="person.created")).build(),
         )
 
@@ -333,13 +359,25 @@ class PersonsTest(TestCase):
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(["person.created", "person.updated", "person.deleted"]).build(),
-            _create_response().with_record(record=_create_persons_event_record(event_type="person.created")).with_record(record=_create_persons_event_record(event_type="person.deleted")).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
+            _create_response()
+            .with_record(record=_create_persons_event_record(event_type="person.created"))
+            .with_record(record=_create_persons_event_record(event_type="person.deleted"))
+            .build(),
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(cursor_datetime).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(cursor_datetime)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_persons_event_record(event_type="person.deleted")).build(),
         )
 
@@ -373,8 +411,12 @@ class PersonsTest(TestCase):
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(start_datetime).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(start_datetime)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_persons_event_record(event_type="person.created")).build(),
         )
 
@@ -406,8 +448,12 @@ class PersonsTest(TestCase):
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_record("events")).with_record(record=_create_record("events")).build(),
         )
 
@@ -429,12 +475,16 @@ class PersonsTest(TestCase):
             [
                 a_response_with_status(429),
                 _create_response().with_record(record=_create_record("persons")).with_record(record=_create_record("persons")).build(),
-            ]
+            ],
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_record("events")).with_record(record=_create_record("events")).build(),
         )
 
@@ -461,19 +511,29 @@ class PersonsTest(TestCase):
 
         # Mock when check_availability is run on the persons incremental stream
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
-            _create_response().with_record(record=_create_persons_event_record(event_type="person.created")).with_record(
-                record=_create_persons_event_record(event_type="person.created")).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
+            _create_response()
+            .with_record(record=_create_persons_event_record(event_type="person.created"))
+            .with_record(record=_create_persons_event_record(event_type="person.created"))
+            .build(),
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(cursor_datetime).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(cursor_datetime)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             [
                 a_response_with_status(429),
                 _create_response().with_record(record=_create_persons_event_record(event_type="person.created")).build(),
-            ]
+            ],
         )
 
         source = SourceStripe(config=_CONFIG, catalog=_create_catalog(sync_mode=SyncMode.incremental))
@@ -501,12 +561,16 @@ class PersonsTest(TestCase):
                 # Used to pass the initial check_availability before starting the sync
                 _create_response().with_record(record=_create_record("persons")).with_record(record=_create_record("persons")).build(),
                 a_response_with_status(429),  # Returns 429 on all subsequent requests to test the maximum number of retries
-            ]
+            ],
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_record("events")).with_record(record=_create_record("events")).build(),
         )
 
@@ -532,15 +596,25 @@ class PersonsTest(TestCase):
 
         # Mock when check_availability is run on the persons incremental stream
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
-            _create_response().with_record(record=_create_persons_event_record(event_type="person.created")).with_record(
-                record=_create_persons_event_record(event_type="person.created")).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
+            _create_response()
+            .with_record(record=_create_persons_event_record(event_type="person.created"))
+            .with_record(record=_create_persons_event_record(event_type="person.created"))
+            .build(),
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(cursor_datetime).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(cursor_datetime)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             a_response_with_status(429),  # Returns 429 on all subsequent requests to test the maximum number of retries
         )
 
@@ -570,8 +644,12 @@ class PersonsTest(TestCase):
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_record("events")).with_record(record=_create_record("events")).build(),
         )
 
@@ -593,12 +671,16 @@ class PersonsTest(TestCase):
             [
                 a_response_with_status(500),
                 _create_response().with_record(record=_create_record("persons")).with_record(record=_create_record("persons")).build(),
-            ]
+            ],
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_record("events")).with_record(record=_create_record("events")).build(),
         )
 
@@ -621,12 +703,16 @@ class PersonsTest(TestCase):
                 # Used to pass the initial check_availability before starting the sync
                 _create_response().with_record(record=_create_record("persons")).with_record(record=_create_record("persons")).build(),
                 a_response_with_status(500),  # Returns 429 on all subsequent requests to test the maximum number of retries
-            ]
+            ],
         )
 
         http_mocker.get(
-            _create_events_request().with_created_gte(_NOW - timedelta(days=30)).with_created_lte(_NOW).with_limit(100).with_types(
-                ["person.created", "person.updated", "person.deleted"]).build(),
+            _create_events_request()
+            .with_created_gte(_NOW - timedelta(days=30))
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(["person.created", "person.updated", "person.deleted"])
+            .build(),
             _create_response().with_record(record=_create_record("events")).with_record(record=_create_record("events")).build(),
         )
 

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_reviews.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_reviews.py
@@ -69,11 +69,7 @@ def _an_event() -> RecordBuilder:
 
 
 def _events_response() -> HttpResponseBuilder:
-    return create_response_builder(
-        find_template("events", __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
-    )
+    return create_response_builder(find_template("events", __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy())
 
 
 def _a_review() -> RecordBuilder:
@@ -87,31 +83,24 @@ def _a_review() -> RecordBuilder:
 
 def _reviews_response() -> HttpResponseBuilder:
     return create_response_builder(
-        find_template(_ENDPOINT_TEMPLATE_NAME, __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        find_template(_ENDPOINT_TEMPLATE_NAME, __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy()
     )
 
 
 def _given_reviews_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.reviews_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _reviews_response().build()
+        StripeRequestBuilder.reviews_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _reviews_response().build()
     )
 
 
 def _given_events_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _events_response().build()
+        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _events_response().build()
     )
 
 
 def _read(
-    config_builder: ConfigBuilder,
-    sync_mode: SyncMode,
-    state: Optional[Dict[str, Any]] = None,
-    expecting_exception: bool = False
+    config_builder: ConfigBuilder, sync_mode: SyncMode, state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = _catalog(sync_mode)
     config = config_builder.build()
@@ -120,7 +109,6 @@ def _read(
 
 @freezegun.freeze_time(_NOW.isoformat())
 class FullRefreshTest(TestCase):
-
     @HttpMocker()
     def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -141,7 +129,12 @@ class FullRefreshTest(TestCase):
             _reviews_response().with_pagination().with_record(_a_review().with_id("last_record_id_from_first_page")).build(),
         )
         http_mocker.get(
-            _reviews_request().with_starting_after("last_record_id_from_first_page").with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
+            _reviews_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(_A_START_DATE)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _reviews_response().with_record(_a_review()).with_record(_a_review()).build(),
         )
 
@@ -185,7 +178,11 @@ class FullRefreshTest(TestCase):
             _reviews_response().build(),
         )
         http_mocker.get(
-            _reviews_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).build(),
+            _reviews_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _reviews_response().build(),
         )
 
@@ -249,7 +246,7 @@ class FullRefreshTest(TestCase):
         events_requests = StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build()
         http_mocker.get(
             events_requests,
-            _events_response().build()  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
+            _events_response().build(),  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
         )
         http_mocker.get(
             _reviews_request().with_any_query_params().build(),
@@ -266,7 +263,6 @@ class FullRefreshTest(TestCase):
 
 @freezegun.freeze_time(_NOW.isoformat())
 class IncrementalTest(TestCase):
-
     @HttpMocker()
     def test_given_no_state_when_read_then_use_reviews_endpoint(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -287,10 +283,13 @@ class IncrementalTest(TestCase):
         _given_reviews_availability_check(http_mocker)
         _given_events_availability_check(http_mocker)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                _an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _a_review().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response().with_record(_an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _a_review().build())).build(),
         )
 
         output = self._read(
@@ -306,13 +305,25 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         state_datetime = _NOW - timedelta(days=5)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_pagination().with_record(
-                _an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _a_review().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_pagination()
+            .with_record(_an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _a_review().build()))
+            .build(),
         )
         http_mocker.get(
-            _events_request().with_starting_after("last_record_id_from_first_page").with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_review_event()).build(),
         )
 
@@ -330,13 +341,25 @@ class IncrementalTest(TestCase):
         slice_datetime = state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES + slice_range
 
         _given_reviews_availability_check(http_mocker)
-        _given_events_availability_check(http_mocker)  # the availability check does not consider the state so we need to define a generic availability check
+        _given_events_availability_check(
+            http_mocker
+        )  # the availability check does not consider the state so we need to define a generic availability check
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(slice_datetime).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_review_event()).build(),
         )
         http_mocker.get(
-            _events_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_review_event()).with_record(self._a_review_event()).build(),
         )
 
@@ -348,7 +371,9 @@ class IncrementalTest(TestCase):
         assert len(output.records) == 3
 
     @HttpMocker()
-    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(self, http_mocker: HttpMocker) -> None:
+    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(
+        self, http_mocker: HttpMocker
+    ) -> None:
         # this seems odd as we would miss some data between start_date and events_lower_boundary. In that case, we should hit the
         # reviews endpoint
         _given_reviews_availability_check(http_mocker)
@@ -356,7 +381,12 @@ class IncrementalTest(TestCase):
         state_value = _NOW - timedelta(days=39)
         events_lower_boundary = _NOW - timedelta(days=30)
         http_mocker.get(
-            _events_request().with_created_gte(events_lower_boundary).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(events_lower_boundary)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_review_event()).build(),
         )
 

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_transactions.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/integration/test_transactions.py
@@ -69,11 +69,7 @@ def _an_event() -> RecordBuilder:
 
 
 def _events_response() -> HttpResponseBuilder:
-    return create_response_builder(
-        find_template("events", __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
-    )
+    return create_response_builder(find_template("events", __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy())
 
 
 def _a_transaction() -> RecordBuilder:
@@ -87,31 +83,25 @@ def _a_transaction() -> RecordBuilder:
 
 def _transactions_response() -> HttpResponseBuilder:
     return create_response_builder(
-        find_template(_ENDPOINT_TEMPLATE_NAME, __file__),
-        FieldPath("data"),
-        pagination_strategy=StripePaginationStrategy()
+        find_template(_ENDPOINT_TEMPLATE_NAME, __file__), FieldPath("data"), pagination_strategy=StripePaginationStrategy()
     )
 
 
 def _given_transactions_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
         StripeRequestBuilder.issuing_transactions_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _transactions_response().build()
+        _transactions_response().build(),
     )
 
 
 def _given_events_availability_check(http_mocker: HttpMocker) -> None:
     http_mocker.get(
-        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(),
-        _events_response().build()
+        StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build(), _events_response().build()
     )
 
 
 def _read(
-    config_builder: ConfigBuilder,
-    sync_mode: SyncMode,
-    state: Optional[Dict[str, Any]] = None,
-    expecting_exception: bool = False
+    config_builder: ConfigBuilder, sync_mode: SyncMode, state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = _catalog(sync_mode)
     config = config_builder.build()
@@ -120,7 +110,6 @@ def _read(
 
 @freezegun.freeze_time(_NOW.isoformat())
 class FullRefreshTest(TestCase):
-
     @HttpMocker()
     def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -141,7 +130,12 @@ class FullRefreshTest(TestCase):
             _transactions_response().with_pagination().with_record(_a_transaction().with_id("last_record_id_from_first_page")).build(),
         )
         http_mocker.get(
-            _transactions_request().with_starting_after("last_record_id_from_first_page").with_created_gte(_A_START_DATE).with_created_lte(_NOW).with_limit(100).build(),
+            _transactions_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(_A_START_DATE)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _transactions_response().with_record(_a_transaction()).with_record(_a_transaction()).build(),
         )
 
@@ -185,7 +179,11 @@ class FullRefreshTest(TestCase):
             _transactions_response().build(),
         )
         http_mocker.get(
-            _transactions_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).build(),
+            _transactions_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .build(),
             _transactions_response().build(),
         )
 
@@ -249,7 +247,7 @@ class FullRefreshTest(TestCase):
         events_requests = StripeRequestBuilder.events_endpoint(_ACCOUNT_ID, _CLIENT_SECRET).with_any_query_params().build()
         http_mocker.get(
             events_requests,
-            _events_response().build()  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
+            _events_response().build(),  # it is important that the event response does not have a record. This is not far fetched as this is what would happend 30 days before now
         )
         http_mocker.get(
             _transactions_request().with_any_query_params().build(),
@@ -266,7 +264,6 @@ class FullRefreshTest(TestCase):
 
 @freezegun.freeze_time(_NOW.isoformat())
 class IncrementalTest(TestCase):
-
     @HttpMocker()
     def test_given_no_state_when_read_then_use_transactions_endpoint(self, http_mocker: HttpMocker) -> None:
         _given_events_availability_check(http_mocker)
@@ -287,10 +284,13 @@ class IncrementalTest(TestCase):
         _given_transactions_availability_check(http_mocker)
         _given_events_availability_check(http_mocker)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_record(
-                _an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _a_transaction().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response().with_record(_an_event().with_cursor(cursor_value).with_field(_DATA_FIELD, _a_transaction().build())).build(),
         )
 
         output = self._read(
@@ -306,13 +306,25 @@ class IncrementalTest(TestCase):
         _given_events_availability_check(http_mocker)
         state_datetime = _NOW - timedelta(days=5)
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
-            _events_response().with_pagination().with_record(
-                _an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _a_transaction().build())
-            ).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
+            _events_response()
+            .with_pagination()
+            .with_record(_an_event().with_id("last_record_id_from_first_page").with_field(_DATA_FIELD, _a_transaction().build()))
+            .build(),
         )
         http_mocker.get(
-            _events_request().with_starting_after("last_record_id_from_first_page").with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_starting_after("last_record_id_from_first_page")
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_transaction_event()).build(),
         )
 
@@ -330,13 +342,25 @@ class IncrementalTest(TestCase):
         slice_datetime = state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES + slice_range
 
         _given_transactions_availability_check(http_mocker)
-        _given_events_availability_check(http_mocker)  # the availability check does not consider the state so we need to define a generic availability check
+        _given_events_availability_check(
+            http_mocker
+        )  # the availability check does not consider the state so we need to define a generic availability check
         http_mocker.get(
-            _events_request().with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(slice_datetime).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(state_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(slice_datetime)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_transaction_event()).build(),
         )
         http_mocker.get(
-            _events_request().with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(slice_datetime + _AVOIDING_INCLUSIVE_BOUNDARIES)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_transaction_event()).with_record(self._a_transaction_event()).build(),
         )
 
@@ -348,7 +372,9 @@ class IncrementalTest(TestCase):
         assert len(output.records) == 3
 
     @HttpMocker()
-    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(self, http_mocker: HttpMocker) -> None:
+    def test_given_state_earlier_than_30_days_when_read_then_query_events_using_types_and_event_lower_boundary(
+        self, http_mocker: HttpMocker
+    ) -> None:
         # this seems odd as we would miss some data between start_date and events_lower_boundary. In that case, we should hit the
         # transactions endpoint
         _given_transactions_availability_check(http_mocker)
@@ -356,7 +382,12 @@ class IncrementalTest(TestCase):
         state_value = _NOW - timedelta(days=39)
         events_lower_boundary = _NOW - timedelta(days=30)
         http_mocker.get(
-            _events_request().with_created_gte(events_lower_boundary).with_created_lte(_NOW).with_limit(100).with_types(_EVENT_TYPES).build(),
+            _events_request()
+            .with_created_gte(events_lower_boundary)
+            .with_created_lte(_NOW)
+            .with_limit(100)
+            .with_types(_EVENT_TYPES)
+            .build(),
             _events_response().with_record(self._a_transaction_event()).build(),
         )
 

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -158,7 +158,7 @@ On the other hand, the following streams use the `updated` field value as a curs
 
 :::note
 
-`updated` is an artificial cursor field introduced by Airbyte for the Incremental sync option.
+`_ab_source_record_last_modified` is an artificial cursor field introduced by Airbyte for the Incremental sync option.
 
 :::
 
@@ -221,13 +221,14 @@ Each record is marked with `is_deleted` flag when the appropriate event happens 
 
 ## Changelog
 
-| Version | Date       | Pull Request                                                 | Subject                                                                                                                                                                                                                       |
-|:--------|:-----------|:-------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.2.0   | 2024-01-18 | [34347](https://github.com/airbytehq/airbyte/pull//34347) | Add new fields invoices and subscription streams. Upgrade the CDK for better memory usage.                                                                                                                                    |
+| Version | Date       | Pull Request                                              | Subject                                                                                                                                                                                                                       |
+|:--------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 6.0.0   | 2024-01-18 | [34408](https://github.com/airbytehq/airbyte/pull/34408)  | Rename the cursor field from `updated` to to _`ab_source_record_last_modified`                                                                                                                                                |
+| 5.2.0   | 2024-01-18 | [34347](https://github.com/airbytehq/airbyte/pull/34347)  | Add new fields invoices and subscription streams. Upgrade the CDK for better memory usage.                                                                                                                                    |
 | 5.1.3   | 2023-12-18 | [33306](https://github.com/airbytehq/airbyte/pull/33306/) | Adding integration tests                                                                                                                                                                                                      |
-| 5.1.2   | 2024-01-04 | [33414](https://github.com/airbytehq/airbyte/pull/33414) | Prepare for airbyte-lib                                                                                                                                                                                                       |
-| 5.1.1   | 2024-01-04 | [33926](https://github.com/airbytehq/airbyte/pull/33926/)    | Update endpoint for `bank_accounts` stream                                                                                                                                                                                    |
-| 5.1.0   | 2023-12-11 | [32908](https://github.com/airbytehq/airbyte/pull/32908/)    | Read full refresh streams concurrently                                                                                                                                                                                        |
+| 5.1.2   | 2024-01-04 | [33414](https://github.com/airbytehq/airbyte/pull/33414)  | Prepare for airbyte-lib                                                                                                                                                                                                       |
+| 5.1.1   | 2024-01-04 | [33926](https://github.com/airbytehq/airbyte/pull/33926/) | Update endpoint for `bank_accounts` stream                                                                                                                                                                                    |
+| 5.1.0   | 2023-12-11 | [32908](https://github.com/airbytehq/airbyte/pull/32908/) | Read full refresh streams concurrently                                                                                                                                                                                        |
 | 5.0.2   | 2023-12-01 | [33038](https://github.com/airbytehq/airbyte/pull/33038)  | Add stream slice logging for SubStream                                                                                                                                                                                        |
 | 5.0.1   | 2023-11-17 | [32638](https://github.com/airbytehq/airbyte/pull/32638/) | Availability stretegy: check availability of both endpoints (if applicable) - common API + events API                                                                                                                         |
 | 5.0.0   | 2023-11-16 | [32286](https://github.com/airbytehq/airbyte/pull/32286/) | Fix multiple issues regarding usage of the incremental sync mode for the `Refunds`, `CheckoutSessions`, `CheckoutSessionsLineItems` streams. Fix schemas for the streams: `Invoices`, `Subscriptions`, `SubscriptionSchedule` |


### PR DESCRIPTION
## What

Resolving https://github.com/airbytehq/airbyte-internal-issues/issues/2377

## How

Rename cursor field from `updated` to to `_ab_source_record_last_modified`

## Recommended reading order
1. `airbyte-integrations/connectors/source-stripe/source_stripe/streams.py`
2. `airbyte-integrations/connectors/source-stripe/schemas/*.json`

## 🚨 User Impact 🚨

schema changes: `updated` to to `_ab_source_record_last_modified`

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
