### PR TITLE
gradle: remove archived connectors

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -155,9 +155,21 @@ cdkPath.eachDir { dir ->
 def integrationsPath = rootDir.toPath().resolve('airbyte-integrations/connectors')
 integrationsPath.eachDir { dir ->
     def buildFiles = file(dir).list { file, name -> name == "build.gradle" }
-    if (buildFiles.length == 1) {
-        include ":airbyte-integrations:connectors:${dir.getFileName()}"
+    if (buildFiles.length != 1) {
+        // Ignore python and other non-gradle connectors.
+        return
     }
+    File metadataFile = dir.resolve("metadata.yaml").toFile()
+    if (!metadataFile.exists()) {
+        // Don't support connectors without metadata.
+        return
+    }
+    String metadataYaml = metadataFile.getText("UTF-8")
+    if (metadataYaml =~ /(?m)^\s+supportLevel:\s*["']?archived["']?\s*$/) {
+        // Ignore archived connectors.
+        return
+    }
+    include ":airbyte-integrations:connectors:${dir.getFileName()}"
 }
 
 // Include miscellaneous modules.


### PR DESCRIPTION
Supports #35359. 

I tested that this change works by basing the above PR's branch on this one and checking that the connectors aren't picked up by gradle.