### PR TITLE
airbyte-lib: Fix docs generation

### DIFF
--- a/airbyte-lib/docs.py
+++ b/airbyte-lib/docs.py
@@ -24,7 +24,9 @@ def run() -> None:
     for d in os.listdir("airbyte_lib"):
         dir_path = pathlib.Path(f"airbyte_lib/{d}")
         if dir_path.is_dir() and not d.startswith("_"):
-            public_modules.append(dir_path)
+            # check whether the directory contains a __init__.py file
+            if (dir_path / "__init__.py").exists():
+                public_modules.append(dir_path)
 
     pdoc.render.configure(template_directory="docs", show_source=False, search=False)
     pdoc.pdoc(*public_modules, output_directory=pathlib.Path("docs/generated"))

--- a/airbyte-lib/docs.py
+++ b/airbyte-lib/docs.py
@@ -23,10 +23,8 @@ def run() -> None:
     # All folders in `airbyte_lib` that don't start with "_" are treated as public modules.
     for d in os.listdir("airbyte_lib"):
         dir_path = pathlib.Path(f"airbyte_lib/{d}")
-        if dir_path.is_dir() and not d.startswith("_"):
-            # check whether the directory contains a __init__.py file
-            if (dir_path / "__init__.py").exists():
-                public_modules.append(dir_path)
+        if dir_path.is_dir() and not d.startswith("_") and (dir_path / "__init__.py").exists():
+            public_modules.append(dir_path)
 
     pdoc.render.configure(template_directory="docs", show_source=False, search=False)
     pdoc.pdoc(*public_modules, output_directory=pathlib.Path("docs/generated"))


### PR DESCRIPTION
This PR fixes the doc generation issue with stale empty directories that occur often when switching between branches.

It adds a condition that modules are only considered for public docs if they contain an init.py file