### PR TITLE
Java CDK (destinations): add tests for 0-record state messages

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/integrations/destination_async/state/GlobalAsyncStateManagerTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/integrations/destination_async/state/GlobalAsyncStateManagerTest.java
@@ -48,12 +48,22 @@ class GlobalAsyncStateManagerTest {
       .withType(Type.STATE)
       .withState(new PartialAirbyteStateMessage()
           .withType(AirbyteStateType.GLOBAL));
+  private static final PartialAirbyteMessage GLOBAL_STATE_MESSAGE3 = new PartialAirbyteMessage()
+      .withType(Type.STATE)
+      .withState(new PartialAirbyteStateMessage()
+          .withType(AirbyteStateType.GLOBAL));
   private static final PartialAirbyteMessage STREAM1_STATE_MESSAGE1 = new PartialAirbyteMessage()
       .withType(Type.STATE)
       .withState(new PartialAirbyteStateMessage()
           .withType(AirbyteStateType.STREAM)
           .withStream(new PartialAirbyteStreamState().withStreamDescriptor(STREAM1_DESC)));
   private static final PartialAirbyteMessage STREAM1_STATE_MESSAGE2 = new PartialAirbyteMessage()
+      .withType(Type.STATE)
+      .withState(new PartialAirbyteStateMessage()
+          .withType(AirbyteStateType.STREAM)
+          .withStream(new PartialAirbyteStreamState().withStreamDescriptor(STREAM1_DESC)));
+
+  private static final PartialAirbyteMessage STREAM1_STATE_MESSAGE3 = new PartialAirbyteMessage()
       .withType(Type.STATE)
       .withState(new PartialAirbyteStateMessage()
           .withType(AirbyteStateType.STREAM)
@@ -150,6 +160,35 @@ class GlobalAsyncStateManagerTest {
     }
 
     @Test
+    void testZeroRecordFlushing() {
+      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
+
+      final var preConvertId0 = simulateIncomingRecords(STREAM1_DESC, 10, stateManager);
+      stateManager.trackState(GLOBAL_STATE_MESSAGE1, STATE_MSG_SIZE, DEFAULT_NAMESPACE);
+      stateManager.decrement(preConvertId0, 10);
+      final Map<PartialAirbyteMessage, AirbyteStateStats> stateWithStats = stateManager.flushStates().stream()
+          .collect(Collectors.toMap(PartialStateWithDestinationStats::stateMessage, PartialStateWithDestinationStats::stats));
+      assertEquals(List.of(GLOBAL_STATE_MESSAGE1), stateWithStats.keySet().stream().toList());
+      assertEquals(List.of(new AirbyteStateStats().withRecordCount(10.0)), stateWithStats.values().stream().toList());
+
+      final var afterConvertId1 = simulateIncomingRecords(STREAM1_DESC, 0, stateManager);
+      stateManager.trackState(GLOBAL_STATE_MESSAGE2, STATE_MSG_SIZE, DEFAULT_NAMESPACE);
+//      stateManager.decrement(afterConvertId1, 0);
+      final Map<PartialAirbyteMessage, AirbyteStateStats> stateWithStats2 = stateManager.flushStates().stream()
+          .collect(Collectors.toMap(PartialStateWithDestinationStats::stateMessage, PartialStateWithDestinationStats::stats));
+      assertEquals(List.of(GLOBAL_STATE_MESSAGE2), stateWithStats2.keySet().stream().toList());
+      assertEquals(List.of(new AirbyteStateStats().withRecordCount(0.0)), stateWithStats2.values().stream().toList());
+
+      final var afterConvertId2 = simulateIncomingRecords(STREAM1_DESC, 10, stateManager);
+      stateManager.trackState(GLOBAL_STATE_MESSAGE3, STATE_MSG_SIZE, DEFAULT_NAMESPACE);
+      stateManager.decrement(afterConvertId2, 10);
+      final Map<PartialAirbyteMessage, AirbyteStateStats> stateWithStats3 = stateManager.flushStates().stream()
+          .collect(Collectors.toMap(PartialStateWithDestinationStats::stateMessage, PartialStateWithDestinationStats::stats));
+      assertEquals(List.of(GLOBAL_STATE_MESSAGE3), stateWithStats3.keySet().stream().toList());
+      assertEquals(List.of(new AirbyteStateStats().withRecordCount(10.0)), stateWithStats3.values().stream().toList());
+    }
+
+    @Test
     void testCorrectFlushingManyStreams() {
       final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
 
@@ -213,6 +252,35 @@ class GlobalAsyncStateManagerTest {
           .collect(Collectors.toMap(PartialStateWithDestinationStats::stateMessage, PartialStateWithDestinationStats::stats));
       assertEquals(List.of(STREAM1_STATE_MESSAGE2), stateWithStats2.keySet().stream().toList());
       assertEquals(List.of(new AirbyteStateStats().withRecordCount(10.0)), stateWithStats2.values().stream().toList());
+    }
+
+    @Test
+    void testZeroRecordFlushing() {
+      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
+
+      var stateId = simulateIncomingRecords(STREAM1_DESC, 3, stateManager);
+      stateManager.trackState(STREAM1_STATE_MESSAGE1, STATE_MSG_SIZE, DEFAULT_NAMESPACE);
+      stateManager.decrement(stateId, 3);
+      final Map<PartialAirbyteMessage, AirbyteStateStats> stateWithStats = stateManager.flushStates().stream()
+          .collect(Collectors.toMap(PartialStateWithDestinationStats::stateMessage, PartialStateWithDestinationStats::stats));
+      assertEquals(List.of(STREAM1_STATE_MESSAGE1), stateWithStats.keySet().stream().toList());
+      assertEquals(List.of(new AirbyteStateStats().withRecordCount(3.0)), stateWithStats.values().stream().toList());
+
+      stateId = simulateIncomingRecords(STREAM1_DESC, 0, stateManager);
+      stateManager.trackState(STREAM1_STATE_MESSAGE2, STATE_MSG_SIZE, DEFAULT_NAMESPACE);
+//      stateManager.decrement(stateId, 0);
+      final Map<PartialAirbyteMessage, AirbyteStateStats> stateWithStats2 = stateManager.flushStates().stream()
+          .collect(Collectors.toMap(PartialStateWithDestinationStats::stateMessage, PartialStateWithDestinationStats::stats));
+      assertEquals(List.of(STREAM1_STATE_MESSAGE2), stateWithStats2.keySet().stream().toList());
+      assertEquals(List.of(new AirbyteStateStats().withRecordCount(0.0)), stateWithStats2.values().stream().toList());
+
+      stateId = simulateIncomingRecords(STREAM1_DESC, 10, stateManager);
+      stateManager.trackState(STREAM1_STATE_MESSAGE3, STATE_MSG_SIZE, DEFAULT_NAMESPACE);
+      stateManager.decrement(stateId, 10);
+      final Map<PartialAirbyteMessage, AirbyteStateStats> stateWithStats3 = stateManager.flushStates().stream()
+          .collect(Collectors.toMap(PartialStateWithDestinationStats::stateMessage, PartialStateWithDestinationStats::stats));
+      assertEquals(List.of(STREAM1_STATE_MESSAGE3), stateWithStats3.keySet().stream().toList());
+      assertEquals(List.of(new AirbyteStateStats().withRecordCount(10.0)), stateWithStats3.values().stream().toList());
     }
 
     @Test

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/integrations/destination_async/state/GlobalAsyncStateManagerTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/java/io/airbyte/cdk/integrations/destination_async/state/GlobalAsyncStateManagerTest.java
@@ -171,9 +171,7 @@ class GlobalAsyncStateManagerTest {
       assertEquals(List.of(GLOBAL_STATE_MESSAGE1), stateWithStats.keySet().stream().toList());
       assertEquals(List.of(new AirbyteStateStats().withRecordCount(10.0)), stateWithStats.values().stream().toList());
 
-      final var afterConvertId1 = simulateIncomingRecords(STREAM1_DESC, 0, stateManager);
       stateManager.trackState(GLOBAL_STATE_MESSAGE2, STATE_MSG_SIZE, DEFAULT_NAMESPACE);
-//      stateManager.decrement(afterConvertId1, 0);
       final Map<PartialAirbyteMessage, AirbyteStateStats> stateWithStats2 = stateManager.flushStates().stream()
           .collect(Collectors.toMap(PartialStateWithDestinationStats::stateMessage, PartialStateWithDestinationStats::stats));
       assertEquals(List.of(GLOBAL_STATE_MESSAGE2), stateWithStats2.keySet().stream().toList());
@@ -266,9 +264,7 @@ class GlobalAsyncStateManagerTest {
       assertEquals(List.of(STREAM1_STATE_MESSAGE1), stateWithStats.keySet().stream().toList());
       assertEquals(List.of(new AirbyteStateStats().withRecordCount(3.0)), stateWithStats.values().stream().toList());
 
-      stateId = simulateIncomingRecords(STREAM1_DESC, 0, stateManager);
       stateManager.trackState(STREAM1_STATE_MESSAGE2, STATE_MSG_SIZE, DEFAULT_NAMESPACE);
-//      stateManager.decrement(stateId, 0);
       final Map<PartialAirbyteMessage, AirbyteStateStats> stateWithStats2 = stateManager.flushStates().stream()
           .collect(Collectors.toMap(PartialStateWithDestinationStats::stateMessage, PartialStateWithDestinationStats::stats));
       assertEquals(List.of(STREAM1_STATE_MESSAGE2), stateWithStats2.keySet().stream().toList());


### PR DESCRIPTION
pure test change, not intending to publish the cdk for this. see [context](https://airbytehq-team.slack.com/archives/C0624HL9UTU/p1705709386741119?thread_ts=1705708792.897849&cid=C0624HL9UTU).