### PR TITLE
airbyte-ci: fix inconsistent log path typing

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -499,9 +499,9 @@ Available commands:
 
 ### Options
 
-| Option              | Required | Default | Mapped environment variable | Description                                                                                 |
-| ------------------- | -------- | ------- | --------------------------- | ------------------------------------------------------------------------------------------- |
-| `--package-path`    | True     |         |                             | The path to the python package to execute a poetry command on.                              |
+| Option           | Required | Default | Mapped environment variable | Description                                                    |
+| ---------------- | -------- | ------- | --------------------------- | -------------------------------------------------------------- |
+| `--package-path` | True     |         |                             | The path to the python package to execute a poetry command on. |
 
 ### Examples
 
@@ -515,12 +515,12 @@ For poetry packages, the package name and version can be taken from the `pyproje
 
 #### Options
 
-| Option                    | Required | Default                 | Mapped environment variable | Description                                                                                                     |
-| ------------------------- | -------- | ----------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `--publish-name`          | False    |                         |                             | The name of the package. Not required for poetry packages that define it in the `pyproject.toml` file           |
-| `--publish-version`       | False    |                         |                             | The version of the package. Not required for poetry packages that define it in the `pyproject.toml` file        |
-| `--python-registry-token` | True     |                         | PYTHON_REGISTRY_TOKEN       | The API token to authenticate with the registry. For pypi, the `pypi-` prefix needs to be specified             |
-| `--registry-url`          | False    | https://pypi.org/simple |                             | The python registry to publish to. Defaults to main pypi |
+| Option                    | Required | Default                 | Mapped environment variable | Description                                                                                              |
+| ------------------------- | -------- | ----------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `--publish-name`          | False    |                         |                             | The name of the package. Not required for poetry packages that define it in the `pyproject.toml` file    |
+| `--publish-version`       | False    |                         |                             | The version of the package. Not required for poetry packages that define it in the `pyproject.toml` file |
+| `--python-registry-token` | True     |                         | PYTHON_REGISTRY_TOKEN       | The API token to authenticate with the registry. For pypi, the `pypi-` prefix needs to be specified      |
+| `--registry-url`          | False    | https://pypi.org/simple |                             | The python registry to publish to. Defaults to main pypi                                                 |
 
 ### <a id="metadata-validate-command-subgroup"></a>`metadata` command subgroup
 
@@ -578,6 +578,7 @@ E.G.: running `pytest` on a specific test folder:
 
 | Version | PR                                                         | Description                                                                                                       |
 | ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 3.6.1   | [#34490](https://github.com/airbytehq/airbyte/pull/34490)  | Fix inconsistent dagger log path typing                                                                           |
 | 3.6.0   | [#34111](https://github.com/airbytehq/airbyte/pull/34111)  | Add python registry publishing                                                                                    |
 | 3.5.3   | [#34339](https://github.com/airbytehq/airbyte/pull/34339)  | only do minimal changes on a connector version_bump                                                               |
 | 3.5.2   | [#34381](https://github.com/airbytehq/airbyte/pull/34381)  | Bind a sidecar docker host for `airbyte-ci test`                                                                  |

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/click_pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/click_pipeline_context.py
@@ -5,6 +5,7 @@
 import io
 import sys
 import tempfile
+from pathlib import Path
 from typing import Any, Callable, Dict, Optional, TextIO, Tuple
 
 import anyio
@@ -108,13 +109,13 @@ class ClickPipelineContext(BaseModel, Singleton):
             log_output, self._click_context().obj["dagger_logs_path"] = self._create_dagger_client_log_file()
             return log_output
 
-    def _create_dagger_client_log_file(self) -> Tuple[TextIO, str]:
+    def _create_dagger_client_log_file(self) -> Tuple[TextIO, Path]:
         """
         Create the dagger client log file.
         """
         dagger_logs_file_descriptor, dagger_logs_temp_file_path = tempfile.mkstemp(dir="/tmp", prefix="dagger_client_", suffix=".log")
         main_logger.info(f"Dagger client logs stored in {dagger_logs_temp_file_path}")
-        return io.TextIOWrapper(io.FileIO(dagger_logs_file_descriptor, "w+")), dagger_logs_temp_file_path
+        return io.TextIOWrapper(io.FileIO(dagger_logs_file_descriptor, "w+")), Path(dagger_logs_temp_file_path)
 
 
 # Create @pass_pipeline_context decorator for use in click commands

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "3.6.0"
+version = "3.6.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
We have multiple code path mutating the `dagger_log_path` value in the context object.
One mutation assigns a string, other `Path`. 
All function using this context value handle `Path`
