### PR TITLE
Publish to pypi batch5

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -20,6 +20,11 @@ data:
   icon: google-analytics.svg
   license: Elv2
   name: Google Analytics (Universal Analytics)
+  remoteRegistries:
+    pypi:
+      enabled: false
+      # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
+      packageName: airbyte-source-google-analytics-v4
   registries:
     cloud:
       enabled: false

--- a/airbyte-integrations/connectors/source-google-directory/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-directory/metadata.yaml
@@ -8,6 +8,10 @@ data:
   icon: googledirectory.svg
   license: MIT
   name: Google Directory
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-google-directory
   registries:
     cloud:
       dockerImageTag: 0.2.1

--- a/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
@@ -8,6 +8,10 @@ data:
   icon: google-pagespeed-insights.svg
   license: MIT
   name: Google PageSpeed Insights
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-google-pagespeed-insights
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
@@ -17,6 +17,11 @@ data:
   icon: googlesearchconsole.svg
   license: Elv2
   name: Google Search Console
+  remoteRegistries:
+    pypi:
+      enabled: false
+      # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
+      packageName: airbyte-source-google-search-console
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-google-webfonts/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-webfonts/metadata.yaml
@@ -8,6 +8,10 @@ data:
   icon: googleworkpace.svg
   license: MIT
   name: Google Webfonts
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-google-webfonts
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-google-workspace-admin-reports/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-workspace-admin-reports/metadata.yaml
@@ -8,6 +8,11 @@ data:
   icon: googleworkpace.svg
   license: MIT
   name: Google Workspace Admin Reports
+  remoteRegistries:
+    pypi:
+      enabled: false
+      # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
+      packageName: airbyte-source-google-workspace-admin-reports
   registries:
     cloud:
       dockerImageTag: 0.1.4

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -17,6 +17,10 @@ data:
   icon: greenhouse.svg
   license: MIT
   name: Greenhouse
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-greenhouse
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-gridly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gridly/metadata.yaml
@@ -8,6 +8,10 @@ data:
   icon: gridly.svg
   license: MIT
   name: Gridly
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-gridly
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-gutendex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gutendex/metadata.yaml
@@ -7,6 +7,10 @@ data:
   githubIssueLabel: source-gutendex
   license: MIT
   name: Gutendex
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-gutendex
   registries:
     cloud:
       enabled: false

--- a/airbyte-integrations/connectors/source-harness/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harness/metadata.yaml
@@ -2,6 +2,10 @@ data:
   allowedHosts:
     hosts:
       - api.harness.io
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-harness
   registries:
     oss:
       enabled: false

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -17,6 +17,10 @@ data:
   icon: harvest.svg
   license: MIT
   name: Harvest
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-harvest
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-hellobaton/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hellobaton/metadata.yaml
@@ -2,6 +2,10 @@ data:
   allowedHosts:
     hosts:
       - ${company}.hellobaton.com
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-hellobaton
   registries:
     oss:
       enabled: true

--- a/airbyte-integrations/connectors/source-hubplanner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubplanner/metadata.yaml
@@ -2,6 +2,10 @@ data:
   allowedHosts:
     hosts:
       - "*" # Please change to the hostname of the source.
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-hubplanner
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -17,6 +17,10 @@ data:
   icon: hubspot.svg
   license: ELv2
   name: HubSpot
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-hubspot
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-insightly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-insightly/metadata.yaml
@@ -2,6 +2,10 @@ data:
   allowedHosts:
     hosts:
       - TODO # Please change to the hostname of the source.
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-insightly
   registries:
     oss:
       enabled: true

--- a/airbyte-integrations/connectors/source-instatus/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instatus/metadata.yaml
@@ -8,6 +8,10 @@ data:
   icon: instatus.svg
   license: MIT
   name: Instatus
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-instatus
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -17,6 +17,11 @@ data:
   icon: intercom.svg
   license: MIT
   name: Intercom
+  remoteRegistries:
+    pypi:
+      enabled: false
+      # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
+      packageName: airbyte-source-intercom
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-intruder/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intruder/metadata.yaml
@@ -8,6 +8,10 @@ data:
   icon: intruder.svg
   license: MIT
   name: Intruder
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-intruder
   registries:
     cloud:
       enabled: false

--- a/airbyte-integrations/connectors/source-ip2whois/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ip2whois/metadata.yaml
@@ -8,6 +8,10 @@ data:
   icon: ip2whois.svg
   license: MIT
   name: IP2Whois
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-ip2whois
   registries:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -18,6 +18,10 @@ data:
   license: MIT
   maxSecondsBetweenMessages: 21600
   name: Jira
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-jira
   registries:
     cloud:
       enabled: true


### PR DESCRIPTION
Publish batch of connectors to pypi.

Connectors that failed the test and won't be enabled:
* source-google-workspace-admin-reports (issue with module pytz not available)
* source-google-search-console (secrets outdated)
* source-intercom (secrets outdated)