### PR TITLE
CDK: allow ConnectorStateManager stream_instance_map to take ConfiguredAirbyteStream or Stream

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/connector_state_manager.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/connector_state_manager.py
@@ -38,7 +38,7 @@ class ConnectorStateManager:
 
     def __init__(
         self,
-        stream_instance_map: Mapping[str, AirbyteStream],
+        stream_instance_map: Mapping[str, Union[Stream, AirbyteStream]],
         state: Optional[Union[List[AirbyteStateMessage], MutableMapping[str, Any]]] = None,
     ):
         shared_state, per_stream_states = self._extract_from_state_message(state, stream_instance_map)
@@ -107,7 +107,9 @@ class ConnectorStateManager:
 
     @classmethod
     def _extract_from_state_message(
-        cls, state: Optional[Union[List[AirbyteStateMessage], MutableMapping[str, Any]]], stream_instance_map: Mapping[str, AirbyteStream]
+        cls,
+        state: Optional[Union[List[AirbyteStateMessage], MutableMapping[str, Any]]],
+        stream_instance_map: Mapping[str, Union[Stream, AirbyteStream]],
     ) -> Tuple[Optional[AirbyteStateBlob], MutableMapping[HashableStreamDescriptor, Optional[AirbyteStateBlob]]]:
         """
         Takes an incoming list of state messages or the legacy state format and extracts state attributes according to type
@@ -159,7 +161,7 @@ class ConnectorStateManager:
 
     @staticmethod
     def _create_descriptor_to_stream_state_mapping(
-        state: MutableMapping[str, Any], stream_to_instance_map: Mapping[str, Stream]
+        state: MutableMapping[str, Any], stream_to_instance_map: Mapping[str, Union[Stream, AirbyteStream]]
     ) -> MutableMapping[HashableStreamDescriptor, Optional[AirbyteStateBlob]]:
         """
         Takes incoming state received in the legacy format and transforms it into a mapping of StreamDescriptor to AirbyteStreamState


### PR DESCRIPTION
In https://github.com/airbytehq/airbyte/pull/34540, the `ConnectorStateManager`'s `stream_instance_map` was updated to take `ConfiguredAirbyteStream`s instead of `Stream`s, because at the point where it was being used by the file-based CDK there was a circular dependency that prevented us from having `AirbyteStream`s available.

However, when revisiting https://github.com/airbytehq/airbyte/pull/34716, which updates usages of the ConnectorStateManager, I realized that the methods called by `ConnectorStateManager` exist on both `Stream` and `AirbyteStream`, and so prefer to take the union of the stream types than to have conditional logic that creates a state manager only if a catalog exists, which we'd have to do to update the Stripe connector.