### PR TITLE
AirbyteLib: improve json schema type detection

### DIFF
--- a/airbyte-lib/pyproject.toml
+++ b/airbyte-lib/pyproject.toml
@@ -134,6 +134,7 @@ ignore = [
     "PIE790", # Allow unnecssary 'pass' (sometimes useful for readability)
     "PERF203",  # exception handling in loop
     "S", # flake8-bandit (noisy, security related)
+    "SIM910", # Allow "None" as second argument to Dict.get(). "Explicit is better than implicit."
     "TD002", # Require author for TODOs
     "TRIO", # flake8-trio (opinionated, noisy)
     "INP001", # Dir 'examples' is part of an implicit namespace package. Add an __init__.py.

--- a/airbyte-lib/tests/unit_tests/test_type_translation.py
+++ b/airbyte-lib/tests/unit_tests/test_type_translation.py
@@ -8,6 +8,10 @@ from airbyte_lib.types import SQLTypeConverter
     "json_schema_property_def, expected_sql_type",
     [
         ({"type": "string"}, types.VARCHAR),
+        ({"type": ["boolean", "null"]}, types.BOOLEAN),
+        ({"type": ["null", "boolean"]}, types.BOOLEAN),
+        ({"type": "string"}, types.VARCHAR),
+        ({"type": ["null", "string"]}, types.VARCHAR),
         ({"type": "boolean"}, types.BOOLEAN),
         ({"type": "string", "format": "date"}, types.DATE),
         ({"type": "string", "format": "date-time", "airbyte_type": "timestamp_without_timezone"}, types.TIMESTAMP),

--- a/airbyte-lib/tests/unit_tests/test_type_translation.py
+++ b/airbyte-lib/tests/unit_tests/test_type_translation.py
@@ -2,7 +2,8 @@
 
 import pytest
 from sqlalchemy import types
-from airbyte_lib.types import SQLTypeConverter
+from airbyte_lib.types import SQLTypeConverter, _get_airbyte_type
+
 
 @pytest.mark.parametrize(
     "json_schema_property_def, expected_sql_type",
@@ -29,3 +30,50 @@ def test_to_sql_type(json_schema_property_def, expected_sql_type):
     converter = SQLTypeConverter()
     sql_type = converter.to_sql_type(json_schema_property_def)
     assert isinstance(sql_type, expected_sql_type)
+
+
+@pytest.mark.parametrize(
+    "json_schema_property_def, expected_airbyte_type",
+    [
+        ({"type": "string"}, "string"),
+        ({"type": ["boolean", "null"]}, "boolean"),
+        ({"type": ["null", "boolean"]}, "boolean"),
+        ({"type": "string"}, "string"),
+        ({"type": ["null", "string"]}, "string"),
+        ({"type": "boolean"}, "boolean"),
+        ({"type": "string", "format": "date"}, "date"),
+        ({"type": "string", "format": "date-time", "airbyte_type": "timestamp_without_timezone"}, "timestamp_without_timezone"),
+        ({"type": "string", "format": "date-time", "airbyte_type": "timestamp_with_timezone"}, "timestamp_with_timezone"),
+        ({"type": "string", "format": "time", "airbyte_type": "time_without_timezone"}, "time_without_timezone"),
+        ({"type": "string", "format": "time", "airbyte_type": "time_with_timezone"}, "time_with_timezone"),
+        ({"type": "integer"}, "integer"),
+        ({"type": "number", "airbyte_type": "integer"}, "integer"),
+        ({"type": "number"}, "number"),
+        ({"type": "array"}, "array"),
+        ({"type": "object"}, "object"),
+    ],
+)
+def test_to_airbyte_type(json_schema_property_def, expected_airbyte_type):
+    airbyte_type, _ = _get_airbyte_type(json_schema_property_def)
+    assert airbyte_type == expected_airbyte_type
+
+
+@pytest.mark.parametrize(
+    "json_schema_property_def, expected_airbyte_type, expected_airbyte_subtype",
+    [
+        ({"type": "string"}, "string", None),
+        ({"type": "number"}, "number", None),
+        ({"type": "array"}, "array", None),
+        ({"type": "object"}, "object", None),
+        ({"type": "array", "items": {"type": ["null", "string"]}}, "array", "string"),
+        ({"type": "array", "items": {"type": ["boolean"]}}, "array", "boolean"),
+    ],
+)
+def test_to_airbyte_subtype(
+    json_schema_property_def,
+    expected_airbyte_type,
+    expected_airbyte_subtype,
+):
+    airbyte_type, subtype = _get_airbyte_type(json_schema_property_def)
+    assert airbyte_type == expected_airbyte_type
+    assert subtype == expected_airbyte_subtype


### PR DESCRIPTION
Resolves: https://github.com/airbytehq/airbyte-lib-private-beta/issues/16

This will significantly decrease the volume of json schema types that trigger warnings like:

```
Could not determine airbyte type from JSON schema: {'type': ['null', 'string']}
```

1. Handle arrays of types, as in the above example.
2. Remove 'null' from an array before evaluating.
3. Add evalution of array subtypes.
4. Return 'object' or 'array' as appropriate, even if 'properties' and 'items' (respectively) are not declared.

Borrows from:

- https://github.com/airbytehq/airbyte/pull/35117

----

Sidebar:

This PR also silences the lint rule [SIM910](https://docs.astral.sh/ruff/rules/dict-get-with-none-default/), which I've never really agreed with and is present in a few places in the touched codebase. (Rationale: [Explicit is better than implicit](https://peps.python.org/pep-0020/) and `.get()` implementations from other classes fail if a second argument is not passed. Rather than ask 'is this safe?' I can know from looking at just that one line 'yes, it is safe and we're properly handling the not-found cases'.)