### PR TITLE
airbyte-ci: fix missing test reports

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -640,8 +640,8 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                |
 | ------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| 4.1.3   | [#TBD](https://github.com/airbytehq/airbyte/pull/TBD)  | Use `poetry install --no-root` in the builder container.                                                                |
-
+| 4.1.4   | [#35039](https://github.com/airbytehq/airbyte/pull/35039)  | Fix bug which prevented gradle test reports from being added.                                                              |
+| 4.1.3   | [#35010](https://github.com/airbytehq/airbyte/pull/35010)  | Use `poetry install --no-root` in the builder container.                                                                   |
 | 4.1.2   | [#34945](https://github.com/airbytehq/airbyte/pull/34945)  | Only install main dependencies when running poetry install.                                                                |
 | 4.1.1   | [#34430](https://github.com/airbytehq/airbyte/pull/34430)  | Speed up airbyte-ci startup (and airbyte-ci format).                                                                       |
 | 4.1.0   | [#34923](https://github.com/airbytehq/airbyte/pull/34923)  | Include gradle test reports in HTML connector test report.                                                                 |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
@@ -12,6 +12,7 @@ from dagger import CacheSharingMode, CacheVolume, Container, QueryError
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.consts import AMAZONCORRETTO_IMAGE
 from pipelines.dagger.actions import secrets
+from pipelines.hacks import never_fail_exec
 from pipelines.helpers.utils import sh_dash_c
 from pipelines.models.steps import Step, StepResult
 
@@ -189,19 +190,14 @@ class GradleTask(Step, ABC):
             gradle_container = gradle_container.with_exec(["yum", "install", "-y", "docker"])
 
         # Run the gradle task that we actually care about.
-        connector_task = f":airbyte-integrations:connectors:{self.context.connector.technical_name}:{self.gradle_task_name}"
-        gradle_container = gradle_container.with_exec(
-            sh_dash_c(
-                [
-                    # Run the gradle task.
-                    self._get_gradle_command(connector_task, task_options=self.params_as_cli_options),
-                ]
-            )
-        )
+        connector_gradle_task = f":airbyte-integrations:connectors:{self.context.connector.technical_name}:{self.gradle_task_name}"
+        gradle_command = self._get_gradle_command(connector_gradle_task, task_options=self.params_as_cli_options)
+        gradle_container = gradle_container.with_(never_fail_exec([gradle_command]))
         return await self.get_step_result(gradle_container)
 
     async def get_step_result(self, container: Container) -> StepResult:
         step_result = await super().get_step_result(container)
+        # Decorate with test report, if applicable.
         return StepResult(
             step=step_result.step,
             status=step_result.status,

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
@@ -239,7 +239,7 @@ class GradleTask(Step, ABC):
 
 
 MAYBE_STARTS_WITH_XML_TAG = re.compile("^ *<")
-ESCAPED_ANSI_COLOR_PATTERN = re.compile(r"\?\[m|\?\[[34][0-9]m")
+ESCAPED_ANSI_COLOR_PATTERN = re.compile(r"\?\[0?m|\?\[[34][0-9]m")
 
 
 def render_junit_xml(testsuites: List[Any]) -> str:

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.1.3"
+version = "4.1.4"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
https://github.com/airbytehq/airbyte/pull/34923 merged yesterday and added junit test reports in the airbyte-ci report when testing a java connector. It has a bug in that if a test fails, the reports aren't added. This defeats the purpose. The fix is fairly simple. This PR also tweaks a regex which that PR introduced which failed to capture a specific character sequence.