### PR TITLE
CAT: fix NoAdditionalPropertiesValidator

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.3
+Аix `NoAdditionalPropertiesValidator` if no type found in `items` 
+
 ## 3.3.2
 Fix TestBasicRead.test_read.validate_schema: set `additionalProperties` to False recursively for objects
 

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/asserts.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/asserts.py
@@ -48,7 +48,7 @@ class NoAdditionalPropertiesValidator(Draft7Validator):
                 elif "type" in prop_value and "array" in prop_value["type"]:
                     if (
                         prop_value.get("items")
-                        and "object" in prop_value.get("items", {}).get("type")
+                        and "object" in prop_value.get("items", {}).get("type", [])
                         and len(prop_value.get("items", {}).get("properties", []))
                     ):
                         prop_value["items"]["additionalProperties"] = False

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "3.3.1"
+version = "3.3.3"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
## What

fix bug in NoAdditionalPropertiesValidator if no type found in `items` 

## How

safe eval `in` method

## Recommended reading order
1. `airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/asserts.py`

## 🚨 User Impact 🚨
no breaking changes


## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

