### PR TITLE
airbyte-ci: upload test artifacts along with reports

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/resources/log4j2-test.xml
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/resources/log4j2-test.xml
@@ -7,8 +7,7 @@
         <Property name="container-log-pattern">%d{yyyy-MM-dd'T'HH:mm:ss,SSS}{GMT+0}`%replace{%X{log_source}}{^ -}{} > %replace{%m}{$${env:LOG_SCRUB_PATTERN:-\*\*\*\*\*}}{*****}%n</Property>
         <!-- Always log INFO by default. -->
         <Property name="log-level">${sys:LOG_LEVEL:-${env:LOG_LEVEL:-INFO}}</Property>
-        <Property name="logSubDir">${env:AIRBYTE_LOG_SUBDIR:-${date:yyyy-MM-dd'T'HH:mm:ss}}</Property>
-        <Property name="logDir">build/test-logs/${logSubDir}</Property>
+        <Property name="logDir">build/test-logs/${date:yyyy-MM-dd'T'HH:mm:ss}</Property>
     </Properties>
 
     <Appenders>

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/templates/test_report.html.j2
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/templates/test_report.html.j2
@@ -167,8 +167,13 @@ function copyToClipBoard(htmlElement) {
       <label for="{{ step_result.step.title }}" class="lbl-toggle">{{ step_result.step.title }} | {{ format_duration(step_result.step.run_duration) }}</label>
     {% endif %}
     <div class="collapsible-content">
-      {% if step_result_to_artifact_link[step_result.step.title] %}
-        <div><a href="{{ step_result_to_artifact_link[step_result.step.title] }}">Test Artifacts</a></div>
+      {% if step_result_to_artifact_links[step_result.step.title] %}
+      <h3>Artifacts</h3>
+      <ul>
+      {% for artifact in step_result_to_artifact_links[step_result.step.title] %}
+        <li><a href="{{ artifact.url }}">{{ artifact.name }}</a></li>
+      {% endfor %}
+      </ul>
       {% endif %}
       <div class="content-inner">
         {% if step_result.stdout %}

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 import anyio
 import asyncclick as click
 import asyncer
-from dagger import Client, Config, Container, ExecError, File, ImageLayerCompression, Platform, Secret
+from dagger import Client, Config, Container, Directory, ExecError, File, ImageLayerCompression, Platform, Secret
 from more_itertools import chunked
 
 if TYPE_CHECKING:
@@ -352,4 +352,25 @@ def java_log_scrub_pattern(secrets_to_mask: List[str]) -> str:
             "}": "&#125;",
             ":": "&#58;",
         },
+    )
+
+
+def dagger_directory_as_zip_file(dagger_client: Client, directory: Directory, directory_name: str) -> File:
+    """Compress a directory and return a File object representing the zip file.
+
+    Args:
+        dagger_client (Client): The dagger client.
+        directory (Path): The directory to compress.
+        directory_name (str): The name of the directory.
+
+    Returns:
+        File: The File object representing the zip file.
+    """
+    return (
+        dagger_client.container()
+        .from_("alpine:3.19.1")
+        .with_exec(sh_dash_c(["apk update", "apk add zip"]))
+        .with_mounted_directory(f"/{directory_name}", directory)
+        .with_exec(["zip", "-r", "/zipped.zip", f"/{directory_name}"])
+        .file("/zipped.zip")
     )

--- a/airbyte-ci/connectors/pipelines/pipelines/models/artifacts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/artifacts.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import dagger
+from pipelines.consts import GCS_PUBLIC_DOMAIN
+from pipelines.dagger.actions import remote_storage
+
+
+@dataclass(kw_only=True)
+class Artifact:
+    """A dataclass to represent an artifact produced by a pipeline execution."""
+
+    name: str
+    content_type: str
+    content: dagger.File
+    to_upload: bool = True
+    local_path: Optional[Path] = None
+    gcs_url: Optional[str] = None
+
+    async def save_to_local_path(self, path: Path) -> Path:
+        exported = await self.content.export(str(path))
+        if exported:
+            self.local_path = path
+            return path
+        else:
+            raise Exception(f"Failed to save artifact {self.name} to local path {path}")
+
+    async def upload_to_gcs(self, dagger_client: dagger.Client, bucket: str, key: str, gcs_credentials: dagger.Secret) -> str:
+        gcs_cp_flags = None if self.content_type is None else [f"--content-type={self.content_type}"]
+
+        report_upload_exit_code, _, _ = await remote_storage.upload_to_gcs(
+            dagger_client=dagger_client,
+            file_to_upload=self.content,
+            key=key,
+            bucket=bucket,
+            gcs_credentials=gcs_credentials,
+            flags=gcs_cp_flags,
+        )
+        if report_upload_exit_code != 0:
+            raise Exception(f"Failed to upload artifact {self.name} to GCS. Exit code: {report_upload_exit_code}.")
+        self.gcs_url = f"{GCS_PUBLIC_DOMAIN}/{bucket}/{key}"
+        return f"{GCS_PUBLIC_DOMAIN}/{bucket}/{key}"

--- a/airbyte-ci/connectors/pipelines/pipelines/models/reports.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/reports.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+import time
 import typing
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -14,9 +15,9 @@ from pathlib import Path
 from typing import List
 
 from connector_ops.utils import console  # type: ignore
-from pipelines.consts import GCS_PUBLIC_DOMAIN, LOCAL_REPORTS_PATH_ROOT
-from pipelines.dagger.actions import remote_storage
-from pipelines.helpers.utils import format_duration
+from pipelines.consts import LOCAL_REPORTS_PATH_ROOT
+from pipelines.helpers.utils import format_duration, slugify
+from pipelines.models.artifacts import Artifact
 from pipelines.models.steps import StepResult, StepStatus
 from rich.console import Group
 from rich.panel import Panel
@@ -42,6 +43,10 @@ class Report:
     @property
     def report_output_prefix(self) -> str:
         return self.pipeline_context.report_output_prefix
+
+    @property
+    def report_dir_path(self) -> Path:
+        return Path(f"{LOCAL_REPORTS_PATH_ROOT}/{self.report_output_prefix}")
 
     @property
     def json_report_file_name(self) -> str:
@@ -83,42 +88,52 @@ class Report:
     def remote_storage_enabled(self) -> bool:
         return self.pipeline_context.is_ci
 
-    async def save_local(self, filename: str, content: str) -> Path:
-        """Save the report files locally."""
-        local_path = Path(f"{LOCAL_REPORTS_PATH_ROOT}/{self.report_output_prefix}/{filename}")
-        local_path.parents[0].mkdir(parents=True, exist_ok=True)
-        local_path.write_text(content)
-        return local_path
-
-    async def save_remote(self, local_path: Path, remote_key: str, content_type: str) -> int:
-        assert self.pipeline_context.ci_report_bucket is not None, "The ci_report_bucket must be set to save reports."
-        gcs_cp_flags = None if content_type is None else [f"--content-type={content_type}"]
-        local_file = self.pipeline_context.dagger_client.host().directory(".", include=[str(local_path)]).file(str(local_path))
-
-        report_upload_exit_code, _, _ = await remote_storage.upload_to_gcs(
-            dagger_client=self.pipeline_context.dagger_client,
-            file_to_upload=local_file,
-            key=remote_key,
-            bucket=self.pipeline_context.ci_report_bucket,
-            gcs_credentials=self.pipeline_context.ci_gcs_credentials_secret,
-            flags=gcs_cp_flags,
-        )
-        gcs_uri = "gs://" + self.pipeline_context.ci_report_bucket + "/" + remote_key
-        public_url = f"{GCS_PUBLIC_DOMAIN}/{self.pipeline_context.ci_report_bucket}/{remote_key}"
-        if report_upload_exit_code != 0:
-            self.pipeline_context.logger.error(f"Uploading {local_path} to {gcs_uri} failed.")
-        else:
-            self.pipeline_context.logger.info(f"Uploading {local_path} to {gcs_uri} succeeded. Public URL: {public_url}")
-        return report_upload_exit_code
-
     async def save(self) -> None:
-        """Save the report files."""
+        self.report_dir_path.mkdir(parents=True, exist_ok=True)
+        await self.save_json_report()
+        await self.save_step_result_artifacts()
 
-        local_json_path = await self.save_local(self.json_report_file_name, self.to_json())
-        absolute_path = local_json_path.absolute()
+    async def save_json_report(self) -> None:
+        """Save the report as JSON, upload it to GCS if the pipeline is running in CI"""
+
+        json_report_path = self.report_dir_path / self.json_report_file_name
+        report_dir = self.pipeline_context.dagger_client.host().directory(str(self.report_dir_path))
+        local_json_report_file = report_dir.with_new_file(self.json_report_file_name, self.to_json()).file(self.json_report_file_name)
+        json_report_artifact = Artifact(name="JSON Report", content_type="application/json", content=local_json_report_file)
+        await json_report_artifact.save_to_local_path(json_report_path)
+        absolute_path = json_report_path.absolute()
         self.pipeline_context.logger.info(f"Report saved locally at {absolute_path}")
-        if self.remote_storage_enabled:
-            await self.save_remote(local_json_path, self.json_report_remote_storage_key, "application/json")
+        if self.remote_storage_enabled and self.pipeline_context.ci_report_bucket and self.pipeline_context.ci_gcs_credentials_secret:
+            gcs_url = await json_report_artifact.upload_to_gcs(
+                dagger_client=self.pipeline_context.dagger_client,
+                bucket=self.pipeline_context.ci_report_bucket,
+                key=self.json_report_remote_storage_key,
+                gcs_credentials=self.pipeline_context.ci_gcs_credentials_secret,
+            )
+            self.pipeline_context.logger.info(f"JSON Report uploaded to {gcs_url}")
+
+    async def save_step_result_artifacts(self) -> None:
+        local_artifacts_dir = self.report_dir_path / "artifacts"
+        local_artifacts_dir.mkdir(parents=True, exist_ok=True)
+        # TODO: concurrent save and upload
+        for step_result in self.steps_results:
+            for artifact in step_result.artifacts:
+                step_artifacts_dir = local_artifacts_dir / slugify(step_result.step.title)
+                step_artifacts_dir.mkdir(parents=True, exist_ok=True)
+                await artifact.save_to_local_path(step_artifacts_dir / artifact.name)
+                if (
+                    self.remote_storage_enabled
+                    and self.pipeline_context.ci_report_bucket
+                    and self.pipeline_context.ci_gcs_credentials_secret
+                ):
+                    upload_time = int(time.time())
+                    gcs_url = await artifact.upload_to_gcs(
+                        dagger_client=self.pipeline_context.dagger_client,
+                        bucket=self.pipeline_context.ci_report_bucket,
+                        key=f"{self.report_output_prefix}/artifacts/{slugify(step_result.step.title)}/{upload_time}_{artifact.name}",
+                        gcs_credentials=self.pipeline_context.ci_gcs_credentials_secret,
+                    )
+                    self.pipeline_context.logger.info(f"Artifact {artifact.name} for {step_result.step.title} uploaded to {gcs_url}")
 
     def to_json(self) -> str:
         """Create a JSON representation of the report.

--- a/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
@@ -19,6 +19,7 @@ from dagger import Client, Container, DaggerError
 from pipelines import main_logger
 from pipelines.helpers import sentry_utils
 from pipelines.helpers.utils import format_duration, get_exec_result
+from pipelines.models.artifacts import Artifact
 
 if TYPE_CHECKING:
     from typing import Any, ClassVar, Optional, Union
@@ -74,7 +75,7 @@ class Result:
     report: Optional[str] = None
     exc_info: Optional[Exception] = None
     output_artifact: Any = None
-    test_artifacts_path: Optional[Path] = None
+    artifacts: List[Artifact] = field(default_factory=list)
 
     @property
     def success(self) -> bool:
@@ -388,7 +389,7 @@ class Step(ABC):
         else:
             return StepStatus.FAILURE
 
-    async def get_step_result(self, container: Container) -> StepResult:
+    async def get_step_result(self, container: Container, *args: Any, **kwargs: Any) -> StepResult:
         """Concurrent retrieval of exit code, stdout and stdout of a container.
 
         Create a StepResult object from these objects.


### PR DESCRIPTION
## What
This PR suggests a more generic approach than https://github.com/airbytehq/airbyte/pull/35317 at uploading test artifacts with reports.

* Introduce a `Artifact` dataclass
* Add a `artifacts` attribute to `Result`
* Save artifacts locally and to GCS on `report.save()`

Report example [here](https://storage.cloud.google.com/airbyte-ci-reports-multi/airbyte-ci/connectors/test/pull_request/augustin_02-21-airbyte-ci_upload_test_artifacts_along_with_reports/1708525633/b8938d7a53a7566db7aeff5300e4230d1115d873/source-postgres/3.3.11/output.html)
