### PR TITLE
Source Monday: add integration tests

### DIFF
--- a/airbyte-integrations/connectors/source-monday/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-monday/acceptance-test-config.yml
@@ -39,7 +39,7 @@ acceptance_tests:
           extra_records: yes
         empty_streams:
           - name: teams
-            bypass_reason: "unable to populate"
+            bypass_reason: "The stream has no test data and tested with integration tests"
         ignored_fields:
           items:
             - name: assets/*/public_url
@@ -55,7 +55,7 @@ acceptance_tests:
           extra_records: yes
         empty_streams:
           - name: teams
-            bypass_reason: "unable to populate"
+            bypass_reason: "The stream has no test data and tested with integration tests"
         ignored_fields:
           items:
             - name: assets/*/public_url

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 80a54ea2-9959-4040-aac1-eee42423ec9b
-  dockerImageTag: 2.0.0
+  dockerImageTag: 2.0.1
   releases:
     breakingChanges:
       2.0.0:

--- a/airbyte-integrations/connectors/source-monday/setup.py
+++ b/airbyte-integrations/connectors/source-monday/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk>=0.44.1",
+    "airbyte-cdk",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/config.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/config.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from typing import Any, Dict
+
+
+class ConfigBuilder:
+    def __init__(self) -> None:
+        self._credentials: Dict[str, str] = {}
+
+    def with_oauth_credentials(self, client_id: str, client_secret: str, access_token: str, subdomain: str) -> "ConfigBuilder":
+        self._credentials["auth_type"] = "oauth2.0"
+        self._credentials["client_id"] = client_id
+        self._credentials["client_secret"] = client_secret
+        self._credentials["access_token"] = access_token
+        self._credentials["subdomain"] = subdomain
+        return self
+
+    def with_api_token_credentials(self, api_token: str) -> "ConfigBuilder":
+        self._credentials["api_token"] = api_token
+        self._credentials["auth_type"] = "api_token"
+        return self
+
+    def build(self) -> Dict[str, Any]:
+        config = {}
+        if self._credentials:
+            config["credentials"] = self._credentials
+        return config

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/__init__.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/__init__.py
@@ -1,0 +1,1 @@
+from .teams_requests_builder import TeamsRequestBuilder

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/base_requests_builder.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/base_requests_builder.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+import abc
+from typing import Any, Dict, Optional
+
+from airbyte_cdk.test.mock_http import HttpRequest
+
+from .request_authenticators.authenticator import Authenticator
+
+
+class MondayRequestBuilder(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def url(self) -> str:
+        """A url"""
+
+    @property
+    @abc.abstractmethod
+    def query_params(self) -> Dict[str, Any]:
+        """Query params"""
+
+    @property
+    @abc.abstractmethod
+    def headers(self) -> Dict[str, Any]:
+        """Headers"""
+
+    @property
+    @abc.abstractmethod
+    def request_body(self) -> Optional[str]:
+        """A request body"""
+
+    def build(self) -> HttpRequest:
+        return HttpRequest(
+            url=self.url,
+            query_params=self.query_params,
+            headers=self.headers,
+            body=self.request_body
+        )
+
+
+class MondayBaseRequestBuilder(MondayRequestBuilder):
+    def __init__(self, resource: str = "") -> None:
+        self._resource: str = resource
+        self._authenticator: str = None
+
+    @property
+    def url(self) -> str:
+        return f"https://api.monday.com/v2/{self._resource}"
+
+    @property
+    def headers(self) -> Dict[str, Any]:
+        return (super().headers or {}) | {
+            "Authorization": self._authenticator.client_access_token,
+        }
+
+    @property
+    def request_body(self):
+        return super().request_body
+
+    def with_authenticator(self, authenticator: Authenticator) -> "MondayBaseRequestBuilder":
+        self._authenticator: Authenticator = authenticator
+        return self

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/request_authenticators/__init__.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/request_authenticators/__init__.py
@@ -1,0 +1,1 @@
+from .api_token_authenticator import ApiTokenAuthenticator

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/request_authenticators/api_token_authenticator.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/request_authenticators/api_token_authenticator.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+import base64
+
+from .authenticator import Authenticator
+
+
+class ApiTokenAuthenticator(Authenticator):
+    def __init__(self, api_token: str) -> None:
+        super().__init__()
+        self._api_token = api_token
+
+    @property
+    def client_access_token(self) -> str:
+        return f"Bearer {self._api_token}"

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/request_authenticators/authenticator.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/request_authenticators/authenticator.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+import abc
+
+
+class Authenticator(abc.ABC):
+    @abc.abstractproperty
+    def client_access_token(self) -> str:
+        """"""

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/teams_requests_builder.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/teams_requests_builder.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from .base_requests_builder import MondayBaseRequestBuilder
+from .request_authenticators.authenticator import Authenticator
+
+
+class TeamsRequestBuilder(MondayBaseRequestBuilder):
+    @classmethod
+    def teams_endpoint(cls, authenticator: Authenticator) -> "TeamsRequestBuilder":
+        return cls().with_authenticator(authenticator)
+
+    @property
+    def query_params(self):
+        params = super().query_params or {}
+        params["query"] = "query{teams{id,name,picture_url,users{id}}}"
+        return params

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/__init__.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/__init__.py
@@ -1,0 +1,2 @@
+from .teams_response_builder import TeamsResponseBuilder
+from .error_response_builder import ErrorResponseBuilder

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/error_response_builder.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/error_response_builder.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+import json
+
+from airbyte_cdk.test.mock_http import HttpResponse
+from airbyte_cdk.test.mock_http.response_builder import find_template
+
+
+class ErrorResponseBuilder:
+    def __init__(self, status_code: int):
+        self._status_code: int = status_code
+
+    @classmethod
+    def response_with_status(cls, status_code) -> "ErrorResponseBuilder":
+        return cls(status_code)
+
+    def build(self) -> HttpResponse:
+        return HttpResponse(json.dumps(find_template(str(self._status_code), __file__)), self._status_code)

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/records/__init__.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/records/__init__.py
@@ -1,0 +1,1 @@
+from .teams_record_builder import TeamsRecordBuilder

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/records/record_builder.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/records/record_builder.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from airbyte_cdk.test.mock_http.response_builder import Path, RecordBuilder, find_template
+
+
+class MondayRecordBuilder(RecordBuilder):
+    @staticmethod
+    def extract_record(resource: str, execution_folder: str, data_field: Path):
+        return data_field.extract(find_template(resource=resource, execution_folder=execution_folder))

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/records/teams_record_builder.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/records/teams_record_builder.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from airbyte_cdk.test.mock_http.response_builder import FieldPath, NestedPath
+
+from .record_builder import MondayRecordBuilder
+
+
+class TeamsRecordBuilder(MondayRecordBuilder):
+    @classmethod
+    def teams_record(cls) -> "TeamsRecordBuilder":
+        record_template = cls.extract_record("teams", __file__, NestedPath(["data", "teams", 0]))
+        return cls(record_template, FieldPath("id"), None)

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/teams_response_builder.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/teams_response_builder.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from airbyte_cdk.test.mock_http.response_builder import HttpResponseBuilder, NestedPath, find_template
+
+
+class TeamsResponseBuilder(HttpResponseBuilder):
+    @classmethod
+    def teams_response(cls) -> "TeamsResponseBuilder":
+        return cls(find_template("teams", __file__), NestedPath(["data", "teams"]), None)

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_teams_stream.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_teams_stream.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+import json
+from unittest import TestCase
+from unittest.mock import patch
+
+from airbyte_cdk.test.mock_http import HttpMocker
+from airbyte_protocol.models import Level as LogLevel
+from airbyte_protocol.models import SyncMode
+
+from .config import ConfigBuilder
+from .monday_requests import TeamsRequestBuilder
+from .monday_requests.request_authenticators import ApiTokenAuthenticator
+from .monday_responses import ErrorResponseBuilder, TeamsResponseBuilder
+from .monday_responses.records import TeamsRecordBuilder
+from .utils import get_log_messages_by_log_level, read_stream
+
+
+class TestTeamsStreamFullRefresh(TestCase):
+    @property
+    def _config(self):
+        return ConfigBuilder().with_api_token_credentials("api-token").build()
+
+    def get_authenticator(self, config):
+        return ApiTokenAuthenticator(api_token=config["credentials"]["api_token"])
+
+    @HttpMocker()
+    def test_given_one_page_when_read_teams_then_return_records(self, http_mocker):
+        """
+        A normal full refresh sync without pagination
+        """
+        api_token_authenticator = self.get_authenticator(self._config)
+
+        http_mocker.get(
+            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
+            TeamsResponseBuilder.teams_response().with_record(TeamsRecordBuilder.teams_record()).build()
+        )
+
+        output = read_stream("teams", SyncMode.full_refresh, self._config)
+        assert len(output.records) == 1
+
+    @HttpMocker()
+    def test_given_retryable_error_and_one_page_when_read_teams_then_return_records(self, http_mocker):
+        """
+        A full refresh sync without pagination completes successfully after one retry
+        """
+        api_token_authenticator = self.get_authenticator(self._config)
+
+        http_mocker.get(
+            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
+            [
+                ErrorResponseBuilder.response_with_status(200).build(),
+                TeamsResponseBuilder.teams_response().with_record(TeamsRecordBuilder.teams_record()).build()
+            ]
+        )
+
+        with patch('time.sleep', return_value=None):
+            output = read_stream("teams", SyncMode.full_refresh, self._config)
+
+        assert len(output.records) == 1
+
+        error_logs = [
+            error for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
+            if f'Response Code: 200, Response Text: {json.dumps({"error_code": "ComplexityException", "status_code": 200})}' in error
+        ]
+        assert len(error_logs) == 1
+
+    @HttpMocker()
+    def test_given_retryable_error_when_read_teams_then_stop_syncing(self, http_mocker):
+        """
+        A full refresh sync without pagination give up after 6 retries
+        """
+        api_token_authenticator = self.get_authenticator(self._config)
+
+        http_mocker.get(
+            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
+            ErrorResponseBuilder.response_with_status(200).build()
+        )
+
+        with patch('time.sleep', return_value=None):
+            output = read_stream("teams", SyncMode.full_refresh, self._config)
+        
+        assert len(output.records) == 0
+
+        error_logs = [
+            error for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
+            if f'Response Code: 200, Response Text: {json.dumps({"error_code": "ComplexityException", "status_code": 200})}' in error
+        ]
+        assert len(error_logs) == 5
+
+    @HttpMocker()
+    def test_given_retryable_500_error_when_read_teams_then_stop_syncing(self, http_mocker):
+        """
+        A full refresh sync without pagination give up after 6 retries
+        """
+        api_token_authenticator = self.get_authenticator(self._config)
+
+        http_mocker.get(
+            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
+            ErrorResponseBuilder.response_with_status(500).build()
+        )
+
+        with patch('time.sleep', return_value=None):
+            output = read_stream("teams", SyncMode.full_refresh, self._config)
+        
+        assert len(output.records) == 0
+
+        error_logs = [
+            error for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
+            if f'Response Code: 500, Response Text: {json.dumps({"error_message": "Internal server error", "status_code": 500})}' in error
+        ]
+        assert len(error_logs) == 5
+
+    @HttpMocker()
+    def test_given_403_error_when_read_teams_then_ignore_the_stream(self, http_mocker):
+        """
+        A full refresh sync without pagination ignore failed stream
+        """
+        api_token_authenticator = self.get_authenticator(self._config)
+
+        http_mocker.get(
+            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
+            ErrorResponseBuilder.response_with_status(403).build()
+        )
+
+        with patch('time.sleep', return_value=None):
+            output = read_stream("teams", SyncMode.full_refresh, self._config)
+
+        assert len(output.records) == 0
+
+        error_logs = [
+            error for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
+            if f'Ignoring response for failed request with error message None' in error
+        ]
+        assert len(error_logs) == 1

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/utils.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/utils.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+import operator
+from typing import Any, Dict, List, Optional
+
+from airbyte_cdk.models import AirbyteMessage
+from airbyte_cdk.models import Level as LogLevel
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput, read
+from airbyte_protocol.models import SyncMode
+from source_monday import SourceMonday
+
+
+def read_stream(
+    stream_name: str,
+    sync_mode: SyncMode,
+    config: Dict[str, Any],
+    state: Optional[Dict[str, Any]] = None,
+    expecting_exception: bool = False
+) -> EntrypointOutput:
+    catalog = CatalogBuilder().with_stream(stream_name, sync_mode).build()
+    return read(SourceMonday(), config, catalog, state, expecting_exception)
+
+
+def get_log_messages_by_log_level(logs: List[AirbyteMessage], log_level: LogLevel) -> List[str]:
+    return map(operator.attrgetter("log.message"), filter(lambda x: x.log.level == log_level, logs))

--- a/airbyte-integrations/connectors/source-monday/unit_tests/resource/http/response/200.json
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/resource/http/response/200.json
@@ -1,0 +1,4 @@
+{
+  "error_code": "ComplexityException",
+  "status_code": 200
+}

--- a/airbyte-integrations/connectors/source-monday/unit_tests/resource/http/response/403.json
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/resource/http/response/403.json
@@ -1,0 +1,4 @@
+{
+  "error_code": "UserUnauthorizedException",
+  "status_code": 403
+}

--- a/airbyte-integrations/connectors/source-monday/unit_tests/resource/http/response/500.json
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/resource/http/response/500.json
@@ -1,0 +1,4 @@
+{
+  "error_message": "Internal server error",
+  "status_code": 500
+}

--- a/airbyte-integrations/connectors/source-monday/unit_tests/resource/http/response/teams.json
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/resource/http/response/teams.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "teams": [
+      {
+        "id": "520480",
+        "name": "Team1",
+        "picture_url": "https://cdn.monday.com/images/dapulse_team_default.png",
+        "users": [
+          {
+            "id": "25479561"
+          }
+        ]
+      }
+    ]
+  },
+  "account_id": 10239240
+}

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -74,6 +74,7 @@ The Monday connector should not run into Monday API limitations under normal usa
 
 | Version | Date       | Pull Request                                              | Subject                                                                 |
 |:--------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------|
+| 2.0.1   | 2024-02-08 | [35016](https://github.com/airbytehq/airbyte/pull/35016)  | Migrated to the latest airbyte cdk                                      |
 | 2.0.0   | 2024-01-12 | [34108](https://github.com/airbytehq/airbyte/pull/34108)  | Migrated to the latest API version: 2024-01                             |
 | 1.1.4   | 2023-12-13 | [33448](https://github.com/airbytehq/airbyte/pull/33448)  | Increase test coverage and migrate to base image                        |
 | 1.1.3   | 2023-09-23 | [30248](https://github.com/airbytehq/airbyte/pull/30248)  | Add new field "type" to board stream                                    |


### PR DESCRIPTION
## What
*The issue: https://github.com/airbytehq/airbyte/issues/34904*

## How
*Cover streams defined as empty in acceptance-test-config.yaml with integraion tests*

## Recommended reading order
1. `unit_tests/integrations/*.py`
2. `unit_tests/integrations/resource/http/response/*.json`

