### PR TITLE
Airbyte docs: Fixed JSON schema rendering issues for dark mode

### DIFF
--- a/docusaurus/src/components/SpecSchema.module.css
+++ b/docusaurus/src/components/SpecSchema.module.css
@@ -39,19 +39,16 @@
 .grid {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-
-  background: var(--ifm-table-border-color);
-  gap: 1px;
-  border: 1px solid var(--ifm-table-border-color);
+  border-top: 1px solid var(--ifm-table-border-color);
+  border-right: 1px solid var(--ifm-table-border-color);
 }
 
 .headerItem {
   grid-row: span 1;
   grid-column: span 1;
-  background-color: white;
+  background-color: var(--ifm-table-cell-color);
   text-align: left;
   align-items: center;
-
   display: flex;
   flex-direction: row;
   gap: 10px;
@@ -59,26 +56,30 @@
   padding: 0;
   font-size: inherit;
   padding: 7px;
+  border-left: 1px solid var(--ifm-table-border-color);
+  border-bottom: 1px solid var(--ifm-table-border-color);
 }
 
 .tableHeader {
-  background-color: #eee;
+  background-color: var(--ifm-table-stripe-background);
   font-weight: bold;
-  border-bottom: 1px solid var(--ifm-table-border-color);
+  border-bottom: 2px solid var(--ifm-table-border-color);
   padding: 7px;
 }
 
 .contentItem {
   grid-row: span 1;
   grid-column: span 1;
-  background-color: white;
+  background-color:var(--ifm-table-cell-color);
   padding: 7px;
 }
 
 .descriptionItem {
   grid-row: span 1;
   grid-column: span 3;
-  background-color: white;
+  background-color:var(--ifm-table-cell-color);
   margin: 0;
   padding: 7px;
+  border-left: 1px solid var(--ifm-table-border-color);
+  border-bottom: 1px solid var(--ifm-table-border-color);
 }


### PR DESCRIPTION
## What
Resolves: https://github.com/airbytehq/airbyte/issues/35472
Attaching "before-fix" and "after-fix" screenshots. (Can also be checked [here](https://airbyte-docs-git-bindi-docsfix-dark-mode-issues-airbyte-growth.vercel.app/integrations/sources/activecampaign#reference))
<img width="1268" alt="before_fix" src="https://github.com/airbytehq/airbyte/assets/158614730/651c8519-f9f4-43fc-bbc2-4e578a5a4a38">
<img width="1278" alt="after_fix" src="https://github.com/airbytehq/airbyte/assets/158614730/985dba4a-3cc8-456d-a1ab-2656fc471a82">
 
## How
- The cell and table backgrounds were set to white. Changed them to css color variables which adjust based on light and dark mode. Followed the table styling for changelog table on same page to determine which colors to use.
- Adjusted border on cells/headers and tables to get the same look and feel as the changelog table below on the same page. 

## 🚨 User Impact 🚨
No breaking changes, localized to docs, in a single CSS file.
