### PR TITLE
java CDK: ContainerFactory properly supports unshared testcontainers

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -166,6 +166,7 @@ MavenLocal debugging steps:
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.16.5  | 2024-02-05 | [\#34865](https://github.com/airbytehq/airbyte/pull/34865) | Improved testcontainers logging and support for unshared containers.                                                                                           |
 | 0.16.4  | 2024-02-01 | [\#34727](https://github.com/airbytehq/airbyte/pull/34727) | Add future based stdout consumer in BaseTypingDedupingTest                                                                                                     |
 | 0.16.3  | 2024-01-30 | [\#34669](https://github.com/airbytehq/airbyte/pull/34669) | Fix org.apache.logging.log4j:log4j-slf4j-impl version conflicts.                                                                                               |
 | 0.16.2  | 2024-01-29 | [\#34630](https://github.com/airbytehq/airbyte/pull/34630) | expose NamingTransformer to sub-classes in destinations JdbcSqlGenerator.                                                                                      |

--- a/airbyte-cdk/java/airbyte-cdk/airbyte-commons/src/main/java/io/airbyte/commons/logging/LoggingHelper.java
+++ b/airbyte-cdk/java/airbyte-cdk/airbyte-commons/src/main/java/io/airbyte/commons/logging/LoggingHelper.java
@@ -22,6 +22,7 @@ public class LoggingHelper {
     YELLOW_BACKGROUND("\u001b[43m"), // destination
     GREEN_BACKGROUND("\u001b[42m"), // normalization
     CYAN_BACKGROUND("\u001b[46m"), // container runner
+    RED_BACKGROUND("\u001b[41m"), // testcontainers
     PURPLE_BACKGROUND("\u001b[45m"); // dbt
 
     private final String ansi;

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.16.4
+version=0.16.5

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
@@ -28,15 +28,17 @@ public interface ContainerFactory<C extends GenericContainer<?>> {
   /**
    * Returns a shared instance of the testcontainer.
    */
+  @SuppressWarnings("unchecked")
   default C shared(String imageName, String... methods) {
-    return ContainerFactoryWrapper.getOrCreateShared(this, imageName, methods);
+    return (C) ContainerFactoryWrapper.getOrCreateShared(this, imageName, methods);
   }
 
   /**
    * Returns a new, unshared instance of the testcontainer.
    */
+  @SuppressWarnings("unchecked")
   default C exclusive(String imageName, String... methods) {
-    return ContainerFactoryWrapper.createExclusive(this, imageName, methods);
+    return (C) ContainerFactoryWrapper.createExclusive(this, imageName, methods);
   }
 
 }

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
@@ -4,8 +4,6 @@
 
 package io.airbyte.cdk.testutils;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -30,11 +28,7 @@ public interface ContainerFactory<C extends JdbcDatabaseContainer<?>> {
    * Returns a shared instance of the testcontainer.
    */
   default C shared(String imageName, String... methods) {
-    final String mapKey = Stream.concat(
-        Stream.of(imageName, this.getClass().getCanonicalName()),
-        Stream.of(methods))
-        .collect(Collectors.joining("+"));
-    return ContainerFactoryWrapper.getOrCreate(mapKey, this);
+    return ContainerFactoryWrapper.getOrCreateShared(this, imageName, methods);
   }
 
 }

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
@@ -4,18 +4,9 @@
 
 package io.airbyte.cdk.testutils;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -43,76 +34,7 @@ public interface ContainerFactory<C extends JdbcDatabaseContainer<?>> {
         Stream.of(imageName, this.getClass().getCanonicalName()),
         Stream.of(methods))
         .collect(Collectors.joining("+"));
-    return Singleton.getOrCreate(mapKey, this);
-  }
-
-  /**
-   * This class is exclusively used by {@link #shared(String, String...)}. It wraps a specific shared
-   * testcontainer instance, which is created exactly once.
-   */
-  class Singleton<C extends JdbcDatabaseContainer<?>> {
-
-    static private final Logger LOGGER = LoggerFactory.getLogger(Singleton.class);
-    static private final ConcurrentHashMap<String, Singleton<?>> LAZY = new ConcurrentHashMap<>();
-
-    @SuppressWarnings("unchecked")
-    static private <C extends JdbcDatabaseContainer<?>> C getOrCreate(String mapKey, ContainerFactory<C> factory) {
-      final Singleton<?> singleton = LAZY.computeIfAbsent(mapKey, Singleton<C>::new);
-      return ((Singleton<C>) singleton).getOrCreate(factory);
-    }
-
-    final private String imageName;
-    final private List<String> methodNames;
-
-    private C sharedContainer;
-    private RuntimeException containerCreationError;
-
-    private Singleton(String imageNamePlusMethods) {
-      final String[] parts = imageNamePlusMethods.split("\\+");
-      this.imageName = parts[0];
-      this.methodNames = Arrays.stream(parts).skip(2).toList();
-    }
-
-    private synchronized C getOrCreate(ContainerFactory<C> factory) {
-      if (sharedContainer == null && containerCreationError == null) {
-        try {
-          create(imageName, factory, methodNames);
-        } catch (RuntimeException e) {
-          sharedContainer = null;
-          containerCreationError = e;
-        }
-      }
-      if (containerCreationError != null) {
-        throw new RuntimeException(
-            "Error during container creation for imageName=" + imageName
-                + ", factory=" + factory.getClass().getName()
-                + ", methods=" + methodNames,
-            containerCreationError);
-      }
-      return sharedContainer;
-    }
-
-    private void create(String imageName, ContainerFactory<C> factory, List<String> methodNames) {
-      LOGGER.info("Creating new shared container based on {} with {}.", imageName, methodNames);
-      try {
-        final var parsed = DockerImageName.parse(imageName);
-        final var methods = new ArrayList<Method>();
-        for (String methodName : methodNames) {
-          methods.add(factory.getClass().getMethod(methodName, factory.getContainerClass()));
-        }
-        sharedContainer = factory.createNewContainer(parsed);
-        sharedContainer.withLogConsumer(new Slf4jLogConsumer(LOGGER));
-        for (Method method : methods) {
-          LOGGER.info("Calling {} in {} on new shared container based on {}.",
-              method.getName(), factory.getClass().getName(), imageName);
-          method.invoke(factory, sharedContainer);
-        }
-        sharedContainer.start();
-      } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
+    return ContainerFactoryWrapper.getOrCreate(mapKey, this);
   }
 
 }

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
@@ -16,6 +16,7 @@ public interface ContainerFactory<C extends JdbcDatabaseContainer<?>> {
   /**
    * Creates a new, unshared testcontainer instance. This usually wraps the default constructor for
    * the testcontainer type.
+   * Unless you know exactly what you're doing, call {@link #shared(String, String...)} or {@link #unshared(String, String...)} instead.
    */
   C createNewContainer(DockerImageName imageName);
 
@@ -31,4 +32,10 @@ public interface ContainerFactory<C extends JdbcDatabaseContainer<?>> {
     return ContainerFactoryWrapper.getOrCreateShared(this, imageName, methods);
   }
 
+  /**
+   * Returns a new, unshared instance of the testcontainer.
+   */
+  default C unshared(String imageName, String... methods) {
+    return ContainerFactoryWrapper.createUnshared(this, imageName, methods);
+  }
 }

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
@@ -16,7 +16,7 @@ public interface ContainerFactory<C extends GenericContainer<?>> {
   /**
    * Creates a new, unshared testcontainer instance. This usually wraps the default constructor for
    * the testcontainer type. Unless you know exactly what you're doing, call
-   * {@link #shared(String, String...)} or {@link #unshared(String, String...)} instead.
+   * {@link #shared(String, String...)} or {@link #exclusive(String, String...)} instead.
    */
   C createNewContainer(DockerImageName imageName);
 
@@ -35,8 +35,8 @@ public interface ContainerFactory<C extends GenericContainer<?>> {
   /**
    * Returns a new, unshared instance of the testcontainer.
    */
-  default C unshared(String imageName, String... methods) {
-    return ContainerFactoryWrapper.createUnshared(this, imageName, methods);
+  default C exclusive(String imageName, String... methods) {
+    return ContainerFactoryWrapper.createExclusive(this, imageName, methods);
   }
 
 }

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
@@ -4,14 +4,14 @@
 
 package io.airbyte.cdk.testutils;
 
-import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
  * ContainerFactory is the companion interface to {@link TestDatabase} for providing it with
  * suitable testcontainer instances.
  */
-public interface ContainerFactory<C extends JdbcDatabaseContainer<?>> {
+public interface ContainerFactory<C extends GenericContainer<?>> {
 
   /**
    * Creates a new, unshared testcontainer instance. This usually wraps the default constructor for

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactory.java
@@ -15,8 +15,8 @@ public interface ContainerFactory<C extends JdbcDatabaseContainer<?>> {
 
   /**
    * Creates a new, unshared testcontainer instance. This usually wraps the default constructor for
-   * the testcontainer type.
-   * Unless you know exactly what you're doing, call {@link #shared(String, String...)} or {@link #unshared(String, String...)} instead.
+   * the testcontainer type. Unless you know exactly what you're doing, call
+   * {@link #shared(String, String...)} or {@link #unshared(String, String...)} instead.
    */
   C createNewContainer(DockerImageName imageName);
 
@@ -38,4 +38,5 @@ public interface ContainerFactory<C extends JdbcDatabaseContainer<?>> {
   default C unshared(String imageName, String... methods) {
     return ContainerFactoryWrapper.createUnshared(this, imageName, methods);
   }
+
 }

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactoryWrapper.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactoryWrapper.java
@@ -58,7 +58,7 @@ class ContainerFactoryWrapper<C extends JdbcDatabaseContainer<?>> {
     this.methodNames = methodNames;
   }
 
-  static private String createMapKey(Class<?> containerFactoryClass,  String imageName, String... methods) {
+  static private String createMapKey(Class<?> containerFactoryClass, String imageName, String... methods) {
     final Stream<String> mapKeyElements = Stream.concat(Stream.of(containerFactoryClass.getCanonicalName(), imageName), Stream.of(methods));
     return mapKeyElements.collect(Collectors.joining("+"));
   }

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactoryWrapper.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactoryWrapper.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.testutils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * This class wraps a specific shared testcontainer instance, which is created exactly once.
+ */
+class ContainerFactoryWrapper<C extends JdbcDatabaseContainer<?>> {
+
+  static private final Logger LOGGER = LoggerFactory.getLogger(ContainerFactoryWrapper.class);
+  static private final ConcurrentHashMap<String, ContainerFactoryWrapper<?>> LAZY = new ConcurrentHashMap<>();
+
+  @SuppressWarnings("unchecked")
+  static <C extends JdbcDatabaseContainer<?>> C getOrCreate(String mapKey, ContainerFactory<C> factory) {
+    final ContainerFactoryWrapper<?> singleton = LAZY.computeIfAbsent(mapKey, ContainerFactoryWrapper<C>::new);
+    return ((ContainerFactoryWrapper<C>) singleton).getOrCreate(factory);
+  }
+
+  final String imageName;
+  final List<String> methodNames;
+
+  private C sharedContainer;
+  private RuntimeException containerCreationError;
+
+  private ContainerFactoryWrapper(String imageNamePlusMethods) {
+    final String[] parts = imageNamePlusMethods.split("\\+");
+    this.imageName = parts[0];
+    this.methodNames = Arrays.stream(parts).skip(2).toList();
+  }
+
+  private synchronized C getOrCreate(ContainerFactory<C> factory) {
+    if (sharedContainer == null && containerCreationError == null) {
+      try {
+        create(imageName, factory, methodNames);
+      } catch (RuntimeException e) {
+        sharedContainer = null;
+        containerCreationError = e;
+      }
+    }
+    if (containerCreationError != null) {
+      throw new RuntimeException(
+          "Error during container creation for imageName=" + imageName
+              + ", factory=" + factory.getClass().getName()
+              + ", methods=" + methodNames,
+          containerCreationError);
+    }
+    return sharedContainer;
+  }
+
+  private void create(String imageName, ContainerFactory<C> factory, List<String> methodNames) {
+    LOGGER.info("Creating new shared container based on {} with {}.", imageName, methodNames);
+    try {
+      final var parsed = DockerImageName.parse(imageName);
+      final var methods = new ArrayList<Method>();
+      for (String methodName : methodNames) {
+        methods.add(factory.getClass().getMethod(methodName, factory.getContainerClass()));
+      }
+      sharedContainer = factory.createNewContainer(parsed);
+      sharedContainer.withLogConsumer(new Slf4jLogConsumer(LOGGER));
+      for (Method method : methods) {
+        LOGGER.info("Calling {} in {} on new shared container based on {}.",
+            method.getName(), factory.getClass().getName(), imageName);
+        method.invoke(factory, sharedContainer);
+      }
+      sharedContainer.start();
+    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactoryWrapper.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactoryWrapper.java
@@ -39,7 +39,7 @@ class ContainerFactoryWrapper<C extends GenericContainer<?>> {
     return ((ContainerFactoryWrapper<C>) singleton).getOrCreate(factory);
   }
 
-  static <C extends GenericContainer<?>> C createUnshared(ContainerFactory<C> factory, String imageName, String... methods) {
+  static <C extends GenericContainer<?>> C createExclusive(ContainerFactory<C> factory, String imageName, String... methods) {
     return new ContainerFactoryWrapper<C>(imageName, List.of(methods)).getOrCreate(factory);
   }
 

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactoryWrapper.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/java/io/airbyte/cdk/testutils/ContainerFactoryWrapper.java
@@ -16,14 +16,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
  * This class wraps a specific shared testcontainer instance, which is created exactly once.
  */
-class ContainerFactoryWrapper<C extends JdbcDatabaseContainer<?>> {
+class ContainerFactoryWrapper<C extends GenericContainer<?>> {
 
   static private final Logger LOGGER = LoggerFactory.getLogger(ContainerFactoryWrapper.class);
   static private final ConcurrentHashMap<String, ContainerFactoryWrapper<?>> SHARED_SINGLETONS = new ConcurrentHashMap<>();
@@ -33,13 +33,13 @@ class ContainerFactoryWrapper<C extends JdbcDatabaseContainer<?>> {
       .setPrefixColor(LoggingHelper.Color.RED_BACKGROUND);
 
   @SuppressWarnings("unchecked")
-  static <C extends JdbcDatabaseContainer<?>> C getOrCreateShared(ContainerFactory<C> factory, String imageName, String... methods) {
+  static <C extends GenericContainer<?>> C getOrCreateShared(ContainerFactory<C> factory, String imageName, String... methods) {
     final String mapKey = createMapKey(factory.getClass(), imageName, methods);
     final ContainerFactoryWrapper<?> singleton = SHARED_SINGLETONS.computeIfAbsent(mapKey, ContainerFactoryWrapper<C>::new);
     return ((ContainerFactoryWrapper<C>) singleton).getOrCreate(factory);
   }
 
-  static <C extends JdbcDatabaseContainer<?>> C createUnshared(ContainerFactory<C> factory, String imageName, String... methods) {
+  static <C extends GenericContainer<?>> C createUnshared(ContainerFactory<C> factory, String imageName, String... methods) {
     return new ContainerFactoryWrapper<C>(imageName, List.of(methods)).getOrCreate(factory);
   }
 

--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -6,7 +6,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.16.5'
     features = ['db-sources']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 configurations.all {

--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.16.0'
+    cdkVersionRequired = '0.16.5'
     features = ['db-sources']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceTest.java
@@ -45,13 +45,11 @@ import java.util.Optional;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.testcontainers.containers.MSSQLServerContainer;
-import org.testcontainers.utility.DockerImageName;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class CdcMssqlSourceTest extends CdcSourceTest<MssqlSource, MsSQLTestDatabase> {
@@ -71,14 +69,7 @@ public class CdcMssqlSourceTest extends CdcSourceTest<MssqlSource, MsSQLTestData
   }
 
   protected MSSQLServerContainer<?> createContainer() {
-    return new MsSQLContainerFactory()
-        .createNewContainer(DockerImageName.parse("mcr.microsoft.com/mssql/server:2022-latest"));
-  }
-
-  @BeforeAll
-  public void beforeAll() {
-    new MsSQLContainerFactory().withAgent(privateContainer);
-    privateContainer.start();
+    return new MsSQLContainerFactory().unshared("mcr.microsoft.com/mssql/server:2022-latest", "withAgent");
   }
 
   @AfterAll

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceTest.java
@@ -69,7 +69,7 @@ public class CdcMssqlSourceTest extends CdcSourceTest<MssqlSource, MsSQLTestData
   }
 
   protected MSSQLServerContainer<?> createContainer() {
-    return new MsSQLContainerFactory().unshared("mcr.microsoft.com/mssql/server:2022-latest", "withAgent");
+    return new MsSQLContainerFactory().exclusive("mcr.microsoft.com/mssql/server:2022-latest", "withAgent");
   }
 
   @AfterAll

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSslSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSslSourceTest.java
@@ -14,7 +14,6 @@ import java.net.UnknownHostException;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.testcontainers.containers.MSSQLServerContainer;
-import org.testcontainers.utility.DockerImageName;
 
 public class CdcMssqlSslSourceTest extends CdcMssqlSourceTest {
 
@@ -23,11 +22,7 @@ public class CdcMssqlSslSourceTest extends CdcMssqlSourceTest {
   }
 
   protected MSSQLServerContainer<?> createContainer() {
-    final MsSQLContainerFactory containerFactory = new MsSQLContainerFactory();
-    final MSSQLServerContainer<?> container =
-        containerFactory.createNewContainer(DockerImageName.parse("mcr.microsoft.com/mssql/server:2022-latest"));
-    containerFactory.withSslCertificates(container);
-    return container;
+    return new MsSQLContainerFactory().unshared("mcr.microsoft.com/mssql/server:2022-latest", "withAgent", "withSslCertificates");
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSslSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSslSourceTest.java
@@ -22,7 +22,7 @@ public class CdcMssqlSslSourceTest extends CdcMssqlSourceTest {
   }
 
   protected MSSQLServerContainer<?> createContainer() {
-    return new MsSQLContainerFactory().unshared("mcr.microsoft.com/mssql/server:2022-latest", "withAgent", "withSslCertificates");
+    return new MsSQLContainerFactory().exclusive("mcr.microsoft.com/mssql/server:2022-latest", "withAgent", "withSslCertificates");
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLContainerFactory.java
+++ b/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLContainerFactory.java
@@ -14,8 +14,7 @@ public class MsSQLContainerFactory implements ContainerFactory<MSSQLServerContai
 
   @Override
   public MSSQLServerContainer<?> createNewContainer(DockerImageName imageName) {
-    MSSQLServerContainer container =
-        new MSSQLServerContainer<>(imageName.asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server")).acceptLicense();
+    var container = new MSSQLServerContainer<>(imageName.asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server")).acceptLicense();
     container.addEnv("MSSQL_MEMORY_LIMIT_MB", "384");
     return container;
   }

--- a/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLContainerFactory.java
+++ b/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLContainerFactory.java
@@ -15,7 +15,7 @@ public class MsSQLContainerFactory implements ContainerFactory<MSSQLServerContai
   @Override
   public MSSQLServerContainer<?> createNewContainer(DockerImageName imageName) {
     var container = new MSSQLServerContainer<>(imageName.asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server")).acceptLicense();
-    container.addEnv("MSSQL_MEMORY_LIMIT_MB", "384");
+    container.addEnv("MSSQL_MEMORY_LIMIT_MB", "768");
     return container;
   }
 


### PR DESCRIPTION
Originally, the db-source's ContainerFactory test fixture was built under the assumption that testcontainers could always be shared by multiple tests. In practice it turns out that that's not always the case, especially for CDC tests where the CDC state is at the RDBMS level. For instance, in mysql, there's only one binlog.

Recently we struggled to debug an issue because an unshared testcontainer didn't forward its logs to the logging back-end. This is done by default for shared containers, but was forgotten for an unshared container in a CDC test. 

Rather than peppering these tests with the suitable logging incantations, this PR adds an `unshared` method to `ContainerFactory` which is like the existing `shared` except that, well, the container is not shared. This way testcontainers are provisioned in the same way regardless of whether they're shared or not.

This PR can be reviewed commit-by-commit.