### PR TITLE
connectors-qa: fix connector type attribute access

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -101,6 +101,9 @@ poe lint
 
 ## Changelog
 
+### 1.0.2
+Fix access to connector types: it should be accessed from the `Connector.connector_type` attribute.
+
 ### 1.0.1
 * Add `applies_to_connector_types` attribute to `Check` class to specify the connector types that the check applies to.
 * Make `CheckPublishToPyPiIsEnabled` run on source connectors only.

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-qa"
-version = "1.0.1"
+version = "1.0.2"
 description = "A package to run QA checks on Airbyte connectors, generate reports and documentation."
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/models.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/models.py
@@ -147,10 +147,10 @@ class Check(ABC):
                 connector,
                 f"Check does not apply to {connector.language.value} connectors",
             )
-        if connector.type not in self.applies_to_connector_types:
+        if connector.connector_type not in self.applies_to_connector_types:
             return self.skip(
                 connector,
-                f"Check does not apply to {connector.type} connectors",
+                f"Check does not apply to {connector.connector_type} connectors",
             )
         return self._run(connector)
 

--- a/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_models.py
+++ b/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_models.py
@@ -53,12 +53,12 @@ class TestCheck:
 
     def test_skip_when_type_does_not_apply(self, mocker):
         # Arrange
-        connector = mocker.MagicMock(type="destination")
+        connector = mocker.MagicMock(connector_type="destination")
 
         # Act
         results = []
         for check in ENABLED_CHECKS:
-            if connector.type not in check.applies_to_connector_types:
+            if connector.connector_type not in check.applies_to_connector_types:
                 results.append(check.run(connector))
 
         # Assert


### PR DESCRIPTION
I mistakenly accessed connector type through an unexisting `Connector.type` attribute, it should be `Connector.connector_type`