### PR TITLE
destination-e2e-test,dev-null: use CDK 0.20.6

### DIFF
--- a/airbyte-integrations/connectors/destination-dev-null/build.gradle
+++ b/airbyte-integrations/connectors/destination-dev-null/build.gradle
@@ -1,22 +1,12 @@
 plugins {
-    id 'application'
     id 'airbyte-java-connector'
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.20.6'
     features = ['db-destinations']
     useLocalCdk = false
 }
-
-//remove once upgrading the CDK version to 0.4.x or later
-java {
-    compileJava {
-        options.compilerArgs.remove("-Werror")
-    }
-}
-
-airbyteJavaConnector.addCdkDependencies()
 
 application {
     mainClass = 'io.airbyte.integrations.destination.dev_null.DevNullDestination'
@@ -25,6 +15,4 @@ application {
 
 dependencies {
     implementation project(':airbyte-integrations:connectors:destination-e2e-test')
-
-    integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-dev-null')
 }

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.3.1
   dockerRepository: airbyte/destination-dev-null
   githubIssueLabel: destination-dev-null
   icon: airbyte.svg

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/java/io/airbyte/integrations/destination/dev_null/DevNullDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/java/io/airbyte/integrations/destination/dev_null/DevNullDestinationAcceptanceTest.java
@@ -58,4 +58,9 @@ public class DevNullDestinationAcceptanceTest extends DestinationAcceptanceTest 
     assertEquals(0, actual.size());
   }
 
+  @Override
+  public void testSyncNotFailsWithNewFields() {
+    // Skip because `retrieveRecords` returns an empty list at all times.
+  }
+
 }

--- a/airbyte-integrations/connectors/destination-e2e-test/build.gradle
+++ b/airbyte-integrations/connectors/destination-e2e-test/build.gradle
@@ -1,25 +1,16 @@
 plugins {
-    id 'application'
     id 'airbyte-java-connector'
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.2.0'
+    cdkVersionRequired = '0.20.6'
     features = ['db-destinations']
     useLocalCdk = false
 }
 
-//remove once upgrading the CDK version to 0.4.x or later
-java {
-    compileJava {
-        options.compilerArgs.remove("-Werror")
-    }
-}
-
-airbyteJavaConnector.addCdkDependencies()
-
 application {
     mainClass = 'io.airbyte.integrations.destination.e2e_test.TestingDestinations'
+    applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0']
 }
 
 dependencies {

--- a/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: unknown
   connectorType: destination
   definitionId: 2eb65e87-983a-4fd7-b3e3-9d9dc6eb8537
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.3.1
   dockerRepository: airbyte/destination-e2e-test
   githubIssueLabel: destination-e2e-test
   icon: airbyte.svg

--- a/airbyte-integrations/connectors/destination-e2e-test/src/test-integration/java/io/airbyte/integrations/destination/e2e_test/TestingSilentDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-e2e-test/src/test-integration/java/io/airbyte/integrations/destination/e2e_test/TestingSilentDestinationAcceptanceTest.java
@@ -59,4 +59,9 @@ public class TestingSilentDestinationAcceptanceTest extends DestinationAcceptanc
     assertEquals(0, actual.size());
   }
 
+  @Override
+  public void testSyncNotFailsWithNewFields() {
+    // Skip because `retrieveRecords` returns an empty list at all times.
+  }
+
 }

--- a/docs/integrations/destinations/e2e-test.md
+++ b/docs/integrations/destinations/e2e-test.md
@@ -46,6 +46,7 @@ The OSS and Cloud variants have the same version number starting from version `0
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------| :------------------------------------------------------- |:----------------------------------------------------------|
+| 0.3.1 | 2024-02-14 | [35278](https://github.com/airbytehq/airbyte/pull/35278) | Adopt CDK 0.20.6 |
 | 0.3.0   | 2023-05-08 | [25776](https://github.com/airbytehq/airbyte/pull/25776) | Standardize spec and change property field to non-keyword |
 | 0.2.4   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors    |
 | 0.2.3   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option              |


### PR DESCRIPTION
This change serendipitously came about while I was doing something else. It's part of an overall effort of getting all java connectors' CI to green.