### PR TITLE
airbyte-lib: Show list of actually available connectors

### DIFF
--- a/airbyte-lib/airbyte_lib/registry.py
+++ b/airbyte-lib/airbyte_lib/registry.py
@@ -101,7 +101,7 @@ def get_connector_metadata(name: str) -> ConnectorMetadata:
             connector_name=name,
             context={
                 "registry_url": _get_registry_url(),
-                "available_connectors": sorted(get_available_connectors()),
+                "available_connectors": get_available_connectors(),
             },
         )
     return cache[name]

--- a/airbyte-lib/airbyte_lib/registry.py
+++ b/airbyte-lib/airbyte_lib/registry.py
@@ -101,7 +101,7 @@ def get_connector_metadata(name: str) -> ConnectorMetadata:
             connector_name=name,
             context={
                 "registry_url": _get_registry_url(),
-                "available_connectors": sorted(cache.keys()),
+                "available_connectors": sorted(get_available_connectors()),
             },
         )
     return cache[name]


### PR DESCRIPTION
When mistyping a connector name, a list of available connectors is printed. However, it currently lists all connectors, not the pypi published ones.

This PR limits the list to the published ones, as the others are not usable anyway.