### PR TITLE
AirbyteLib: Require stream selection

### DIFF
--- a/airbyte-lib/airbyte_lib/_factories/connector_factories.py
+++ b/airbyte-lib/airbyte_lib/_factories/connector_factories.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import shutil
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +10,32 @@ from airbyte_lib import exceptions as exc
 from airbyte_lib._executor import PathExecutor, VenvExecutor
 from airbyte_lib.registry import ConnectorMetadata, get_connector_metadata
 from airbyte_lib.source import Source
+
+
+def get_connector(
+    name: str,
+    config: dict[str, Any] | None = None,
+    *,
+    version: str | None = None,
+    pip_url: str | None = None,
+    local_executable: Path | str | None = None,
+    install_if_missing: bool = True,
+) -> Source:
+    """Deprecated. Use get_source instead."""
+    warnings.warn(
+        "The `get_connector()` function is deprecated and will be removed in a future version."
+        "Please use `get_source()` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_source(
+        name=name,
+        config=config,
+        version=version,
+        pip_url=pip_url,
+        local_executable=local_executable,
+        install_if_missing=install_if_missing,
+    )
 
 
 def get_source(

--- a/airbyte-lib/airbyte_lib/exceptions.py
+++ b/airbyte-lib/airbyte_lib/exceptions.py
@@ -134,6 +134,17 @@ class AirbyteLibInputError(AirbyteError, ValueError):
     input_value: str | None = None
 
 
+class AirbyteLibNoStreamsSelectedError(AirbyteLibInputError):
+    """No streams were selected for the source."""
+
+    guidance = (
+        "Please call `select_streams()` to select at least one stream from the list provided. "
+        "You can also call `select_all_streams()` to select all available streams for this source."
+    )
+    connector_name: str | None = None
+    available_streams: list[str] | None = None
+
+
 # AirbyteLib Cache Errors
 
 

--- a/airbyte-lib/airbyte_lib/exceptions.py
+++ b/airbyte-lib/airbyte_lib/exceptions.py
@@ -134,6 +134,7 @@ class AirbyteLibInputError(AirbyteError, ValueError):
     input_value: str | None = None
 
 
+@dataclass
 class AirbyteLibNoStreamsSelectedError(AirbyteLibInputError):
     """No streams were selected for the source."""
 

--- a/airbyte-lib/docs/generated/airbyte_lib.html
+++ b/airbyte-lib/docs/generated/airbyte_lib.html
@@ -568,13 +568,45 @@ methods except for __getitem__, __iter__, and __len__.</p>
     </div>
     <a class="headerlink" href="#Source.set_streams"></a>
     
-            <div class="docstring"><p>Optionally, select the stream names that should be read from the connector.</p>
+            <div class="docstring"><p>Deprecated. See select_streams().</p>
+</div>
+
+
+                            </div>
+                            <div id="Source.select_all_streams" class="classattr">
+                                <div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">select_all_streams</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">) -> <span class="kc">None</span>:</span></span>
+
+        
+    </div>
+    <a class="headerlink" href="#Source.select_all_streams"></a>
+    
+            <div class="docstring"><p>Select all streams.</p>
+
+<p>This is a more streamlined equivalent to:</p>
+
+<blockquote>
+  <p>source.select_streams(source.get_available_streams()).</p>
+</blockquote>
+</div>
+
+
+                            </div>
+                            <div id="Source.select_streams" class="classattr">
+                                <div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">select_streams</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span>, </span><span class="param"><span class="n">streams</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span></span><span class="return-annotation">) -> <span class="kc">None</span>:</span></span>
+
+        
+    </div>
+    <a class="headerlink" href="#Source.select_streams"></a>
+    
+            <div class="docstring"><p>Select the stream names that should be read from the connector.</p>
 
 <p>Currently, if this is not set, all streams will be read.</p>
-
-<p>TODO: In the future if not set, the default behavior may exclude streams which the connector
-would default to disabled. (For instance, streams that require a premium license
-are sometimes disabled by default within the connector.)</p>
 </div>
 
 
@@ -591,7 +623,7 @@ are sometimes disabled by default within the connector.)</p>
     
             <div class="docstring"><p>Get the selected streams.</p>
 
-<p>If no streams are selected, return all available streams.</p>
+<p>If no streams are selected, return an empty list.</p>
 </div>
 
 

--- a/airbyte-lib/examples/run_faker.py
+++ b/airbyte-lib/examples/run_faker.py
@@ -26,7 +26,7 @@ source = ab.get_source(
 )
 print("Faker source installed.")
 source.check()
-source.set_streams(["products", "users", "purchases"])
+source.select_streams(["products", "users", "purchases"])
 
 result = source.read()
 

--- a/airbyte-lib/examples/run_github.py
+++ b/airbyte-lib/examples/run_github.py
@@ -24,7 +24,7 @@ source.set_config(
     }
 )
 source.check()
-source.set_streams(["issues", "pull_requests", "commits"])
+source.select_streams(["issues", "pull_requests", "commits"])
 
 result = source.read()
 

--- a/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
+++ b/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
@@ -184,6 +184,7 @@ def test_file_write_and_cleanup() -> None:
         cache_wo_cleanup = ab.new_local_cache(cache_dir=temp_dir_2, cleanup=False)
 
         source = ab.get_source("source-test", config={"apiKey": "test"})
