### PR TITLE
Destination Postgres: Remove varchar limit of 64k, defaults to 10MiB limit

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 0.6.2
+  dockerImageTag: 0.6.3
   dockerRepository: airbyte/destination-postgres-strict-encrypt
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 0.6.2
+  dockerImageTag: 0.6.3
   dockerRepository: airbyte/destination-postgres
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresSqlGenerator.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresSqlGenerator.java
@@ -103,6 +103,19 @@ public class PostgresSqlGenerator extends JdbcSqlGenerator {
   }
 
   @Override
+  public DataType<?> toDialectType(AirbyteProtocolType airbyteProtocolType) {
+    if (airbyteProtocolType.equals(AirbyteProtocolType.STRING)) {
+      // https://www.postgresql.org/docs/current/datatype-character.html
+      // If specified, the length n must be greater than zero and cannot exceed 10,485,760 (10 MB).
+      // If you desire to store long strings with no specific upper limit,
+      // use text or character varying without a length specifier,
+      // rather than making up an arbitrary length limit.
+      return SQLDataType.VARCHAR;
+    }
+    return super.toDialectType(airbyteProtocolType);
+  }
+
+  @Override
   public Sql createTable(final StreamConfig stream, final String suffix, final boolean force) {
     final List<Sql> statements = new ArrayList<>();
     final Name finalTableName = name(stream.id().finalNamespace(), stream.id().finalName() + suffix);

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresTypingDedupingTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresTypingDedupingTest.java
@@ -163,11 +163,9 @@ public class PostgresTypingDedupingTest extends JdbcTypingDedupingTest {
             .withSyncMode(SyncMode.FULL_REFRESH)
             .withDestinationSyncMode(DestinationSyncMode.OVERWRITE)
             .withStream(new AirbyteStream()
-                            .withNamespace(streamNamespace)
-                            .withName(streamName)
-                            .withJsonSchema(SCHEMA))));
-
-
+                .withNamespace(streamNamespace)
+                .withName(streamName)
+                .withJsonSchema(SCHEMA))));
 
     final AirbyteMessage message = new AirbyteMessage();
     final String largeString = generateBigString();

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresTypingDedupingTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresTypingDedupingTest.java
@@ -6,10 +6,9 @@ package io.airbyte.integrations.destination.postgres.typing_deduping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
 import io.airbyte.cdk.db.JdbcCompatibleSourceOperations;
 import io.airbyte.cdk.integrations.standardtest.destination.typing_deduping.JdbcTypingDedupingTest;
 import io.airbyte.commons.json.Jsons;
@@ -26,7 +25,6 @@ import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.v0.DestinationSyncMode;
 import io.airbyte.protocol.models.v0.SyncMode;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -36,30 +34,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class PostgresTypingDedupingTest extends JdbcTypingDedupingTest {
-
-  public static class TestMessage {
-
-    private final Map<String, Object> additionalProperties = new HashMap<>();
-
-    // Empty constructor for jackson
-    public TestMessage() {}
-
-    @JsonAnyGetter
-    public Map<String, Object> getAdditionalProperties() {
-      return this.additionalProperties;
-    }
-
-    @JsonAnySetter
-    public void setAdditionalProperty(String name, Object value) {
-      this.additionalProperties.put(name, value);
-    }
-
-    public TestMessage withAdditionalProperty(String name, Object value) {
-      this.additionalProperties.put(name, value);
-      return this;
-    }
-
-  }
 
   protected static PostgresTestDatabase testContainer;
 
@@ -169,17 +143,16 @@ public class PostgresTypingDedupingTest extends JdbcTypingDedupingTest {
 
     final AirbyteMessage message = new AirbyteMessage();
     final String largeString = generateBigString();
-    final TestMessage testMessage =
-        new TestMessage()
-            .withAdditionalProperty("id1", 1)
-            .withAdditionalProperty("id2", 200)
-            .withAdditionalProperty("updated_at", "2021-01-01T00:00:00Z")
-            .withAdditionalProperty("name", largeString);
+    final Map<String, Object> data = ImmutableMap.of(
+        "id1", 1,
+        "id2", 200,
+        "updated_at", "2021-01-01T00:00:00Z",
+        "name", largeString);
     message.setType(Type.RECORD);
     message.setRecord(new AirbyteRecordMessage()
         .withNamespace(streamNamespace)
         .withStream(streamName)
-        .withData(Jsons.jsonNode(testMessage))
+        .withData(Jsons.jsonNode(data))
         .withEmittedAt(1000L));
     final List<AirbyteMessage> messages1 = new ArrayList<>();
     messages1.add(message);

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -170,6 +170,7 @@ Now that you have set up the Postgres destination connector, check out the follo
 
 | Version | Date       | Pull Request                                               | Subject                                                                                             |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 0.6.3   | 2024-02-06 | [34891](https://github.com/airbytehq/airbyte/pull/34891)   | Remove varchar limit, use system defaults                                                           |
 | 0.6.2   | 2024-01-30 | [34683](https://github.com/airbytehq/airbyte/pull/34683)   | CDK Upgrade 0.16.3; Fix dependency mismatches in slf4j lib                                          |
 | 0.6.1   | 2024-01-29 | [34630](https://github.com/airbytehq/airbyte/pull/34630)   | CDK Upgrade; Use lowercase raw table in T+D queries.                                                |
 | 0.6.0   | 2024-01-19 | [34372](https://github.com/airbytehq/airbyte/pull/34372)   | Add dv2 flag in spec                                                                                |


### PR DESCRIPTION
## What
Fixes: https://github.com/airbytehq/alpha-beta-issues/issues/2874

## How
* Removing the Varchar limit imposed in base JdbcSqlGen. Postgres limit is much higher. 
