### PR TITLE
airbyte-lib: Use connector metadata

### DIFF
--- a/airbyte-lib/airbyte_lib/caches/base.py
+++ b/airbyte-lib/airbyte_lib/caches/base.py
@@ -14,8 +14,7 @@ import pyarrow as pa
 import sqlalchemy
 import ulid
 from overrides import overrides
-from sqlalchemy import Column, String, create_engine, text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import create_engine, text
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.elements import TextClause
 
@@ -47,20 +46,6 @@ if TYPE_CHECKING:
 
 
 DEBUG_MODE = False  # Set to True to enable additional debug logging.
-
-
-STREAMS_TABLE_NAME = "_airbytelib_streams"
-
-Base = declarative_base()
-
-
-class CachedStream(Base):  # type: ignore[valid-type,misc]
-    __tablename__ = STREAMS_TABLE_NAME
-
-    stream_name = Column(String)
-    source_name = Column(String)
-    table_name = Column(String, primary_key=True)
-    catalog_metadata = Column(String)
 
 
 class RecordDedupeMode(enum.Enum):

--- a/airbyte-lib/airbyte_lib/exceptions.py
+++ b/airbyte-lib/airbyte_lib/exceptions.py
@@ -182,6 +182,14 @@ class AirbyteConnectorNotRegisteredError(AirbyteConnectorRegistryError):
     guidance = "Please double check the connector name."
 
 
+@dataclass
+class AirbyteConnectorNotPyPiPublishedError(AirbyteConnectorRegistryError):
+    """Connector found, but not published to PyPI."""
+
+    connector_name: str | None = None
+    guidance = "This likely means that the connector is not ready for use with airbyte-lib."
+
+
 # Connector Errors
 
 

--- a/airbyte-lib/airbyte_lib/validate.py
+++ b/airbyte-lib/airbyte_lib/validate.py
@@ -137,6 +137,9 @@ def validate(connector_dir: str, sample_config: str, *, validate_install_only: b
             {
                 "dockerRepository": f"airbyte/{connector_name}",
                 "dockerImageTag": "0.0.1",
+                "remoteRegistries": {
+                    "pypi": {"packageName": "airbyte-{connector_name}", "enabled": True}
+                },
             },
         ],
     }

--- a/airbyte-lib/examples/run_pokeapi.py
+++ b/airbyte-lib/examples/run_pokeapi.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+"""A simple test of AirbyteLib, using the Faker source connector.
+
+Usage (from airbyte-lib root directory):
+> poetry run python ./examples/run_faker.py
+
+No setup is needed, but you may need to delete the .venv-source-faker folder
+if your installation gets interrupted or corrupted.
+"""
+from __future__ import annotations
+
+import airbyte_lib as ab
+
+
+SCALE = 50  # Number of records to generate between users and purchases.
+
+
+source = ab.get_connector(
+    "source-pokeapi",
+    config={"pokemon_name": "bulbasaur"},
+    install_if_missing=True,
+)
+source.check()
+
+print(list(source.get_records("pokemon")))

--- a/airbyte-lib/examples/run_pokeapi.py
+++ b/airbyte-lib/examples/run_pokeapi.py
@@ -1,18 +1,15 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-"""A simple test of AirbyteLib, using the Faker source connector.
+"""A simple test of AirbyteLib, using the PokeAPI source connector.
 
 Usage (from airbyte-lib root directory):
-> poetry run python ./examples/run_faker.py
+> poetry run python ./examples/run_pokeapi.py
 
