### PR TITLE
source-monday: publish to pypi

### DIFF
--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -36,8 +36,11 @@ data:
   name: Monday
   remoteRegistries:
     pypi:
-      enabled: false
-      # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
+      enabled: true
+      packageName: airbyte-source-monday
+  remoteRegistries:
+    pypi:
+      enabled: true
       packageName: airbyte-source-monday
   registries:
     cloud:


### PR DESCRIPTION
When the batch was prepared, source-monday was failing its test, but they are green again and pass the airbyte-lib smoketest now.