### PR TITLE
AirbyteLib: fix examples in getting started

### DIFF
--- a/airbyte-lib/examples/run_faker.py
+++ b/airbyte-lib/examples/run_faker.py
@@ -17,15 +17,13 @@ SCALE = 5_000_000  # Number of records to generate between users and purchases.
 
 source = ab.get_connector(
     "source-faker",
-    pip_url="-e ../airbyte-integrations/connectors/source-faker",
     config={"count": SCALE / 2},
     install_if_missing=True,
 )
 source.check()
 source.set_streams(["products", "users", "purchases"])
 
-cache = ab.new_local_cache()
-result = source.read(cache)
+result = source.read()
 
-for name, records in result.cache.streams.items():
+for name, records in result.streams.items():
     print(f"Stream {name}: {len(list(records))} records")

--- a/docs/using-airbyte/airbyte-lib/getting-started.mdx
+++ b/docs/using-airbyte/airbyte-lib/getting-started.mdx
@@ -13,7 +13,7 @@ pip install airbyte-lib
 Or during the beta, you may want to install the latest from from source with:
 
 ```bash
-pip install 'git+airbytehq/airbyte.git@master#egg=airbyte-lib&subdirectory=airbyte-lib'
+pip install 'git+https://www.github.com/airbytehq/airbyte.git@master#egg=airbyte-lib&subdirectory=airbyte-lib'
 ```
 
 ## Usage
@@ -24,19 +24,15 @@ Data can be extracted from sources and loaded into caches:
 import airbyte_lib as ab
 
 source = ab.get_connector(
-    "source-spacex-api",
-    config={"id": "605b4b6aaa5433645e37d03f"},
+    "source-faker",
+    config={"count": 5_000},
     install_if_missing=True,
 )
 source.check()
+result = source.read()
 
-source.set_streams(["launches", "rockets", "capsules"])
-
-cache = ab.new_local_cache()
-result = source.read_all(cache)
-
-for name, records in result.cache.streams.items():
-    print(f"Stream {name}: {len(records)} records")
+for name, records in result.streams.items():
+    print(f"Stream {name}: {len(list(records))} records")
 ```
 
 ## API Reference


### PR DESCRIPTION
This fixes some stale code as pointed out by beta testers. also removes pip_url where this is no longer needed.