### PR TITLE
File-based CDK: log warning on no sync mode instead of raising exception

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_source.py
@@ -182,7 +182,7 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
             for catalog_stream in self.catalog.streams:
                 if stream.name == catalog_stream.stream.name:
                     return catalog_stream.sync_mode
-            raise RuntimeError(f"No sync mode was found for {stream.name}.")
+            self.logger.warning(f"No sync mode was found for {stream.name}.")
         return None
 
     def read(


### PR DESCRIPTION
If the sync mode isn't set, just return a normal stream.

We weren't previously requiring `SyncMode` to be set for every stream so this more is consistent with prior behavior.

Fixes https://airbytehq.sentry.io/issues/4946215065/?alert_rule_id=11478402&alert_type=issue&notification_uuid=2db8ac52-4e0a-492f-a39d-0b79e7c0f1a3&project=6527718&referrer=slack.