### PR TITLE
Weaviate: Fix tests

### DIFF
--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: 7b7d7a0d-954c-45a0-bcfc-39a634b97736
-  dockerImageTag: 0.2.14
+  dockerImageTag: 0.2.15
   dockerRepository: airbyte/destination-weaviate
   documentationUrl: https://docs.airbyte.com/integrations/destinations/weaviate
   githubIssueLabel: destination-weaviate

--- a/airbyte-integrations/connectors/destination-weaviate/setup.py
+++ b/airbyte-integrations/connectors/destination-weaviate/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = ["airbyte-cdk[vector-db-based]==0.57.0", "weaviate-client==3.25.2"]
 
-TEST_REQUIREMENTS = ["pytest~=6.2", "docker", "pytest-docker"]
+TEST_REQUIREMENTS = ["pytest~=6.2", "docker", "pytest-docker==2.0.1"]
 
 setup(
     name="destination_weaviate",

--- a/docs/integrations/destinations/weaviate.md
+++ b/docs/integrations/destinations/weaviate.md
@@ -85,6 +85,7 @@ When using [multi-tenancy](https://weaviate.io/developers/weaviate/manage-data/m
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| 0.2.15 | 2023-01-25 | [34529](https://github.com/airbytehq/airbyte/pull/34529) | Fix tests |
 | 0.2.14 | 2023-01-15 | [34229](https://github.com/airbytehq/airbyte/pull/34229) | Allow configuring tenant id |
 | 0.2.13 | 2023-12-11 | [33303](https://github.com/airbytehq/airbyte/pull/33303) | Fix bug with embedding special tokens |
 | 0.2.12 | 2023-12-07 | [33218](https://github.com/airbytehq/airbyte/pull/33218) | Normalize metadata field names |


### PR DESCRIPTION
Tests for destination-weaviate started failing due to the most recent release of `pytest-docker`, pinning the latest one:
https://pypi.org/project/pytest-docker/#history

From test failures:
```
  File "/usr/local/lib/python3.9/site-packages/pytest_docker/__init__.py", line 24, in 
    def pytest_addoption(parser: pytest.Parser) -> None:
AttributeError: module 'pytest' has no attribute 'Parser'
``` 