### PR TITLE
✨ Source Google Analytics Data API: Add spec parameter to convert `conversions:purchase` to float

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.2.2
+  dockerImageTag: 2.3.0
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -213,6 +213,10 @@ class GoogleAnalyticsDataApiBaseStream(GoogleAnalyticsDataApiAbstractStream):
             }
         )
 
+        # change the type of `conversions:purchase` metric from int to float: https://github.com/airbytehq/oncall/issues/4130
+        if self.config.get("convert_conversions_purchase", False) and "conversions:purchase" in schema["properties"]:
+            schema["properties"]["conversions:purchase"]["type"] = ["null", "float"]
+
         return schema
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
@@ -250,6 +254,10 @@ class GoogleAnalyticsDataApiBaseStream(GoogleAnalyticsDataApiAbstractStream):
         dimensions = [h.get("name") for h in r.get("dimensionHeaders", [{}])]
         metrics = [h.get("name") for h in r.get("metricHeaders", [{}])]
         metrics_type_map = {h.get("name"): h.get("type") for h in r.get("metricHeaders", [{}]) if "name" in h}
+
+        # change the type of `conversions:purchase` metric from int to float: https://github.com/airbytehq/oncall/issues/4130
+        if self.config.get("convert_conversions_purchase", False) and "conversions:purchase" in metrics_type_map:
+            metrics_type_map["conversions:purchase"] = "TYPE_FLOAT"
 
         for row in r.get("rows", []):
             record = {

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/spec.json
@@ -2242,6 +2242,13 @@
         "description": "If false, each row with all metrics equal to 0 will not be returned. If true, these rows will be returned if they are not separately removed by a filter. More information is available in <a href=\"https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport#request-body\">the documentation</a>.",
         "default": false,
         "order": 6
+      },
+      "convert_conversions_purchase": {
+        "type": "boolean",
+        "title": "Convert `conversions:purchase` Metric to Float",
+        "description": "Determines whether the `conversions:purchase` metric, typically returned as an integer, should be converted to a float to prevent rounding. This option is useful if you're encountering issues with the API returning float values for the `conversions:purchase` field.",
+        "default": false,
+        "order": 7
       }
     }
   },

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -264,6 +264,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------|
+| 2.3.0   | 2024-02-06 | [34907](https://github.com/airbytehq/airbyte/pull/34907) | Add new parameter to spec to convert `conversions:purchase` field to float      |
 | 2.2.2   | 2024-02-01 | [34708](https://github.com/airbytehq/airbyte/pull/34708) | Add rounding integer values that may be float                                   |
 | 2.2.1   | 2024-01-18 | [34352](https://github.com/airbytehq/airbyte/pull/34352) | Add incorrect custom reports config handling                                    |
 | 2.2.0   | 2024-01-10 | [34176](https://github.com/airbytehq/airbyte/pull/34176) | Add a report option keepEmptyRows                                               |


### PR DESCRIPTION
## What
This PR introduces the option to convert the `conversions:purchase` column to a float type. This change addresses the issue documented in https://github.com/airbytehq/oncall/issues/4130.

## How
For some users, Google Analytics API returns float values for the `conversions:purchase` column, which is expected to be an integer. To mitigate data discrepancies caused by rounding float values to integers in the previous connector version, this update introduces a new specification parameter, `convert_conversions_purchase`. When activated, this parameter ensures the `conversions:purchase` column is treated as a float, preserving the accuracy of the data returned by the API.