### PR TITLE
airbyte-lib: Fix telemetry for streaming

### DIFF
--- a/airbyte-lib/airbyte_lib/source.py
+++ b/airbyte-lib/airbyte_lib/source.py
@@ -407,6 +407,8 @@ class Source:
         """
         source_tracking_information = self.executor.get_telemetry_info()
         send_telemetry(source_tracking_information, cache_info, SyncState.STARTED)
+        sync_failed = False
+        self._processed_records = 0  # Reset the counter before we start
         try:
             with as_temp_files(
                 [self._config, catalog.json(), json.dumps(state) if state else "[]"]
@@ -430,14 +432,16 @@ class Source:
             send_telemetry(
                 source_tracking_information, cache_info, SyncState.FAILED, self._processed_records
             )
+            sync_failed = True
             raise
         finally:
-            send_telemetry(
-                source_tracking_information,
-                cache_info,
-                SyncState.SUCCEEDED,
-                self._processed_records,
-            )
+            if not sync_failed:
+                send_telemetry(
+                    source_tracking_information,
+                    cache_info,
+                    SyncState.SUCCEEDED,
+                    self._processed_records,
+                )
 
     def _add_to_logs(self, message: str) -> None:
         self._last_log_messages.append(message)
@@ -460,11 +464,13 @@ class Source:
             for line in self.executor.execute(args):
                 try:
                     message = AirbyteMessage.parse_raw(line)
-                    yield message
+                    if message.type is Type.RECORD:
+                        self._processed_records += 1
                     if message.type == Type.LOG:
                         self._add_to_logs(message.log.message)
                     if message.type == Type.TRACE and message.trace.type == TraceType.ERROR:
                         self._add_to_logs(message.trace.error.message)
+                    yield message
                 except Exception:
                     self._add_to_logs(line)
         except Exception as e:
@@ -481,8 +487,6 @@ class Source:
         progress.reset(len(self._selected_stream_names or []))
 
         for message in messages:
-            if message.type is Type.RECORD:
-                self._processed_records += 1
             yield message
             progress.log_records_read(self._processed_records)
 

--- a/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
+++ b/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
@@ -3,7 +3,8 @@
 from collections.abc import Mapping
 import os
 import shutil
-import subprocess
+import itertools
+from contextlib import nullcontext as does_not_raise
 from typing import Any
 from unittest.mock import Mock, call, patch
 import tempfile
@@ -559,16 +560,30 @@ def test_airbyte_lib_version() -> None:
 @patch('airbyte_lib.telemetry.requests')
 @patch('airbyte_lib.telemetry.datetime')
 @pytest.mark.parametrize(
-    "raises, api_key, expected_state, expected_number_of_records, request_call_fails, extra_env, expected_flags",
+    "raises, api_key, expected_state, expected_number_of_records, request_call_fails, extra_env, expected_flags, cache_type, number_of_records_read",
     [
-        pytest.param(True, "test_fail_during_sync", "failed", 1, False, {"CI": ""}, {"CI": False}, id="fail_during_sync"),
-        pytest.param(False, "test", "succeeded", 3, False, {"CI": ""}, {"CI": False}, id="succeed_during_sync"),
-        pytest.param(False, "test", "succeeded", 3, True, {"CI": ""}, {"CI": False}, id="fail_request_without_propagating"),
-        pytest.param(False, "test", "succeeded", 3, False, {"CI": ""}, {"CI": False}, id="falsy_ci_flag"),
-        pytest.param(False, "test", "succeeded", 3, False, {"CI": "true"}, {"CI": True}, id="truthy_ci_flag"),
+        pytest.param(pytest.raises(Exception), "test_fail_during_sync", "failed", 1, False, {"CI": ""}, {"CI": False}, "duckdb", None, id="fail_during_sync"),
+        pytest.param(does_not_raise(), "test", "succeeded", 3, False, {"CI": ""}, {"CI": False}, "duckdb", None, id="succeed_during_sync"),
+        pytest.param(does_not_raise(), "test", "succeeded", 3, True, {"CI": ""}, {"CI": False}, "duckdb", None,id="fail_request_without_propagating"),
+        pytest.param(does_not_raise(), "test", "succeeded", 3, False, {"CI": ""}, {"CI": False}, "duckdb", None,id="falsy_ci_flag"),
+        pytest.param(does_not_raise(), "test", "succeeded", 3, False, {"CI": "true"}, {"CI": True}, "duckdb", None,id="truthy_ci_flag"),
+        pytest.param(pytest.raises(Exception), "test_fail_during_sync", "failed", 1,  False, {"CI": ""}, {"CI": False}, "streaming", 3, id="streaming_fail_during_sync"),
+        pytest.param(does_not_raise(), "test", "succeeded", 2,  False, {"CI": ""}, {"CI": False}, "streaming", 2, id="streaming_succeed"),
+        pytest.param(does_not_raise(), "test", "succeeded", 1,  False, {"CI": ""}, {"CI": False}, "streaming", 1, id="streaming_partial_read"),
     ],
 )
-def test_tracking(mock_datetime: Mock, mock_requests: Mock, raises: bool, api_key: str, expected_state: str, expected_number_of_records: int, request_call_fails: bool, extra_env: dict[str, str], expected_flags: dict[str, bool]):
+def test_tracking(
+    mock_datetime: Mock,
+    mock_requests: Mock,
+    raises, api_key: str,
+    expected_state: str,
+    expected_number_of_records: int,
+    request_call_fails: bool,
+    extra_env: dict[str, str],
+    expected_flags: dict[str, bool],
+    cache_type: str, 
+    number_of_records_read: int
+):
     """
     Test that the telemetry is sent when the sync is successful.
     This is done by mocking the requests.post method and checking that it is called with the right arguments.
