### PR TITLE
Have StateBuilder return our actual state object and not simply a dict

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte-cdk/python/airbyte_cdk/test/entrypoint_wrapper.py
@@ -26,7 +26,8 @@ from airbyte_cdk.entrypoint import AirbyteEntrypoint
 from airbyte_cdk.exception_handler import assemble_uncaught_exception
 from airbyte_cdk.logger import AirbyteLogFormatter
 from airbyte_cdk.sources import Source
-from airbyte_protocol.models import AirbyteLogMessage, AirbyteMessage, AirbyteStreamStatus, ConfiguredAirbyteCatalog, Level, TraceType, Type
+from airbyte_protocol.models import AirbyteLogMessage, AirbyteMessage, AirbyteStreamStatus, ConfiguredAirbyteCatalog, Level, TraceType, \
+    Type, AirbyteStateMessage
 from pydantic.error_wrappers import ValidationError
 
 
@@ -104,7 +105,7 @@ def read(
     source: Source,
     config: Mapping[str, Any],
     catalog: ConfiguredAirbyteCatalog,
-    state: Optional[Any] = None,
+    state: Optional[List[AirbyteStateMessage]] = None,
     expecting_exception: bool = False,
 ) -> EntrypointOutput:
     """
@@ -133,7 +134,7 @@ def read(
             args.extend(
                 [
                     "--state",
-                    make_file(tmp_directory_path / "state.json", state),
+                    make_file(tmp_directory_path / "state.json", f"[{','.join([stream_state.json() for stream_state in state])}]"),
                 ]
             )
         args.append("--debug")

--- a/airbyte-cdk/python/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte-cdk/python/airbyte_cdk/test/entrypoint_wrapper.py
@@ -26,8 +26,16 @@ from airbyte_cdk.entrypoint import AirbyteEntrypoint
 from airbyte_cdk.exception_handler import assemble_uncaught_exception
 from airbyte_cdk.logger import AirbyteLogFormatter
 from airbyte_cdk.sources import Source
-from airbyte_protocol.models import AirbyteLogMessage, AirbyteMessage, AirbyteStreamStatus, ConfiguredAirbyteCatalog, Level, TraceType, \
-    Type, AirbyteStateMessage
+from airbyte_protocol.models import (
+    AirbyteLogMessage,
+    AirbyteMessage,
+    AirbyteStateMessage,
+    AirbyteStreamStatus,
+    ConfiguredAirbyteCatalog,
+    Level,
+    TraceType,
+    Type,
+)
 from pydantic.error_wrappers import ValidationError
 
 

--- a/airbyte-cdk/python/airbyte_cdk/test/state_builder.py
+++ b/airbyte-cdk/python/airbyte_cdk/test/state_builder.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
-from typing import Any, Dict, List
+from typing import Any, List
+
+from airbyte_protocol.models import AirbyteStateMessage
 
 
 class StateBuilder:
     def __init__(self) -> None:
-        self._state: List[Dict[str, Any]] = []
+        self._state: List[AirbyteStateMessage] = []
 
     def with_stream_state(self, stream_name: str, state: Any) -> "StateBuilder":
-        self._state.append({
+        self._state.append(AirbyteStateMessage.parse_obj({
             "type": "STREAM",
             "stream": {
                 "stream_state": state,
@@ -16,8 +18,8 @@ class StateBuilder:
                     "name": stream_name
                 }
             }
-        })
+        }))
         return self
 
-    def build(self) -> List[Dict[str, Any]]:
+    def build(self) -> List[AirbyteStateMessage]:
         return self._state

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/incremental_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/incremental_scenarios.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+from airbyte_cdk.test.state_builder import StateBuilder
 from unit_tests.sources.file_based.helpers import LowHistoryLimitCursor
 from unit_tests.sources.file_based.scenarios.file_based_source_builder import FileBasedSourceBuilder
 from unit_tests.sources.file_based.scenarios.scenario_builder import IncrementalScenarioConfig, TestScenarioBuilder
@@ -39,17 +40,9 @@ single_csv_input_state_is_earlier_scenario = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[
-                {
-                    "type": "STREAM",
-                    "stream": {
-                        "stream_state": {
-                            "history": {"some_old_file.csv": "2023-06-01T03:54:07.000000Z"},
-                        },
-                        "stream_descriptor": {"name": "stream1"},
-                    },
-                }
-            ],
+            input_state=StateBuilder().with_stream_state("stream1", {
+                "history": {"some_old_file.csv": "2023-06-01T03:54:07.000000Z"},
+            }).build(),
         )
     )
     .set_expected_records(
@@ -140,17 +133,9 @@ single_csv_file_is_skipped_if_same_modified_at_as_in_history = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[
-                {
-                    "type": "STREAM",
-                    "stream": {
-                        "stream_state": {
-                            "history": {"a.csv": "2023-06-05T03:54:07.000000Z"},
-                        },
-                        "stream_descriptor": {"name": "stream1"},
-                    },
-                }
-            ],
+            input_state=StateBuilder().with_stream_state("stream1", {
+                "history": {"a.csv": "2023-06-05T03:54:07.000000Z"},
+            }).build(),
         )
     )
     .set_expected_records(
@@ -223,17 +208,9 @@ single_csv_file_is_synced_if_modified_at_is_more_recent_than_in_history = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[
-                {
-                    "type": "STREAM",
-                    "stream": {
-                        "stream_state": {
-                            "history": {"a.csv": "2023-06-01T03:54:07.000000Z"},
-                        },
-                        "stream_descriptor": {"name": "stream1"},
-                    },
-                }
-            ],
+            input_state=StateBuilder().with_stream_state("stream1", {
+                "history": {"a.csv": "2023-06-01T03:54:07.000000Z"},
+            }).build(),
         )
     )
     .set_expected_records(
@@ -377,7 +354,7 @@ single_csv_no_input_state_scenario = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[],
+            input_state=StateBuilder().build(),
         )
     )
 ).build()
@@ -499,7 +476,7 @@ multi_csv_same_timestamp_scenario = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[],
+            input_state=StateBuilder().build(),
         )
     )
 ).build()
@@ -593,15 +570,9 @@ single_csv_input_state_is_later_scenario = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[
-                {
-                    "type": "STREAM",
-                    "stream": {
-                        "stream_state": {"history": {"recent_file.csv": "2023-07-15T23:59:59.000000Z"}},
-                        "stream_descriptor": {"name": "stream1"},
-                    },
-                }
-            ],
+            input_state=StateBuilder().with_stream_state("stream1", {
+                "history": {"recent_file.csv": "2023-07-15T23:59:59.000000Z"},
+            }).build(),
         )
     )
 ).build()
@@ -731,7 +702,7 @@ multi_csv_different_timestamps_scenario = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[],
+            input_state=StateBuilder().build(),
         )
     )
 ).build()
@@ -891,7 +862,7 @@ multi_csv_per_timestamp_scenario = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[],
+            input_state=StateBuilder().build(),
         )
     )
 ).build()
@@ -1035,15 +1006,9 @@ multi_csv_skip_file_if_already_in_history = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[
-                {
-                    "type": "STREAM",
-                    "stream": {
-                        "stream_state": {"history": {"a.csv": "2023-06-05T03:54:07.000000Z"}},
-                        "stream_descriptor": {"name": "stream1"},
-                    },
-                }
-            ],
+            input_state=StateBuilder().with_stream_state("stream1", {
+                "history": {"a.csv": "2023-06-05T03:54:07.000000Z"},
+            }).build(),
         )
     )
 ).build()
@@ -1163,17 +1128,9 @@ multi_csv_include_missing_files_within_history_range = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[
-                {
-                    "type": "STREAM",
-                    "stream": {
-                        "stream_state": {
-                            "history": {"a.csv": "2023-06-05T03:54:07.000000Z", "c.csv": "2023-06-06T03:54:07.000000Z"},
-                        },
-                        "stream_descriptor": {"name": "stream1"},
-                    },
-                }
-            ],
+            input_state=StateBuilder().with_stream_state("stream1", {
+                "history": {"a.csv": "2023-06-05T03:54:07.000000Z", "c.csv": "2023-06-06T03:54:07.000000Z"},
+            }).build(),
         )
     )
 ).build()
@@ -1348,21 +1305,13 @@ multi_csv_remove_old_files_if_history_is_full_scenario = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[
-                {
-                    "type": "STREAM",
-                    "stream": {
-                        "stream_state": {
-                            "history": {
-                                "very_very_old_file.csv": "2023-06-01T03:54:07.000000Z",
-                                "very_old_file.csv": "2023-06-02T03:54:07.000000Z",
-                                "old_file_same_timestamp_as_a.csv": "2023-06-06T03:54:07.000000Z",
-                            },
-                        },
-                        "stream_descriptor": {"name": "stream1"},
-                    },
-                }
-            ],
+            input_state=StateBuilder().with_stream_state("stream1", {
+                "history": {
+                    "very_very_old_file.csv": "2023-06-01T03:54:07.000000Z",
+                    "very_old_file.csv": "2023-06-02T03:54:07.000000Z",
+                    "old_file_same_timestamp_as_a.csv": "2023-06-06T03:54:07.000000Z",
+                },
+            }).build(),
         )
     )
 ).build()
@@ -1546,7 +1495,7 @@ multi_csv_same_timestamp_more_files_than_history_size_scenario = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[],
+            input_state=StateBuilder().build(),
         )
     )
 ).build()
@@ -1652,21 +1601,13 @@ multi_csv_sync_recent_files_if_history_is_incomplete_scenario = (
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[
-                {
-                    "type": "STREAM",
-                    "stream": {
-                        "stream_state": {
-                            "history": {
-                                "b.csv": "2023-06-05T03:54:07.000000Z",
-                                "c.csv": "2023-06-05T03:54:07.000000Z",
-                                "d.csv": "2023-06-05T03:54:07.000000Z",
-                            },
-                        },
-                        "stream_descriptor": {"name": "stream1"},
-                    },
-                }
-            ],
+            input_state=StateBuilder().with_stream_state("stream1", {
+                "history": {
+                    "b.csv": "2023-06-05T03:54:07.000000Z",
+                    "c.csv": "2023-06-05T03:54:07.000000Z",
+                    "d.csv": "2023-06-05T03:54:07.000000Z",
+                },
+            }).build(),
         )
     )
 ).build()
@@ -1794,21 +1735,13 @@ multi_csv_sync_files_within_time_window_if_history_is_incomplete__different_time
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[
-                {
-                    "type": "STREAM",
-                    "stream": {
-                        "stream_state": {
-                            "history": {
-                                "c.csv": "2023-06-07T03:54:07.000000Z",
-                                "d.csv": "2023-06-08T03:54:07.000000Z",
-                                "e.csv": "2023-06-08T03:54:07.000000Z",
-                            },
-                        },
-                        "stream_descriptor": {"name": "stream1"},
-                    },
-                }
-            ],
+            input_state=StateBuilder().with_stream_state("stream1", {
+                "history": {
+                    "c.csv": "2023-06-07T03:54:07.000000Z",
+                    "d.csv": "2023-06-08T03:54:07.000000Z",
+                    "e.csv": "2023-06-08T03:54:07.000000Z",
+                },
+            }).build(),
         )
     )
 ).build()
@@ -1962,21 +1895,13 @@ multi_csv_sync_files_within_history_time_window_if_history_is_incomplete_differe
     )
     .set_incremental_scenario_config(
         IncrementalScenarioConfig(
-            input_state=[
-                {
-                    "type": "STREAM",
-                    "stream": {
-                        "stream_state": {
-                            "history": {
-                                "old_file.csv": "2023-06-05T00:00:00.000000Z",
-                                "c.csv": "2023-06-07T03:54:07.000000Z",
-                                "d.csv": "2023-06-08T03:54:07.000000Z",
-                            },
-                        },
-                        "stream_descriptor": {"name": "stream1"},
-                    },
-                }
-            ],
+            input_state=StateBuilder().with_stream_state("stream1", {
+                "history": {
+                    "old_file.csv": "2023-06-05T00:00:00.000000Z",
+                    "c.csv": "2023-06-07T03:54:07.000000Z",
+                    "d.csv": "2023-06-08T03:54:07.000000Z",
+                },
+            }).build(),
         )
     )
 ).build()

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/incremental_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/incremental_scenarios.py
@@ -3,6 +3,7 @@
 #
 from airbyte_cdk.sources.streams.concurrent.cursor import CursorField
 from airbyte_cdk.sources.streams.concurrent.state_converters.abstract_stream_state_converter import ConcurrencyCompatibleStateType
+from airbyte_cdk.test.state_builder import StateBuilder
 from unit_tests.sources.file_based.scenarios.scenario_builder import IncrementalScenarioConfig, TestScenarioBuilder
 from unit_tests.sources.streams.concurrent.scenarios.stream_facade_builder import StreamFacadeSourceBuilder
 from unit_tests.sources.streams.concurrent.scenarios.utils import MockStream
@@ -84,7 +85,7 @@ test_incremental_stream_with_slice_boundaries_no_input_state = (
 )
 
 
-LEGACY_STATE = [{"type": "STREAM", "stream": {"stream_state": {"cursor_field": 0}, "stream_descriptor": {"name": "stream1"}}}]
+LEGACY_STATE = StateBuilder().with_stream_state("stream1", {"cursor_field": 0}).build()
 test_incremental_stream_without_slice_boundaries_with_legacy_state = (
     TestScenarioBuilder()
     .set_name("test_incremental_stream_without_slice_boundaries_with_legacy_state")
@@ -160,18 +161,10 @@ test_incremental_stream_with_slice_boundaries_with_legacy_state = (
 )
 
 
-CONCURRENT_STATE = [
-    {
-        "type": "STREAM",
-        "stream": {
-            "stream_state": {
-                "slices": [{"start": 0, "end": 0}],
-                "state_type": ConcurrencyCompatibleStateType.date_range.value,
-            },
-            "stream_descriptor": {"name": "stream1"},
-        },
-    },
-]
+CONCURRENT_STATE = StateBuilder().with_stream_state("stream1", {
+    "slices": [{"start": 0, "end": 0}],
+    "state_type": ConcurrencyCompatibleStateType.date_range.value,
+}).build()
 test_incremental_stream_without_slice_boundaries_with_concurrent_state = (
     TestScenarioBuilder()
     .set_name("test_incremental_stream_without_slice_boundaries_with_concurrent_state")

--- a/airbyte-cdk/python/unit_tests/test/test_entrypoint_wrapper.py
+++ b/airbyte-cdk/python/unit_tests/test/test_entrypoint_wrapper.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 from airbyte_cdk.sources.abstract_source import AbstractSource
 from airbyte_cdk.test.entrypoint_wrapper import read
+from airbyte_cdk.test.state_builder import StateBuilder
 from airbyte_protocol.models import (
     AirbyteAnalyticsTraceMessage,
     AirbyteErrorTraceMessage,
@@ -91,7 +92,7 @@ _A_CATALOG = ConfiguredAirbyteCatalog.parse_obj(
         ]
     }
 )
-_A_STATE = {"state_key": "state_value"}
+_A_STATE = StateBuilder().with_stream_state(_A_STREAM_NAME, {"state_key": "state_value"}).build()
 _A_LOG_MESSAGE = "a log message"
 
 


### PR DESCRIPTION
## What
Have the state builder return our action `TState` domain object and not the internal `state[X].stream. stream_state`. Without this, all the integration tests/scenario based test needs to know how are state messages created which is flaky as if the implementation change, all those tests would have to be updated while if it changes and we use `StateBuilder`, we might have a change to make the change non-breaking. This is how it looks for both:

#### Scenario-based
https://github.com/airbytehq/airbyte/compare/maxi297/statebuilder-create-state-not-dict?expand=1#diff-7a5029caa174d3c73bca535ec76e6ea66b577aef2149b2cac27baaf53d72aac7L42-R45

#### Integration tests
This is what triggered the change as we would only have to pass the state to the entrypoint wrapper that would save this list/dicts as json. However, adding the state as a parameter of SourceStripe.__init__ would make the integration tests handle two types of state: the one for the entrypoint wrapper and the one that is returned by <source>.read_state which is not a `List[AirbyteStateMessage]`. So usage changes to:

```
SourceStripe(catalog, config, StateBuilder(). with_stream_state(_STREAM_NAME, state_dict).build())
```

... instead of 
```
state = [
    {
        "type": "STREAM",
        "stream": {
            "stream_state": state_dict,
            "stream_descriptor": {"name": _STREAM_NAME},
        },
    }
]
SourceStripe(catalog, config, state)
```

## 🚨 User Impact 🚨
Scenario based tests were updated as part of this PR. As for integration tests, they will be updated as part of https://github.com/airbytehq/airbyte/issues/32057. This might impact https://github.com/airbytehq/airbyte/pull/33996#discussion_r1469999773 though @askarpets 
