### PR TITLE
airbyte-lib: Prepare for published connectors

### DIFF
--- a/airbyte-lib/airbyte_lib/_executor.py
+++ b/airbyte-lib/airbyte_lib/_executor.py
@@ -251,7 +251,6 @@ class VenvExecutor(Executor):
             if raise_on_error:
                 raise
 
-            print("no version could be detected!!!!")
             return None
 
     @property

--- a/airbyte-lib/airbyte_lib/_executor.py
+++ b/airbyte-lib/airbyte_lib/_executor.py
@@ -147,8 +147,7 @@ class VenvExecutor(Executor):
 
         # This is a temporary install path that will be replaced with a proper package
         # name once they are published.
-        # TODO: Replace with `f"airbyte-{self.name}"`
-        self.pip_url = pip_url or f"../airbyte-integrations/connectors/{self.name}"
+        self.pip_url = pip_url or f"airbyte-{self.name}"
         self.install_root = install_root or Path.cwd()
 
     def _get_venv_name(self) -> str:
@@ -239,11 +238,12 @@ class VenvExecutor(Executor):
             return None
 
         try:
+            package_name = f"airbyte-{connector_name}"
             return subprocess.check_output(
                 [
                     self.interpreter_path,
                     "-c",
-                    f"from importlib.metadata import version; print(version('{connector_name}'))",
+                    f"from importlib.metadata import version; print(version('{package_name}'))",
                 ],
                 universal_newlines=True,
             ).strip()
@@ -251,6 +251,7 @@ class VenvExecutor(Executor):
             if raise_on_error:
                 raise
 
+            print("no version could be detected!!!!")
             return None
 
     @property

--- a/airbyte-lib/tests/integration_tests/fixtures/source-broken/setup.py
+++ b/airbyte-lib/tests/integration_tests/fixtures/source-broken/setup.py
@@ -3,10 +3,10 @@
 #
 
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 setup(
-    name="source_broken",
+    name="airbyte-source-broken",
     version="0.0.1",
     description="Test Soutce",
     author="Airbyte",

--- a/airbyte-lib/tests/integration_tests/fixtures/source-test/setup.py
+++ b/airbyte-lib/tests/integration_tests/fixtures/source-test/setup.py
@@ -3,10 +3,10 @@
 #
 
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 setup(
-    name="source_test",
+    name="airbyte-source-test",
     version="0.0.1",
     description="Test Soutce",
     author="Airbyte",


### PR DESCRIPTION
As I'm starting to actually publish connectors now, let's load them from pypi as well.

Also fix a small issue with the version check that went unnoticed.