@@ -588,12 +603,11 @@ def test_tracking(mock_datetime: Mock, mock_requests: Mock, raises: bool, api_ke
         mock_post.side_effect = Exception("test exception")
 
     with patch.dict('os.environ', extra_env):
-        if raises:
-            with pytest.raises(Exception):
+        with raises:
+            if cache_type == "streaming":
+                list(itertools.islice(source.get_records("stream1"), number_of_records_read))
+            else:
                 source.read(cache)
-        else:
-            source.read(cache)
-
 
     mock_post.assert_has_calls([
             call("https://api.segment.io/v1/track",
@@ -605,7 +619,7 @@ def test_tracking(mock_datetime: Mock, mock_requests: Mock, raises: bool, api_ke
                     "version": get_version(),
                     "source": {'name': 'source-test', 'version': '0.0.1', 'type': 'venv'},
                     "state": "started",
-                    "cache": {"type": "duckdb"},
+                    "cache": {"type": cache_type},
                     "ip": "0.0.0.0",
                     "flags": expected_flags
                 },
@@ -623,7 +637,7 @@ def test_tracking(mock_datetime: Mock, mock_requests: Mock, raises: bool, api_ke
                     "source": {'name': 'source-test', 'version': '0.0.1', 'type': 'venv'},
                     "state": expected_state,
                     "number_of_records": expected_number_of_records,
-                    "cache": {"type": "duckdb"},
+                    "cache": {"type": cache_type},
                     "ip": "0.0.0.0",
                     "flags": expected_flags
                 },


### PR DESCRIPTION
As discussed, currently telemetry has the following issues:
* Even for failed syncs, a success event is tracked
* Number of records is not tracked when `get_records` is used

This PR fixes both problems:
* Make sure the record counter is always increased, no matter whether the records are sent to the cache or not by moving it into the generic `_execute` method
* Make sure the success event is only tracked if no failure event is tracked for a single sync call

This also works if `get_records` doesn't exhaust the record iterator - if it falls out of scope before all records are read, it will be considered a successful sync with the number of records that have been fetched so far.

