### PR TITLE
🐛 Source Typeform: Fix pagination stop condition

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 1.2.3
+  dockerImageTag: 1.2.4
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   githubIssueLabel: source-typeform

--- a/airbyte-integrations/connectors/source-typeform/source_typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/source_typeform/manifest.yaml
@@ -125,7 +125,7 @@ definitions:
         pagination_strategy:
           type: CursorPagination
           cursor_value: "{{ last_records[-1]['token'] }}"
-          stop_condition: "{{ not response['total_items'] }}"
+          stop_condition: "{{ not last_records }}"
           page_size: 1000
       partition_router:
         $ref: "#/definitions/form_id_partition_router"

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -90,7 +90,8 @@ API rate limits \(2 requests per second\): [https://developer.typeform.com/get-s
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.2.3   | 2024-01-11 | [34145](https://github.com/airbytehq/airbyte/pull/34145) | prepare for airbyte-lib                                                        |
+| 1.2.4   | 2024-01-24 | [34484](https://github.com/airbytehq/airbyte/pull/34484) | Fix pagination stop condition                                                                   |
+| 1.2.3   | 2024-01-11 | [34145](https://github.com/airbytehq/airbyte/pull/34145) | prepare for airbyte-lib                                                                         |
 | 1.2.2   | 2023-12-12 | [33345](https://github.com/airbytehq/airbyte/pull/33345) | Fix single use refresh token authentication                                                     |
 | 1.2.1   | 2023-12-04 | [32775](https://github.com/airbytehq/airbyte/pull/32775) | Add 499 status code handling                                                                    |
 | 1.2.0   | 2023-11-29 | [32745](https://github.com/airbytehq/airbyte/pull/32745) | Add `response_type` field to `responses` schema                                                 |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -90,7 +90,8 @@ API rate limits \(2 requests per second\): [https://developer.typeform.com/get-s
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 1.2.3   | 2024-01-11 | [34145](https://github.com/airbytehq/airbyte/pull/34145) | prepare for airbyte-lib                                                        |
+| 1.2.4   | 2024-01-24 | [34145](https://github.com/airbytehq/airbyte/pull/34145) | prepare for airbyte-lib                                                                         |
+| 1.2.3   | 2024-01-11 | [34145](https://github.com/airbytehq/airbyte/pull/34145) | prepare for airbyte-lib                                                                         |
 | 1.2.2   | 2023-12-12 | [33345](https://github.com/airbytehq/airbyte/pull/33345) | Fix single use refresh token authentication                                                     |
 | 1.2.1   | 2023-12-04 | [32775](https://github.com/airbytehq/airbyte/pull/32775) | Add 499 status code handling                                                                    |
 | 1.2.0   | 2023-11-29 | [32745](https://github.com/airbytehq/airbyte/pull/32745) | Add `response_type` field to `responses` schema                                                 |


### PR DESCRIPTION
## What

https://github.com/airbytehq/oncall/issues/4047

## How

fix pagination stop condition

`response['total_items']` somehow (was unable to reproduce) was not zero, and connector tried to extract next_page_token from `last_records`, which were empty. To be more consistent stop_condition is defined as check for `len(last_records)`

## Recommended reading order
1. `airbyte-integrations/connectors/source-typeform/source_typeform/manifest.yaml`

## 🚨 User Impact 🚨

no breaking changes


## Pre-merge Actions


<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

