### PR TITLE
📘Docs: Update source Linnworks page

### DIFF
--- a/docs/integrations/sources/linnworks.md
+++ b/docs/integrations/sources/linnworks.md
@@ -1,54 +1,71 @@
 # Linnworks
 
-## Sync overview
+This page contains the setup guide and reference information for the [Linnworks](https://www.linnworks.com) source connector.
 
-Linnworks source supports both Full Refresh and Incremental syncs. You can choose if this connector will copy only the new or updated data, or all rows in the tables and columns you set up for replication, every time a sync is run.
+## Prerequisites
 
-Airbyte uses [Linnworks API](https://apps.linnworks.net/Api) to fetch data from Linnworks.
+- A Linnworks account
 
-### Output schema
+## Setup guide
 
-This Source is capable of syncing the following data as streams:
+### Generate Credentials in Linnworks
 
-- [StockLocations](https://apps.linnworks.net/Api/Method/Inventory-GetStockLocations)
-- [StockLocationDetails](https://apps.linnworks.net/Api/Method/Locations-GetLocation)
-- [StockItems](https://apps.linnworks.net//Api/Method/Stock-GetStockItemsFull)
-- [ProcessedOrders](https://apps.linnworks.net/Api/Method/ProcessedOrders-SearchProcessedOrders)
-- [ProcessedOrderDetails](https://apps.linnworks.net/Api/Method/Orders-GetOrdersById)
+1. The Linnworks platform has two portals: seller and developer. To generate the necessary credentials, log in to the [developer portal](https://developer.linnworks.com) and select **+ New App**.
+2. Input a name for your application and set the **Application Type** to `System Integration`.
+3. Select **Edit** for your new application. In the **General** tab, find and copy your **Application ID** and **Application Secret**. Click on the **Installation URL** to complete the installation of your app and acquire your **API Token**.
+
+:::tip
+The value of your API Token can be viewed at any time from the main dashboard of your account, listed in your app's **Installs** table.
+:::
+
+### Set up the connector in Airbyte
+
+1. Log in to your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
+2. From the Airbyte UI, click **Sources** > **+ New Source**.
+3. Select **Linnworks** from the list of available sources.
+4. Enter a **Source name** of your choosing.
+5. Enter your **Application ID**, **Application Secret** and **API Token**.
+6. Enter a **Start date** using the provided datepicker. When using Incremental sync mode, only data generated after this date will be fetched.
+7. Select **Set up source** and wait for the connection test to complete.
+
+## Supported streams and sync modes
+
+The Linnworks source connector supports the following streams and [sync modes](https://docs.airbyte.com/cloud/core-concepts/#connection-sync-mode):
+
+| Stream Name                                                                                    | Full Refresh | Incremental  |
+| :--------------------------------------------------------------------------------------------- | :----------- | :----------- |
+| [ProcessedOrders](https://apps.linnworks.net/Api/Method/ProcessedOrders-SearchProcessedOrders) | ✓           | ✓            |
+| [ProcessedOrderDetails](https://apps.linnworks.net/Api/Method/Orders-GetOrdersById)            | ✓           | ✓            |
+| [StockItems](https://apps.linnworks.net//Api/Method/Stock-GetStockItemsFull)                   | ✓           | X             |
+| [StockLocations](https://apps.linnworks.net/Api/Method/Inventory-GetStockLocations)            | ✓           | X             |
+| [StockLocationDetails](https://apps.linnworks.net/Api/Method/Locations-GetLocation)            | ✓           | X             |
 
 ### Data type mapping
 
-| Integration Type | Airbyte Type | Notes                      |
+| Integration Type | Airbyte Type | Example                    |
 | :--------------- | :----------- | :------------------------- |
-| `number`         | `number`     | float number               |
-| `integer`        | `integer`    | whole number               |
-| `date`           | `string`     | FORMAT YYYY-MM-DD          |
-| `datetime`       | `string`     | FORMAT YYYY-MM-DDThh:mm:ss |
-| `array`          | `array`      |                            |
+| `number`         | `number`     | 50.23                      |
+| `integer`        | `integer`    | 50                         |
+| `date`           | `string`     | 2020-12-31                 |
+| `datetime`       | `string`     | 2020-12-31T07:30:00        |
+| `array`          | `array`      | ["Item 1", "Item 2"]       |
 | `boolean`        | `boolean`    | True/False                 |
-| `string`         | `string`     |                            |
+| `string`         | `string`     | Item 3                     |
 
-### Features
+## Limitations & Troubleshooting
 
-| Feature                                   | Supported?\(Yes/No\) | Notes |
-| :---------------------------------------- | :------------------- | :---- |
-| Full Refresh Overwrite Sync               | Yes                  |       |
-| Full Refresh Append Sync                  | Yes                  |       |
-| Incremental - Append Sync                 | Yes                  |       |
-| Incremental - Append + Deduplication Sync | Yes                  |       |
-| Namespaces                                | No                   |       |
+<details>
+<summary>
 
-### Performance considerations
+Expand to see details about Linnworks connector limitations and troubleshooting
 
-Rate limit varies across Linnworks API endpoint. See the endpoint documentation to learn more. Rate limited requests will receive a 429 response. The Linnworks connector should not run into Linnworks API limitations under normal usage.
+</summary>
 
-## Getting started
+### Rate limits
 
-### Authentication
+Rate limits for the Linnworks API vary across endpoints. Use the [links in the **Supported Streams** table](#supported-streams) to view each endpoint's limits. Rate limited requests will receive a 429 response, but the Linnworks connector should not run into Linnworks API limitations under normal usage.
 
-Linnworks platform has two portals: seller and developer. First, to create API credentials, log in to the [developer portal](https://developer.linnworks.com) and create an application of type `System Integration`. Then click on provided Installation URL and proceed with an installation wizard. The wizard will show a token that you will need for authentication. The installed application will be present on your account on [seller portal](https://login.linnworks.net/).
-
-Authentication credentials can be obtained on developer portal section Applications -> _Your application name_ -> Edit -> General. And the token, if you missed it during the install, can be obtained anytime under the section Applications -> _Your application name_ -> Installs.
+</details>
 
 ## Changelog
 

--- a/docs/integrations/sources/linnworks.md
+++ b/docs/integrations/sources/linnworks.md
@@ -63,7 +63,7 @@ Expand to see details about Linnworks connector limitations and troubleshooting
 
 ### Rate limits
 
-Rate limits for the Linnworks API vary across endpoints. Use the [links in the **Supported Streams** table](#supported-streams) to view each endpoint's limits. Rate limited requests will receive a 429 response, but the Linnworks connector should not run into Linnworks API limitations under normal usage.
+Rate limits for the Linnworks API vary across endpoints. Use the [links in the **Supported Streams** table](#supported-streams-and-sync-modes) to view each endpoint's limits. Rate limited requests will receive a 429 response, but the Linnworks connector should not run into Linnworks API limitations under normal usage.
 
 </details>
 

--- a/docs/integrations/sources/linnworks.md
+++ b/docs/integrations/sources/linnworks.md
@@ -10,7 +10,7 @@ This page contains the setup guide and reference information for the [Linnworks]
 
 ### Generate Credentials in Linnworks
 
-1. The Linnworks platform has two portals: seller and developer. To generate the necessary credentials, log in to the [developer portal](https://developer.linnworks.com) and select **+ New App**.
+1. The Linnworks platform has two portals: Seller and Developer. To generate the necessary credentials, log in to the [developer portal](https://developer.linnworks.com) and select **+ New App**.
 2. Input a name for your application and set the **Application Type** to `System Integration`.
 3. Select **Edit** for your new application. In the **General** tab, find and copy your **Application ID** and **Application Secret**. Click on the **Installation URL** to complete the installation of your app and acquire your **API Token**.
 
@@ -23,7 +23,7 @@ The value of your API Token can be viewed at any time from the main dashboard of
 1. Log in to your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. From the Airbyte UI, click **Sources** > **+ New Source**.
 3. Select **Linnworks** from the list of available sources.
-4. Enter a **Source name** of your choosing.
+4. Enter a **Name** of your choosing.
 5. Enter your **Application ID**, **Application Secret** and **API Token**.
 6. Enter a **Start date** using the provided datepicker. When using Incremental sync mode, only data generated after this date will be fetched.
 7. Select **Set up source** and wait for the connection test to complete.


### PR DESCRIPTION
## What

Updated the docs page for source Linnworks, resolving #34790 

## How

- Updated setup steps for obtaining credentials and moved to setup guide section at top of page
- Added setup instructions for navigating Airbyte UI
- Added table of streams with associated sync modes
- Updated `data type mapping` table with examples of each data type
- Added collapsible troubleshooting section