### PR TITLE
airbyte-ci: run `poetry check` before `poetry install` on poetry package install

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -640,6 +640,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                |
 | ------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| 4.2.1   | [#35204](https://github.com/airbytehq/airbyte/pull/35204)  | Run `poetry check` before `poetry install` on poetry package install.                                                      |
 | 4.2.0   | [#35103](https://github.com/airbytehq/airbyte/pull/35103)  | Java 21 support.                                                                                                           |
 | 4.1.4   | [#35039](https://github.com/airbytehq/airbyte/pull/35039)  | Fix bug which prevented gradle test reports from being added.                                                              |
 | 4.1.3   | [#35010](https://github.com/airbytehq/airbyte/pull/35010)  | Use `poetry install --no-root` in the builder container.                                                                   |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/common.py
@@ -37,9 +37,9 @@ class BuildConnectorImagesBase(Step, ABC):
                 connector = await self._build_connector(platform, *args)
                 try:
                     await connector.with_exec(["spec"])
-                except ExecError:
+                except ExecError as e:
                     return StepResult(
-                        step=self, status=StepStatus.FAILURE, stderr=f"Failed to run spec on the connector built for platform {platform}."
+                        step=self, status=StepStatus.FAILURE, stderr=str(e), stdout=f"Failed to run the spec command on the connector container for platform {platform}."
                     )
                 build_results_per_platform[platform] = connector
             except QueryError as e:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/python_connectors.py
@@ -45,7 +45,7 @@ class BuildConnectorImages(BuildConnectorImagesBase):
         Returns:
             Container: The builder container, with installed dependencies.
         """
-        ONLY_BUILD_FILES = ["pyproject.toml", "poetry.lock", "poetry.toml", "setup.py", "requirements.txt"]
+        ONLY_BUILD_FILES = ["pyproject.toml", "poetry.lock", "poetry.toml", "setup.py", "requirements.txt", "README.md"]
         
         builder = await with_python_connector_installed(
             self.context,
@@ -54,7 +54,6 @@ class BuildConnectorImages(BuildConnectorImagesBase):
             install_root_package=False,
             include=ONLY_BUILD_FILES
         )
-
         return builder
 
     async def _build_from_base_image(self, platform: Platform) -> Container:

--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
@@ -161,6 +161,7 @@ def _install_python_dependencies_from_poetry(
     pip_install_poetry_cmd = ["pip", "install", "poetry"]
     poetry_disable_virtual_env_cmd = ["poetry", "config", "virtualenvs.create", "false"]
     poetry_install_cmd = ["poetry", "install"]
+    poetry_check_cmd = ["poetry", "check"]
     if not install_root_package:
         poetry_install_cmd += ["--no-root"]
     if additional_dependency_groups:
@@ -168,7 +169,12 @@ def _install_python_dependencies_from_poetry(
             poetry_install_cmd += ["--with", group]
     else:
         poetry_install_cmd += ["--only", "main"]
-    return container.with_exec(pip_install_poetry_cmd).with_exec(poetry_disable_virtual_env_cmd).with_exec(poetry_install_cmd)
+    return (
+        container.with_exec(pip_install_poetry_cmd)
+        .with_exec(poetry_disable_virtual_env_cmd)
+        .with_exec(poetry_check_cmd)
+        .with_exec(poetry_install_cmd)
+    )
 
 
 async def with_installed_python_package(

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.2.0"
+version = "4.2.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_python_connectors.py
@@ -175,4 +175,4 @@ class TestAirbyteLibValidationTests:
             result = await AirbyteLibValidation(context_for_invalid_connector)._run(mocker.MagicMock())
             assert isinstance(result, StepResult)
             assert result.status == StepStatus.FAILURE
-            assert "does not appear to be a Python project" in result.stderr
+            assert "is not installable" in result.stderr


### PR DESCRIPTION
A change in an `airbyte-lib` output message broke the `airbyte-ci` unit tests.