### PR TITLE
AirbyteLib: Mark and deprioritize slow tests

### DIFF
--- a/airbyte-lib/pyproject.toml
+++ b/airbyte-lib/pyproject.toml
@@ -58,6 +58,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "requires_creds: marks a test as requiring credentials (skip when secrets unavailable)"
 ]
 
 [tool.ruff.pylint]

--- a/airbyte-lib/pyproject.toml
+++ b/airbyte-lib/pyproject.toml
@@ -56,7 +56,9 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-# addopts = "--mypy"  # FIXME: This sometimes blocks test discovery and execution
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.ruff.pylint]
 max-args = 8  # Relaxed from default of 5

--- a/airbyte-lib/tests/conftest.py
+++ b/airbyte-lib/tests/conftest.py
@@ -44,7 +44,9 @@ def pytest_collection_modifyitems(items: list[Item]) -> None:
     'integration' tests because 'u' comes after 'i' alphabetically.
     """
     def test_priority(item: Item) -> int:
-        if 'lint_tests' in str(item.fspath):
+        if item.get_closest_marker(name="slow"):
+            return 9  # slow tests have the lowest priority
+        elif 'lint_tests' in str(item.fspath):
             return 1  # lint tests have high priority
         elif 'unit_tests' in str(item.fspath):
             return 2  # unit tests have highest priority

--- a/airbyte-lib/tests/integration_tests/test_snowflake_cache.py
+++ b/airbyte-lib/tests/integration_tests/test_snowflake_cache.py
@@ -98,6 +98,8 @@ def snowflake_cache(snowflake_config) -> Generator[caches.SnowflakeCache, None, 
 # Uncomment this line if you want to see performance trace logs.
 # You can render perf traces using the viztracer CLI or the VS Code VizTracer Extension.
 #@viztracer.trace_and_save(output_dir=".pytest_cache/snowflake_trace/")
+@pytest.mark.requires_creds
+@pytest.mark.slow
 def test_faker_read_to_snowflake(
     source_faker_seed_a: ab.Source,
     snowflake_cache: ab.SnowflakeCache,
@@ -109,6 +111,8 @@ def test_faker_read_to_snowflake(
     assert len(list(result.cache.streams["users"])) == FAKER_SCALE_A
 
 
+@pytest.mark.requires_creds
+@pytest.mark.slow
 def test_replace_strategy(
     source_faker_seed_a: ab.Source,
     snowflake_cache: ab.SnowflakeCache,
@@ -121,6 +125,8 @@ def test_replace_strategy(
     assert len(list(result.cache.streams["users"])) == FAKER_SCALE_A
 
 
+@pytest.mark.requires_creds
+@pytest.mark.slow
 def test_merge_strategy(
     source_faker_seed_a: ab.Source,
     source_faker_seed_b: ab.Source,

--- a/airbyte-lib/tests/integration_tests/test_source_faker_integration.py
+++ b/airbyte-lib/tests/integration_tests/test_source_faker_integration.py
@@ -141,6 +141,7 @@ def test_faker_pks(
     assert read_result.cache._get_primary_keys("purchases") == ["id"]
 
 
+@pytest.mark.slow
 def test_replace_strategy(
     source_faker_seed_a: ab.Source,
     all_cache_types: ab.DuckDBCache,
@@ -155,6 +156,7 @@ def test_replace_strategy(
             assert len(list(result.cache.streams["purchases"])) == FAKER_SCALE_A
 
 
+@pytest.mark.slow
 def test_append_strategy(
     source_faker_seed_a: ab.Source,
     all_cache_types: ab.DuckDBCache,
@@ -167,6 +169,7 @@ def test_append_strategy(
             assert len(list(result.cache.streams["purchases"])) == FAKER_SCALE_A * iteration
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("strategy", ["merge", "auto"])
 def test_merge_strategy(
     strategy: str,

--- a/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
+++ b/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
@@ -688,6 +688,7 @@ def test_sync_to_postgres(new_pg_cache_config: PostgresCacheConfig, expected_tes
             check_dtype=False,
         )
 
+@pytest.mark.slow
 def test_sync_to_snowflake(snowflake_config: SnowflakeCacheConfig, expected_test_stream_data: dict[str, list[dict[str, str | int]]]):
     source = ab.get_source("source-test", config={"apiKey": "test"})
     source.select_all_streams()

--- a/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
+++ b/airbyte-lib/tests/integration_tests/test_source_test_fixture.py
@@ -689,6 +689,7 @@ def test_sync_to_postgres(new_pg_cache_config: PostgresCacheConfig, expected_tes
         )
 
 @pytest.mark.slow
+@pytest.mark.requires_creds
 def test_sync_to_snowflake(snowflake_config: SnowflakeCacheConfig, expected_test_stream_data: dict[str, list[dict[str, str | int]]]):
     source = ab.get_source("source-test", config={"apiKey": "test"})
     source.select_all_streams()


### PR DESCRIPTION
Replaces: https://github.com/airbytehq/airbyte/pull/34901

Resolves: https://github.com/airbytehq/airbyte-lib-private-beta/issues/32

This allows slow tests to be skipped. By default, this also puts slow tests last in the execution order, to prioritize other tests which can return faster.

This also adds a 'requires_creds' mark in pytest, which can be used if we want a subset of tests to be able to run on contributors' forks.

-------

## To skip slow tests

```
poetry run pytest -m "not slow"
```

As of now, this finishes in about 30 seconds.

## To show execution times

We can just the not-slow tests and report back the slowest 10 tests' durations. This is helpful in finding slow tests that are not yet marked as such.

```
poetry run pytest -m "not slow" --durations=10
```

We can run just the slow tests and report back all durations. This is helpful in finding tests that were incorrectly marked slow, or which are now longer slow.

```
poetry run pytest -m "slow" --durations=0
```