+        source.select_all_streams()
 
         _ = source.read(cache_w_cleanup)
         _ = source.read(cache_wo_cleanup)
@@ -207,6 +208,8 @@ def assert_cache_data(expected_test_stream_data: dict[str, list[dict[str, str | 
 
 def test_sync_to_duckdb(expected_test_stream_data: dict[str, list[dict[str, str | int]]]):
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
+
     cache = ab.new_local_cache()
 
     result: ReadResult = source.read(cache)
@@ -217,6 +220,7 @@ def test_sync_to_duckdb(expected_test_stream_data: dict[str, list[dict[str, str 
 
 def test_read_result_mapping():
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
     result: ReadResult = source.read(ab.new_local_cache())
     assert len(result) == 2
     assert isinstance(result, Mapping)
@@ -228,6 +232,8 @@ def test_read_result_mapping():
 
 def test_dataset_list_and_len(expected_test_stream_data):
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
+
     result: ReadResult = source.read(ab.new_local_cache())
     stream_1 = result["stream1"]
     assert len(stream_1) == 2
@@ -250,6 +256,8 @@ def test_read_from_cache(expected_test_stream_data: dict[str, list[dict[str, str
     """
     cache_name = str(ulid.ULID())
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
+
     cache = ab.new_local_cache(cache_name)
 
     source.read(cache)
@@ -268,6 +276,7 @@ def test_read_isolated_by_prefix(expected_test_stream_data: dict[str, list[dict[
     cache_name = str(ulid.ULID())
     db_path = Path(f"./.cache/{cache_name}.duckdb")
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
     cache = ab.DuckDBCache(config=ab.DuckDBCacheConfig(db_path=db_path, table_prefix="prefix_"))
 
     source.read(cache)
@@ -325,6 +334,8 @@ def test_merge_streams_in_cache(expected_test_stream_data: dict[str, list[dict[s
 
 def test_read_result_as_list(expected_test_stream_data: dict[str, list[dict[str, str | int]]]):
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
+
     cache = ab.new_local_cache()
 
     result: ReadResult = source.read(cache)
@@ -354,6 +365,8 @@ def test_sync_with_merge_to_duckdb(expected_test_stream_data: dict[str, list[dic
     # TODO: Add a check with a primary key to ensure that the merge strategy works as expected.
     """
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
+
     cache = ab.new_local_cache()
 
     # Read twice to test merge strategy
@@ -373,6 +386,8 @@ def test_cached_dataset(
     expected_test_stream_data: dict[str, list[dict[str, str | int]]],
 ) -> None:
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
+
     result: ReadResult = source.read(ab.new_local_cache())
 
     stream_name = "stream1"
@@ -435,6 +450,8 @@ def test_cached_dataset(
 
 def test_cached_dataset_filter():
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
+
     result: ReadResult = source.read(ab.new_local_cache())
 
     stream_name = "stream1"
@@ -532,6 +549,8 @@ def test_sync_with_merge_to_postgres(new_pg_cache_config: PostgresCacheConfig, e
     # TODO: Add a check with a primary key to ensure that the merge strategy works as expected.
     """
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
+
     cache = PostgresCache(config=new_pg_cache_config)
 
     # Read twice to test merge strategy
@@ -582,6 +601,8 @@ def test_tracking(mock_datetime: Mock, mock_requests: Mock, raises: bool, api_ke
     mock_requests.post = mock_post
 
     source = ab.get_source("source-test", config={"apiKey": api_key})
+    source.select_all_streams()
+
     cache = ab.new_local_cache()
 
     if request_call_fails:
@@ -635,6 +656,8 @@ def test_tracking(mock_datetime: Mock, mock_requests: Mock, raises: bool, api_ke
 
 def test_sync_to_postgres(new_pg_cache_config: PostgresCacheConfig, expected_test_stream_data: dict[str, list[dict[str, str | int]]]):
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
+
     cache = PostgresCache(config=new_pg_cache_config)
 
     result: ReadResult = source.read(cache)
@@ -649,6 +672,8 @@ def test_sync_to_postgres(new_pg_cache_config: PostgresCacheConfig, expected_tes
 
 def test_sync_to_snowflake(snowflake_config: SnowflakeCacheConfig, expected_test_stream_data: dict[str, list[dict[str, str | int]]]):
     source = ab.get_source("source-test", config={"apiKey": "test"})
+    source.select_all_streams()
+
     cache = SnowflakeSQLCache(config=snowflake_config)
 
     with cache.get_sql_connection() as con:

--- a/docs/using-airbyte/airbyte-lib/getting-started.mdx
+++ b/docs/using-airbyte/airbyte-lib/getting-started.mdx
@@ -29,6 +29,7 @@ source = ab.get_source(
     install_if_missing=True,
 )
 source.check()
+source.select_all_streams()
 result = source.read()
 
 for name, records in result.streams.items():


### PR DESCRIPTION
With this change, users will be directed to call "select_streams()" or "select_all_streams()" if they attempt to call "source.read()" without having already done so.

Resolves:
- https://github.com/airbytehq/airbyte-lib-private-beta/issues/17

This also renames "set_streams()" to "select_streams()" to align with the 'select' verb and 'selected' decriptor used elsewhere.

I've kept 'set_streams()' alive and still works, but it will now emit a `DeprecationWarning` when called, instructing users they should have called  `select_streams()`.

I've also brought back `get_connector()` as an alias of `get_source()` using the same deprecation warning approach.
