### PR TITLE
CDK: fix flaky scenario-based tests by sorting on k & v

### DIFF
--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -81,11 +81,11 @@ def _verify_read_output(output: EntrypointOutput, scenario: TestScenario[Abstrac
 
     sorted_expected_records = sorted(
         filter(lambda e: "data" in e, expected_records),
-        key=lambda x: ",".join(f"{k}={v}" for k, v in sorted(x["data"].items(), key=lambda x: (x[0], x[1])) if k != "emitted_at"),
+        key=lambda record: ",".join(f"{k}={v}" for k, v in sorted(record["data"].items(), key=lambda items: (items[0], items[1])) if k != "emitted_at"),
     )
     sorted_records = sorted(
         filter(lambda r: r.record, records),
-        key=lambda x: ",".join(f"{k}={v}" for k, v in sorted(x.record.data.items(), key=lambda x: (x[0], x[1])) if k != "emitted_at"),
+        key=lambda record: ",".join(f"{k}={v}" for k, v in sorted(record.record.data.items(), key=lambda items: (items[0], items[1])) if k != "emitted_at"),
     )
     for actual, expected in zip(sorted_records, sorted_expected_records):
         if actual.record:

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -81,11 +81,11 @@ def _verify_read_output(output: EntrypointOutput, scenario: TestScenario[Abstrac
 
     sorted_expected_records = sorted(
         filter(lambda e: "data" in e, expected_records),
-        key=lambda x: ",".join(f"{k}={v}" for k, v in sorted(x["data"].items(), key=lambda x: x[0]) if k != "emitted_at"),
+        key=lambda x: ",".join(f"{k}={v}" for k, v in sorted(x["data"].items(), key=lambda x: (x[0], x[1])) if k != "emitted_at"),
     )
     sorted_records = sorted(
         filter(lambda r: r.record, records),
-        key=lambda x: ",".join(f"{k}={v}" for k, v in sorted(x.record.data.items(), key=lambda x: x[0]) if k != "emitted_at"),
+        key=lambda x: ",".join(f"{k}={v}" for k, v in sorted(x.record.data.items(), key=lambda x: (x[0], x[1])) if k != "emitted_at"),
     )
     for actual, expected in zip(sorted_records, sorted_expected_records):
         if actual.record:


### PR DESCRIPTION
Fixes a scenario-based test that appears to be flaky due to streams being processed in an unexpected order. (I was not able to repro the failures locally but examples in CI are [here](https://github.com/airbytehq/airbyte/actions/runs/7787685739/job/21235468214) and [here](https://github.com/airbytehq/airbyte/actions/runs/7799159847/job/21269442120).)