### PR TITLE
airbyte-lib: Fix processed records counter

### DIFF
--- a/airbyte-lib/airbyte_lib/progress.py
+++ b/airbyte-lib/airbyte_lib/progress.py
@@ -197,7 +197,7 @@ class ReadProgress:
         # We want to update the display more often when the count is low, and less
         # often when the count is high.
         updated_period = min(
-            MAX_UPDATE_FREQUENCY, 10 ** math.floor(math.log10(self.total_records_read) / 4)
+            MAX_UPDATE_FREQUENCY, 10 ** math.floor(math.log10(max(self.total_records_read, 1)) / 4)
         )
         if self.total_records_read % updated_period != 0:
             return

--- a/airbyte-lib/airbyte_lib/source.py
+++ b/airbyte-lib/airbyte_lib/source.py
@@ -13,7 +13,6 @@ from rich import print
 from airbyte_protocol.models import (
     AirbyteCatalog,
     AirbyteMessage,
-    AirbyteRecordMessage,
     ConfiguredAirbyteCatalog,
     ConfiguredAirbyteStream,
     ConnectorSpecification,
@@ -352,7 +351,7 @@ class Source:
         """
         self.executor.uninstall()
 
-    def _read(self, cache_info: CacheTelemetryInfo) -> Iterable[AirbyteRecordMessage]:
+    def _read(self, cache_info: CacheTelemetryInfo) -> Iterable[AirbyteMessage]:
         """
         Call read on the connector.
 
@@ -440,14 +439,15 @@ class Source:
 
     def _tally_records(
         self,
-        messages: Iterable[AirbyteRecordMessage],
-    ) -> Generator[AirbyteRecordMessage, Any, None]:
+        messages: Iterable[AirbyteMessage],
+    ) -> Generator[AirbyteMessage, Any, None]:
         """This method simply tallies the number of records processed and yields the messages."""
         self._processed_records = 0  # Reset the counter before we start
         progress.reset(len(self._selected_stream_names or []))
 
         for message in messages:
-            self._processed_records += 1
+            if message.type is Type.RECORD:
+                self._processed_records += 1
             yield message
             progress.log_records_read(self._processed_records)
 

--- a/airbyte-lib/tests/integration_tests/fixtures/source-test/source_test/run.py
+++ b/airbyte-lib/tests/integration_tests/fixtures/source-test/source_test/run.py
@@ -124,6 +124,7 @@ def run():
         args = parse_args()
         catalog = get_json_file(args["--catalog"])
         config = get_json_file(args["--config"])
+        print(json.dumps({"type": "LOG", "log": {"level": "INFO", "message": "Starting sync"}}))
         for stream in catalog["streams"]:
             if stream["stream"]["name"] == "stream1":
                 print(json.dumps(sample_record1_stream1))


### PR DESCRIPTION
Due to a refactoring, `processed_records` wasn't counting the actual records, but all messages coming (through including logs and so on).

This PR fixes the problem and makes the number accurate again.