### PR TITLE
ci: check for required reviewers on destinations

### DIFF
--- a/.github/workflows/connector_teams_review_requirements.yml
+++ b/.github/workflows/connector_teams_review_requirements.yml
@@ -9,9 +9,11 @@ on:
       - synchronize
     paths:
       - "airbyte-integrations/connectors/source-**"
+      - "airbyte-integrations/connectors/destination-**"
   pull_request_review:
     paths:
       - "airbyte-integrations/connectors/source-**"
+      - "airbyte-integrations/connectors/destination-**"
 jobs:
   check-review-requirements:
     name: "Check if a review is required from Connector teams"


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What

The required reviewers checks were only running for sources. This means review won't be requested for destinations that contain breaking changes so that we ensure messaging is correct/user friendly.

We should change this to also include destinations.

## How

Add destinations paths.

Note: this was originally filtered out here https://github.com/airbytehq/airbyte/pull/23030, but maybe it was an oversight to not include destinations as well
