### PR TITLE
🐛 Source Orb: update enrich ledger entry with event stream to pass timeframe bounds

### DIFF
--- a/airbyte-integrations/connectors/source-orb/Dockerfile
+++ b/airbyte-integrations/connectors/source-orb/Dockerfile
@@ -34,5 +34,5 @@ COPY source_orb ./source_orb
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.1.0
+LABEL io.airbyte.version=1.1.1
 LABEL io.airbyte.name=airbyte/source-orb

--- a/airbyte-integrations/connectors/source-orb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orb/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 7f0455fb-4518-4ec0-b7a3-d808bf8081cc
-  dockerImageTag: 1.1.0
+  dockerImageTag: 1.1.1
   dockerRepository: airbyte/source-orb
   githubIssueLabel: source-orb
   icon: orb.svg

--- a/airbyte-integrations/connectors/source-orb/source_orb/source.py
+++ b/airbyte-integrations/connectors/source-orb/source_orb/source.py
@@ -595,9 +595,9 @@ class CreditsLedgerEntries(IncrementalOrbStream):
 
         for entry in ledger_entries:
             maybe_event_id: Optional[str] = entry.get("event_id")
-            min_created_at_timestamp = min(min_created_at_timestamp, pendulum.parse(entry["created_at"]))
-            max_created_at_timestamp = max(max_created_at_timestamp, pendulum.parse(entry["created_at"]))
             if maybe_event_id:
+                min_created_at_timestamp = min(min_created_at_timestamp, pendulum.parse(entry["created_at"]))
+                max_created_at_timestamp = max(max_created_at_timestamp, pendulum.parse(entry["created_at"]))
                 # There can be multiple entries with the same event ID
                 event_id_to_ledger_entries[maybe_event_id] = event_id_to_ledger_entries.get(maybe_event_id, []) + [entry]
 

--- a/airbyte-integrations/connectors/source-orb/source_orb/source.py
+++ b/airbyte-integrations/connectors/source-orb/source_orb/source.py
@@ -591,7 +591,7 @@ class CreditsLedgerEntries(IncrementalOrbStream):
         # to enrich with event metadata.
         event_id_to_ledger_entries = {}
         min_created_at_timestamp = pendulum.now()
-        max_created_at_timestamp = pendulum.from_timestamp(0)
+        max_created_at_timestamp = pendulum.now()
 
         for entry in ledger_entries:
             maybe_event_id: Optional[str] = entry.get("event_id")

--- a/airbyte-integrations/connectors/source-orb/source_orb/source.py
+++ b/airbyte-integrations/connectors/source-orb/source_orb/source.py
@@ -590,8 +590,13 @@ class CreditsLedgerEntries(IncrementalOrbStream):
         # Build up a list of the subset of ledger entries we are expected
         # to enrich with event metadata.
         event_id_to_ledger_entries = {}
+        min_created_at_timestamp = pendulum.now()
+        max_created_at_timestamp = pendulum.from_timestamp(0)
+
         for entry in ledger_entries:
             maybe_event_id: Optional[str] = entry.get("event_id")
+            min_created_at_timestamp = min(min_created_at_timestamp, pendulum.parse(entry["created_at"]))
+            max_created_at_timestamp = max(max_created_at_timestamp, pendulum.parse(entry["created_at"]))
             if maybe_event_id:
                 # There can be multiple entries with the same event ID
                 event_id_to_ledger_entries[maybe_event_id] = event_id_to_ledger_entries.get(maybe_event_id, []) + [entry]
@@ -621,7 +626,11 @@ class CreditsLedgerEntries(IncrementalOrbStream):
 
         # The events endpoint is a `POST` endpoint which expects a list of
         # event_ids to filter on
-        request_filter_json = {"event_ids": list(event_id_to_ledger_entries)}
+        request_filter_json = {
+            "event_ids": list(event_id_to_ledger_entries),
+            "timeframe_start": min_created_at_timestamp.to_iso8601_string(),
+            "timeframe_end": max_created_at_timestamp.add(minutes=1).to_iso8601_string()
+        }
 
         # Prepare request with self._session, which should
         # automatically deal with the authentication header.

--- a/airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py
@@ -256,7 +256,7 @@ def test_credits_ledger_entries_transform_record(mocker):
 @responses.activate
 def test_credits_ledger_entries_no_matching_events(mocker):
     stream = CreditsLedgerEntries(string_event_properties_keys=["ping"])
