### PR TITLE
🐛 Source OpsGenie: fix parsing of updated_at timestamps from OpsGenie

### DIFF
--- a/airbyte-integrations/connectors/source-opsgenie/Dockerfile
+++ b/airbyte-integrations/connectors/source-opsgenie/Dockerfile
@@ -34,5 +34,5 @@ COPY source_opsgenie ./source_opsgenie
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.3.0
+LABEL io.airbyte.version=0.3.1
 LABEL io.airbyte.name=airbyte/source-opsgenie

--- a/airbyte-integrations/connectors/source-opsgenie/metadata.yaml
+++ b/airbyte-integrations/connectors/source-opsgenie/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 06bdb480-2598-40b8-8b0f-fc2e2d2abdda
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.3.1
   dockerRepository: airbyte/source-opsgenie
   githubIssueLabel: source-opsgenie
   license: MIT

--- a/airbyte-integrations/connectors/source-opsgenie/source_opsgenie/manifest.yaml
+++ b/airbyte-integrations/connectors/source-opsgenie/source_opsgenie/manifest.yaml
@@ -107,6 +107,7 @@ definitions:
       cursor_field: updatedAt
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S.%fZ"
+        - "%Y-%m-%dT%H:%M:%SZ"
       datetime_format: "%s"
       start_datetime:
         datetime: "{{ config['start_date'] }}"

--- a/docs/integrations/sources/opsgenie.md
+++ b/docs/integrations/sources/opsgenie.md
@@ -51,6 +51,7 @@ The Opsgenie connector uses the most recent API version for each source of data.
 
 | Version | Date       | Pull Request                                         | Subject |
 |:--------|:-----------|:-----------------------------------------------------| :--- |
+| 0.3.1   | 2024-02-14 | [35269](https://github.com/airbytehq/airbyte/pull/35269) | Fix parsing of updated_at timestamps in alerts |
 | 0.3.0   | 2023-10-19 | [31552](https://github.com/airbytehq/airbyte/pull/31552) | Migrated to Low Code |
 | 0.2.0   | 2023-10-24 | [31777](https://github.com/airbytehq/airbyte/pull/31777) | Fix schema |
 | 0.1.0   | 2022-09-14 | [16768](https://github.com/airbytehq/airbyte/pull/16768) | Initial Release |


### PR DESCRIPTION
Fixes #35020

## What
The OpsGenie API will truncate the `updated_at` timestamp of alerts where the timestamp falls exactly on the second.

This change extends the list of accepted cursor-based timestamp formats to include a format without fractions of seconds to correctly handle the response in this circumstance.

## How
Adding `"%Y-%m-%dT%H:%M:%SZ"` as a secondary accepted format to `cursor_datetime_formats` for the connector will allow the parser to correctly parse this alternative timestamp from the API.

## Recommended reading order
1. `manifest.yaml`

## 🚨 User Impact 🚨
This change should not cause any user impact.


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>