### PR TITLE
airbyte-lib: Treat error trace as logs

### DIFF
--- a/airbyte-lib/airbyte_lib/source.py
+++ b/airbyte-lib/airbyte_lib/source.py
@@ -19,6 +19,7 @@ from airbyte_protocol.models import (
     DestinationSyncMode,
     Status,
     SyncMode,
+    TraceType,
     Type,
 )
 
@@ -395,6 +396,8 @@ class Source:
                     yield message
                     if message.type == Type.LOG:
                         self._add_to_logs(message.log.message)
+                    if message.type == Type.TRACE and message.trace.type == TraceType.ERROR:
+                        self._add_to_logs(message.trace.error.message)
                 except Exception:
                     self._add_to_logs(line)
         except Exception as e:


### PR DESCRIPTION
In some situations, connectors only return an "error trace" message which is ignored by airbyte-lib, making debugging difficult.

This PR treats them like regular log messages so they show up when the connector doesn't emit expected messages (like a catalog or so)