### PR TITLE
File-based CDK: enqueue AirbyteMessage of type record instead of sending to the message repository

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py
@@ -243,6 +243,9 @@ class FileBasedStreamPartition(Partition):
                     data_to_return = dict(record_data)
                     self._stream.transformer.transform(data_to_return, self._stream.get_json_schema())
                     yield Record(data_to_return, self.stream_name())
+                elif isinstance(record_data, AirbyteMessage) and record_data.type == Type.RECORD:
+                    # `AirbyteMessage`s of type `Record` should also be yielded so they are enqueued
+                    yield Record(record_data.record.data, self.stream_name())
                 else:
                     self._message_repository.emit_message(record_data)
         except Exception as e:


### PR DESCRIPTION
The `DefaultFileBasedStream` emits `AirbyteRecordMessage`s, but the `FileBasedStreamAdapter` was sending these to the message repository instead of enqueuing them.

This was causing a [failure of a new CAT](https://github.com/airbytehq/airbyte/pull/35055), preventing us from reverting an unrelated rollback.