### PR TITLE
Add heartbeat_action_query parameter

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcProperties.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresCdcProperties.java
@@ -68,7 +68,9 @@ public class PostgresCdcProperties {
             ? HEARTBEAT_INTERVAL_IN_TESTS
             : HEARTBEAT_INTERVAL;
     props.setProperty("heartbeat.interval.ms", Long.toString(heartbeatInterval.toMillis()));
-
+    if(!sourceConfig.get("replication_method").get("heartbeat_action_query").asText().isEmpty()) {
+      props.setProperty("heartbeat.action.query", sourceConfig.get("replication_method").get("heartbeat_action_query").asText());
+    }
     if (PostgresUtils.shouldFlushAfterSync(sourceConfig)) {
       props.setProperty("flush.lsn.source", "false");
     }

--- a/airbyte-integrations/connectors/source-postgres/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-postgres/src/main/resources/spec.json
@@ -289,6 +289,13 @@
                 ],
                 "default": "After loading Data in the destination",
                 "order": 7
+              },
+              "heartbeat_action_query": {
+                "type": "string",
+                "title": "Debezium commit heartbeat action query",
+                "description": "Debezium setting. Specifies a query that the connector executes on the source database when the connector sends a heartbeat message.",
+                "default": "",
+                "order": 8
               }
             }
           },


### PR DESCRIPTION


## What
The current version of the Postgres connector does not have the ability to pass the heartbeat.action.query parameter to Debezium.

## How
The parameter heartbeat_action_query has been added for the update method in CDC.

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
No impact onto current connectors. Only new code appended.


## Pre-merge Actions

Updating a connector

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
