### PR TITLE
🐛  source-stripe: Temporarily pin stripe connector to 5.1.3

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -20,8 +20,10 @@ data:
   registries:
     cloud:
       enabled: true
+      dockerImageTag: 5.1.3
     oss:
       enabled: true
+      dockerImageTag: 5.1.3
   releaseStage: generally_available
   releases:
     breakingChanges:


### PR DESCRIPTION
## What
* Pin stripe to 5.1.3 
* I used destination-mysql-strict-encrypt as a model for how to pin the version both on cloud and oss

## How
* Set dockerImageTag to the cloud and oss registries

An alternative would be to release the connector with the previous version of the CDK.

## Recommended reading order
1. `airbyte-integrations/connectors/source-stripe/metadata.yaml`

## 🚨 User Impact 🚨
Cloud users will use 5.1.3
New OSS deploys will use 5.1.3. Existing ones won't be automatically updated.