### PR TITLE
airbyte-ci: Require `pypi.enabled=true` for certified connectors

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.3.3"
+version = "0.4.0"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/referenced_image_in_dockerhub/metadata_base_image_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/referenced_image_in_dockerhub/metadata_base_image_exists.yaml
@@ -17,6 +17,10 @@ data:
   icon: alloy-db.svg
   license: MIT
   name: AlloyDB for PostgreSQL
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-google-sheets
   registries:
     cloud:
       enabled: true

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/required_top_level_property_missing/metadata_missing_pypi_publishing.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/required_top_level_property_missing/metadata_missing_pypi_publishing.yaml
@@ -1,0 +1,19 @@
+metadataSpecVersion: 1.0
+data:
+  name: AlloyDB for PostgreSQL
+  definitionId: 1fa90628-2b9e-11ed-a261-0242ac120002
+  connectorType: source
+  dockerRepository: airbyte/image-exists-1
+  githubIssueLabel: source-alloydb-strict-encrypt
+  dockerImageTag: 0.0.1
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
+  connectorSubtype: database
+  releaseStage: generally_available
+  supportLevel: certified
+  remoteRegistries:
+    pypi:
+      enabled: false
+      packageName: airbyte-source-alloydb-strict-encrypt
+  license: MIT
+  tags:
+    - language:python

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/metadata_build_base_image.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/metadata_build_base_image.yaml
@@ -18,6 +18,10 @@ data:
       enabled: true
     oss:
       enabled: true
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-google-sheets
   releaseStage: generally_available
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-sheets
   tags:


### PR DESCRIPTION
To make sure certified connectors are well supported by airbyte-lib, this PR makes it a requirement to enable pypi publishing for certified connectors.