### PR TITLE
conectors-qa: verify connector breaking changes are at least 7 days ahead

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -16,8 +16,9 @@ following command from this directory:
 pipx install .
 ```
 
-This will make `connectors-qa` available in your `PATH`. Run `connectors-qa --help` to see the
-available commands and options.
+This will make `connectors-qa` available in your `PATH`.
+
+Feel free to run `connectors-qa --help` to see the available commands and options.
 
 ### Examples
 
@@ -63,7 +64,7 @@ connectors-qa generate-documentation qa_checks.md
 ## Development
 
 ```bash
-poetry install
+poetry install --with dev
 ```
 
 ### Dependencies

--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -104,8 +104,11 @@ poe type_check
 ```bash
 poe lint
 ```
-
 ## Changelog
+
+### 1.2.0
+
+Added `ValidateBreakingChangesDeadlines` check that verifies the minimal compliance of breaking change rollout deadline.
 
 ### 1.1.0
 Introduced the `Check.run_on_released_connectors` flag.
@@ -129,5 +132,4 @@ Fix access to connector types: it should be accessed from the `Connector.connect
 - Make `CheckPublishToPyPiIsEnabled` run on source connectors only.
 
 ### 1.0.0
-
 Initial release of `connectors-qa` package.

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -9,9 +9,9 @@ packages = [
 ]
 [tool.poetry.dependencies]
 python = "^3.10"
-airbyte-connectors-base-images = {path = "../base_images", develop = false}
-connector-ops = {path = "../connector_ops", develop = false}
-metadata-service = {path = "../metadata_service/lib", develop = false}
+airbyte-connectors-base-images = { path = "../base_images", develop = false }
+connector-ops = { path = "../connector_ops", develop = false }
+metadata-service = { path = "../metadata_service/lib", develop = false }
 pydash = "^6.0.2"
 jinja2 = "^3.1.3"
 toml = "^0.10.2"
@@ -42,4 +42,11 @@ lint = "ruff check src"
 [tool.airbyte_ci]
 optional_poetry_groups = ["dev"]
 poe_tasks = ["type_check", "lint", "test"]
-required_environment_variables = ["DOCKER_HUB_USERNAME", "DOCKER_HUB_PASSWORD",]
+required_environment_variables = ["DOCKER_HUB_USERNAME", "DOCKER_HUB_PASSWORD"]
+
+[tool.pyright]
+reportMissingImports = true
+reportMissingTypeStubs = false
+pythonVersion = "3.10"
+venvPath = "."
+venv = ".venv"

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-qa"
-version = "1.1.0"
+version = "1.2.0"
 description = "A package to run QA checks on Airbyte connectors, generate reports and documentation."
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"
@@ -43,10 +43,3 @@ lint = "ruff check src"
 optional_poetry_groups = ["dev"]
 poe_tasks = ["type_check", "lint", "test"]
 required_environment_variables = ["DOCKER_HUB_USERNAME", "DOCKER_HUB_PASSWORD"]
-
-[tool.pyright]
-reportMissingImports = true
-reportMissingTypeStubs = false
-pythonVersion = "3.10"
-venvPath = "."
-venv = ".venv"

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
 
-from datetime import datetime, timedelta
 import os
+from datetime import datetime, timedelta
 
 import toml
-
 from connector_ops.utils import Connector, ConnectorLanguage  # type: ignore
 from connectors_qa import consts
 from connectors_qa.models import Check, CheckCategory, CheckResult
@@ -150,13 +149,15 @@ class CheckConnectorCDKTag(MetadataCheck):
             message=f"CDK tag {self.get_expected_cdk_tag(connector)} is present in the metadata file",
         )
 
+
 class ValidateBreakingChangesDeadlines(MetadataCheck):
     """
     Verify that _if_ the the most recent connector version has a breaking change,
     it's deadline is at least a week in the future.
     """
-    name = "Breaking change opt-in should be a week in the future"
-    description = f"If the connector version has a breaking change, the deadline field must be set to at least a week in the future."
+
+    name = "Breaking change deadline should be a week in the future"
+    description = "If the connector version has a breaking change, the deadline field must be set to at least a week in the future."
     runs_on_released_connectors = False
     minimum_days_until_deadline = 7
 
@@ -188,7 +189,7 @@ class ValidateBreakingChangesDeadlines(MetadataCheck):
                 message="No breaking changes found for the current version.",
             )
 
-        upgrade_deadline = current_version_breaking_changes.get('upgradeDeadline')
+        upgrade_deadline = current_version_breaking_changes.get("upgradeDeadline")
 
         if not upgrade_deadline:
             return self.fail(
@@ -202,13 +203,10 @@ class ValidateBreakingChangesDeadlines(MetadataCheck):
         if upgrade_deadline_datetime <= one_week_from_now:
             return self.fail(
                 connector=connector,
-                message=f"The upgrade deadline for the breaking changes in {current_version} is less than {self.minimum_days_until_deadline} days from today. Please extend the deadline.",
+                message=f"The upgrade deadline for the breaking changes in {current_version} is less than {self.minimum_days_until_deadline} days from today. Please extend the deadline",
             )
 
-        return self.pass_(
-            connector=connector,
-            message="Breaking changes deadline is at least a week in the future.",
-        )
+        return self.pass_(connector=connector, message="The upgrade deadline is set to at least a week in the future")
 
 
 ENABLED_CHECKS = [

--- a/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_models.py
+++ b/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_models.py
@@ -9,7 +9,7 @@ from connectors_qa.models import CheckStatus
 class TestCheck:
     def test_fail_when_requires_metadata_and_metata_is_missing(self, mocker):
         # Arrange
-        connector = mocker.MagicMock(metadata={})
+        connector = mocker.MagicMock(metadata={}, is_released=False)
 
         # Act
         results = []

--- a/docs/contributing-to-airbyte/resources/qa-checks.md
+++ b/docs/contributing-to-airbyte/resources/qa-checks.md
@@ -43,6 +43,11 @@ Connectors must have a language tag in their metadata. It must be set in the `ta
 *Applies to the following connector languages: python, low-code*
 
 Python connectors must have a CDK tag in their metadata. It must be set in the `tags` field in metadata.yaml. The values can be `cdk:low-code`, `cdk:python`, or `cdk:file`.
+### Breaking change deadline should be a week in the future
+*Applies to the following connector types: source, destination*
+*Applies to the following connector languages: java, low-code, python*
+
+If the connector version has a breaking change, the deadline field must be set to at least a week in the future.
 
 ## 📦 Packaging
 


### PR DESCRIPTION
## Summary

This PR adds a check to `connectors-qa` by @alafanechere to verify that if a connector has a breaking change defined in it's most recent version, than it's `upgradeDeadline` is at least 7 days away.

Closes [airbytehq/airbyte-internal-issues#6294](https://github.com/airbytehq/airbyte-internal-issues/issues/6294)

That's assuming that we actually run connectors-qa on all connectors, including certified 🙃 

## Impact

- It's a CI check, no product feature changes, safe to ship.
- I verified that it works on a few examples locally.

## TODOs
- [x] A unit test would be nice.
