### PR TITLE
airbyte-lib: Clean up test schema in Snowflake

### DIFF
--- a/airbyte-lib/tests/conftest.py
+++ b/airbyte-lib/tests/conftest.py
@@ -19,6 +19,7 @@ import pytest
 from _pytest.nodes import Item
 from google.cloud import secretmanager
 from pytest_docker.plugin import get_docker_ip
+from sqlalchemy import create_engine
 
 from airbyte_lib.caches import PostgresCacheConfig
 
@@ -188,10 +189,14 @@ def snowflake_config():
         database=secret["database"],
         warehouse=secret["warehouse"],
         role=secret["role"],
-        schema_name=f"test{str(ulid.ULID()).lower()[-6:]}",
+        schema_name=f"localtest{str(ulid.ULID()).lower()[-6:]}",
     )
 
     yield config
+
+    engine = create_engine(config.get_sql_alchemy_url())
+    with engine.begin() as connection:
+        connection.execute(f"DROP SCHEMA IF EXISTS {config.schema_name}")
 
 
 @pytest.fixture(autouse=True)

--- a/airbyte-lib/tests/conftest.py
+++ b/airbyte-lib/tests/conftest.py
@@ -189,7 +189,7 @@ def snowflake_config():
         database=secret["database"],
         warehouse=secret["warehouse"],
         role=secret["role"],
-        schema_name=f"localtest{str(ulid.ULID()).lower()[-6:]}",
+        schema_name=f"test{str(ulid.ULID()).lower()[-6:]}",
     )
 
     yield config

--- a/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
+++ b/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
@@ -680,9 +680,6 @@ def test_sync_to_snowflake(snowflake_config: SnowflakeCacheConfig, expected_test
 
     cache = SnowflakeSQLCache(config=snowflake_config)
 
-    with cache.get_sql_connection() as con:
-        con.execute("DROP SCHEMA IF EXISTS AIRBYTE_RAW")
-
     result: ReadResult = source.read(cache)
 
     assert result.processed_records == 3
@@ -692,6 +689,7 @@ def test_sync_to_snowflake(snowflake_config: SnowflakeCacheConfig, expected_test
             pd.DataFrame(expected_data),
             check_dtype=False,
         )
+
 
 def test_sync_limited_streams(expected_test_stream_data):
     source = ab.get_source("source-test", config={"apiKey": "test"})


### PR DESCRIPTION
With https://github.com/airbytehq/airbyte/pull/34592 we generate a random schema name for the snowflake tests. This prevents concurrency issues in case snowflake tests are ran in multiple places at once, but the test schemas were not cleaned up - we already had 500 schemas or so.

This PR cleans up after the test to keep the test account clean - there's still a risk for stale schemas, but it's greatly reduced. Also removes the leftover no-op call.