### PR TITLE
connectors_qa: make `CheckPublishToPyPiIsEnabled` only run on source connectors

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -98,3 +98,12 @@ poe type_check
 ```bash
 poe lint
 ```
+
+## Changelog
+
+### 1.0.1
+* Add `applies_to_connector_types` attribute to `Check` class to specify the connector types that the check applies to.
+* Make `CheckPublishToPyPiIsEnabled` run on source connectors only.
+
+### 1.0.0
+Initial release of `connectors-qa` package.

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-qa"
-version = "1.0.0"
+version = "1.0.1"
 description = "A package to run QA checks on Airbyte connectors, generate reports and documentation."
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/packaging.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/packaging.py
@@ -49,6 +49,7 @@ class CheckPublishToPyPiIsEnabled(PackagingCheck):
         ConnectorLanguage.PYTHON,
         ConnectorLanguage.LOW_CODE,
     ]
+    applies_to_connector_types = ["source"]
 
     def _run(self, connector: Connector) -> CheckResult:
         publish_to_pypi_is_enabled = get(connector.metadata, "remoteRegistries.pypi.enabled", False)

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/models.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/models.py
@@ -19,6 +19,8 @@ ALL_LANGUAGES = [
     ConnectorLanguage.PYTHON,
 ]
 
+ALL_TYPES = ["source", "destination"]
+
 
 class CheckCategory(Enum):
     """The category of a QA check"""
@@ -111,6 +113,15 @@ class Check(ABC):
         return ALL_LANGUAGES
 
     @property
