### PR TITLE
improve startup performance of airbyte-ci

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -640,6 +640,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                |
 | ------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| 4.1.1  | [#34430](https://github.com/airbytehq/airbyte/pull/34430)  | Speed up airbyte-ci startup (and airbyte-ci format).                                         |
 | 4.1.0  | [#34923](https://github.com/airbytehq/airbyte/pull/34923)  | Include gradle test reports in HTML connector test report.                                                                 |
 | 4.0.0  | [#34736](https://github.com/airbytehq/airbyte/pull/34736)  | Run poe tasks declared in internal poetry packages.                                         |
 | 3.10.4  | [#34867](https://github.com/airbytehq/airbyte/pull/34867)  | Remove connector ops team                                                                                                  |

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.1.0"
+version = "4.1.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_helpers/test_utils.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_helpers/test_utils.py
@@ -12,6 +12,7 @@ from pipelines import consts
 from pipelines.cli.dagger_pipeline_command import DaggerPipelineCommand
 from pipelines.helpers import utils
 from pipelines.helpers.connectors.modifed import get_connector_modified_files, get_modified_connectors
+from pipelines.models.contexts.pipeline_context import PipelineContext
 from tests.utils import pick_a_random_connector
 
 
@@ -241,3 +242,19 @@ async def test_export_container_to_tarball_failure(mocker, tmp_path):
         str(tmp_path / f"my_connector_my_git_revision_{platform.replace('/', '_')}.tar"),
         forced_compression=dagger.ImageLayerCompression.Gzip,
     )
+
+
+# @pytest.mark.anyio
+async def test_get_repo_dir(dagger_client):
+    test_context = PipelineContext(pipeline_name="test", is_local=True, git_branch="test", git_revision="test", report_output_prefix="test")
+    test_context.dagger_client = dagger_client
+    # we know airbyte-ci/connectors/pipelines/ is excluded
+    filtered_entries = await test_context.get_repo_dir("airbyte-ci/connectors/pipelines/").entries()
+    assert not filtered_entries
+    unfiltered_entries = await dagger_client.host().directory("airbyte-ci/connectors/pipelines/").entries()
+    assert unfiltered_entries
+    # we also know that **/secrets is excluded and that source-mysql contains a secrets file
+    filtered_entries = await test_context.get_repo_dir("airbyte-integrations/connectors/source-mysql/").entries()
+    assert "secrets" not in filtered_entries
+    unfiltered_entries = await dagger_client.host().directory("airbyte-integrations/connectors/source-mysql/").entries()
+    assert "secrets" in unfiltered_entries


### PR DESCRIPTION
when using airbyte ci, I noticed that it's very slow to start. That's especially visible if pre-push hooks are set up to call airbyte-ci format. A little bit of inspection showed me that the main contributors were the calls to `clob(pattern, recursive=true)`, which seem unnecessary.
The hypothesys mostly come form the fac that https://github.com/airbytehq/airbyte/pull/31525/files introduced the new behavior, and that the previous behavior can be seen at https://github.com/airbytehq/airbyte/pull/31525/files#diff-b86e6d2f27d70812919004f8b786a5bb0ea5a7a28ec99c5ffd8773d9eb424eecL75

```
✔ ~/dev/airbyte [stephane/01-22-improve_startup_performance_of_airbyte-ci|⚑ 2]
14:32 $ time airbyte-ci --disable-update-check format check all > /dev/null

real    1m44.166s
user    0m12.037s
sys     0m8.598s
✔ ~/dev/airbyte [stephane/01-22-improve_startup_performance_of_airbyte-ci|⚑ 2]
14:33 $ time airbyte-ci --disable-update-check format check all > /dev/null

real    0m26.372s
user    0m8.554s
sys     0m7.045s
✔ ~/dev/airbyte [stephane/01-22-improve_startup_performance_of_airbyte-ci|⚑ 2]
14:37 $ time airbyte-ci-dev --disable-update-check format check all > /dev/null

real    1m6.916s
user    0m6.614s
sys     0m4.071s
✔ ~/dev/airbyte [stephane/01-22-improve_startup_performance_of_airbyte-ci|⚑ 2]
14:39 $ time airbyte-ci-dev --disable-update-check format check all > /dev/null

real    0m7.116s
user    0m4.616s
sys     0m3.042s
✔ ~/dev/airbyte [stephane/01-22-improve_startup_performance_of_airbyte-ci|⚑ 2]
```

For some reason the 1st call to airbyte-ci or airbyte-ci-dev is much slower than subsequent calls. But you can see the 1st call going from 1m44s to 1m6s, and the 2nd call going from 26s to 7s...

There should also be some memory consumption improvements because we are not storing the list of files we want to ignore anymore.