### PR TITLE
source-mssql: adopt JDK 0.16.6

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.16.0'
+    cdkVersionRequired = '0.16.6'
     features = ['db-sources']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceTest.java
@@ -45,13 +45,11 @@ import java.util.Optional;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.testcontainers.containers.MSSQLServerContainer;
-import org.testcontainers.utility.DockerImageName;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class CdcMssqlSourceTest extends CdcSourceTest<MssqlSource, MsSQLTestDatabase> {
@@ -71,14 +69,9 @@ public class CdcMssqlSourceTest extends CdcSourceTest<MssqlSource, MsSQLTestData
   }
 
   protected MSSQLServerContainer<?> createContainer() {
-    return new MsSQLContainerFactory()
-        .createNewContainer(DockerImageName.parse("mcr.microsoft.com/mssql/server:2022-latest"));
-  }
-
-  @BeforeAll
-  public void beforeAll() {
-    new MsSQLContainerFactory().withAgent(privateContainer);
-    privateContainer.start();
+    return new MsSQLContainerFactory().exclusive(
+        MsSQLTestDatabase.BaseImage.MSSQL_2022.reference,
+        MsSQLTestDatabase.ContainerModifier.AGENT.methodName);
   }
 
   @AfterAll

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSslSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSslSourceTest.java
@@ -13,21 +13,18 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 import javax.sql.DataSource;
+import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.containers.MSSQLServerContainer;
-import org.testcontainers.utility.DockerImageName;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CdcMssqlSslSourceTest extends CdcMssqlSourceTest {
 
-  CdcMssqlSslSourceTest() {
-    super();
-  }
-
+  @Override
   protected MSSQLServerContainer<?> createContainer() {
-    final MsSQLContainerFactory containerFactory = new MsSQLContainerFactory();
-    final MSSQLServerContainer<?> container =
-        containerFactory.createNewContainer(DockerImageName.parse("mcr.microsoft.com/mssql/server:2022-latest"));
-    containerFactory.withSslCertificates(container);
-    return container;
+    return new MsSQLContainerFactory().exclusive(
+        MsSQLTestDatabase.BaseImage.MSSQL_2022.reference,
+        MsSQLTestDatabase.ContainerModifier.AGENT.methodName,
+        MsSQLTestDatabase.ContainerModifier.WITH_SSL_CERTIFICATES.methodName);
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcStateCompressionTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcStateCompressionTest.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MSSQLServerContainer;
 
 public class CdcStateCompressionTest {
 
@@ -54,20 +53,13 @@ public class CdcStateCompressionTest {
 
   static private final int ADDED_COLUMNS = 1000;
 
-  static private final MSSQLServerContainer<?> CONTAINER = new MsSQLContainerFactory().shared(
-      "mcr.microsoft.com/mssql/server:2022-latest", "withAgent");
-
   private MsSQLTestDatabase testdb;
 
   @BeforeEach
   public void setup() {
-    testdb = new MsSQLTestDatabase(CONTAINER);
-    testdb = testdb
-        .withConnectionProperty("encrypt", "false")
-        .withConnectionProperty("databaseName", testdb.getDatabaseName())
-        .initialized()
-        .withCdc()
-        .withWaitUntilAgentRunning();
+    testdb = MsSQLTestDatabase.in(MsSQLTestDatabase.BaseImage.MSSQL_2022, MsSQLTestDatabase.ContainerModifier.AGENT)
+        .withWaitUntilAgentRunning()
+        .withCdc();
 
     // Create a test schema and a bunch of test tables with CDC enabled.
     // Insert one row in each table so that they're not empty.

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlDataSourceFactoryTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlDataSourceFactoryTest.java
@@ -12,24 +12,24 @@ import io.airbyte.cdk.db.factory.DataSourceFactory;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MSSQLServerContainer;
 
 public class MssqlDataSourceFactoryTest {
 
   @Test
   protected void testCreatingDataSourceWithConnectionTimeoutSetBelowDefault() {
-    final MSSQLServerContainer container = new MsSQLContainerFactory().shared("mcr.microsoft.com/mssql/server:2019-latest");
-    final Map<String, String> connectionProperties = Map.of("loginTimeout", String.valueOf(5));
-    final DataSource dataSource = DataSourceFactory.create(
-        container.getUsername(),
-        container.getPassword(),
-        container.getDriverClassName(),
-        container.getJdbcUrl(),
-        connectionProperties,
-        new MssqlSource().getConnectionTimeoutMssql(connectionProperties));
-    assertNotNull(dataSource);
-    assertEquals(HikariDataSource.class, dataSource.getClass());
-    assertEquals(5000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
+    try (var testdb = MsSQLTestDatabase.in(MsSQLTestDatabase.BaseImage.MSSQL_2022)) {
+      final Map<String, String> connectionProperties = Map.of("loginTimeout", String.valueOf(5));
+      final DataSource dataSource = DataSourceFactory.create(
+          testdb.getUserName(),
+          testdb.getPassword(),
+          testdb.getDatabaseDriver().getDriverClassName(),
+          testdb.getJdbcUrl(),
+          connectionProperties,
+          new MssqlSource().getConnectionTimeoutMssql(connectionProperties));
+      assertNotNull(dataSource);
+      assertEquals(HikariDataSource.class, dataSource.getClass());
+      assertEquals(5000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
+    }
   }
 
 }

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlStressTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlStressTest.java
@@ -5,80 +5,22 @@
 package io.airbyte.integrations.source.mssql;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
-import io.airbyte.cdk.db.factory.DataSourceFactory;
-import io.airbyte.cdk.db.factory.DatabaseDriver;
-import io.airbyte.cdk.db.jdbc.DefaultJdbcDatabase;
-import io.airbyte.cdk.db.jdbc.JdbcDatabase;
-import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.cdk.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.cdk.integrations.source.jdbc.test.JdbcStressTest;
-import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.string.Strings;
 import java.sql.JDBCType;
-import java.time.Duration;
-import java.util.Map;
 import java.util.Optional;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
-import org.testcontainers.containers.MSSQLServerContainer;
 
 @Disabled
 public class MssqlStressTest extends JdbcStressTest {
 
-  private static final Duration CONNECTION_TIMEOUT = Duration.ofSeconds(60);
-  private static MSSQLServerContainer<?> dbContainer;
-  private JsonNode config;
-
-  @BeforeAll
-  static void init() {
-    dbContainer = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-latest").acceptLicense();
-    dbContainer.start();
-  }
+  private MsSQLTestDatabase testdb;
 
   @BeforeEach
   public void setup() throws Exception {
-    final JsonNode configWithoutDbName = Jsons.jsonNode(ImmutableMap.builder()
-        .put(JdbcUtils.HOST_KEY, dbContainer.getHost())
-        .put(JdbcUtils.PORT_KEY, dbContainer.getFirstMappedPort())
-        .put(JdbcUtils.USERNAME_KEY, dbContainer.getUsername())
-        .put(JdbcUtils.PASSWORD_KEY, dbContainer.getPassword())
-        .build());
-
-    final DataSource dataSource = DataSourceFactory.create(
-        configWithoutDbName.get(JdbcUtils.USERNAME_KEY).asText(),
-        configWithoutDbName.get(JdbcUtils.PASSWORD_KEY).asText(),
-        DatabaseDriver.MSSQLSERVER.getDriverClassName(),
-        String.format("jdbc:sqlserver://%s:%d;",
-            configWithoutDbName.get(JdbcUtils.HOST_KEY).asText(),
-            configWithoutDbName.get(JdbcUtils.PORT_KEY).asInt()),
-        Map.of("encrypt", "false"),
-        CONNECTION_TIMEOUT);
-
-    try {
-      final JdbcDatabase database = new DefaultJdbcDatabase(dataSource);
-
-      final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
-
-      database.execute(ctx -> ctx.createStatement().execute(String.format("CREATE DATABASE %s;", dbName)));
-
-      config = Jsons.clone(configWithoutDbName);
-      ((ObjectNode) config).put(JdbcUtils.DATABASE_KEY, dbName);
-      ((ObjectNode) config).put("is_test", true);
-
-      super.setup();
-    } finally {
-      DataSourceFactory.close(dataSource);
-    }
-  }
-
-  @AfterAll
-  public static void tearDown() {
-    dbContainer.close();
+    testdb = MsSQLTestDatabase.in(MsSQLTestDatabase.BaseImage.MSSQL_2022);
+    super.setup();
   }
 
   @Override
@@ -88,7 +30,7 @@ public class MssqlStressTest extends JdbcStressTest {
 
   @Override
   public JsonNode getConfig() {
-    return Jsons.clone(config);
+    return testdb.testConfigBuilder().with("is_test", true).build();
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLContainerFactory.java
+++ b/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLContainerFactory.java
@@ -10,19 +10,14 @@ import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
-public class MsSQLContainerFactory implements ContainerFactory<MSSQLServerContainer<?>> {
+public class MsSQLContainerFactory extends ContainerFactory<MSSQLServerContainer<?>> {
 
   @Override
-  public MSSQLServerContainer<?> createNewContainer(DockerImageName imageName) {
-    MSSQLServerContainer container =
-        new MSSQLServerContainer<>(imageName.asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server")).acceptLicense();
+  protected MSSQLServerContainer<?> createNewContainer(DockerImageName imageName) {
+    imageName = imageName.asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server");
+    var container = new MSSQLServerContainer<>(imageName).acceptLicense();
     container.addEnv("MSSQL_MEMORY_LIMIT_MB", "384");
     return container;
-  }
-
-  @Override
-  public Class<?> getContainerClass() {
-    return MSSQLServerContainer.class;
   }
 
   /**

--- a/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLTestDatabase.java
+++ b/airbyte-integrations/connectors/source-mssql/src/testFixtures/java/io/airbyte/integrations/source/mssql/MsSQLTestDatabase.java
@@ -27,29 +27,30 @@ public class MsSQLTestDatabase extends TestDatabase<MSSQLServerContainer<?>, MsS
 
   static public final int MAX_RETRIES = 60;
 
-  public static enum BaseImage {
+  public enum BaseImage {
 
     MSSQL_2022("mcr.microsoft.com/mssql/server:2022-latest"),
     MSSQL_2017("mcr.microsoft.com/mssql/server:2017-latest"),
     ;
 
-    private final String reference;
+    public final String reference;
 
-    private BaseImage(final String reference) {
+    BaseImage(final String reference) {
       this.reference = reference;
     }
 
   }
 
-  public static enum ContainerModifier {
+  public enum ContainerModifier {
 
     NETWORK("withNetwork"),
     AGENT("withAgent"),
-    WITH_SSL_CERTIFICATES("withSslCertificates");
+    WITH_SSL_CERTIFICATES("withSslCertificates"),
+    ;
 
-    private final String methodName;
+    public final String methodName;
 
-    private ContainerModifier(final String methodName) {
+    ContainerModifier(final String methodName) {
       this.methodName = methodName;
     }
 


### PR DESCRIPTION
We expect this to fail CI because of unresolved issues: https://github.com/airbytehq/airbyte-internal-issues/issues/2911

I checked and it passes `airbyte-ci connectors --name=source-mssql test` locally.