### PR TITLE
[ISSUE #34910] add headers to HttpResponse for test framework

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/test/mock_http/mocker.py
+++ b/airbyte-cdk/python/airbyte_cdk/test/mock_http/mocker.py
@@ -60,7 +60,9 @@ class HttpMocker(contextlib.ContextDecorator):
         getattr(self._mocker, method)(
             requests_mock.ANY,
             additional_matcher=self._matches_wrapper(matcher),
-            response_list=[{"text": response.body, "status_code": response.status_code} for response in responses],
+            response_list=[
+                {"text": response.body, "status_code": response.status_code, "headers": response.headers} for response in responses
+            ],
         )
 
     def get(self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]) -> None:

--- a/airbyte-cdk/python/airbyte_cdk/test/mock_http/response.py
+++ b/airbyte-cdk/python/airbyte_cdk/test/mock_http/response.py
@@ -1,10 +1,14 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
+from types import MappingProxyType
+from typing import Mapping
+
 
 class HttpResponse:
-    def __init__(self, body: str, status_code: int = 200):
+    def __init__(self, body: str, status_code: int = 200, headers: Mapping[str, str] = MappingProxyType({})):
         self._body = body
         self._status_code = status_code
+        self._headers = headers
 
     @property
     def body(self) -> str:
@@ -13,3 +17,7 @@ class HttpResponse:
     @property
     def status_code(self) -> int:
         return self._status_code
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return self._headers

--- a/airbyte-cdk/python/unit_tests/test/mock_http/test_mocker.py
+++ b/airbyte-cdk/python/unit_tests/test/mock_http/test_mocker.py
@@ -15,6 +15,7 @@ _ANOTHER_RESPONSE_BODY = "another body"
 _A_RESPONSE = HttpResponse("any response")
 _SOME_QUERY_PARAMS = {"q1": "query value"}
 _SOME_HEADERS = {"h1": "header value"}
+_OTHER_HEADERS = {"h2": "another header value"}
 _SOME_REQUEST_BODY_MAPPING = {"first_field": "first_value", "second_field": 2}
 _SOME_REQUEST_BODY_STR = "some_request_body"
 
@@ -24,13 +25,14 @@ class HttpMockerTest(TestCase):
     def test_given_get_request_match_when_decorate_then_return_response(self, http_mocker):
         http_mocker.get(
             HttpRequest(_A_URL, _SOME_QUERY_PARAMS, _SOME_HEADERS),
-            HttpResponse(_A_RESPONSE_BODY, 474),
+            HttpResponse(_A_RESPONSE_BODY, 474, _OTHER_HEADERS),
         )
 
         response = requests.get(_A_URL, params=_SOME_QUERY_PARAMS, headers=_SOME_HEADERS)
 
         assert response.text == _A_RESPONSE_BODY
         assert response.status_code == 474
+        assert response.headers == _OTHER_HEADERS
 
     @HttpMocker()
     def test_given_loose_headers_matching_when_decorate_then_match(self, http_mocker):


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/34910

## How
Add headers that are empty dict by default and allow to user to optionally provide them

## 🚨 User Impact 🚨
Will unblock https://github.com/airbytehq/airbyte/pull/34933#issuecomment-1936132791 and allow future users to add headers to responses
