### PR TITLE
AirbyteLib: Ignore unused Airbyte message types

### DIFF
--- a/airbyte-lib/airbyte_lib/_processors.py
+++ b/airbyte-lib/airbyte_lib/_processors.py
@@ -170,16 +170,10 @@ class RecordProcessor(abc.ABC):
                     stream_name = stream_state.stream_descriptor.name
                     self._pending_state_messages[stream_name].append(state_msg)
 
-            elif message.type in [Type.LOG, Type.TRACE]:
-                pass
-
             else:
-                raise exc.AirbyteConnectorError(
-                    message="Unexpected message type.",
-                    context={
-                        "message_type": message.type,
-                    },
-                )
+                # Ignore unexpected or unhandled message types:
+                # Type.LOG, Type.TRACE, Type.CONTROL, etc.
+                pass
 
         # We are at the end of the stream. Process whatever else is queued.
         for stream_name, stream_batch in stream_batches.items():

--- a/airbyte-lib/airbyte_lib/_processors.py
+++ b/airbyte-lib/airbyte_lib/_processors.py
@@ -30,7 +30,6 @@ from airbyte_protocol.models import (
     Type,
 )
 
-from airbyte_lib import exceptions as exc
 from airbyte_lib._util import protocol_util  # Internal utility functions
 from airbyte_lib.progress import progress
 


### PR DESCRIPTION
TL;DR: A user reported an issue where a CONTROL message received would crash the sync. This PR resolves the bug by ignoring unexpected/unused message types.

More context: 

Early on, we wanted to make sure we were handling or ignoring the necssary messages. At this point, anything not handled should probably be considered un-needed, and we'll add handling for additional message types as needed.

For now, this PR updates behavior so that unhandled message types are simply ignored.