-No setup is needed, but you may need to delete the .venv-source-faker folder
+No setup is needed, but you may need to delete the .venv-source-pokeapi folder
 if your installation gets interrupted or corrupted.
 """
 from __future__ import annotations
 
 import airbyte_lib as ab
-
-
-SCALE = 50  # Number of records to generate between users and purchases.
 
 
 source = ab.get_connector(

--- a/airbyte-lib/tests/integration_tests/fixtures/registry.json
+++ b/airbyte-lib/tests/integration_tests/fixtures/registry.json
@@ -9,6 +9,12 @@
       "icon": "test.svg",
       "iconUrl": "https://connectors.airbyte.com/files/metadata/airbyte/source-test/latest/icon.svg",
       "sourceType": "api",
+      "remoteRegistries": {
+        "pypi": {
+          "packageName": "airbyte-source-test",
+          "enabled": true
+        }
+      },
       "spec": {
         "documentationUrl": "https://docs.airbyte.com/integrations/sources/test",
         "connectionSpecification": {
@@ -34,6 +40,48 @@
       },
       "tags": ["language:python"],
       "githubIssueLabel": "source-test",
+      "license": "MIT"
+    },
+    {
+      "sourceDefinitionId": "9f32dab3-77cb-45a1-9d33-347aa5fbe333",
+      "name": "Non-published source",
+      "dockerRepository": "airbyte/source-non-published",
+      "dockerImageTag": "0.0.1",
+      "documentationUrl": "https://docs.airbyte.com/integrations/sources/test",
+      "icon": "test.svg",
+      "iconUrl": "https://connectors.airbyte.com/files/metadata/airbyte/source-test/latest/icon.svg",
+      "sourceType": "api",
+      "remoteRegistries": {
+        "pypi": {
+          "packageName": "airbyte-source-non-published",
+          "enabled": false
+        }
+      },
+      "spec": {
+        "documentationUrl": "https://docs.airbyte.com/integrations/sources/test",
+        "connectionSpecification": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "apiKey": {
+              "type": "string",
+              "title": "API Key",
+              "description": "The API key for the service"
+            }
+          }
+        }
+      },
+      "tombstone": false,
+      "public": true,
+      "custom": false,
+      "releaseStage": "alpha",
+      "supportLevel": "community",
+      "ab_internal": {
+        "sl": 100,
+        "ql": 200
+      },
+      "tags": ["language:python"],
+      "githubIssueLabel": "source-source-non-published",
       "license": "MIT"
     }
   ]

--- a/airbyte-lib/tests/integration_tests/fixtures/source-broken/metadata.yaml
+++ b/airbyte-lib/tests/integration_tests/fixtures/source-broken/metadata.yaml
@@ -10,4 +10,8 @@ data:
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/apify-dataset
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-broken
 metadataSpecVersion: "1.0"

--- a/airbyte-lib/tests/integration_tests/fixtures/source-test/metadata.yaml
+++ b/airbyte-lib/tests/integration_tests/fixtures/source-test/metadata.yaml
@@ -10,4 +10,8 @@ data:
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/apify-dataset
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-test
 metadataSpecVersion: "1.0"

--- a/airbyte-lib/tests/integration_tests/test_integration.py
+++ b/airbyte-lib/tests/integration_tests/test_integration.py
@@ -117,6 +117,9 @@ def test_non_existing_connector():
     with pytest.raises(Exception):
         ab.get_connector("source-not-existing", config={"apiKey": "abc"})
 
+def test_non_enabled_connector():
+    with pytest.raises(exc.AirbyteConnectorNotPyPiPublishedError):
+        ab.get_connector("source-non-published", config={"apiKey": "abc"})
 
 @pytest.mark.parametrize(
     "latest_available_version, requested_version, raises",
@@ -138,7 +141,7 @@ def test_version_enforcement(raises, latest_available_version, requested_version
     In this test, the actually installed version is 0.0.1
     """
     patched_entry = registry.ConnectorMetadata(
-        name="source-test", latest_available_version=latest_available_version
+        name="source-test", latest_available_version=latest_available_version, pypi_package_name="airbyte-source-test"
     )
     with patch.dict("airbyte_lib.registry.__cache", {"source-test": patched_entry}, clear=False):
         if raises:


### PR DESCRIPTION
As we have connectors published on regular pypi now, this PR switches over the installation process to truly use it:
* If a connector is in the registry, but doesn't have `remoteRegistries.pypi.enabled`, there's a new exception now
* Use the package name from the metadata.yml instead of constructing it manually
* Add a test for this

Drive-by change: I noticed there was some leftover code in the cache base class which got moved to the catalog  manager, I removed that.