### PR TITLE
Fix syntax error in `tools/bin/manage.sh`, used to publish airbyte cdk

### DIFF
--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -191,7 +191,7 @@ cmd_publish() {
   _error_if_tag_exists "$versioned_image"
 
   # building the connector
-  if [ "$path" != "airbyte-cdk/python"]
+  if [ "$path" != "airbyte-cdk/python" ]; then
     # The python CDK will already have been built and tested earlier in the github workflow.
     cmd_build "$path" "$run_tests"
   fi


### PR DESCRIPTION
See the workflow error [here](https://github.com/airbytehq/airbyte/actions/runs/7981794828/job/21794219989) for reference.