### PR TITLE
AirbyteLib: Fix column count mismatch bug

### DIFF
--- a/airbyte-lib/airbyte_lib/_file_writers/base.py
+++ b/airbyte-lib/airbyte_lib/_file_writers/base.py
@@ -51,7 +51,7 @@ class FileWriterBase(RecordProcessor, abc.ABC):
         self,
         stream_name: str,
         batch_id: str,
-        record_batch: pa.Table | pa.RecordBatch,
+        record_batch: pa.Table,
     ) -> FileWriterBatchHandle:
         """Process a record batch.
 
@@ -64,7 +64,7 @@ class FileWriterBase(RecordProcessor, abc.ABC):
         self,
         stream_name: str,
         batch_id: str,
-        record_batch: pa.Table | pa.RecordBatch,
+        record_batch: pa.Table,
     ) -> FileWriterBatchHandle:
         """Write a batch of records to the cache.
 

--- a/airbyte-lib/airbyte_lib/_file_writers/parquet.py
+++ b/airbyte-lib/airbyte_lib/_file_writers/parquet.py
@@ -9,7 +9,7 @@ from typing import cast
 import pyarrow as pa
 import ulid
 from overrides import overrides
-from pyarrow import null, parquet
+from pyarrow import parquet
 
 from airbyte_lib import exceptions as exc
 from airbyte_lib._file_writers.base import (
@@ -49,15 +49,10 @@ class ParquetWriter(FileWriterBase):
     ) -> list[str]:
         """Return a list of columns that are missing in the batch."""
         if not self._catalog_manager:
-            raise exc.AirbyteLibInternalError(
-                message="Catalog manager should exist but does not."
-            )
+            raise exc.AirbyteLibInternalError(message="Catalog manager should exist but does not.")
         stream = self._catalog_manager.get_stream_config(stream_name)
         stream_property_names = stream.stream.json_schema["properties"].keys()
-        return [
-            col for col in stream_property_names
-            if col not in record_batch.schema.names
-        ]
+        return [col for col in stream_property_names if col not in record_batch.schema.names]
 
     @overrides
     def _write_batch(

--- a/airbyte-lib/airbyte_lib/_processors.py
+++ b/airbyte-lib/airbyte_lib/_processors.py
@@ -31,6 +31,7 @@ from airbyte_protocol.models import (
     Type,
 )
 
+from airbyte_lib import exceptions as exc
 from airbyte_lib._util import protocol_util  # Internal utility functions
 from airbyte_lib.progress import progress
 

--- a/airbyte-lib/airbyte_lib/_processors.py
+++ b/airbyte-lib/airbyte_lib/_processors.py
@@ -64,6 +64,7 @@ class RecordProcessor(abc.ABC):
     def __init__(
         self,
         config: CacheConfigBase | dict | None,
+        *,
         catalog_manager: CatalogManager | None = None,
     ) -> None:
         if isinstance(config, dict):
@@ -96,6 +97,10 @@ class RecordProcessor(abc.ABC):
         stream_names: set[str],
     ) -> None:
         """Register the source name and catalog."""
