### PR TITLE
fix `:airbyte-integrations:connectors:destination-duckdb' could not be found in project`

### DIFF
--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -48,7 +48,6 @@ tasks.named('check').configure {
         'mssql',
         'clickhouse',
         'tidb',
-        'duckdb',
 ].each {destinationName ->
     tasks.matching { it.name == 'integrationTestPython' }.configureEach {
         dependsOn project(":airbyte-integrations:connectors:destination-$destinationName").tasks.named('assemble')


### PR DESCRIPTION
`destination-duck-db` gradle file was removed as it's not a java connector.
Legacy `integrationTestPython` depended on the `assemble` task of this connector.

