### PR TITLE
AirbyteLib: suppress duckdb reflection warnings

### DIFF
--- a/airbyte-lib/airbyte_lib/caches/duckdb.py
+++ b/airbyte-lib/airbyte_lib/caches/duckdb.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from textwrap import dedent, indent
 from typing import cast
@@ -13,6 +14,14 @@ from overrides import overrides
 from airbyte_lib._file_writers import ParquetWriter, ParquetWriterConfig
 from airbyte_lib.caches.base import SQLCacheBase, SQLCacheConfigBase
 from airbyte_lib.telemetry import CacheTelemetryInfo
+
+
+# Suppress warnings from DuckDB about reflection on indices.
+# https://github.com/Mause/duckdb_engine/issues/905
+warnings.filterwarnings(
+    "ignore",
+    message="duckdb-engine doesn't yet support reflection on indices",
+)
 
 
 class DuckDBCacheConfig(SQLCacheConfigBase, ParquetWriterConfig):


### PR DESCRIPTION
A small quick change that reduced log noise.

Tested manually, once with the code commented out and once with the code in place, via:

```
poetry run python examples/run_faker.py
```

With the code commented out, the warning prints. But with the code in place, the code is silenced as expected. 

(Set to auto-merge after approval + successful tests.)