### PR TITLE
Update documentation for aws secret manager configs

### DIFF
--- a/docs/operator-guides/configuring-airbyte.md
+++ b/docs/operator-guides/configuring-airbyte.md
@@ -57,6 +57,8 @@ The following variables are relevant to both Docker and Kubernetes.
 7. `VAULT_AUTH_METHOD` - How vault will preform authentication. Currently, only supports Token auth. Defaults to token. Alpha Support.
 8. `AWS_ACCESS_KEY` - Defines the aws_access_key_id from the AWS credentials to use for AWS Secret Manager.
 9. `AWS_SECRET_ACCESS_KEY`- Defines aws_secret_access_key to use for the AWS Secret Manager.
+10. `AWS_KMS_KEY_ARN` - Optional param that defines the KMS Encryption key used for the AWS Secret Manager.
+11. `AWS_SECRET_MANAGER_SECRET_TAGS` - Defines the tags that will be included to all writes to the AWS Secret Manager. The format should be "key1=value1, key2=value2" with the whitespace being optional.
 
 #### Database
 

--- a/docs/operator-guides/configuring-airbyte.md
+++ b/docs/operator-guides/configuring-airbyte.md
@@ -58,7 +58,7 @@ The following variables are relevant to both Docker and Kubernetes.
 8. `AWS_ACCESS_KEY` - Defines the aws_access_key_id from the AWS credentials to use for AWS Secret Manager.
 9. `AWS_SECRET_ACCESS_KEY`- Defines aws_secret_access_key to use for the AWS Secret Manager.
 10. `AWS_KMS_KEY_ARN` - Optional param that defines the KMS Encryption key used for the AWS Secret Manager.
-11. `AWS_SECRET_MANAGER_SECRET_TAGS` - Defines the tags that will be included to all writes to the AWS Secret Manager. The format should be "key1=value1, key2=value2" with the whitespace being optional.
+11. `AWS_SECRET_MANAGER_SECRET_TAGS` - Defines the tags that will be included to all writes to the AWS Secret Manager. The format should be "key1=value1,key2=value2".
 
 #### Database
 


### PR DESCRIPTION
Updating docs to introduce two new env vars:

`AWS_KMS_KEY_ARN` - the kms key to be included in the write requests to AWS Secret Manager. This should be the kms key arn.
`AWS_SECRET_MANAGER_SECRET_TAGS` - The tags that will be included to all writes to the AWS Secret Manager. The format should be "key1=value1, key2=value2" with the whitespace being optional.

As a reminder, to use the aws secret manager, the SECRET_PERSISTENCE env var should be set to AWS_SECRET_MANAGER.