### PR TITLE
source-postgres/mysql: fix wrong tags in metadata

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -30,5 +30,4 @@ data:
   supportLevel: certified
   tags:
     - language:java
-    - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -26,5 +26,4 @@ data:
   supportLevel: certified
   tags:
     - language:java
-    - language:python
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
`source-mysql` and `source-postgres` had `language:python` tags...