### PR TITLE
fix low-code tags on source-sendgrid/sentry/intercom

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -37,6 +37,5 @@ data:
       - companies
   supportLevel: certified
   tags:
-    - language:low-code
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -46,6 +46,5 @@ data:
   releaseStage: generally_available
   supportLevel: certified
   tags:
-    - language:low-code
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -30,6 +30,5 @@ data:
   releaseStage: generally_available
   supportLevel: certified
   tags:
-    - language:low-code
     - language:python
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
These connectors were not correctly tagged: they are not low code