### PR TITLE
Destination Postgres: Upgrade CDK with fixed dependency and unpin cloud

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.16.2'
+    cdkVersionRequired = '0.16.3'
     features = [
             'db-sources', // required for tests
             'db-destinations'

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 0.6.1
+  dockerImageTag: 0.6.2
   dockerRepository: airbyte/destination-postgres-strict-encrypt
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres
@@ -16,7 +16,6 @@ data:
   registries:
     cloud:
       enabled: false
-      dockerImageTag: 0.6.0
     oss:
       enabled: false
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.16.2'
+    cdkVersionRequired = '0.16.3'
     features = [
             'db-sources', // required for tests
             'db-destinations',

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 0.6.1
+  dockerImageTag: 0.6.2
   dockerRepository: airbyte/destination-postgres
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres
@@ -19,7 +19,6 @@ data:
   registries:
     cloud:
       dockerRepository: airbyte/destination-postgres-strict-encrypt
-      dockerImageTag: 0.6.0
       enabled: true
     oss:
       enabled: true

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -170,6 +170,7 @@ Now that you have set up the Postgres destination connector, check out the follo
 
 | Version | Date       | Pull Request                                               | Subject                                                                                             |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 0.6.2   | 2024-01-30 | [34630](https://github.com/airbytehq/airbyte/pull/34630)   | CDK Upgrade 0.16.3; Fix dependency mismatches in slf4j lib                                          |
 | 0.6.1   | 2024-01-29 | [34630](https://github.com/airbytehq/airbyte/pull/34630)   | CDK Upgrade; Use lowercase raw table in T+D queries.                                                |
 | 0.6.0   | 2024-01-19 | [34372](https://github.com/airbytehq/airbyte/pull/34372)   | Add dv2 flag in spec                                                                                |
 | 0.5.5   | 2024-01-18 | [34236](https://github.com/airbytehq/airbyte/pull/34236)   | Upgrade CDK to 0.13.1; Add indexes in raw table for query optimization                              |

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -170,7 +170,7 @@ Now that you have set up the Postgres destination connector, check out the follo
 
 | Version | Date       | Pull Request                                               | Subject                                                                                             |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| 0.6.2   | 2024-01-30 | [34630](https://github.com/airbytehq/airbyte/pull/34630)   | CDK Upgrade 0.16.3; Fix dependency mismatches in slf4j lib                                          |
+| 0.6.2   | 2024-01-30 | [34683](https://github.com/airbytehq/airbyte/pull/34683)   | CDK Upgrade 0.16.3; Fix dependency mismatches in slf4j lib                                          |
 | 0.6.1   | 2024-01-29 | [34630](https://github.com/airbytehq/airbyte/pull/34630)   | CDK Upgrade; Use lowercase raw table in T+D queries.                                                |
 | 0.6.0   | 2024-01-19 | [34372](https://github.com/airbytehq/airbyte/pull/34372)   | Add dv2 flag in spec                                                                                |
 | 0.5.5   | 2024-01-18 | [34236](https://github.com/airbytehq/airbyte/pull/34236)   | Upgrade CDK to 0.13.1; Add indexes in raw table for query optimization                              |


### PR DESCRIPTION
## What
* CDK had a dependency covergency issue with slf4j leading to NoSuchMethodError in previous version

## How
* Fixed in CDK 0.16.3, Upgrading CDK version and unpinning the cloud


