### PR TITLE
Airbyte CDK: refactor max_time value class variable

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -38,6 +38,7 @@ class HttpStream(Stream, ABC):
 
     source_defined_cursor = True  # Most HTTP streams use a source defined cursor (i.e: the user can't configure it like on a SQL table)
     page_size: Optional[int] = None  # Use this variable to define page size for API http requests with pagination support
+    DEFAULT_MAX_TIME_IN_SECONDS = 60 * 10
 
     # TODO: remove legacy HttpAuthenticator authenticator references
     def __init__(self, authenticator: Optional[Union[AuthBase, HttpAuthenticator]] = None, api_budget: Optional[APIBudget] = None):
@@ -125,7 +126,7 @@ class HttpStream(Stream, ABC):
         """
         Override if needed. Specifies maximum total waiting time (in seconds) for backoff policy. Return None for no limit.
         """
-        return 60 * 10
+        return self.DEFAULT_MAX_TIME_IN_SECONDS
 
     @property
     def retry_factor(self) -> float:


### PR DESCRIPTION
## What

Resolving https://github.com/airbytehq/airbyte/pull/34503, Need to get max_time value without initialization.

## How

move max_time to class variable

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py`

## 🚨 User Impact 🚨

no breaking changes


## Pre-merge Actions
<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
