### PR TITLE
🐛 Source Coin API: Fix catalog typos

### DIFF
--- a/airbyte-integrations/connectors/source-coin-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-coin-api/Dockerfile
@@ -34,5 +34,5 @@ COPY source_coin_api ./source_coin_api
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.2.0
 LABEL io.airbyte.name=airbyte/source-coin-api

--- a/airbyte-integrations/connectors/source-coin-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coin-api/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 919984ef-53a2-479b-8ffe-9c1ddb9fc3f3
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-coin-api
   githubIssueLabel: source-coin-api
   icon: coinapi.svg

--- a/airbyte-integrations/connectors/source-coin-api/source_coin_api/schemas/quotes_historical_data.json
+++ b/airbyte-integrations/connectors/source-coin-api/source_coin_api/schemas/quotes_historical_data.json
@@ -19,10 +19,10 @@
     "ask_size": {
       "type": ["null", "number"]
     },
-    "big_price": {
+    "bid_price": {
       "type": ["null", "number"]
     },
-    "big_size": {
+    "bid_size": {
       "type": ["null", "number"]
     }
   }

--- a/docs/integrations/sources/coin-api.md
+++ b/docs/integrations/sources/coin-api.md
@@ -50,6 +50,6 @@ The following fields are required fields for the connector to work:
 
 | Version | Date       | Pull Request                                             | Subject    |
 |:--------|:-----------|:---------------------------------------------------------|:-----------|
-| 0.2.0   | 2022-02-05 | [#34826](https://github.com/airbytehq/airbyte/pull/34826) | Fix catalog types for fields `bid_price` and `bid_size` in stream  `quotes_historical_data`. |
+| 0.2.0   | 2024-02-05 | [#34826](https://github.com/airbytehq/airbyte/pull/34826) | Fix catalog types for fields `bid_price` and `bid_size` in stream  `quotes_historical_data`. |
 | 0.1.1   | 2022-12-19 | [#20600](https://github.com/airbytehq/airbyte/pull/20600) | Add quotes historical data stream|
 | 0.1.0   | 2022-10-21 | [#18302](https://github.com/airbytehq/airbyte/pull/18302) | New source |

--- a/docs/integrations/sources/coin-api.md
+++ b/docs/integrations/sources/coin-api.md
@@ -50,5 +50,6 @@ The following fields are required fields for the connector to work:
 
 | Version | Date       | Pull Request                                             | Subject    |
 |:--------|:-----------|:---------------------------------------------------------|:-----------|
-| 0.1.1   | 2022-12-19 | [20600](https://github.com/airbytehq/airbyte/pull/20600) | Add quotes historical data stream|
-| 0.1.0   | 2022-10-21 | [18302](https://github.com/airbytehq/airbyte/pull/18302) | New source |
+| 0.2.0   | 2022-02-05 | [#34826](https://github.com/airbytehq/airbyte/pull/34826) | Fix catalog types for fields `bid_price` and `bid_size` in stream  `quotes_historical_data`. |
+| 0.1.1   | 2022-12-19 | [#20600](https://github.com/airbytehq/airbyte/pull/20600) | Add quotes historical data stream|
+| 0.1.0   | 2022-10-21 | [#18302](https://github.com/airbytehq/airbyte/pull/18302) | New source |


### PR DESCRIPTION
This fixes some bugs in the source catalog for the Coin API source.

Complete:

1. [x] Changelog
1. [x] Version bump
1. [x] Manual tests

(Set to auto-merge on approval.)