### PR TITLE
S3 and Google Analytics v4: Enable pypi publishing

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -22,8 +22,7 @@ data:
   name: Google Analytics (Universal Analytics)
   remoteRegistries:
     pypi:
-      enabled: false
-      # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
+      enabled: true
       packageName: airbyte-source-google-analytics-v4
   registries:
     cloud:

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -19,8 +19,7 @@ data:
   name: S3
   remoteRegistries:
     pypi:
-      enabled: false
-      # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
+      enabled: true
       packageName: airbyte-source-s3
   registries:
     cloud:


### PR DESCRIPTION
As CI tests seem to pass again, this PR enables pypi publishing for S3 and Google Analytics