### PR TITLE
Fix Cursor interface change + FileBased change at the same time

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py
@@ -78,6 +78,7 @@ class FileBasedStreamFacade(AbstractStreamFacade[DefaultStream], AbstractFileBas
                 cursor_field=cursor_field,
                 logger=logger,
                 namespace=stream.namespace,
+                cursor=cursor,
             ),
             stream,
             cursor,

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/cursor.py
@@ -83,5 +83,8 @@ class FileBasedNoopCursor(AbstractFileBasedConcurrentCursor):
     def close_partition(self, partition: Partition) -> None:
         return None
 
+    def ensure_at_least_one_state_emitted(self) -> None:
+        return None
+
     def set_pending_partitions(self, partitions: Iterable[Partition]) -> None:
         return None


### PR DESCRIPTION
## What
Fix master as there was a change introducing the cursor for File Based CDK while there was another change changing the interface of the cursor. 

## How
Adding the new method to the NOOP fcdk cursor. As it is NOOP, there is nothing to do in the implementation
