### PR TITLE
Docs: Make sure reference section is always added

### DIFF
--- a/docusaurus/src/remark/specDecoration.js
+++ b/docusaurus/src/remark/specDecoration.js
@@ -53,10 +53,13 @@ async function injectDefaultAirbyteLibSection(vfile, ast) {
       });
     }
   });
+  if (!added) {
+    throw new Error(`Could not find a changelog heading in ${vfile.path} to add the default airbyte-lib section. This connector won't have a reference section. Make sure there is either a ## Changelog section or add a manual reference section.`);
+  }
 }
 
 function isChangelogHeading(node) {
-  return node.depth === 2 && node.children.length === 1 && node.children[0].value === "Changelog";
+  return node.depth === 2 && node.children.length === 1 && node.children[0].value.toLowerCase() === "changelog";
 }
 
 


### PR DESCRIPTION
Some connector documentations have a `## CHANGELOG` section instead of `## Changelog`. This caused the existing logic to not add the reference section for airbyte-lib properly.

This PR is using case-insensitive comparison and also fails the docs build in case it can't add a reference section, making sure it will always be added.