### PR TITLE
qa-checks: make base image, publish to pypi and  poetry use required

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
@@ -363,6 +363,18 @@ class Connector:
         return (self.code_directory / "Dockerfile").is_file()
 
     @property
+    def has_poetry_lock(self) -> bool:
+        return (self.code_directory / "poetry.lock").is_file()
+
+    @property
+    def has_setup_py(self) -> bool:
+        return (self.code_directory / "setup.py").is_file()
+
+    @property
+    def has_pyproject_toml(self) -> bool:
+        return (self.code_directory / "pyproject.toml").is_file()
+
+    @property
     def metadata_file_path(self) -> Path:
         return self.code_directory / METADATA_FILE_NAME
 

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector_ops"
-version = "0.3.3"
+version = "0.4.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
Closes airbytehq/airbyte-internal-issues#2905
To undertake a global migration of our python connectors to poetry we want to enforce the use of our base image and poetry in connectors.

I also ported there the check that a python connector is published to Pypi, for airbyte-lib.

## How
Introduce new python source specific QA checks:
* check_is_using_poetry
* check_has_no_setup_py
* check_is_using_python_base_image
* check_publish_to_pypi_is_enabled


## 🚨 User Impact 🚨
**This should not be merged until**:
- the migration to poetry is finalized for certified connectors
- we have clear documentation on how to migrate a connector to poetry
