### PR TITLE
✨ Source SFTP Bulk: improve transfer performance for large files

### DIFF
--- a/airbyte-integrations/connectors/source-sftp-bulk/Dockerfile
+++ b/airbyte-integrations/connectors/source-sftp-bulk/Dockerfile
@@ -13,5 +13,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-sftp-bulk

--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 31e3242f-dee7-4cdc-a4b8-8e06c5458517
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   dockerRepository: airbyte/source-sftp-bulk
   documentationUrl: https://docs.airbyte.com/integrations/sources/sftp-bulk
   githubIssueLabel: source-sftp-bulk

--- a/airbyte-integrations/connectors/source-sftp-bulk/setup.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.2",
+    "airbyte-cdk==0.60.2",
     "paramiko==2.11.0",
     "backoff==1.8.0",
     "terminaltables==3.1.0",

--- a/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/source.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/source.py
@@ -55,7 +55,7 @@ class SourceFtp(AbstractSource):
 
         # Get last file to infer schema
         # Use pandas `infer_objects` to infer dtypes
-        df = connection.fetch_file(fn=files[-1], file_type=config["file_type"], separator=config.get("separator"))
+        df = next(connection.fetch_file(fn=files[-1], file_type=config["file_type"], separator=config.get("separator")))
         df = df.infer_objects()
 
         # Default column used for incremental sync

--- a/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/streams.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/streams.py
@@ -76,4 +76,5 @@ class FTPStream(Stream, IncrementalMixin):
                 if self._cursor_value and cursor > self._cursor_value:
                     self._cursor_value = cursor
 
-            yield from records
+            for record_set in records:
+                yield from record_set

--- a/docs/integrations/sources/sftp-bulk.md
+++ b/docs/integrations/sources/sftp-bulk.md
@@ -118,8 +118,9 @@ More formats \(e.g. Apache Avro\) will be supported in the future.
 
 ## Changelog
 
-| Version | Date       | Pull Request                                              | Subject                       |
-| :------ | :--------- | :-------------------------------------------------------- | :---------------------------- |
-| 0.1.2   | 2023-04-19 | [#19224](https://github.com/airbytehq/airbyte/pull/19224) | Support custom CSV separators |
-| 0.1.1   | 2023-03-17 | [#24180](https://github.com/airbytehq/airbyte/pull/24180) | Fix field order               |
-| 0.1.0   | 2021-24-05 |                                                           | Initial version               |
+| Version | Date       | Pull Request                                              | Subject                             |
+| :------ | :--------- | :-------------------------------------------------------- | :---------------------------------- |
+| 0.1.3   | 2024-02-01 | [#34773](https://github.com/airbytehq/airbyte/pull/34773) | Improve performance for large files |
+| 0.1.2   | 2023-04-19 | [#19224](https://github.com/airbytehq/airbyte/pull/19224) | Support custom CSV separators       |
+| 0.1.1   | 2023-03-17 | [#24180](https://github.com/airbytehq/airbyte/pull/24180) | Fix field order                     |
+| 0.1.0   | 2021-24-05 |                                                           | Initial version                     |


### PR DESCRIPTION
## What
Using the SFTP bulk source to transfer a larger file (~250 MB) hangs/times out after 30+ minutes while Pandas reads the CSV.

## How
After some research and experimentation, I found that prefetching the file reduces transfer time to only a few minutes: https://stackoverflow.com/a/58434257. Additionally, chunk reading using Pandas.

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>