### PR TITLE
CDK destinations: Future based output reader for T+D test

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -166,6 +166,7 @@ MavenLocal debugging steps:
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.16.4  | 2024-02-01 | [\#34727](https://github.com/airbytehq/airbyte/pull/34727) | Add future based stdout consumer in BaseTypingDedupingTest                                                                                                     |
 | 0.16.3  | 2024-01-30 | [\#34669](https://github.com/airbytehq/airbyte/pull/34669) | Fix org.apache.logging.log4j:log4j-slf4j-impl version conflicts.                                                                                               |
 | 0.16.2  | 2024-01-29 | [\#34630](https://github.com/airbytehq/airbyte/pull/34630) | expose NamingTransformer to sub-classes in destinations JdbcSqlGenerator.                                                                                      |
 | 0.16.1  | 2024-01-29 | [\#34533](https://github.com/airbytehq/airbyte/pull/34533) | Add a safe method to execute DatabaseMetadata's Resultset returning queries.                                                                                   |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.16.3
+version=0.16.4

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
@@ -779,7 +780,7 @@ public abstract class BaseTypingDedupingTest {
   // stdout in real time, to prevent the buffer from filling up and blocking the destination.
   private CompletableFuture<List<io.airbyte.protocol.models.AirbyteMessage>> destinationOutputFuture(final AirbyteDestination destination) {
     final CompletableFuture<List<io.airbyte.protocol.models.AirbyteMessage>> outputFuture = new CompletableFuture<>();
-    Executors.newSingleThreadExecutor().submit(() -> {
+    Executors.newSingleThreadExecutor().submit((Callable<Void>) () -> {
       final List<io.airbyte.protocol.models.AirbyteMessage> destinationMessages = new ArrayList<>();
       while (!destination.isFinished()) {
         // attemptRead isn't threadsafe, we read stdout fully here.

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
@@ -598,18 +598,21 @@ public abstract class BaseTypingDedupingTest {
     // Start two concurrent syncs
     final AirbyteDestination sync1 = startSync(catalog1);
     final AirbyteDestination sync2 = startSync(catalog2);
+    CompletableFuture<List<io.airbyte.protocol.models.AirbyteMessage>> outFuture1 = destinationOutputFuture(sync1);
+    CompletableFuture<List<io.airbyte.protocol.models.AirbyteMessage>> outFuture2 = destinationOutputFuture(sync2);
+
     // Write some messages to both syncs. Write a lot of data to sync 2 to try and force a flush.
     pushMessages(messages1, sync1);
     for (int i = 0; i < 100_000; i++) {
       pushMessages(messages2, sync2);
     }
-    endSync(sync1, destinationOutputFuture(sync1));
+    endSync(sync1, outFuture1);
     // Write some more messages to the second sync. It should not be affected by the first sync's
     // shutdown.
     for (int i = 0; i < 100_000; i++) {
       pushMessages(messages2, sync2);
     }
-    endSync(sync2, destinationOutputFuture(sync2));
+    endSync(sync2, outFuture2);
 
     // For simplicity, don't verify the raw table. Assume that if the final table is correct, then
     // the raw data is correct. This is generally a safe assumption.

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
@@ -770,8 +770,9 @@ public abstract class BaseTypingDedupingTest {
                          final Function<JsonNode, JsonNode> configTransformer)
       throws Exception {
     final AirbyteDestination destination = startSync(catalog, imageName, configTransformer);
+    final CompletableFuture<List<io.airbyte.protocol.models.AirbyteMessage>> outputFuture = destinationOutputFuture(destination);
     pushMessages(messages, destination);
-    endSync(destination, destinationOutputFuture(destination));
+    endSync(destination, outputFuture);
   }
 
   // In the background, read messages from the destination until it terminates. We need to clear

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/java/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.java
@@ -774,7 +774,7 @@ public abstract class BaseTypingDedupingTest {
   // In the background, read messages from the destination until it terminates. We need to clear
   // stdout in real time, to prevent the buffer from filling up and blocking the destination.
   private CompletableFuture<List<io.airbyte.protocol.models.AirbyteMessage>> destinationOutputFuture(final AirbyteDestination destination) {
-    CompletableFuture<List<io.airbyte.protocol.models.AirbyteMessage>> outputFuture = new CompletableFuture<>();
+    final CompletableFuture<List<io.airbyte.protocol.models.AirbyteMessage>> outputFuture = new CompletableFuture<>();
     Executors.newSingleThreadExecutor().submit(() -> {
       final List<io.airbyte.protocol.models.AirbyteMessage> destinationMessages = new ArrayList<>();
       while (!destination.isFinished()) {


### PR DESCRIPTION
## What
Fix non-deterministic flaky tests. Currently the `hasNext()` is called from main thread and background thread and depending on when the call enters shared code 
this can lead to non-deterministic behavior leading to below errors. 
```
BigQueryGcsRawOverrideTypingDedupingTest > testRawTableJsonToStringMigration() FAILED
    java.lang.NullPointerException: Cannot invoke "java.util.stream.Sink.cancellationRequested()" because "this.bufferSink" is null
        at java.base/java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206)
        at java.base/java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:169)
        at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:298)
        at java.base/java.util.Spliterators$1Adapter.hasNext(Spliterators.java:681)
        at io.airbyte.workers.internal.DefaultAirbyteDestination.isFinished(DefaultAirbyteDestination.java:156)
        at io.airbyte.integrations.base.destination.typing_deduping.BaseTypingDedupingTest.endSync(BaseTypingDedupingTest.java:859)
        at io.airbyte.integrations.base.destination.typing_deduping.BaseTypingDedupingTest.runSync(BaseTypingDedupingTest.java:771)
        at io.airbyte.integrations.base.destination.typing_deduping.BaseTypingDedupingTest.runSync(BaseTypingDedupingTest.java:761)
        at io.airbyte.integrations.base.destination.typing_deduping.BaseTypingDedupingTest.runSync(BaseTypingDedupingTest.java:757)
```

## How
Add more deterministic way of ending the sync using instance level methods and having a handle of the CompletableFuture


