### PR TITLE
Source Azure Table: update use of ConnectorStateManager

### DIFF
--- a/airbyte-integrations/connectors/source-azure-table/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-table/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 798ae795-5189-42b6-b64e-3cb91db93338
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   dockerRepository: airbyte/source-azure-table
   githubIssueLabel: source-azure-table
   icon: azureblobstorage.svg

--- a/airbyte-integrations/connectors/source-azure-table/setup.py
+++ b/airbyte-integrations/connectors/source-azure-table/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk", "azure.data.tables"]
+MAIN_REQUIREMENTS = ["airbyte-cdk>=0.62.0", "azure.data.tables"]
 
 TEST_REQUIREMENTS = [
     "requests-mock~=1.9.3",

--- a/airbyte-integrations/connectors/source-azure-table/source_azure_table/source.py
+++ b/airbyte-integrations/connectors/source-azure-table/source_azure_table/source.py
@@ -101,7 +101,7 @@ class SourceAzureTable(AbstractSource):
         This method is overridden to check whether the stream `quotes` exists in the source, if not skip reading that stream.
         """
         stream_instances = {s.name: s for s in self.streams(logger=logger, config=config)}
-        state_manager = ConnectorStateManager(stream_instance_map=stream_instances, state=state)
+        state_manager = ConnectorStateManager(stream_instance_map={s.stream.name: s.stream for s in catalog.streams}, state=state)
         logger.info(f"Starting syncing {self.name}")
         config, internal_config = split_config(config)
         self._stream_to_instance_map = stream_instances

--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b117307c-14b6-41aa-9422-947e34922962
-  dockerImageTag: 2.3.0
+  dockerImageTag: 2.3.1
   dockerRepository: airbyte/source-salesforce
   documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce
   githubIssueLabel: source-salesforce

--- a/airbyte-integrations/connectors/source-salesforce/setup.py
+++ b/airbyte-integrations/connectors/source-salesforce/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk~=0.59.0", "pandas"]
+MAIN_REQUIREMENTS = ["airbyte-cdk~=0.62.0", "pandas"]
 
 TEST_REQUIREMENTS = ["freezegun", "pytest~=6.1", "pytest-mock~=3.6", "requests-mock~=1.9.3", "pytest-timeout"]
 

--- a/docs/integrations/sources/azure-table.md
+++ b/docs/integrations/sources/azure-table.md
@@ -66,6 +66,7 @@ We recommend creating a restricted key specifically for Airbyte access. This wil
 
 | Version | Date       | Pull Request                                             | Subject                                           |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------ |
+| 0.1.5   | 2024-01-31 | [34716](https://github.com/airbytehq/airbyte/pull/34716) | Update use of ConnectorStateManager               |
 | 0.1.4   | 2024-01-26 | [34576](https://github.com/airbytehq/airbyte/pull/34576) | Migrate to per-stream/global state                |
 | 0.1.3   | 2022-08-12 | [15591](https://github.com/airbytehq/airbyte/pull/15591) | Clean instantiation of AirbyteStream              |
 | 0.1.2   | 2021-12-23 | [14212](https://github.com/airbytehq/airbyte/pull/14212) | Adding incremental load capability                |

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -193,6 +193,7 @@ Now that you have set up the Salesforce source connector, check out the followin
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 2.3.1   | 2024-02-07 | [34716](https://github.com/airbytehq/airbyte/pull/34716) | Update use of ConnectorStateManager                                                                                                                 |
 | 2.3.0   | 2023-12-15 | [33522](https://github.com/airbytehq/airbyte/pull/33522) | Sync streams concurrently in all sync modes                                                                                          |
 | 2.2.2   | 2024-01-04 | [33936](https://github.com/airbytehq/airbyte/pull/33936) | Prepare for airbyte-lib                                                                                                              |
 | 2.2.1   | 2023-12-12 | [33342](https://github.com/airbytehq/airbyte/pull/33342) | Added new ContentDocumentLink stream                                                                                                 |


### PR DESCRIPTION
Depends on CDK updates in https://github.com/airbytehq/airbyte/pull/34540.

The `ConnectorStateManager` has been updated to take a mapping of stream name: `AirbyteStream` instead of name: `Stream` instance. This updates the connectors that use the `ConnectorStateManager` to conform to this change.

TODO: update to real version of CDK once https://github.com/airbytehq/airbyte/pull/34540 has been released.