### PR TITLE
airbyte-ci: disable update check in CI

### DIFF
--- a/.github/actions/airbyte-ci-requirements/action.yml
+++ b/.github/actions/airbyte-ci-requirements/action.yml
@@ -84,7 +84,7 @@ runs:
       id: get-dagger-version
       shell: bash
       run: |
-        dagger_version=$(airbyte-ci ${{ inputs.airbyte_ci_command }} --ci-requirements | tail -n 1 | jq -r '.dagger_version')
+        dagger_version=$(airbyte-ci --disable-update-check ${{ inputs.airbyte_ci_command }} --ci-requirements | tail -n 1 | jq -r '.dagger_version')
         echo "dagger_version=${dagger_version}" >> "$GITHUB_OUTPUT"
 
     - name: Get runner name

--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -157,7 +157,7 @@ runs:
       shell: bash
       run: |
         export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-        airbyte-ci --disable-dagger-run --is-ci --gha-workflow-run-id=${{ github.run_id }} ${{ inputs.subcommand }} ${{ inputs.options }}
+        airbyte-ci --disable-update-check --disable-dagger-run --is-ci --gha-workflow-run-id=${{ github.run_id }} ${{ inputs.subcommand }} ${{ inputs.options }}
       env:
         CI_CONTEXT: "${{ inputs.context }}"
         CI_GIT_BRANCH: ${{ inputs.git_branch || github.head_ref }}


### PR DESCRIPTION
When branches are not up to date with master CI on branches complains the `airbyte-ci` binary is not up to date.
Example [here](https://github.com/airbytehq/airbyte/actions/runs/7643857680/job/20826851424)
We can disable update checks in CI.