### PR TITLE
fix version of airbyte-cdk in Dockerfile pip install

### DIFF
--- a/airbyte-cdk/python/Dockerfile
+++ b/airbyte-cdk/python/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache upgrade \
     && apk --no-cache add tzdata build-base
 
 # install airbyte-cdk
-RUN pip install --prefix=/install airbyte-cdk==0.58.5
+RUN pip install --prefix=/install airbyte-cdk==0.61.0
 
 # build a clean environment
 FROM base


### PR DESCRIPTION
## What
The [.bumpversion.cfg file](https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/.bumpversion.cfg) in `airbyte-cdk/python` usually handles bumping the version of the airbyte-cdk used in [this](https://github.com/airbytehq/airbyte/blob/58de015de449f753f010d5c4173b64ddd68429b9/airbyte-cdk/python/Dockerfile#L13) `RUN pip install` line of the airbyte-cdk Dockerfile.

However, the CDK version seems to have been manually bumped in [this PR](https://github.com/airbytehq/airbyte/pull/32589), and that line was missed in this manual change.

This caused that line to be left 1 version behind, and since then the `bumpversion` script has not modified that line on future version bump commits because it didn't match the current cdk version from that point forward.

The effect of this is that [this platform PR](https://github.com/airbytehq/airbyte-platform-internal/pull/10285) to update the CDK version used in the platform cannot succeed, as the old CDK version is still being used by the declarative source image, so builder connectors never pass the `check` command as their manifest version is larger than the CDK version in the declarative source image.

## How
This PR fixes the issue for future CDK version bumps by updating the version in that line to match the current version.

It is unclear if this change alone will fix the platform PR linked above - that may require a republishing of the airbyte CDK image.
