### PR TITLE
Docs reference: Fix bug with hidden array item properties

### DIFF
--- a/docusaurus/src/components/SpecSchema.jsx
+++ b/docusaurus/src/components/SpecSchema.jsx
@@ -19,6 +19,9 @@ export const SpecSchema = ({
 function JSONSchemaViewer(props) {
   return <div>
     <Heading as="h4">Config fields reference</Heading>
+    <pre>
+      {JSON.stringify(props.schema, null, 2)}
+    </pre>
     <div class={styles.grid}>
       <div class={className(styles.headerItem, styles.tableHeader)}>
         Field
@@ -83,11 +86,11 @@ function isObjectArray(schema) {
 }
 
 function showCollapsible(schema) {
-  return (schema.type === "array" && schema.items && schema.items.type !== "object") || (schema.type === "object" && schema.properties) || showDescription(schema)
+  return (schema.type === "object" && schema.properties) || showDescription(schema)
 }
 
 function showDescription(schema) {
-  return typeof schema.default !== "undefined" || schema.pattern || schema.examples || schema.description || isOneOf(schema);
+  return typeof schema.default !== "undefined" || schema.pattern || schema.examples || schema.description || isOneOf(schema) || (schema.type === "array" && schema.items && schema.items.type === "object");
 }
 
 function getIndentStyle(depth) {

--- a/docusaurus/src/components/SpecSchema.jsx
+++ b/docusaurus/src/components/SpecSchema.jsx
@@ -19,9 +19,6 @@ export const SpecSchema = ({
 function JSONSchemaViewer(props) {
   return <div>
     <Heading as="h4">Config fields reference</Heading>
-    <pre>
-      {JSON.stringify(props.schema, null, 2)}
-    </pre>
     <div class={styles.grid}>
       <div class={className(styles.headerItem, styles.tableHeader)}>
         Field


### PR DESCRIPTION
This PR fixes the issue of an array of object field without description not rendering the item properties.

Old:
<img width="999" alt="Screenshot 2024-02-07 at 11 15 52" src="https://github.com/airbytehq/airbyte/assets/1508364/4e463984-4166-47f8-a7bb-f719ecb74e7b">

New:
<img width="1015" alt="Screenshot 2024-02-07 at 11 14 45" src="https://github.com/airbytehq/airbyte/assets/1508364/23030666-d6e6-4815-b287-85438de146e8">