+        if not self._catalog_manager:
+            raise exc.AirbyteLibInternalError(
+                message="Catalog manager should exist but does not.",
+            )
         self._catalog_manager.register_source(
             source_name,
             incoming_source_catalog=incoming_source_catalog,
@@ -223,7 +228,7 @@ class RecordProcessor(abc.ABC):
         self,
         stream_name: str,
         batch_id: str,
-        record_batch: pa.Table | pa.RecordBatch,
+        record_batch: pa.Table,
     ) -> BatchHandle:
         """Process a single batch.
 
@@ -334,6 +339,11 @@ class RecordProcessor(abc.ABC):
         stream_name: str,
     ) -> ConfiguredAirbyteStream:
         """Return the column definitions for the given stream."""
+        if not self._catalog_manager:
+            raise exc.AirbyteLibInternalError(
+                message="Catalog manager should exist but does not.",
+            )
+
         return self._catalog_manager.get_stream_config(stream_name)
 
     @final

--- a/airbyte-lib/airbyte_lib/_processors.py
+++ b/airbyte-lib/airbyte_lib/_processors.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, cast, final
 
 import pyarrow as pa
 import ulid
+from overrides import overrides
 
 from airbyte_protocol.models import (
     AirbyteMessage,
@@ -27,6 +28,7 @@ from airbyte_protocol.models import (
     AirbyteStateType,
     AirbyteStreamState,
     ConfiguredAirbyteCatalog,
+    ConfiguredAirbyteStream,
     Type,
 )
 
@@ -38,6 +40,7 @@ from airbyte_lib.progress import progress
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Iterator
 
+    from airbyte_lib.caches._catalog_manager import CatalogManager
     from airbyte_lib.config import CacheConfigBase
 
 
@@ -61,6 +64,7 @@ class RecordProcessor(abc.ABC):
     def __init__(
         self,
         config: CacheConfigBase | dict | None,
+        catalog_manager: CatalogManager | None = None,
     ) -> None:
         if isinstance(config, dict):
             config = self.config_class(**config)
@@ -73,8 +77,6 @@ class RecordProcessor(abc.ABC):
             )
             raise TypeError(err_msg)
 
-        self.source_catalog: ConfiguredAirbyteCatalog | None = None
-
         self._pending_batches: dict[str, dict[str, Any]] = defaultdict(lambda: {}, {})
         self._finalized_batches: dict[str, dict[str, Any]] = defaultdict(lambda: {}, {})
 
@@ -84,22 +86,21 @@ class RecordProcessor(abc.ABC):
             list[AirbyteStateMessage],
         ] = defaultdict(list, {})
 
+        self._catalog_manager: CatalogManager | None = catalog_manager
         self._setup()
 
     def register_source(
         self,
         source_name: str,
         incoming_source_catalog: ConfiguredAirbyteCatalog,
+        stream_names: set[str],
     ) -> None:
-        """Register the source name and catalog.
-
-        For now, only one source at a time is supported.
-        If this method is called multiple times, the last call will overwrite the previous one.
-
-        TODO: Expand this to handle multiple sources.
-        """
-        _ = source_name
-        self.source_catalog = incoming_source_catalog
+        """Register the source name and catalog."""
+        self._catalog_manager.register_source(
+            source_name,
+            incoming_source_catalog=incoming_source_catalog,
+            incoming_stream_names=stream_names,
+        )
 
     @property
     def _streams_with_data(self) -> set[str]:
@@ -326,3 +327,19 @@ class RecordProcessor(abc.ABC):
     def __del__(self) -> None:
         """Teardown temporary resources when instance is unloaded from memory."""
         self._teardown()
+
+    @final
+    def _get_stream_config(
+        self,
+        stream_name: str,
+    ) -> ConfiguredAirbyteStream:
+        """Return the column definitions for the given stream."""
+        return self._catalog_manager.get_stream_config(stream_name)
+
+    @final
+    def _get_stream_json_schema(
+        self,
+        stream_name: str,
+    ) -> dict[str, Any]:
+        """Return the column definitions for the given stream."""
+        return self._get_stream_config(stream_name).stream.json_schema

--- a/airbyte-lib/airbyte_lib/_processors.py
+++ b/airbyte-lib/airbyte_lib/_processors.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Any, cast, final
 
 import pyarrow as pa
 import ulid
-from overrides import overrides
 
 from airbyte_protocol.models import (
     AirbyteMessage,

--- a/airbyte-lib/airbyte_lib/caches/_catalog_manager.py
+++ b/airbyte-lib/airbyte_lib/caches/_catalog_manager.py
@@ -119,7 +119,7 @@ class CatalogManager:
         source_name: str,
         incoming_source_catalog: ConfiguredAirbyteCatalog,
         incoming_stream_names: set[str],
-    ) -> str:
+    ) -> None:
         self._ensure_internal_tables()
         engine = self._engine
         with Session(engine) as session:

--- a/airbyte-lib/airbyte_lib/caches/_catalog_manager.py
+++ b/airbyte-lib/airbyte_lib/caches/_catalog_manager.py
@@ -47,7 +47,7 @@ class CatalogManager:
     ) -> None:
         self._engine: Engine = engine
         self._table_name_resolver = table_name_resolver
-        self.source_catalog: ConfiguredAirbyteCatalog | None = None
+        self.source_catalog: ConfiguredAirbyteCatalog
         self._load_catalog_from_internal_table()
         assert self.source_catalog is not None
 

--- a/airbyte-lib/airbyte_lib/caches/_catalog_manager.py
+++ b/airbyte-lib/airbyte_lib/caches/_catalog_manager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING, Callable
-from pytest import Config
 
 from sqlalchemy import Column, String
 from sqlalchemy.ext.declarative import declarative_base
@@ -75,18 +74,16 @@ class CatalogManager:
         else:
             # Keep existing streams untouched if not incoming
             unchanged_streams: list[ConfiguredAirbyteStream] = [
-                stream for stream in
-                self.source_catalog.streams
+                stream
+                for stream in self.source_catalog.streams
                 if stream.stream.name not in incoming_stream_names
             ]
             new_streams: list[ConfiguredAirbyteStream] = [
-                stream for stream in
-                incoming_source_catalog.streams
+                stream
+                for stream in incoming_source_catalog.streams
                 if stream.stream.name in incoming_stream_names
             ]
-            self.source_catalog = ConfiguredAirbyteCatalog(
-                streams=unchanged_streams + new_streams
-            )
+            self.source_catalog = ConfiguredAirbyteCatalog(streams=unchanged_streams + new_streams)
 
         self._ensure_internal_tables()
         engine = self._engine
@@ -96,9 +93,11 @@ class CatalogManager:
                 self._table_name_resolver(incoming_stream_name)
                 for incoming_stream_name in incoming_stream_names
             ]
-            result = session.query(CachedStream).filter(
-                CachedStream.table_name.in_(table_name_entries_to_delete)
-            ).delete()
+            result = (
+                session.query(CachedStream)
+                .filter(CachedStream.table_name.in_(table_name_entries_to_delete))
+                .delete()
+            )
             _ = result
             session.commit()
             insert_streams = [
@@ -131,10 +130,9 @@ class CatalogManager:
                 stream_name=stream_name,
                 context={
                     "available_streams": [
-                        stream.stream.name
-                        for stream in self.source_catalog.streams
+                        stream.stream.name for stream in self.source_catalog.streams
                     ],
-                }
+                },
             )
 
         if len(matching_streams) > 1:

--- a/airbyte-lib/airbyte_lib/caches/base.py
+++ b/airbyte-lib/airbyte_lib/caches/base.py
@@ -116,15 +116,12 @@ class SQLCacheBase(RecordProcessor):
         self.config: SQLCacheConfigBase
         self._engine: Engine | None = None
         self._connection_to_reuse: Connection | None = None
-        super().__init__(
-            config,
-            # catalog_manager=catalog_manager,  # TODO: Clean this up.
-        )
+        super().__init__(config)
         self._ensure_schema_exists()
-        catalog_manager = CatalogManager(
-            self.get_sql_engine(), lambda stream_name: self.get_sql_table_name(stream_name)
+        self._catalog_manager = CatalogManager(
+            engine=self.get_sql_engine(),
+            table_name_resolver=lambda stream_name: self.get_sql_table_name(stream_name)
         )
-        self._catalog_manager = catalog_manager
         self.file_writer = file_writer or self.file_writer_class(
             config, catalog_manager=self._catalog_manager
         )

--- a/airbyte-lib/airbyte_lib/caches/base.py
+++ b/airbyte-lib/airbyte_lib/caches/base.py
@@ -120,7 +120,7 @@ class SQLCacheBase(RecordProcessor):
         self._ensure_schema_exists()
         self._catalog_manager = CatalogManager(
             engine=self.get_sql_engine(),
-            table_name_resolver=lambda stream_name: self.get_sql_table_name(stream_name)
+            table_name_resolver=lambda stream_name: self.get_sql_table_name(stream_name),
         )
         self.file_writer = file_writer or self.file_writer_class(
             config, catalog_manager=self._catalog_manager

--- a/airbyte-lib/airbyte_lib/caches/base.py
+++ b/airbyte-lib/airbyte_lib/caches/base.py
@@ -7,7 +7,7 @@ import abc
 import enum
 from contextlib import contextmanager
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, cast, final
+from typing import TYPE_CHECKING, cast, final
 
 import pandas as pd
 import pyarrow as pa
@@ -38,7 +38,6 @@ if TYPE_CHECKING:
 
     from airbyte_protocol.models import (
         ConfiguredAirbyteCatalog,
-        ConfiguredAirbyteStream,
     )
 
     from airbyte_lib.datasets._base import DatasetBase
@@ -113,7 +112,6 @@ class SQLCacheBase(RecordProcessor):
         self,
         config: SQLCacheConfigBase | None = None,
         file_writer: FileWriterBase | None = None,
-        **kwargs: dict[str, Any],  # Added for future proofing purposes.
     ) -> None:
         self.config: SQLCacheConfigBase
         self._engine: Engine | None = None

--- a/airbyte-lib/airbyte_lib/source.py
+++ b/airbyte-lib/airbyte_lib/source.py
@@ -295,10 +295,8 @@ class Source:
                 yield {**record, **appended_dict}
 
         iterator: Iterator[dict[str, Any]] = _with_missing_columns(
-                protocol_util.airbyte_messages_to_record_dicts(
-                self._read_with_catalog(
-                    streaming_cache_info, configured_catalog
-                ),
+            protocol_util.airbyte_messages_to_record_dicts(
+                self._read_with_catalog(streaming_cache_info, configured_catalog),
             )
         )
         return LazyDataset(iterator)

--- a/airbyte-lib/airbyte_lib/source.py
+++ b/airbyte-lib/airbyte_lib/source.py
@@ -449,7 +449,7 @@ class Source:
         cache.register_source(
             source_name=self.name,
             incoming_source_catalog=self.configured_catalog,
-            stream_names=self.get_selected_streams(),
+            stream_names=set(self.get_selected_streams()),
         )
         cache.process_airbyte_messages(self._tally_records(self._read(cache.get_telemetry_info())))
 

--- a/airbyte-lib/airbyte_lib/source.py
+++ b/airbyte-lib/airbyte_lib/source.py
@@ -110,6 +110,16 @@ class Source:
                 )
         self._selected_stream_names = streams
 
+    def get_selected_streams(self) -> list[str]:
+        """Get the selected streams.
+
+        If no streams are selected, return all available streams.
+        """
+        if self._selected_stream_names:
+            return self._selected_stream_names
+
+        return self.get_available_streams()
+
     def set_config(
         self,
         config: dict[str, Any],
@@ -274,8 +284,22 @@ class Source:
                 },
             ) from KeyError(stream)
 
-        iterator: Iterator[dict[str, Any]] = protocol_util.airbyte_messages_to_record_dicts(
-            self._read_with_catalog(streaming_cache_info, configured_catalog),
+        configured_stream = configured_catalog.streams[0]
+        col_list = configured_stream.stream.json_schema["properties"].keys()
+
+        def _with_missing_columns(records: Iterable[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+            """Add missing columns to the record with null values."""
+            for record in records:
+                appended_columns = set(col_list) - set(record.keys())
+                appended_dict = {col: None for col in appended_columns}
+                yield {**record, **appended_dict}
+
+        iterator: Iterator[dict[str, Any]] = _with_missing_columns(
+                protocol_util.airbyte_messages_to_record_dicts(
+                self._read_with_catalog(
+                    streaming_cache_info, configured_catalog
+                ),
+            )
         )
         return LazyDataset(iterator)
 
@@ -423,7 +447,9 @@ class Source:
             cache = get_default_cache()
 
         cache.register_source(
-            source_name=self.name, incoming_source_catalog=self.configured_catalog
+            source_name=self.name,
+            incoming_source_catalog=self.configured_catalog,
+            stream_names=self.get_selected_streams(),
         )
         cache.process_airbyte_messages(self._tally_records(self._read(cache.get_telemetry_info())))
 

--- a/airbyte-lib/docs/generated/airbyte_lib.html
+++ b/airbyte-lib/docs/generated/airbyte_lib.html
@@ -131,7 +131,6 @@ so we insert as values instead.</p>
             </div>
             <div><dt>airbyte_lib._processors.RecordProcessor</dt>
                                 <dd id="DuckDBCache.skip_finalize_step" class="variable">skip_finalize_step</dd>
-                <dd id="DuckDBCache.source_catalog" class="variable">source_catalog</dd>
                 <dd id="DuckDBCache.process_stdin" class="function">process_stdin</dd>
                 <dd id="DuckDBCache.process_input_stream" class="function">process_input_stream</dd>
                 <dd id="DuckDBCache.process_airbyte_messages" class="function">process_airbyte_messages</dd>

--- a/airbyte-lib/docs/generated/airbyte_lib.html
+++ b/airbyte-lib/docs/generated/airbyte_lib.html
@@ -483,6 +483,23 @@ are sometimes disabled by default within the connector.)</p>
 
 
                             </div>
+                            <div id="Source.get_selected_streams" class="classattr">
+                                <div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">get_selected_streams</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">) -> <span class="nb">list</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span>:</span></span>
+
+        
+    </div>
+    <a class="headerlink" href="#Source.get_selected_streams"></a>
+    
+            <div class="docstring"><p>Get the selected streams.</p>
+
+<p>If no streams are selected, return all available streams.</p>
+</div>
+
+
+                            </div>
                             <div id="Source.set_config" class="classattr">
                                 <div class="attr function">
             

--- a/airbyte-lib/docs/generated/airbyte_lib/caches.html
+++ b/airbyte-lib/docs/generated/airbyte_lib/caches.html
@@ -668,18 +668,18 @@ or another import method. (Relatively low priority, since for now it works fine 
                     <div class="decorator">@overrides</div>
 
         <span class="def">def</span>
-        <span class="name">register_source</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="bp">self</span>,</span><span class="param">	<span class="n">source_name</span><span class="p">:</span> <span class="nb">str</span>,</span><span class="param">	<span class="n">incoming_source_catalog</span><span class="p">:</span> <span class="n">airbyte_protocol</span><span class="o">.</span><span class="n">models</span><span class="o">.</span><span class="n">airbyte_protocol</span><span class="o">.</span><span class="n">ConfiguredAirbyteCatalog</span></span><span class="return-annotation">) -> <span class="kc">None</span>:</span></span>
+        <span class="name">register_source</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="bp">self</span>,</span><span class="param">	<span class="n">source_name</span><span class="p">:</span> <span class="nb">str</span>,</span><span class="param">	<span class="n">incoming_source_catalog</span><span class="p">:</span> <span class="n">airbyte_protocol</span><span class="o">.</span><span class="n">models</span><span class="o">.</span><span class="n">airbyte_protocol</span><span class="o">.</span><span class="n">ConfiguredAirbyteCatalog</span>,</span><span class="param">	<span class="n">stream_names</span><span class="p">:</span> <span class="nb">set</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span></span><span class="return-annotation">) -> <span class="kc">None</span>:</span></span>
 
         
     </div>
     <a class="headerlink" href="#SQLCacheBase.register_source"></a>
     
-            <div class="docstring"><p>Register the source name and catalog.</p>
+            <div class="docstring"><p>Register the source with the cache.</p>
 
-<p>For now, only one source at a time is supported.
-If this method is called multiple times, the last call will overwrite the previous one.</p>
+<p>We use stream_names to determine which streams will receive data, and
+we only register the stream if is expected to receive data.</p>
 
-<p>TODO: Expand this to handle multiple sources.</p>
+<p>This method is called by the source when it is initialized.</p>
 </div>
 
 

--- a/airbyte-lib/docs/generated/airbyte_lib/caches.html
+++ b/airbyte-lib/docs/generated/airbyte_lib/caches.html
@@ -60,7 +60,6 @@ so we insert as values instead.</p>
             </div>
             <div><dt>airbyte_lib._processors.RecordProcessor</dt>
                                 <dd id="DuckDBCache.skip_finalize_step" class="variable">skip_finalize_step</dd>
-                <dd id="DuckDBCache.source_catalog" class="variable">source_catalog</dd>
                 <dd id="DuckDBCache.process_stdin" class="function">process_stdin</dd>
                 <dd id="DuckDBCache.process_input_stream" class="function">process_input_stream</dd>
                 <dd id="DuckDBCache.process_airbyte_messages" class="function">process_airbyte_messages</dd>
@@ -274,7 +273,6 @@ or another import method. (Relatively low priority, since for now it works fine 
             </div>
             <div><dt>airbyte_lib._processors.RecordProcessor</dt>
                                 <dd id="PostgresCache.skip_finalize_step" class="variable">skip_finalize_step</dd>
-                <dd id="PostgresCache.source_catalog" class="variable">source_catalog</dd>
                 <dd id="PostgresCache.process_stdin" class="function">process_stdin</dd>
                 <dd id="PostgresCache.process_input_stream" class="function">process_input_stream</dd>
                 <dd id="PostgresCache.process_airbyte_messages" class="function">process_airbyte_messages</dd>
@@ -703,7 +701,6 @@ we only register the stream if is expected to receive data.</p>
                                 <dl>
                                     <div><dt>airbyte_lib._processors.RecordProcessor</dt>
                                 <dd id="SQLCacheBase.skip_finalize_step" class="variable">skip_finalize_step</dd>
-                <dd id="SQLCacheBase.source_catalog" class="variable">source_catalog</dd>
                 <dd id="SQLCacheBase.process_stdin" class="function">process_stdin</dd>
                 <dd id="SQLCacheBase.process_input_stream" class="function">process_input_stream</dd>
                 <dd id="SQLCacheBase.process_airbyte_messages" class="function">process_airbyte_messages</dd>
@@ -949,7 +946,6 @@ we only register the stream if is expected to receive data.</p>
             </div>
             <div><dt>airbyte_lib._processors.RecordProcessor</dt>
                                 <dd id="SnowflakeSQLCache.skip_finalize_step" class="variable">skip_finalize_step</dd>
-                <dd id="SnowflakeSQLCache.source_catalog" class="variable">source_catalog</dd>
                 <dd id="SnowflakeSQLCache.process_stdin" class="function">process_stdin</dd>
                 <dd id="SnowflakeSQLCache.process_input_stream" class="function">process_input_stream</dd>
                 <dd id="SnowflakeSQLCache.process_airbyte_messages" class="function">process_airbyte_messages</dd>

--- a/airbyte-lib/tests/integration_tests/fixtures/source-test/source_test/run.py
+++ b/airbyte-lib/tests/integration_tests/fixtures/source-test/source_test/run.py
@@ -31,6 +31,7 @@ sample_catalog = {
                     "properties": {
                         "column1": {"type": "string"},
                         "column2": {"type": "number"},
+                        "empty_column": {"type": "string"},
                     },
                 },
             },

--- a/airbyte-lib/tests/integration_tests/test_integration.py
+++ b/airbyte-lib/tests/integration_tests/test_integration.py
@@ -63,7 +63,7 @@ def expected_test_stream_data() -> dict[str, list[dict[str, str | int]]]:
             {"column1": "value2", "column2": 2},
         ],
         "stream2": [
-            {"column1": "value1", "column2": 1},
+            {"column1": "value1", "column2": 1, "empty_column": None},
         ],
     }
 
@@ -219,7 +219,7 @@ def test_sync_to_duckdb(expected_test_stream_data: dict[str, list[dict[str, str 
 
 def test_read_result_mapping():
     source = ab.get_connector("source-test", config={"apiKey": "test"})
-    result: ReadResult = source.read()
+    result: ReadResult = source.read(ab.new_local_cache())
     assert len(result) == 2
     assert isinstance(result, Mapping)
     assert "stream1" in result
@@ -230,7 +230,7 @@ def test_read_result_mapping():
 
 def test_dataset_list_and_len(expected_test_stream_data):
     source = ab.get_connector("source-test", config={"apiKey": "test"})
-    result: ReadResult = source.read()
+    result: ReadResult = source.read(ab.new_local_cache())
     stream_1 = result["stream1"]
     assert len(stream_1) == 2
     assert len(list(stream_1)) == 2
@@ -584,7 +584,7 @@ def test_tracking(mock_datetime: Mock, mock_requests: Mock, raises: bool, api_ke
     mock_requests.post = mock_post
 
     source = ab.get_connector("source-test", config={"apiKey": api_key})
-    cache = ab.get_default_cache()
+    cache = ab.new_local_cache()
 
     if request_call_fails:
         mock_post.side_effect = Exception("test exception")

--- a/airbyte-lib/tests/unit_tests/test_writers.py
+++ b/airbyte-lib/tests/unit_tests/test_writers.py
@@ -30,7 +30,6 @@ def test_parquet_writer_has_config():
 def test_parquet_writer_has_source_catalog():
     config = ParquetWriterConfig(cache_dir='test_path')
     writer = ParquetWriter(config)
-    assert hasattr(writer, 'source_catalog')
 
 def test_parquet_writer_source_catalog_is_none():
     config = ParquetWriterConfig(cache_dir='test_path')

--- a/airbyte-lib/tests/unit_tests/test_writers.py
+++ b/airbyte-lib/tests/unit_tests/test_writers.py
@@ -35,4 +35,3 @@ def test_parquet_writer_has_source_catalog():
 def test_parquet_writer_source_catalog_is_none():
     config = ParquetWriterConfig(cache_dir='test_path')
     writer = ParquetWriter(config)
-    assert writer.source_catalog is None


### PR DESCRIPTION
This PR resolves a bug when a fully-null or fully-missing column causes the insert to fail, because the number of named columns in the destination table does not match the number of columns in the parquet files.

The actual implementation required a large bit of refactoring.

1. File writers now also get initialized with a catalog manager. This allows the file writer to make decisions based upon the catalog schema. In our case, this means detecting which properties are expected for the given stream so they can be appended.
2. Source's `get_records()` implementation needed similar treatment for adding any missed properties. Now both Lazy and Cached datasets will have all top-level keys present, even if the source omits them entirely.
3. I moved some methods like `_get_stream_config()` and `_get_stream_json_schema()` down from the `SQLCache` class into the underlying `RecordProcessors` base class, so that FileWriters can share the same code.


Drive-by changes:
1. `source_catalog` was deprecated from processors but not removed. Now it is removed.
2. Catalog managers' initialization is cleaned up. Only streams that are 'incoming' will actually have their catalog metadata written.
4. "streams with data" has been tightened up somewhat.
5. We had typed "`pa.Table | pa.RecordBatch`" in several places, even though the type is always `pa.Table`. Since only `Table` as the `append_column()` method, I've now made typing consistent across the board so there's no confusion about the expected type.
6. I've broken out the large `register_source()` method in the catalog manager into smaller methods: `_update_catalog()` and `_save_catalog_to_internal_table()`.
