### PR TITLE
🐛 Source Harvest: Revert  poetry update

### DIFF
--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -24,6 +24,7 @@ data:
   registries:
     cloud:
       enabled: true
+      dockerImageTag: 0.1.21
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
Since [the poetry update](https://github.com/airbytehq/airbyte/pull/35090), we are seeing `"Unable to connect to Harvest API with the provided credentials - HTTPError('400 Client Error: Bad Request for url: https://api.harvestapp.com/v2/users?per_page=50&updated_since=2010-01-01+00%3A00%3A00%2B00%3A00')"` The hypothesis is that an update on pendulum changed the formating for the datetime in the URL. 

## How
More to be investigated but for now, revert (yay!!)
