### PR TITLE
airbyte-lib: Fix validation

### DIFF
--- a/airbyte-lib/airbyte_lib/validate.py
+++ b/airbyte-lib/airbyte_lib/validate.py
@@ -123,7 +123,7 @@ def validate(connector_dir: str, sample_config: str, *, validate_install_only: b
 
     pip_path = str(venv_path / "bin" / "pip")
 
-    _run_subprocess_and_raise_on_failure([pip_path, "install", "-e", connector_dir])
+    _run_subprocess_and_raise_on_failure([pip_path, "install", connector_dir])
 
     # write basic registry to temp json file
     registry = {

--- a/airbyte-lib/tests/integration_tests/fixtures/source-broken/setup.py
+++ b/airbyte-lib/tests/integration_tests/fixtures/source-broken/setup.py
@@ -11,7 +11,7 @@ setup(
     description="Test Soutce",
     author="Airbyte",
     author_email="contact@airbyte.io",
-    packages=find_packages(),
+    packages=["source_broken"],
     entry_points={
         "console_scripts": [
             "source-broken=source_broken.run:run",

--- a/airbyte-lib/tests/integration_tests/fixtures/source-test/setup.py
+++ b/airbyte-lib/tests/integration_tests/fixtures/source-test/setup.py
@@ -11,7 +11,7 @@ setup(
     description="Test Soutce",
     author="Airbyte",
     author_email="contact@airbyte.io",
-    packages=find_packages(),
+    packages=["source_test"],
     entry_points={
         "console_scripts": [
             "source-test=source_test.run:run",


### PR DESCRIPTION
The `airbyte-lib-validate-source` script is installing the connector under test to a venv to validate it works. However, it used to install using the `-e` flag which is linking back to the original source.

This is a bit faster than "regular" installs, but comes at the cost of not catching certain error conditions like non-python files not being included in the distribution bundle.

According to https://pip.pypa.io/en/stable/topics/local-project-installs/#regular-installs , doing a `pip install <folder name>` is a sufficient test for this kind of situation:
> This will install the project into the Python that pip is associated with, in a manner similar to how it would actually be installed.

> This is what should be used in CI system and for deployments, since it most closely mirrors how a package would get installed if you build a distribution and installed from it (because that’s exactly what it does).

