### PR TITLE
rename airbyte-ci-test.yml workflow to internal-poetry-packages-ci.yml

### DIFF
--- a/.github/workflows/internal_poetry_packages_ci.yml
+++ b/.github/workflows/internal_poetry_packages_ci.yml
@@ -17,9 +17,7 @@ on:
       - synchronize
 jobs:
   run-airbyte-ci-poetry-ci:
-    #name: Internal Poetry packages CI
-    # To rename in a follow up PR
-    name: Run Airbyte CI tests
+    name: Internal Poetry packages CI
     runs-on: tooling-test-large
     permissions:
       pull-requests: read


### PR DESCRIPTION
Renaming the `airbyte-ci-test.yml` to a name consistent with what it's actually doing: testing internal poetry packages.

To do: Change the branch protection rule settings to change the required check from `Pipeline Unit test` to `Internal Poetry packages CI`

## User impact
Developers will have to update their branch following this merge to get the `Internal Poetry packages CI` status check on their branch.