### PR TITLE
airbyte-lib: fix CI change detection

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -79,7 +79,7 @@ jobs:
               - 'airbyte-ci/connectors/metadata_service/orchestrator/**'
               - '!**/*.md'
             airbyte_lib:
-              - 'airbyte_lib/**'
+              - 'airbyte-lib/**'
               - '!**/*.md'
 
       - name: Run airbyte-ci/connectors/connector_ops tests


### PR DESCRIPTION
Fix a typo in the change detection rules for `airbyte-lib` tests.