### PR TITLE
airbyte-lib: Allow to skip slower tests

### DIFF
--- a/airbyte-lib/README.md
+++ b/airbyte-lib/README.md
@@ -7,7 +7,7 @@ airbyte-lib is a library that allows to run Airbyte syncs embedded into any Pyth
 - Make sure [Poetry is installed](https://python-poetry.org/docs/#).
 - Run `poetry install`
 - For examples, check out the `examples` folder. They can be run via `poetry run python examples/<example file>`
-- Unit tests and type checks can be run via `poetry run pytest`
+- Unit tests and type checks can be run via `poetry run pytest`. Snowflake and postgres integration tests run a little longer, to do a quick local validation you can skip them by running `poetry run pytest -m "not slow"`
 
 ## Release
 

--- a/airbyte-lib/pyproject.toml
+++ b/airbyte-lib/pyproject.toml
@@ -53,7 +53,10 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-# addopts = "--mypy"  # FIXME: This sometimes blocks test discovery and execution
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+
 
 [tool.ruff.pylint]
 max-args = 8  # Relaxed from default of 5

--- a/airbyte-lib/tests/integration_tests/test_source_faker_integration.py
+++ b/airbyte-lib/tests/integration_tests/test_source_faker_integration.py
@@ -122,16 +122,19 @@ def postgres_cache(new_pg_cache_config) -> Generator[caches.PostgresCache, None,
 
 @pytest.fixture
 def all_cache_types(
+    request,
     duckdb_cache: ab.DuckDBCache,
-    snowflake_cache: ab.SnowflakeCache,
-    postgres_cache: ab.PostgresCache,
 ):
-    _ = postgres_cache
-    return [
-        duckdb_cache,
-        postgres_cache,
-        # snowflake_cache,  # Snowflake works, but is slow and expensive to test. # TODO: Re-enable.
-    ]
+    if 'not slow' in request.config.getoption("-m"):
+        # Return only duckdb_cache if 'slow' tests are excluded
+        return [duckdb_cache]
+    else:
+        # Return all caches otherwise
+        return [
+            duckdb_cache,
+            request.getfixturevalue("postgres_cache"),
+            # request.getfixturevalue("snowflake_cache"),  # Snowflake works, but is very slow and expensive to test. # TODO: Re-enable.
+        ]
 
 
 def test_faker_pks(

--- a/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
+++ b/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
@@ -648,6 +648,7 @@ def test_sync_to_postgres(new_pg_cache_config: PostgresCacheConfig, expected_tes
             check_dtype=False,
         )
 
+@pytest.mark.slow
 def test_sync_to_snowflake(snowflake_config: SnowflakeCacheConfig, expected_test_stream_data: dict[str, list[dict[str, str | int]]]):
     source = ab.get_connector("source-test", config={"apiKey": "test"})
     cache = SnowflakeSQLCache(config=snowflake_config)


### PR DESCRIPTION
I always let the tests run locally to validate things after a change. However, the tests currently take 1.5 minutes roughly - as half of this is spent with snowflake and postgres tests which usually are not relevant to core library changes (as all sql caches work the same), this PR is flagging some tests so it's easy to skip them via `poetry run pytest -m "not slow"`.

We could also re-arrange our tests and put all the slow ones in one file or so, but this seems like a good strategy for the specific issue.

Without the slow tests, the whole suite takes 45 seconds instead, but gives mostly the same guarantees as there are extensive integration tests with duckdb.