### PR TITLE
airbyte-ci: disable a flaky test

### DIFF
--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -57,7 +57,7 @@ shell = "pyinstaller --additional-hooks-dir=pyinstaller_hooks --collect-all pipe
 args = [{name = "ARTIFACT_NAME", default="airbyte-ci", positional = true}]
 
 [tool.poe.tasks]
-test = "pytest tests"
+test = "pytest tests -m 'not flaky'"
 type_check = "mypy pipelines --disallow-untyped-defs"
 lint = "ruff check pipelines"
 

--- a/airbyte-ci/connectors/pipelines/pytest.ini
+++ b/airbyte-ci/connectors/pipelines/pytest.ini
@@ -2,3 +2,4 @@
 addopts = --cov=pipelines
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    flaky: marks tests as flaky (deselect with '-m "not flaky"')

--- a/airbyte-ci/connectors/pipelines/tests/test_tests/test_common.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_tests/test_common.py
@@ -193,6 +193,10 @@ class TestAcceptanceTests:
         env_vars = {await env_var.name(): await env_var.value() for env_var in await cat_container.env_variables()}
         assert "CACHEBUSTER" in env_vars
 
+    @pytest.mark.flaky
+    # This test has shown some flakiness in CI
+    # This should be investigated and fixed
+    # https://github.com/airbytehq/airbyte-internal-issues/issues/6304
     async def test_cat_container_caching(
         self,
         dagger_client,


### PR DESCRIPTION
## What
The `test_cat_container_caching` is flaky in CI.
This PR disables this until we prioritize its fixing (https://github.com/airbytehq/airbyte-internal-issues/issues/6304)