### PR TITLE
source-s3: unpin connector on cloud

### DIFF
--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -23,7 +23,6 @@ data:
       packageName: airbyte-source-s3
   registries:
     cloud:
-      dockerImageTag: 4.4.1
       enabled: true
     oss:
       enabled: true


### PR DESCRIPTION
`source-s3` was pinned to `4.4.1` on Cloud to resolve [this incident](https://github.com/airbytehq/oncall/issues/4247).
@clnoll has deployed a fix in https://github.com/airbytehq/airbyte/pull/34930

The connector can now bin unpinned in cloud