-    ledger_entries = [{"event_id": "foo-event-id", "entry_type": "decrement"}, {"event_id": "bar-event-id", "entry_type": "decrement"}]
+    ledger_entries = [{"event_id": "foo-event-id", "entry_type": "decrement", "created_at": "2022-02-21T07:00:00+00:00"}, {"event_id": "bar-event-id", "entry_type": "decrement", "created_at": "2022-02-21T07:00:00+00:00"}]
     mock_response = {
         "data": [
             {
@@ -276,8 +276,8 @@ def test_credits_ledger_entries_no_matching_events(mocker):
     # We failed to enrich either event, but still check that the schema was
     # transformed as expected
     assert enriched_entries == [
-        {"event": {"id": "foo-event-id"}, "entry_type": "decrement"},
-        {"event": {"id": "bar-event-id"}, "entry_type": "decrement"},
+        {"event": {"id": "foo-event-id"}, "entry_type": "decrement", "created_at": "2022-02-21T07:00:00+00:00"},
+        {"event": {"id": "bar-event-id"}, "entry_type": "decrement", "created_at": "2022-02-21T07:00:00+00:00"},
     ]
 
 
@@ -300,7 +300,7 @@ def test_credits_ledger_entries_enriches_selected_property_keys(
         string_event_properties_keys=selected_string_property_keys, numeric_event_properties_keys=selected_numeric_property_keys
     )
     original_entry_1 = {"entry_type": "increment"}
-    ledger_entries = [{"event_id": "foo-event-id", "entry_type": "decrement"}, original_entry_1]
+    ledger_entries = [{"event_id": "foo-event-id", "entry_type": "decrement", "created_at": "2022-02-21T07:00:00+00:00"}, original_entry_1]
     mock_response = {
         "data": [
             {
@@ -316,7 +316,7 @@ def test_credits_ledger_entries_enriches_selected_property_keys(
     responses.add(responses.POST, f"{stream.url_base}events", json=mock_response, status=200)
     enriched_entries = stream.enrich_ledger_entries_with_event_data(ledger_entries)
 
-    assert enriched_entries[0] == {"entry_type": "decrement", "event": {"id": "foo-event-id", "properties": resulting_properties}}
+    assert enriched_entries[0] == {"entry_type": "decrement", "created_at": "2022-02-21T07:00:00+00:00", "event": {"id": "foo-event-id", "properties": resulting_properties}}
     # Does not enrich, but still passes back, irrelevant (for enrichment purposes) ledger entry
     assert enriched_entries[1] == original_entry_1
 
@@ -324,7 +324,7 @@ def test_credits_ledger_entries_enriches_selected_property_keys(
 @responses.activate
 def test_credits_ledger_entries_enriches_with_multiple_entries_per_event(mocker):
     stream = CreditsLedgerEntries(string_event_properties_keys=["ping"])
-    ledger_entries = [{"event_id": "foo-event-id", "entry_type": "decrement"}, {"event_id": "foo-event-id", "entry_type": "decrement"}]
+    ledger_entries = [{"event_id": "foo-event-id", "entry_type": "decrement", "created_at": "2022-02-21T07:00:00+00:00",}, {"event_id": "foo-event-id", "entry_type": "decrement", "created_at": "2022-02-21T07:00:00+00:00",}]
     mock_response = {
         "data": [
             {
@@ -342,8 +342,8 @@ def test_credits_ledger_entries_enriches_with_multiple_entries_per_event(mocker)
 
     # We expect both events are enriched correctly
     assert enriched_entries == [
-        {"event": {"id": "foo-event-id", "properties": {"ping": "pong"}}, "entry_type": "decrement"},
-        {"event": {"id": "foo-event-id", "properties": {"ping": "pong"}}, "entry_type": "decrement"},
+        {"event": {"id": "foo-event-id", "properties": {"ping": "pong"}}, "entry_type": "decrement", "created_at": "2022-02-21T07:00:00+00:00",},
+        {"event": {"id": "foo-event-id", "properties": {"ping": "pong"}}, "entry_type": "decrement", "created_at": "2022-02-21T07:00:00+00:00",},
     ]
 
 

--- a/docs/integrations/sources/orb.md
+++ b/docs/integrations/sources/orb.md
@@ -54,6 +54,7 @@ an Orb Account and API Key.
 
 | Version | Date       | Pull Request                                             | Subject |
 | --- |------------|----------------------------------------------------------| --- |
+| 1.1.1 | 2024-02-07 | [35005](https://github.com/airbytehq/airbyte/pull/35005) | Pass timeframe_start, timeframe_end to events query
 | 1.1.0 | 2023-03-03 | [24567](https://github.com/airbytehq/airbyte/pull/24567) | Add Invoices incremental stream (merged from [#24737](https://github.com/airbytehq/airbyte/pull/24737)
 | 1.0.0 | 2023-02-02 | [21951](https://github.com/airbytehq/airbyte/pull/21951) | Add SubscriptionUsage stream, and made `start_date` a required field
 | 0.1.4 | 2022-10-07 | [17761](https://github.com/airbytehq/airbyte/pull/17761) | Fix bug with enriching ledger entries with multiple credit blocks


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Orb's event search [API](https://docs.withorb.com/reference/search-events) is moving to require a timestamp boundary alongside the `event_id` to improve the performance of the endpoint. This PR updates the Airbyte connector to pass in the timestamp bounds derived from the `ledger_entry.created_at` field.

## How
We now use the `created_at` timestamp in the `ledger_entry` to determine the start and end bounds for the event search query.

## Recommended reading order
1. `source.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*
No breaking changes

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added
<img width="1728" alt="CleanShot 2024-02-07 at 23 04 29@2x" src="https://github.com/airbytehq/airbyte/assets/14226694/acf44494-901c-4644-a0b0-8032d653f402">
<img width="1728" alt="CleanShot 2024-02-07 at 23 05 24@2x" src="https://github.com/airbytehq/airbyte/assets/14226694/1019fd05-d841-472f-bcfa-a9b5bf0abfe1">

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
