### PR TITLE
[DNM] .github: add blacksmith_evaluation.yml workflow

### DIFF
--- a/.github/workflows/blacksmith_evaluation.yml
+++ b/.github/workflows/blacksmith_evaluation.yml
@@ -1,0 +1,34 @@
+name: Blacksmith - Test Runner
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  run-source-postgres-build:
+    runs-on: connector-test-large
+    name: Build source-postgres
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "21"
+      - name: Install Pip
+        run: curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3
+      - name: Install Pyenv
+        run: python3 -m pip install virtualenv --user
+      - name: Docker login
+        # Some tests use testcontainers which pull images from DockerHub.
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Build source-postgres
+        run: CI=true ./gradlew --scan --no-daemon --no-watch-fs :airbyte-integrations:connectors:source-postgres:check


### PR DESCRIPTION
Runs `./gradlew :airbyte-integrations:connectors:source-postgres:check`:
- gradle step takes 3m52 ( https://gradle.com/s/fwovulwo275qs ) on `connector-test-large` (github, 16 cores) runner with 04c965663a261991c7987fecb0536d3de347b919: https://github.com/airbytehq/airbyte/actions/runs/7964801249/job/21743071824?pr=35425
- gradle step takes 3m40 ( https://gradle.com/s/mqfukltimm4bm ) on `blacksmith-16vcpu-ubuntu-2204` with d270b5e95ac85b9feef4dc1ad2831e04863a30cd: https://github.com/airbytehq/airbyte/actions/runs/7964746436/job/21742918626?pr=35425

This gradle task which should be representative of what runs in CI in a typical connector pull request, minus all the dagger stuff, build caches, secret credentials, etc.

I tried with `build` instead of `check` but the `buildConnectorImage` task on which `build` depends installs dagger and gets stuck, so I gave up.