### PR TITLE
connectors_qa: bump to 1.0.3

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -101,6 +101,9 @@ poe lint
 
 ## Changelog
 
+### 1.0.3
+Disable `CheckDocumentationStructure` for now. 
+
 ### 1.0.2
 Fix access to connector types: it should be accessed from the `Connector.connector_type` attribute.
 

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-qa"
-version = "1.0.2"
+version = "1.0.3"
 description = "A package to run QA checks on Airbyte connectors, generate reports and documentation."
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/pull/35458 disabled a check but did not bump the package version.