### PR TITLE
[ISSUE #34755] do not propagate parameters on InlineSchemaLoader

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/manifest_component_transformer.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/manifest_component_transformer.py
@@ -74,6 +74,10 @@ CUSTOM_COMPONENTS_MAPPING: Mapping[str, str] = {
     "SimpleRetriever.partition_router": "CustomPartitionRouter",
 }
 
+_PROPAGATION_EXCLUSION_TYPES = {
+    "InlineSchemaLoader"  # propagation of extra parameters leads to invalid JSON schemas
+}
+
 
 class ManifestComponentTransformer:
     def propagate_types_and_parameters(
@@ -103,7 +107,7 @@ class ManifestComponentTransformer:
                 propagated_component["type"] = found_type
 
         # When there is no resolved type, we're not processing a component (likely a regular object) and don't need to propagate parameters
-        if "type" not in propagated_component:
+        if "type" not in propagated_component or propagated_component["type"] in _PROPAGATION_EXCLUSION_TYPES:
             return propagated_component
 
         # Combines parameters defined at the current level with parameters from parent components. Parameters at the current

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/manifest_component_transformer.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/manifest_component_transformer.py
@@ -74,9 +74,7 @@ CUSTOM_COMPONENTS_MAPPING: Mapping[str, str] = {
     "SimpleRetriever.partition_router": "CustomPartitionRouter",
 }
 
-_PROPAGATION_EXCLUSION_TYPES = {
-    "InlineSchemaLoader"  # propagation of extra parameters leads to invalid JSON schemas
-}
+_PROPAGATION_EXCLUSION_TYPES = {"InlineSchemaLoader"}  # propagation of extra parameters leads to invalid JSON schemas
 
 
 class ManifestComponentTransformer:

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_manifest_component_transformer.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_manifest_component_transformer.py
@@ -355,7 +355,14 @@ def test_do_not_propagate_parameters_on_inline_schema_loader():
         "streams": [
             {
                 "type": "DeclarativeStream",
-                "schema_loader": {"type": "InlineSchemaLoader", "file_path": './source_coffee/schemas/{{ parameters["name"] }}.json'},
+                "schema_loader": {
+                    "type": "InlineSchemaLoader",
+                    "schema": {
+                        "type": "object",
+                        "$schema": "http://json-schema.org/schema#",
+                        "properties": {"id": {"type": "string"}},
+                    },
+                },
                 "$parameters": {
                     "name": "roasters",
                     "primary_key": "id",
@@ -373,7 +380,11 @@ def test_do_not_propagate_parameters_on_inline_schema_loader():
                 "primary_key": "id",
                 "schema_loader": {
                     "type": "InlineSchemaLoader",
-                    "file_path": './source_coffee/schemas/{{ parameters["name"] }}.json',
+                    "schema": {
+                        "type": "object",
+                        "$schema": "http://json-schema.org/schema#",
+                        "properties": {"id": {"type": "string"}},
+                    },
                 },
                 "$parameters": {
                     "name": "roasters",

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_manifest_component_transformer.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_manifest_component_transformer.py
@@ -349,7 +349,7 @@ def test_only_propagate_parameters_to_components():
     assert actual_component == expected_component
 
 
-def test_do_not_propagate_parameters_on_inline_schema_loader():
+def test_do_not_propagate_parameters_on_json_schema_object():
     component = {
         "type": "DeclarativeStream",
         "streams": [
@@ -380,10 +380,16 @@ def test_do_not_propagate_parameters_on_inline_schema_loader():
                 "primary_key": "id",
                 "schema_loader": {
                     "type": "InlineSchemaLoader",
+                    "name": "roasters",
+                    "primary_key": "id",
                     "schema": {
                         "type": "object",
                         "$schema": "http://json-schema.org/schema#",
                         "properties": {"id": {"type": "string"}},
+                    },
+                    "$parameters": {
+                        "name": "roasters",
+                        "primary_key": "id",
                     },
                 },
                 "$parameters": {

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_manifest_component_transformer.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_manifest_component_transformer.py
@@ -347,3 +347,43 @@ def test_only_propagate_parameters_to_components():
     actual_component = transformer.propagate_types_and_parameters("", component, {})
 
     assert actual_component == expected_component
+
+
+def test_do_not_propagate_parameters_on_inline_schema_loader():
+    component = {
+        "type": "DeclarativeStream",
+        "streams": [
+            {
+                "type": "DeclarativeStream",
+                "schema_loader": {"type": "InlineSchemaLoader", "file_path": './source_coffee/schemas/{{ parameters["name"] }}.json'},
+                "$parameters": {
+                    "name": "roasters",
+                    "primary_key": "id",
+                },
+            }
+        ],
+    }
+
+    expected_component = {
+        "type": "DeclarativeStream",
+        "streams": [
+            {
+                "type": "DeclarativeStream",
+                "name": "roasters",
+                "primary_key": "id",
+                "schema_loader": {
+                    "type": "InlineSchemaLoader",
+                    "file_path": './source_coffee/schemas/{{ parameters["name"] }}.json',
+                },
+                "$parameters": {
+                    "name": "roasters",
+                    "primary_key": "id",
+                },
+            }
+        ],
+    }
+
+    transformer = ManifestComponentTransformer()
+    actual_component = transformer.propagate_types_and_parameters("", component, {})
+
+    assert actual_component == expected_component


### PR DESCRIPTION
## What
Addresses #34755 

## How
During component transformation, exclude type `InlineSchemaLoader` from the propagation.

## 🚨 User Impact 🚨
### Migration

TLDR: nothing to do to update sources that were currently affected by this.

Running the following command, we can see that only three connectors currently have both `$parameters` and `InlineSchemaLoader`:
```
connectors% grep -l 'InlineSchemaLoader' `grep -l '$parameters' source-*/source_*/manifest.yaml`
source-coingecko-coins/source_coingecko_coins/manifest.yaml
source-gnews/source_gnews/manifest.yaml
source-news-api/source_news_api/manifest.yaml
```

#### source-coingecko-coins
I was very surprised to see that source-coingecko-coins did not have the issue while running `docker run -v $(pwd)/secrets:/data airbyte/source-coingecko-coins:0.1.0 discover --config /data/config.json`. However, when checking in the docker image using `docker run --rm -it --entrypoint bash airbyte/source-coingecko-coins:0.1.0`,  we can see that there is a mismatch between [the current code](https://github.com/airbytehq/airbyte/tree/63d0532acefd5a4d4cd65be8293699749e845b3f/airbyte-integrations/connectors/source-coingecko-coins/source_coingecko_coins)

```
bash-5.1# ls -al
total 28
drwxr-xr-x    3 root     root          4096 Nov 18  2022 .
drwxr-xr-x    1 root     root          4096 Nov 18  2022 ..
-rw-r--r--    1 root     root           140 Nov 18  2022 __init__.py
-rw-r--r--    1 root     root          1906 Nov 18  2022 coingecko_coins.yaml
drwxr-xr-x    2 root     root          4096 Nov 18  2022 schemas
-rw-r--r--    1 root     root           490 Nov 18  2022 source.py
-rw-r--r--    1 root     root          1392 Nov 18  2022 spec.yaml
```

`coingecko_coins.yaml` is old enough to rely on `$options` instead of `$parameters`. At this point in time, either propagation wasn't implemented or InlineSchema was excluded.

#### source-gnews
The same logic from source-coingecko-coins apply to gnews as we can see with this file structure:
```
bash-5.1# ls -al source_gnews/
total 44
drwxr-xr-x    3 root     root          4096 Jan 17  2023 .
drwxr-xr-x    1 root     root          4096 Jan 17  2023 ..
-rw-r--r--    1 root     root           241 Jan 17  2023 __init__.py
drwxr-xr-x    2 root     root          4096 Jan 17  2023 __pycache__
-rw-r--r--    1 root     root          5439 Jan 17  2023 gnews.yaml
-rw-r--r--    1 root     root           471 Jan 17  2023 source.py
-rw-r--r--    1 root     root          8245 Jan 17  2023 spec.yaml
-rw-r--r--    1 root     root           969 Jan 17  2023 wait_until_midnight_backoff_strategy.py
```

#### source-news-api
source-news-api is affected by the propagation but in a way that is non breaking as `name`, `primary_key` and `path` seems to be ignored by `jsonschema.Draft7Validator.check_schema(...)`

```
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "type": "object",
    "properties": {...},
    "name": "everything",
    "primary_key": "publishedAt",
    "path": "/everything",
    "$parameters": {
        "name": "everything",
        "primary_key": "publishedAt",
        "path": "/everything"
    }
}
```

Hence, even though the current schema didn't seem to cause issue, it'll be cleaned up.