### PR TITLE
Source Zoom: Disable pypi

### DIFF
--- a/airbyte-integrations/connectors/source-zoom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoom/metadata.yaml
@@ -26,4 +26,9 @@ data:
     sl: 100
     ql: 200
   supportLevel: community
+  releases:
+    breakingChanges:
+      1.0.0:
+        upgradeDeadline: 2023-08-30
+        message: "Update spec to use token and ingest all 3 streams correctly"
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zoom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoom/metadata.yaml
@@ -30,5 +30,5 @@ data:
     breakingChanges:
       1.0.0:
         upgradeDeadline: 2023-08-30
-        message: "Update spec to use token and ingest all 3 streams correctly"
+        message: "Replace JWT Auth methods with server-to-server Oauth"
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zoom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoom/metadata.yaml
@@ -10,7 +10,8 @@ data:
   name: Zoom
   remoteRegistries:
     pypi:
-      enabled: true
+      # TODO: Enable once build problems are fixed
+      enabled: false
       packageName: airbyte-source-zoom
   registries:
     cloud:
@@ -26,9 +27,4 @@ data:
     sl: 100
     ql: 200
   supportLevel: community
-  releases:
-    breakingChanges:
-      1.0.0:
-        upgradeDeadline: 2023-08-30
-        message: "Replace JWT Auth methods with server-to-server Oauth"
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
The source-zoom CI is currently broken for a variety of reasons, to make the registry consistent with the repository again this PR is reverting the enabling of pypi publishing for now.