### PR TITLE
airbyte-ci: simplify gradle task execution

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -578,6 +578,7 @@ E.G.: running `pytest` on a specific test folder:
 
 | Version | PR                                                         | Description                                                                                                       |
 | ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 3.7.3   | [#34560](https://github.com/airbytehq/airbyte/pull/34560)  | Simplify Gradle task execution framework by removing local maven repo support.                                    |
 | 3.7.2   | [#34555](https://github.com/airbytehq/airbyte/pull/34555)  | Override secret masking in some very specific special cases.                                                      |
 | 3.7.1   | [#34441](https://github.com/airbytehq/airbyte/pull/34441)  | Support masked secret scrubbing for java CDK v0.15+                                                               |
 | 3.7.0   | [#34343](https://github.com/airbytehq/airbyte/pull/34343)  | allow running connector upgrade_cdk for java connectors                                                           |

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "3.7.2"
+version = "3.7.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
The gradle task execution framework we built in airbyte-ci includes a `:airbyte-cdk:java:airbyte-cdk:publishSnapshotIfNeeded` task which never actually did anything. It was there in anticipation of the java CDK workflow making use of SNAPSHOT releases. This never materialized, and considering where @stephane-airbyte and I are taking the CDK release workflow, this won't materialize for a while at least. We can therefore remove anything to do with the local maven repository, aka `/root/.m2`. This simplifies and speeds up gradle in dagger/airbyte-ci.

Relates to airbytehq/airbyte-internal-issues#2475 .