### PR TITLE
File based sources fix sync mode bug

### DIFF
--- a/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: fdaaba68-4875-4ed9-8fcd-4ae1e0a25093
-  dockerImageTag: 0.3.3
+  dockerImageTag: 0.3.4
   dockerRepository: airbyte/source-azure-blob-storage
   documentationUrl: https://docs.airbyte.com/integrations/sources/azure-blob-storage
   githubIssueLabel: source-azure-blob-storage

--- a/airbyte-integrations/connectors/source-azure-blob-storage/setup.py
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk[file-based]>=0.60.1",
+    "airbyte-cdk[file-based]>=0.61.0",
     "smart_open[azure]",
     "pytz",
 ]

--- a/airbyte-integrations/connectors/source-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gcs/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 2a8c41ae-8c23-4be0-a73f-2ab10ca1a820
-  dockerImageTag: 0.3.6
+  dockerImageTag: 0.3.7
   dockerRepository: airbyte/source-gcs
   documentationUrl: https://docs.airbyte.com/integrations/sources/gcs
   githubIssueLabel: source-gcs

--- a/airbyte-integrations/connectors/source-gcs/setup.py
+++ b/airbyte-integrations/connectors/source-gcs/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk[file-based]>=0.60.1",
+    "airbyte-cdk[file-based]>=0.61.0",
     "google-cloud-storage==2.12.0",
     "smart-open[s3]==5.1.0",
     "pandas==1.5.3",

--- a/airbyte-integrations/connectors/source-google-drive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-drive/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 9f8dda77-1048-4368-815b-269bf54ee9b8
-  dockerImageTag: 0.0.8
+  dockerImageTag: 0.0.9
   dockerRepository: airbyte/source-google-drive
   githubIssueLabel: source-google-drive
   icon: google-drive.svg

--- a/airbyte-integrations/connectors/source-google-drive/setup.py
+++ b/airbyte-integrations/connectors/source-google-drive/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk[file-based]>=0.60.1",
+    "airbyte-cdk[file-based]>=0.61.0",
     "google-api-python-client==2.104.0",
     "google-auth-httplib2==0.1.1",
     "google-auth-oauthlib==1.1.0",

--- a/airbyte-integrations/connectors/source-microsoft-onedrive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-onedrive/metadata.yaml
@@ -20,7 +20,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 01d1c685-fd4a-4837-8f4c-93fe5a0d2188
-  dockerImageTag: 0.1.5
+  dockerImageTag: 0.1.6
   dockerRepository: airbyte/source-microsoft-onedrive
   githubIssueLabel: source-microsoft-onedrive
   icon: microsoft-onedrive.svg

--- a/airbyte-integrations/connectors/source-microsoft-onedrive/setup.py
+++ b/airbyte-integrations/connectors/source-microsoft-onedrive/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk[file-based]>=0.60.1",
+    "airbyte-cdk[file-based]>=0.61.0",
     "msal~=1.25.0",
     "Office365-REST-Python-Client~=2.5.2",
     "smart-open~=6.4.0",

--- a/docs/integrations/sources/azure-blob-storage.md
+++ b/docs/integrations/sources/azure-blob-storage.md
@@ -193,6 +193,7 @@ To perform the text extraction from PDF and Docx files, the connector uses the [
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
+| 0.3.4   | 2024-02-06 | [34936](https://github.com/airbytehq/airbyte/pull/34936)  | Bump CDK version to avoid missing SyncMode errors                                            |
 | 0.3.3   | 2024-01-30 | [34681](https://github.com/airbytehq/airbyte/pull/34681)  | Unpin CDK version to make compatible with the Concurrent CDK                                 |
 | 0.3.2   | 2024-01-30 | [34661](https://github.com/airbytehq/airbyte/pull/34661)  | Pin CDK version until upgrade for compatibility with the Concurrent CDK                      |
 | 0.3.1   | 2024-01-10 | [34084](https://github.com/airbytehq/airbyte/pull/34084)  | Fix bug for running check with document file format                                          |

--- a/docs/integrations/sources/gcs.md
+++ b/docs/integrations/sources/gcs.md
@@ -148,6 +148,7 @@ Leaving this field blank (default option) will disallow escaping.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------|
+| 0.3.7   | 2024-02-06 | [34936](https://github.com/airbytehq/airbyte/pull/34936)  | Bump CDK version to avoid missing SyncMode errors                           |
 | 0.3.6   | 2024-01-30 | [34681](https://github.com/airbytehq/airbyte/pull/34681)  | Unpin CDK version to make compatible with the Concurrent CDK                           |
 | 0.3.5   | 2024-01-30 | [34661](https://github.com/airbytehq/airbyte/pull/34661)  | Pin CDK version until upgrade for compatibility with the Concurrent CDK                |
 | 0.3.4   | 2024-01-11 | [34158](https://github.com/airbytehq/airbyte/pull/34158) | Fix issue in stream reader for document file type parser                               |

--- a/docs/integrations/sources/google-drive.md
+++ b/docs/integrations/sources/google-drive.md
@@ -247,6 +247,7 @@ Before parsing each document, the connector exports Google Document files to Doc
 
 | Version | Date       | Pull Request                                              | Subject                                                      |
 |---------|------------|-----------------------------------------------------------|--------------------------------------------------------------|
+| 0.0.9   | 2024-02-06 | [34936](https://github.com/airbytehq/airbyte/pull/34936)  | Bump CDK version to avoid missing SyncMode errors                      |
 | 0.0.8   | 2024-01-30 | [34681](https://github.com/airbytehq/airbyte/pull/34681)  | Unpin CDK version to make compatible with the Concurrent CDK                      |
 | 0.0.7   | 2024-01-30 | [34661](https://github.com/airbytehq/airbyte/pull/34661)  | Pin CDK version until upgrade for compatibility with the Concurrent CDK                      |
 | 0.0.6   | 2023-12-16 | [33414](https://github.com/airbytehq/airbyte/pull/33414) | Prepare for airbyte-lib |

--- a/docs/integrations/sources/microsoft-onedrive.md
+++ b/docs/integrations/sources/microsoft-onedrive.md
@@ -121,6 +121,7 @@ The connector is restricted by normal Microsoft Graph [requests limitation](http
 
 | Version | Date       | Pull Request                                             | Subject                   |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------|
+| 0.1.6   | 2024-02-06 | [34936](https://github.com/airbytehq/airbyte/pull/34936)  | Bump CDK version to avoid missing SyncMode errors                      |
 | 0.1.5   | 2024-01-30 | [34681](https://github.com/airbytehq/airbyte/pull/34681)  | Unpin CDK version to make compatible with the Concurrent CDK                      |
 | 0.1.4   | 2024-01-30 | [34661](https://github.com/airbytehq/airbyte/pull/34661)  | Pin CDK version until upgrade for compatibility with the Concurrent CDK                      |
 | 0.1.3   | 2024-01-24 | [34478](https://github.com/airbytehq/airbyte/pull/34478) | Fix OAuth                 |


### PR DESCRIPTION
Bumps the CDK version for file-based sources.

An issue was identified with the S3 connector where some invocations of the `stream` command were erroring because they had a catalog but no `SyncMode`.

This issue hasn't been seen in any other connectors, but I'm bumping the version as a precaution.