### PR TITLE
Fix log4j-slf4j-impl version conflicts

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -166,6 +166,7 @@ MavenLocal debugging steps:
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.16.3  | 2024-01-30 | [\#34669](https://github.com/airbytehq/airbyte/pull/34669) | Fix org.apache.logging.log4j:log4j-slf4j-impl version conflicts.                                                                                               |
 | 0.16.2  | 2024-01-29 | [\#34630](https://github.com/airbytehq/airbyte/pull/34630) | expose NamingTransformer to sub-classes in destinations JdbcSqlGenerator.                                                                                      |
 | 0.16.1  | 2024-01-29 | [\#34533](https://github.com/airbytehq/airbyte/pull/34533) | Add a safe method to execute DatabaseMetadata's Resultset returning queries.                                                                                   |
 | 0.16.0  | 2024-01-26 | [\#34573](https://github.com/airbytehq/airbyte/pull/34573) | Untangle Debezium harness dependencies.                                                                                                                        |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.16.2
+version=0.16.3

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.16.2'
+    cdkVersionRequired = '0.16.3'
     features = [
             'db-sources', // required for tests
             'db-destinations',

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -9,7 +9,7 @@ airbyteJavaConnector {
             'db-sources', // required for tests
             'db-destinations',
     ]
-    useLocalCdk = true
+    useLocalCdk = false
 }
 
 //remove once upgrading the CDK version to 0.4.x or later

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.16.3'
+    cdkVersionRequired = '0.16.2'
     features = [
             'db-sources', // required for tests
             'db-destinations',

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -9,7 +9,7 @@ airbyteJavaConnector {
             'db-sources', // required for tests
             'db-destinations',
     ]
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 //remove once upgrading the CDK version to 0.4.x or later

--- a/deps.toml
+++ b/deps.toml
@@ -81,7 +81,8 @@ kotlinx-cli-jvm = { module = "org.jetbrains.kotlinx:kotlinx-cli-jvm", version = 
 launchdarkly = { module = "com.launchdarkly:launchdarkly-java-server-sdk", version = "6.0.1" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
-log4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j" }
+log4j-slf4j2-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j" }
+log4j-slf4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j-impl", version.ref = "log4j" }
 log4j-over-slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "slf4j" }
 log4j-web = { module = "org.apache.logging.log4j:log4j-web", version.ref = "log4j" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
@@ -117,7 +118,7 @@ apache = ["apache-commons", "apache-commons-lang"]
 datadog = ["datadog-trace-api", "datadog-trace-ot"]
 jackson = ["jackson-databind", "jackson-annotations", "jackson-dataformat", "jackson-datatype"]
 junit = ["junit-jupiter-api", "junit-jupiter-params", "mockito-junit-jupiter"]
-log4j = ["log4j-api", "log4j-core", "log4j-impl", "log4j-web"]
+log4j = ["log4j-api", "log4j-core", "log4j-slf4j-impl", "log4j-slf4j2-impl", "log4j-web"]
 slf4j = ["jul-to-slf4j", "jcl-over-slf4j", "log4j-over-slf4j"]
 temporal = ["temporal-sdk", "temporal-serviceclient"]
 


### PR DESCRIPTION
The deps.toml defines a `log4j-slf4j2-impl` dependency but not `log4j-slf4j-impl`. This would sometimes cause version conflicts when running integration tests, because the latter gets transitively pulled by airbyte-protocol.