+    def applies_to_connector_types(self) -> List[str]:
+        """The connector types that the QA check applies to
+
+        Returns:
+            List[str]: The connector types that the QA check applies to
+        """
+        return ALL_TYPES
+
+    @property
     @abstractmethod
     def category(self) -> CheckCategory:
         """The category of the QA check
@@ -135,6 +146,11 @@ class Check(ABC):
             return self.skip(
                 connector,
                 f"Check does not apply to {connector.language.value} connectors",
+            )
+        if connector.type not in self.applies_to_connector_types:
+            return self.skip(
+                connector,
+                f"Check does not apply to {connector.type} connectors",
             )
         return self._run(connector)
 

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/templates/qa_checks.md.j2
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/templates/qa_checks.md.j2
@@ -10,6 +10,7 @@ They are by no mean replacing the need for a manual review of the connector code
 ## {{ category.value }}
 {% for check in checks %}
 ### {{ check.name }}
+*Applies to the following connector types: {{ ', '.join(check.applies_to_connector_types) }}*
 *Applies to the following connector languages: {{ ', '.join(check.applies_to_connector_languages) }}*
 
 {{ check.description }}

--- a/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_models.py
+++ b/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_models.py
@@ -50,3 +50,16 @@ class TestCheck:
 
         # Assert
         assert all(result.status == CheckStatus.SKIPPED for result in results)
+
+    def test_skip_when_type_does_not_apply(self, mocker):
+        # Arrange
+        connector = mocker.MagicMock(type="destination")
+
+        # Act
+        results = []
+        for check in ENABLED_CHECKS:
+            if connector.type not in check.applies_to_connector_types:
+                results.append(check.run(connector))
+
+        # Assert
+        assert all(result.status == CheckStatus.SKIPPED for result in results)

--- a/docs/contributing-to-airbyte/resources/qa-checks.md
+++ b/docs/contributing-to-airbyte/resources/qa-checks.md
@@ -10,19 +10,23 @@ They are by no mean replacing the need for a manual review of the connector code
 ## 📄 Documentation
 
 ### Breaking changes must be accompanied by a migration guide
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: java, low-code, python*
 
 When a breaking change is introduced, we check that a migration guide is available. It should be stored under  `./docs/integrations/<connector-type>s/<connector-name>-migrations.md`.
 This document should contain a section for each breaking change, in order of the version descending. It must explain users which action to take to migrate to the new version.
 ### Connectors must have user facing documentation
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: java, low-code, python*
 
 The user facing connector documentation should be stored under `./docs/integrations/<connector-type>s/<connector-name>.md`.
 ### Connectors documentation follows our guidelines
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: java, low-code, python*
 
 The user facing connector documentation should follow the guidelines defined in the [documentation standards](https://hackmd.io/Bz75cgATSbm7DjrAqgl4rw).
 ### Connectors must have a changelog entry for each version
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: java, low-code, python*
 
 Each new version of a connector must have a changelog entry defined in the user facing documentation in `./docs/integrations/<connector-type>s/<connector-name>.md`.
@@ -30,6 +34,7 @@ Each new version of a connector must have a changelog entry defined in the user 
 ## 📝 Metadata
 
 ### Connectors must have valid metadata.yaml file
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: java, low-code, python*
 
 Connectors must have a `metadata.yaml` file at the root of their directory. This file is used to build our connector registry. Its structure must follow our metadata schema. Field values are also validated. This is to ensure that all connectors have the required metadata fields and that the metadata is valid. More details in this [documentation](https://docs.airbyte.com/connector-development/connector-metadata-file).
@@ -37,26 +42,32 @@ Connectors must have a `metadata.yaml` file at the root of their directory. This
 ## 📦 Packaging
 
 ### Connectors must use Poetry for dependency management
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: python, low-code*
 
 Connectors must use [Poetry](https://python-poetry.org/) for dependency management. This is to ensure that all connectors use a dependency management tool which locks dependencies and ensures reproducible installs.
 ### Connectors must be licensed under MIT or Elv2
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: java, low-code, python*
 
 Connectors must be licensed under the MIT or Elv2 license. This is to ensure that all connectors are licensed under a permissive license. More details in our [License FAQ](https://docs.airbyte.com/developer-guides/licenses/license-faq).
 ### Connector license in metadata.yaml and pyproject.toml file must match
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: python, low-code*
 
 Connectors license in metadata.yaml and pyproject.toml file must match. This is to ensure that all connectors are consistently licensed.
 ### Connector version must follow Semantic Versioning
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: java, low-code, python*
 
 Connector version must follow the Semantic Versioning scheme. This is to ensure that all connectors follow a consistent versioning scheme. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) for more details.
 ### Connector version in metadata.yaml and pyproject.toml file must match
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: python, low-code*
 
 Connector version in metadata.yaml and pyproject.toml file must match. This is to ensure that connector release is consistent.
 ### Python connectors must have PyPi publishing enabled
+*Applies to the following connector types: source*
 *Applies to the following connector languages: python, low-code*
 
 Python connectors must have [PyPi](https://pypi.org/) publishing enabled in their `metadata.yaml` file. This is declared by setting `remoteRegistries.pypi.enabled` to `true` in metadata.yaml. This is to ensure that all connectors can be published to PyPi and can be used in `airbyte-lib`.
@@ -64,6 +75,7 @@ Python connectors must have [PyPi](https://pypi.org/) publishing enabled in thei
 ## 💼 Assets
 
 ### Connectors must have an icon
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: java, low-code, python*
 
 Each connector must have an icon available in at the root of the connector code directory. It must be an SVG file named `icon.svg` and must be a square.
@@ -71,10 +83,12 @@ Each connector must have an icon available in at the root of the connector code 
 ## 🔒 Security
 
 ### Connectors must use HTTPS only
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: java, low-code, python*
 
 Connectors must use HTTPS only when making requests to external services.
 ### Python connectors must not use a Dockerfile and must declare their base image in metadata.yaml file
+*Applies to the following connector types: source, destination*
 *Applies to the following connector languages: python, low-code*
 
 Connectors must use our Python connector base image (`docker.io/airbyte/python-connector-base`), declared through the `connectorBuildOptions.baseImage` in their `metadata.yaml`.


### PR DESCRIPTION
## What
Publishing to Pypi is only a requirement for source connectors and their use with `PyAirbyte`
