### PR TITLE
source-google-sheets: fix license in pyproject.toml

### DIFF
--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 71607ba1-c0ac-4799-8049-7f4b90dd50f7
-  dockerImageTag: 0.3.15
+  dockerImageTag: 0.3.16
   dockerRepository: airbyte/source-google-sheets
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-sheets
   githubIssueLabel: source-google-sheets

--- a/airbyte-integrations/connectors/source-google-sheets/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-sheets/pyproject.toml
@@ -3,11 +3,11 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.3.15"
+version = "0.3.16"
 name = "source-google-sheets"
 description = "Source implementation for Google Sheets."
 authors = [ "Airbyte <contact@airbyte.io>",]
-license = "MIT"
+license = "Elv2"
 readme = "README.md"
 documentation = "https://docs.airbyte.com/integrations/sources/google-sheets"
 homepage = "https://airbyte.com"

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -151,6 +151,7 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 
 | Version | Date       | Pull Request                                             | Subject                                                                           |
 | ------- | ---------- | -------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| 0.3.16  | 2024-02-12 | [35136](https://github.com/airbytehq/airbyte/pull/35136) | Fix license in `pyproject.toml`.                                                  |
 | 0.3.15  | 2024-02-07 | [34944](https://github.com/airbytehq/airbyte/pull/34944) | Manage dependencies with Poetry.                                                  |
 | 0.3.14  | 2024-01-23 | [34437](https://github.com/airbytehq/airbyte/pull/34437) | Fix header cells filtering                                                        |
 | 0.3.13  | 2024-01-19 | [34376](https://github.com/airbytehq/airbyte/pull/34376) | Fix names conversion                                                              |


### PR DESCRIPTION
This connector license is Elv2 according to metadata. But on our migration to poetry we've set the license to MIT in `pyproject.toml`. This PR sets the correct license in `pyproject.toml`.
