### PR TITLE
Revert "Add destination-kvdb to OSS registry"

### DIFF
--- a/airbyte-integrations/connectors/destination-kvdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kvdb/metadata.yaml
@@ -3,7 +3,7 @@ data:
     cloud:
       enabled: false
     oss:
-      enabled: true
+      enabled: false
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:1.2.0@sha256:c22a9d97464b69d6ef01898edf3f8612dc11614f05a84984451dde195f337db9
   connectorSubtype: api


### PR DESCRIPTION
Remove from the registry for now as `archived` support level will break platform OSS.

We still want to find a way to show this in the docs, and will come up with either a better solution for that or the platform code for handling it later. 