### PR TITLE
Add noop alloydb doc for publishing

### DIFF
--- a/docs/integrations/sources/alloydb.md
+++ b/docs/integrations/sources/alloydb.md
@@ -1,0 +1,3 @@
+# Alloydb
+
+This destination has been removed


### PR DESCRIPTION
https://github.com/airbytehq/airbyte/pull/34624 didn't work because there was a missing doc.  Publishing now requires docs.
* https://storage.cloud.google.com/airbyte-ci-reports-multi/airbyte-ci/connectors/publish/master/master/1706555680/3bec4f0dec1e15feac5dca4adaf0d6264573ec64/source-alloydb/3.1.8/output.html
```
Running validator: validate_all_tags_are_keyvalue_pairs
Running validator: validate_at_least_one_language_tag
Running validator: validate_major_version_bump_has_breaking_change_entry
Running validator: validate_docs_path_exists
Running validator: validate_metadata_base_images_in_dockerhub
Running validator: validate_pypi_only_for_python
Running validator: validate_metadata_images_in_dockerhub
Checking that the following images are on dockerhub: [('airbyte/source-alloydb', '3.1.8')]
Local airbyte-integrations/connectors/source-alloydb/metadata.yaml md5_hash: TBljBXffLMW7NTaVjXZqog==
Remote metadata/airbyte/source-alloydb/3.1.8/metadata.yaml md5_hash: TBljBXffLMW7NTaVjXZqog==
The metadata file could not be uploaded: Expected to find connector doc file at docs/integrations/sources/alloydb.md, but none was found.[0m
```

