### PR TITLE
AirbyteLib: friendly install and post-install messaging

### DIFF
--- a/airbyte-lib/airbyte_lib/_executor.py
+++ b/airbyte-lib/airbyte_lib/_executor.py
@@ -227,7 +227,11 @@ class VenvExecutor(Executor):
 
         # Assuming the installation succeeded, store the installed version
         self.reported_version = self._get_installed_version(raise_on_error=False, recheck=True)
-        print(f"Connector '{self.name}' installed successfully!\n")
+        print(
+            f"Connector '{self.name}' installed successfully!\n"
+            f"For more information, see the {self.name} documentation:\n"
+            f"{self.docs_url}#reference\n"
+        )
 
     def _get_installed_version(
         self,

--- a/airbyte-lib/airbyte_lib/_executor.py
+++ b/airbyte-lib/airbyte_lib/_executor.py
@@ -217,14 +217,9 @@ class VenvExecutor(Executor):
 
         # Assuming the installation succeeded, store the installed version
         self.reported_version = self._get_installed_version(raise_on_error=False, recheck=True)
-
-        # TODO: Get this docs URL from metadata
-        docs_url = "https://docs.airbyte.com/integrations/sources/" + self.name.lower().replace(
-            "source-", ""
-        )
         print(
             "Source connector installed successfully! For configuration instructions, see: \n"
-            f"{docs_url}#reference\n"
+            f"{self.docs_url}#reference\n"
         )
 
     def _get_installed_version(

--- a/airbyte-lib/airbyte_lib/_executor.py
+++ b/airbyte-lib/airbyte_lib/_executor.py
@@ -217,10 +217,7 @@ class VenvExecutor(Executor):
 
         # Assuming the installation succeeded, store the installed version
         self.reported_version = self._get_installed_version(raise_on_error=False, recheck=True)
-        print(
-            "Source connector installed successfully! For configuration instructions, see: \n"
-            f"{self.docs_url}#reference\n"
-        )
+        print("Source connector installed successfully!\n")
 
     def _get_installed_version(
         self,

--- a/airbyte-lib/airbyte_lib/_executor.py
+++ b/airbyte-lib/airbyte_lib/_executor.py
@@ -169,7 +169,10 @@ class VenvExecutor(Executor):
     def _get_connector_path(self) -> Path:
         return self._get_venv_path() / "bin" / self.name
 
-    def _run_subprocess_and_raise_on_failure(self, args: list[str]) -> None:
+    def _run_subprocess_and_raise_on_failure(
+        self,
+        args: list[str],
+    ) -> None:
         result = subprocess.run(
             args,
             check=False,
@@ -198,7 +201,7 @@ class VenvExecutor(Executor):
         )
 
         pip_path = str(self._get_venv_path() / "bin" / "pip")
-
+        print(f"Installing '{self.name}' from '{self.pip_url}'...")
         try:
             self._run_subprocess_and_raise_on_failure(
                 args=[pip_path, "install", *shlex.split(self.pip_url)]
@@ -214,6 +217,13 @@ class VenvExecutor(Executor):
 
         # Assuming the installation succeeded, store the installed version
         self.reported_version = self._get_installed_version(raise_on_error=False, recheck=True)
+        docs_url = "https://docs.airbyte.com/integrations/sources/" + self.name.lower().replace(
+            "source-", ""
+        )
+        print(
+            "Installation completed successfully."
+            f"For configuration instructions, see: \n{docs_url}#reference\n"
+        )
 
     def _get_installed_version(
         self,

--- a/airbyte-lib/airbyte_lib/_executor.py
+++ b/airbyte-lib/airbyte_lib/_executor.py
@@ -201,7 +201,10 @@ class VenvExecutor(Executor):
         )
 
         pip_path = str(self._get_venv_path() / "bin" / "pip")
-        print(f"Installing '{self.name}' from '{self.pip_url}'...")
+        print(
+            f"Installing '{self.name}' into virtual environment '{self._get_venv_path()!s}'."
+            f"Running 'pip install {self.pip_url}'..."
+        )
         try:
             self._run_subprocess_and_raise_on_failure(
                 args=[pip_path, "install", *shlex.split(self.pip_url)]
@@ -223,8 +226,8 @@ class VenvExecutor(Executor):
             "source-", ""
         )
         print(
-            "Installation completed successfully."
-            f"For configuration instructions, see: \n{docs_url}#reference\n"
+            "Installation completed successfully. For configuration instructions, see: \n"
+            f"{docs_url}#reference\n"
         )
 
     def _get_installed_version(

--- a/airbyte-lib/airbyte_lib/_executor.py
+++ b/airbyte-lib/airbyte_lib/_executor.py
@@ -217,6 +217,8 @@ class VenvExecutor(Executor):
 
         # Assuming the installation succeeded, store the installed version
         self.reported_version = self._get_installed_version(raise_on_error=False, recheck=True)
+
+        # TODO: Get this docs URL from metadata
         docs_url = "https://docs.airbyte.com/integrations/sources/" + self.name.lower().replace(
             "source-", ""
         )

--- a/airbyte-lib/airbyte_lib/_executor.py
+++ b/airbyte-lib/airbyte_lib/_executor.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from shutil import rmtree
 from typing import IO, TYPE_CHECKING, Any, NoReturn, cast
 
+from rich import print
+
 from airbyte_lib import exceptions as exc
 from airbyte_lib.registry import ConnectorMetadata
 from airbyte_lib.telemetry import SourceTelemetryInfo, SourceType
@@ -188,6 +190,14 @@ class VenvExecutor(Executor):
 
         self.reported_version = None  # Reset the reported version from the previous installation
 
+    @property
+    def docs_url(self) -> str:
+        """Get the URL to the connector's documentation."""
+        # TODO: Refactor installation so that this can just live in the Source class.
+        return "https://docs.airbyte.com/integrations/sources/" + self.name.lower().replace(
+            "source-", ""
+        )
+
     def install(self) -> None:
         """Install the connector in a virtual environment.
 
@@ -217,7 +227,7 @@ class VenvExecutor(Executor):
 
         # Assuming the installation succeeded, store the installed version
         self.reported_version = self._get_installed_version(raise_on_error=False, recheck=True)
-        print("Source connector installed successfully!\n")
+        print(f"Connector '{self.name}' installed successfully!\n")
 
     def _get_installed_version(
         self,

--- a/airbyte-lib/airbyte_lib/_executor.py
+++ b/airbyte-lib/airbyte_lib/_executor.py
@@ -169,10 +169,7 @@ class VenvExecutor(Executor):
     def _get_connector_path(self) -> Path:
         return self._get_venv_path() / "bin" / self.name
 
-    def _run_subprocess_and_raise_on_failure(
-        self,
-        args: list[str],
-    ) -> None:
+    def _run_subprocess_and_raise_on_failure(self, args: list[str]) -> None:
         result = subprocess.run(
             args,
             check=False,
@@ -202,8 +199,8 @@ class VenvExecutor(Executor):
 
         pip_path = str(self._get_venv_path() / "bin" / "pip")
         print(
-            f"Installing '{self.name}' into virtual environment '{self._get_venv_path()!s}'."
-            f"Running 'pip install {self.pip_url}'..."
+            f"Installing '{self.name}' into virtual environment '{self._get_venv_path()!s}'.\n"
+            f"Running 'pip install {self.pip_url}'...\n"
         )
         try:
             self._run_subprocess_and_raise_on_failure(
@@ -226,7 +223,7 @@ class VenvExecutor(Executor):
             "source-", ""
         )
         print(
-            "Installation completed successfully. For configuration instructions, see: \n"
+            "Source connector installed successfully! For configuration instructions, see: \n"
             f"{docs_url}#reference\n"
         )
 

--- a/airbyte-lib/airbyte_lib/exceptions.py
+++ b/airbyte-lib/airbyte_lib/exceptions.py
@@ -225,7 +225,11 @@ class AirbyteConnectorMissingSpecError(AirbyteConnectorError):
 
 
 class AirbyteConnectorCheckFailedError(AirbyteConnectorError):
-    """Connector did not return a spec."""
+    """Connector check failed."""
+
+    guidance = (
+        "Please double-check your config or review the connector's logs for more information."
+    )
 
 
 @dataclass

--- a/airbyte-lib/airbyte_lib/exceptions.py
+++ b/airbyte-lib/airbyte_lib/exceptions.py
@@ -36,6 +36,7 @@ In addition, the following principles are applied for exception class design:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from textwrap import indent
 from typing import Any
 
 
@@ -75,25 +76,25 @@ class AirbyteError(Exception):
             if k not in special_properties and not k.startswith("_") and v is not None
         }
         display_properties.update(self.context or {})
-        context_str = "\n".join(
+        context_str = "\n    ".join(
             f"{str(k).replace('_', ' ').title()}: {v!r}"
             for k, v in display_properties.items()
         )
         exception_str = f"{self.__class__.__name__}: {self.get_message()}\n"
         if context_str:
-            exception_str += context_str
+            exception_str += "    " + context_str
 
         if self.log_text:
             if isinstance(self.log_text, list):
                 self.log_text = "\n".join(self.log_text)
 
-            exception_str += f"\n\n Log output: {self.log_text}"
+            exception_str += f"\nLog output: \n    {indent(self.log_text, '    ')}"
 
         if self.guidance:
-            exception_str += f"\n\n Suggestion: {self.guidance}"
+            exception_str += f"\nSuggestion: {self.guidance}"
 
         if self.help_url:
-            exception_str += f"\n\n More info: {self.help_url}"
+            exception_str += f"\nMore info: {self.help_url}"
 
         return exception_str
 

--- a/airbyte-lib/airbyte_lib/exceptions.py
+++ b/airbyte-lib/airbyte_lib/exceptions.py
@@ -69,15 +69,19 @@ class AirbyteError(Exception):
         return self.__doc__.split("\n")[0] if self.__doc__ else ""
 
     def __str__(self) -> str:
-        special_properties = ["message", "guidance", "help_url", "log_text"]
-        properties_str = ", ".join(
-            f"{k}={v!r}"
-            for k, v in self.__dict__.items()
+        special_properties = ["message", "guidance", "help_url", "log_text", "context"]
+        display_properties = {
+            k: v for k, v in self.__dict__.items()
             if k not in special_properties and not k.startswith("_") and v is not None
+        }
+        display_properties.update(self.context or {})
+        context_str = "\n    ".join(
+            f"{str(k).replace('_', ' ').title()}: {v!r}"
+            for k, v in display_properties
         )
         exception_str = f"{self.__class__.__name__}: {self.get_message()}."
-        if properties_str:
-            exception_str += f" ({properties_str})"
+        if context_str:
+            exception_str += f"Additional Context:\n    {context_str}"
 
         if self.log_text:
             if isinstance(self.log_text, list):

--- a/airbyte-lib/airbyte_lib/exceptions.py
+++ b/airbyte-lib/airbyte_lib/exceptions.py
@@ -75,13 +75,13 @@ class AirbyteError(Exception):
             if k not in special_properties and not k.startswith("_") and v is not None
         }
         display_properties.update(self.context or {})
-        context_str = "\n    ".join(
+        context_str = "\n".join(
             f"{str(k).replace('_', ' ').title()}: {v!r}"
             for k, v in display_properties.items()
         )
-        exception_str = f"{self.__class__.__name__}: {self.get_message()}."
+        exception_str = f"{self.__class__.__name__}: {self.get_message()}\n"
         if context_str:
-            exception_str += f"Additional Context:\n    {context_str}"
+            exception_str += context_str
 
         if self.log_text:
             if isinstance(self.log_text, list):

--- a/airbyte-lib/airbyte_lib/exceptions.py
+++ b/airbyte-lib/airbyte_lib/exceptions.py
@@ -72,13 +72,13 @@ class AirbyteError(Exception):
     def __str__(self) -> str:
         special_properties = ["message", "guidance", "help_url", "log_text", "context"]
         display_properties = {
-            k: v for k, v in self.__dict__.items()
+            k: v
+            for k, v in self.__dict__.items()
             if k not in special_properties and not k.startswith("_") and v is not None
         }
         display_properties.update(self.context or {})
         context_str = "\n    ".join(
-            f"{str(k).replace('_', ' ').title()}: {v!r}"
-            for k, v in display_properties.items()
+            f"{str(k).replace('_', ' ').title()}: {v!r}" for k, v in display_properties.items()
         )
         exception_str = f"{self.__class__.__name__}: {self.get_message()}\n"
         if context_str:

--- a/airbyte-lib/airbyte_lib/exceptions.py
+++ b/airbyte-lib/airbyte_lib/exceptions.py
@@ -77,7 +77,7 @@ class AirbyteError(Exception):
         display_properties.update(self.context or {})
         context_str = "\n    ".join(
             f"{str(k).replace('_', ' ').title()}: {v!r}"
-            for k, v in display_properties
+            for k, v in display_properties.items()
         )
         exception_str = f"{self.__class__.__name__}: {self.get_message()}."
         if context_str:

--- a/airbyte-lib/airbyte_lib/source.py
+++ b/airbyte-lib/airbyte_lib/source.py
@@ -216,9 +216,8 @@ class Source:
     def docs_url(self) -> str:
         """Get the URL to the connector's documentation."""
         # TODO: Replace with docs URL from metadata when available
-        return (
-            "https://docs.airbyte.com/integrations/sources/" +
-            self.name.lower().replace("source-", "")
+        return "https://docs.airbyte.com/integrations/sources/" + self.name.lower().replace(
+            "source-", ""
         )
 
     @property
@@ -330,7 +329,7 @@ class Source:
                             help_url=self.docs_url,
                             context={
                                 "failure_reason": msg.connectionStatus.message,
-                            }
+                            },
                         )
                 raise exc.AirbyteConnectorCheckFailedError(log_text=self._last_log_messages)
             except exc.AirbyteConnectorReadError as ex:

--- a/airbyte-lib/airbyte_lib/source.py
+++ b/airbyte-lib/airbyte_lib/source.py
@@ -341,6 +341,10 @@ class Source:
     def install(self) -> None:
         """Install the connector if it is not yet installed."""
         self.executor.install()
+        print(
+            "For configuration instructions, see: \n"
+            f"{self.docs_url}#reference\n"
+        )
 
     def uninstall(self) -> None:
         """Uninstall the connector if it is installed.

--- a/airbyte-lib/airbyte_lib/source.py
+++ b/airbyte-lib/airbyte_lib/source.py
@@ -213,6 +213,15 @@ class Source:
         return yaml.dump(spec_dict)
 
     @property
+    def docs_url(self) -> str:
+        """Get the URL to the connector's documentation."""
+        # TODO: Replace with docs URL from metadata when available
+        return (
+            "https://docs.airbyte.com/integrations/sources/" +
+            self.name.lower().replace("source-", "")
+        )
+
+    @property
     def discovered_catalog(self) -> AirbyteCatalog:
         """Get the raw catalog for the given streams.
 
@@ -318,8 +327,9 @@ class Source:
                             return  # Success!
 
                         raise exc.AirbyteConnectorCheckFailedError(
+                            help_url=self.docs_url,
                             context={
-                                "message": msg.connectionStatus.message,
+                                "failure_reason": msg.connectionStatus.message,
                             }
                         )
                 raise exc.AirbyteConnectorCheckFailedError(log_text=self._last_log_messages)

--- a/airbyte-lib/airbyte_lib/source.py
+++ b/airbyte-lib/airbyte_lib/source.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import jsonschema
 import yaml
+from rich import print
 
 from airbyte_protocol.models import (
     AirbyteCatalog,
@@ -341,10 +342,7 @@ class Source:
     def install(self) -> None:
         """Install the connector if it is not yet installed."""
         self.executor.install()
-        print(
-            "For configuration instructions, see: \n"
-            f"{self.docs_url}#reference\n"
-        )
+        print("For configuration instructions, see: \n" f"{self.docs_url}#reference\n")
 
     def uninstall(self) -> None:
         """Uninstall the connector if it is installed.

--- a/airbyte-lib/airbyte_lib/types.py
+++ b/airbyte-lib/airbyte_lib/types.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import cast
 
 import sqlalchemy
+from rich import print
 
 
 # Compare to documentation here: https://docs.airbyte.com/understanding-airbyte/supported-data-types

--- a/airbyte-lib/airbyte_lib/validate.py
+++ b/airbyte-lib/airbyte_lib/validate.py
@@ -14,6 +14,7 @@ import tempfile
 from pathlib import Path
 
 import yaml
+from rich import print
 
 import airbyte_lib as ab
 from airbyte_lib import exceptions as exc

--- a/airbyte-lib/docs/generated/airbyte_lib.html
+++ b/airbyte-lib/docs/generated/airbyte_lib.html
@@ -551,6 +551,19 @@ is called.</p>
 
 
                             </div>
+                            <div id="Source.docs_url" class="classattr">
+                                <div class="attr variable">
+            <span class="name">docs_url</span><span class="annotation">: str</span>
+
+        
+    </div>
+    <a class="headerlink" href="#Source.docs_url"></a>
+    
+            <div class="docstring"><p>Get the URL to the connector's documentation.</p>
+</div>
+
+
+                            </div>
                             <div id="Source.discovered_catalog" class="classattr">
                                 <div class="attr variable">
             <span class="name">discovered_catalog</span><span class="annotation">: airbyte_protocol.models.airbyte_protocol.AirbyteCatalog</span>


### PR DESCRIPTION
This PR adds a new print message at the beginning and end of connector installations.

After installation we print 'success' along with a link to the settings documentation:

> <img width="799" alt="image" src="https://github.com/airbytehq/airbyte/assets/18150651/b3469d2f-152f-48de-8acf-75a5e8c348ea">
