### PR TITLE
AirbyteLib: Add len() support on SQL datasets and Mapping behaviors for ReadResult (#34763)

### DIFF
--- a/airbyte-lib/airbyte_lib/datasets/_base.py
+++ b/airbyte-lib/airbyte_lib/datasets/_base.py
@@ -11,10 +11,23 @@ from pandas import DataFrame
 class DatasetBase(ABC):
     """Base implementation for all datasets."""
 
+    def __init__(self) -> None:
+        self.__length: int | None = None
+
     @abstractmethod
     def __iter__(self) -> Iterator[Mapping[str, Any]]:
         """Return the iterator of records."""
         raise NotImplementedError
+
+    def __len__(self) -> int:
+        """Return the number of records in the dataset.
+
+        This method caches the length of the dataset after the first call.
+        """
+        if self.__length is None:
+            self.__length = sum(1 for _ in self)
+
+        return self.__length
 
     def to_pandas(self) -> DataFrame:
         """Return a pandas DataFrame representation of the dataset.

--- a/airbyte-lib/airbyte_lib/datasets/_base.py
+++ b/airbyte-lib/airbyte_lib/datasets/_base.py
@@ -25,7 +25,7 @@ class DatasetBase(ABC):
         This method caches the length of the dataset after the first call.
         """
         if self._length is None:
-            self._length = sum(1 for _ in self)
+            self._length = sum(1 for _ in iter(self))
 
         return self._length
 

--- a/airbyte-lib/airbyte_lib/datasets/_base.py
+++ b/airbyte-lib/airbyte_lib/datasets/_base.py
@@ -12,7 +12,7 @@ class DatasetBase(ABC):
     """Base implementation for all datasets."""
 
     def __init__(self) -> None:
-        self.__length: int | None = None
+        self._length: int | None = None
 
     @abstractmethod
     def __iter__(self) -> Iterator[Mapping[str, Any]]:
@@ -24,10 +24,10 @@ class DatasetBase(ABC):
 
         This method caches the length of the dataset after the first call.
         """
-        if self.__length is None:
-            self.__length = sum(1 for _ in self)
+        if self._length is None:
+            self._length = sum(1 for _ in self)
 
-        return self.__length
+        return self._length
 
     def to_pandas(self) -> DataFrame:
         """Return a pandas DataFrame representation of the dataset.

--- a/airbyte-lib/airbyte_lib/datasets/_base.py
+++ b/airbyte-lib/airbyte_lib/datasets/_base.py
@@ -11,23 +11,10 @@ from pandas import DataFrame
 class DatasetBase(ABC):
     """Base implementation for all datasets."""
 
-    def __init__(self) -> None:
-        self._length: int | None = None
-
     @abstractmethod
     def __iter__(self) -> Iterator[Mapping[str, Any]]:
         """Return the iterator of records."""
         raise NotImplementedError
-
-    def __len__(self) -> int:
-        """Return the number of records in the dataset.
-
-        This method caches the length of the dataset after the first call.
-        """
-        if self._length is None:
-            self._length = sum(1 for _ in iter(self))
-
-        return self._length
 
     def to_pandas(self) -> DataFrame:
         """Return a pandas DataFrame representation of the dataset.

--- a/airbyte-lib/airbyte_lib/datasets/_lazy.py
+++ b/airbyte-lib/airbyte_lib/datasets/_lazy.py
@@ -20,6 +20,7 @@ class LazyDataset(DatasetBase):
         iterator: Iterator[Mapping[str, Any]],
     ) -> None:
         self._iterator: Iterator[Mapping[str, Any]] = iterator
+        super().__init__()
 
     @overrides
     def __iter__(self) -> Iterator[Mapping[str, Any]]:

--- a/airbyte-lib/airbyte_lib/results.py
+++ b/airbyte-lib/airbyte_lib/results.py
@@ -29,7 +29,10 @@ class ReadResult(Mapping[str, CachedDataset]):
 
         return CachedDataset(self._cache, stream)
 
-    def __contains__(self, stream: str) -> bool:
+    def __contains__(self, stream: object) -> bool:
+        if not isinstance(stream, str):
+            return False
+
         return stream in self._processed_streams
 
     def __iter__(self) -> Iterator[str]:

--- a/airbyte-lib/airbyte_lib/results.py
+++ b/airbyte-lib/airbyte_lib/results.py
@@ -1,20 +1,21 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from airbyte_lib.datasets import CachedDataset
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping
+    from collections.abc import Iterator
 
     from sqlalchemy.engine import Engine
 
     from airbyte_lib.caches import SQLCacheBase
 
 
-class ReadResult:
+class ReadResult(Mapping[str, CachedDataset]):
     def __init__(
         self, processed_records: int, cache: SQLCacheBase, processed_streams: list[str]
     ) -> None:
@@ -33,6 +34,9 @@ class ReadResult:
 
     def __iter__(self) -> Iterator[str]:
         return self._processed_streams.__iter__()
+
+    def __len__(self) -> int:
+        return len(self._processed_streams)
 
     def get_sql_engine(self) -> Engine:
         return self._cache.get_sql_engine()

--- a/airbyte-lib/docs/generated/airbyte_lib.html
+++ b/airbyte-lib/docs/generated/airbyte_lib.html
@@ -325,13 +325,19 @@ working directory.</p>
                     <div class="attr class">
             
     <span class="def">class</span>
-    <span class="name">ReadResult</span>:
+    <span class="name">ReadResult</span><wbr>(<span class="base">collections.abc.Mapping[str, airbyte_lib.datasets._sql.CachedDataset]</span>):
 
         
     </div>
     <a class="headerlink" href="#ReadResult"></a>
     
-    
+            <div class="docstring"><p>A Mapping is a generic container for associating key/value
+pairs.</p>
+
+<p>This class provides concrete generic implementations of all
+methods except for __getitem__, __iter__, and __len__.</p>
+</div>
+
 
                             <div id="ReadResult.__init__" class="classattr">
                                 <div class="attr function">
@@ -390,6 +396,18 @@ working directory.</p>
     
     
 
+                            </div>
+                            <div class="inherited">
+                                <h5>Inherited Members</h5>
+                                <dl>
+                                    <div><dt>collections.abc.Mapping</dt>
+                                <dd id="ReadResult.get" class="function">get</dd>
+                <dd id="ReadResult.keys" class="function">keys</dd>
+                <dd id="ReadResult.items" class="function">items</dd>
+                <dd id="ReadResult.values" class="function">values</dd>
+
+            </div>
+                                </dl>
                             </div>
                 </section>
                 <section id="Source">

--- a/airbyte-lib/tests/integration_tests/test_integration.py
+++ b/airbyte-lib/tests/integration_tests/test_integration.py
@@ -217,6 +217,35 @@ def test_sync_to_duckdb(expected_test_stream_data: dict[str, list[dict[str, str 
     assert_cache_data(expected_test_stream_data, cache)
 
 
+def test_read_result_mapping():
+    source = ab.get_connector("source-test", config={"apiKey": "test"})
+    result: ReadResult = source.read()
+    assert len(result) == 2
+    assert isinstance(result, Mapping)
+    assert "stream1" in result
+    assert "stream2" in result
+    assert "stream3" not in result
+    assert result.keys() == {"stream1", "stream2"}
+
+
+def test_dataset_list_and_len(expected_test_stream_data):
+    source = ab.get_connector("source-test", config={"apiKey": "test"})
+    result: ReadResult = source.read()
+    stream_1 = result["stream1"]
+    assert len(stream_1) == 2
+    assert len(list(stream_1)) == 2
+    # Make sure we can iterate over the stream after calling len
+    assert list(stream_1) == [{"column1": "value1", "column2": 1}, {"column1": "value2", "column2": 2}]
+    # Make sure we can iterate over the stream a second time
+    assert list(stream_1) == [{"column1": "value1", "column2": 1}, {"column1": "value2", "column2": 2}]
+
+    assert isinstance(result, Mapping)
+    assert "stream1" in result
+    assert "stream2" in result
+    assert "stream3" not in result
+    assert result.keys() == {"stream1", "stream2"}
+
+
 def test_read_from_cache(expected_test_stream_data: dict[str, list[dict[str, str | int]]]):
     """
     Test that we can read from a cache that already has data (identigier by name)


### PR DESCRIPTION
1. Make ReadResult inherit from Mapping[str, CachedDataset], including support for .keys() and .len().
1. Add len() supports on datasets.