### PR TITLE
.github: fix java cdk publish workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -80,7 +80,10 @@ jobs:
         env:
           CI: true
         with:
+          job-id: gradle-check
           read-only: ${{ github.ref != 'refs/heads/master' }}
+          gradle-distribution-sha-256-sum-warning: false
+          concurrent: true
           # TODO: be able to remove the skipSlowTests property
           arguments: --scan --no-daemon --no-watch-fs check -DskipSlowTests=true
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -85,7 +85,7 @@ jobs:
           gradle-distribution-sha-256-sum-warning: false
           concurrent: true
           # TODO: be able to remove the skipSlowTests property
-          arguments: --scan --no-daemon --no-watch-fs check -DskipSlowTests=true
+          arguments: --scan check -DskipSlowTests=true
 
   set-instatus-incident-on-failure:
     name: Create Instatus Incident on Failure

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -41,7 +41,6 @@ concurrency:
 
 env:
   # Use the provided GITREF or default to the branch triggering the workflow.
-  REPO: ${{ github.event.inputs.repo }}
   GITREF: ${{ github.event.inputs.gitref || github.ref }}
   FORCE: "${{ github.event.inputs.force == null && 'false' || github.event.inputs.force }}"
   DRY_RUN: "${{ github.event.inputs.dry-run == null && 'true' || github.event.inputs.dry-run }}"
@@ -64,7 +63,6 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
         with:
-          repository: ${{ env.REPO }}
           ref: ${{ env.GITREF }}
 
       - name: Read Target Java CDK version

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: connector-test-xxlarge
     timeout-minutes: 30
     steps:
-      - name: Link comment to workflow run
+      - name: Link comment to Workflow Run
         if: github.event.inputs.comment-id
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -100,7 +100,7 @@ jobs:
           gradle-distribution-sha-256-sum-warning: false
           arguments: --scan :airbyte-cdk:java:airbyte-cdk:cdkBuild
 
-      - name: Check for already-published version (${{ env.CDK_VERSION }}, FORCE=${{ env.FORCE }})
+      - name: Check for Existing Version
         if: ${{ !(env.FORCE == 'true') }}
         uses: burrunan/gradle-cache-action@v1
         env:
@@ -112,7 +112,7 @@ jobs:
           gradle-distribution-sha-256-sum-warning: false
           arguments: --scan :airbyte-cdk:java:airbyte-cdk:assertCdkVersionNotPublished
 
-      - name: Publish Java Modules to CloudRepo
+      - name: Publish Poms and Jars to CloudRepo
         if: ${{ env.DRY_RUN == 'false' }}
         uses: burrunan/gradle-cache-action@v1
         env:

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -44,6 +44,8 @@ env:
   FORCE: "${{ github.event.inputs.force == null && 'false' || github.event.inputs.force }}"
   DRY_RUN: "${{ github.event.inputs.dry-run == null && 'true' || github.event.inputs.dry-run }}"
   CDK_VERSION_FILE_PATH: "./airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties"
+  S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+  S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
 
 jobs:
   publish-cdk:
@@ -80,15 +82,6 @@ jobs:
           distribution: "zulu"
           java-version: "21"
 
-      - name: Check for already-published version (${{ env.CDK_VERSION }}, FORCE=${{ env.FORCE }})
-        if: ${{ !(env.FORCE == 'true') }}
-        uses: burrunan/gradle-cache-action@v1
-        env:
-          CI: true
-        with:
-          read-only: true
-          arguments: --scan :airbyte-cdk:java:airbyte-cdk:assertCdkVersionNotPublished
-
       - name: Docker login
         # Some tests use testcontainers which pull images from DockerHub.
         uses: docker/login-action@v1
@@ -101,8 +94,23 @@ jobs:
         env:
           CI: true
         with:
+          job-id: cdk-build
           read-only: ${{ !(env.DRY_RUN == 'false') }}
+          concurrent: true
+          gradle-distribution-sha-256-sum-warning: false
           arguments: --scan :airbyte-cdk:java:airbyte-cdk:cdkBuild
+
+      - name: Check for already-published version (${{ env.CDK_VERSION }}, FORCE=${{ env.FORCE }})
+        if: ${{ !(env.FORCE == 'true') }}
+        uses: burrunan/gradle-cache-action@v1
+        env:
+          CI: true
+        with:
+          job-id: cdk-assert
+          read-only: true
+          concurrent: true
+          gradle-distribution-sha-256-sum-warning: false
+          arguments: --scan :airbyte-cdk:java:airbyte-cdk:assertCdkVersionNotPublished
 
       - name: Publish Java Modules to CloudRepo
         if: ${{ env.DRY_RUN == 'false' }}
@@ -112,7 +120,11 @@ jobs:
           CLOUDREPO_USER: ${{ secrets.CLOUDREPO_USER }}
           CLOUDREPO_PASSWORD: ${{ secrets.CLOUDREPO_PASSWORD }}
         with:
+          job-id: cdk-publish
           read-only: true
+          concurrent: true
+          execution-only-caches: true
+          gradle-distribution-sha-256-sum-warning: false
           arguments: --scan :airbyte-cdk:java:airbyte-cdk:cdkPublish
 
       - name: Add Success Comment

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -8,12 +8,6 @@
 #    /publish-java-cdk force=true     # Force-publish if needing to replace an already published version
 name: Publish Java CDK
 on:
-  # Temporarily run on commits to the 'java-cdk/publish-workflow' branch.
-  # TODO: Remove this 'push' trigger before merging to master.
-  push:
-    branches:
-      - java-cdk/publish-workflow
-
   workflow_dispatch:
     inputs:
       repo:
@@ -30,7 +24,7 @@ on:
         type: boolean
         default: false
       force:
-        description: "Force release (ignore existing)"
+        description: "Force release (overwrite existing)"
         required: true
         type: boolean
         default: false
@@ -40,9 +34,6 @@ on:
       comment-id:
         description: "Optional comment-id of the slash command. Ignore if not applicable."
         required: false
-      # uuid:
-      #   description: "Custom UUID of workflow run. Used because GitHub dispatches endpoint does not return workflow run id."
-      #   required: false
 
 concurrency:
   group: publish-airbyte-cdk
@@ -69,11 +60,13 @@ jobs:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
             > :clock2: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
       - name: Checkout Airbyte
         uses: actions/checkout@v3
         with:
           repository: ${{ env.REPO }}
           ref: ${{ env.GITREF }}
+
       - name: Read Target Java CDK version
         id: read-target-java-cdk-version
         run: |
@@ -83,22 +76,20 @@ jobs:
             exit 1
           fi
           echo "CDK_VERSION=${cdk_version}" >> $GITHUB_ENV
+
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: "21"
+
       - name: Check for already-published version (${{ env.CDK_VERSION }}, FORCE=${{ env.FORCE }})
         if: ${{ !(env.FORCE == 'true') }}
         run: ./gradlew :airbyte-cdk:java:airbyte-cdk:assertCdkVersionNotPublished
+
       - name: Build Java CDK
         run: ./gradlew --scan :airbyte-cdk:java:airbyte-cdk:cdkBuild
-      - name: Upload jars as artifacts
-        if: ${{ !(env.DRY_RUN == 'false') }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: mavenlocal-jars
-          path: ~/.m2/repository/io/airbyte/
+
       - name: Publish Java Modules to CloudRepo
         if: ${{ env.DRY_RUN == 'false' }}
         run: ./gradlew --scan :airbyte-cdk:java:airbyte-cdk:cdkPublish
@@ -114,6 +105,7 @@ jobs:
           edit-mode: append
           body: |
             > :white_check_mark: Successfully published Java CDK ${{ env.CDK_VERSION }}!
+
       - name: Add Failure Comment
         if: github.event.inputs.comment-id && failure()
         uses: peter-evans/create-or-update-comment@v1
@@ -122,7 +114,8 @@ jobs:
           edit-mode: append
           body: |
             > :x: Publish Java CDK ${{ env.CDK_VERSION }} failed!
-      - name: "Post failure to Slack channel `#dev-connectors-extensibility-releases`"
+
+      - name: "Post failure to Slack channel"
         if: ${{ env.DRY_RUN == 'false' && failure() }}
         uses: slackapi/slack-github-action@v1.23.0
         continue-on-error: true
@@ -150,7 +143,8 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
-      - name: "Post success to Slack channel `#dev-connectors-extensibility-releases`"
+
+      - name: "Post success to Slack channel"
         if: ${{ env.DRY_RUN == 'false' && !failure() }}
         uses: slackapi/slack-github-action@v1.23.0
         continue-on-error: true

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -121,7 +121,7 @@ jobs:
         if: ${{ !(env.FORCE == 'true') }}
         run: ./gradlew :airbyte-cdk:java:airbyte-cdk:assertCdkVersionNotPublished
       - name: Build Java CDK
-        run: ./gradlew --no-daemon :airbyte-cdk:java:airbyte-cdk:build
+        run: ./gradlew --scan :airbyte-cdk:java:airbyte-cdk:cdkBuild
       - name: Upload jars as artifacts
         if: ${{ !(env.DRY_RUN == 'false') }}
         uses: actions/upload-artifact@v2
@@ -130,7 +130,7 @@ jobs:
           path: ~/.m2/repository/io/airbyte/
       - name: Publish Java Modules to CloudRepo
         if: ${{ env.DRY_RUN == 'false' }}
-        run: ./gradlew --no-daemon :airbyte-cdk:java:airbyte-cdk:publish
+        run: ./gradlew --scan :airbyte-cdk:java:airbyte-cdk:cdkPublish
         env:
           CLOUDREPO_USER: ${{ secrets.CLOUDREPO_USER }}
           CLOUDREPO_PASSWORD: ${{ secrets.CLOUDREPO_PASSWORD }}

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -50,7 +50,7 @@ env:
 jobs:
   publish-cdk:
     name: Publish Java CDK
-    runs-on: connector-test-xxlarge
+    runs-on: connector-test-large
     timeout-minutes: 30
     steps:
       - name: Link comment to Workflow Run

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -94,7 +94,7 @@ jobs:
         env:
           CI: true
         with:
-          job-id: cdk-build
+          job-id: cdk-publish
           read-only: ${{ !(env.DRY_RUN == 'false') }}
           concurrent: true
           gradle-distribution-sha-256-sum-warning: false
@@ -106,7 +106,7 @@ jobs:
         env:
           CI: true
         with:
-          job-id: cdk-assert
+          job-id: cdk-publish
           read-only: true
           concurrent: true
           gradle-distribution-sha-256-sum-warning: false

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -12,7 +12,6 @@ on:
     inputs:
       repo:
         description: "Repo to check out code from. Defaults to the main airbyte repo."
-        # TODO: If publishing from forks is needed, we'll need to revert type to `string` of `choice`.
         type: choice
         required: true
         default: airbytehq/airbyte
@@ -83,17 +82,38 @@ jobs:
 
       - name: Check for already-published version (${{ env.CDK_VERSION }}, FORCE=${{ env.FORCE }})
         if: ${{ !(env.FORCE == 'true') }}
-        run: ./gradlew :airbyte-cdk:java:airbyte-cdk:assertCdkVersionNotPublished
+        uses: burrunan/gradle-cache-action@v1
+        env:
+          CI: true
+        with:
+          read-only: true
+          arguments: --scan :airbyte-cdk:java:airbyte-cdk:assertCdkVersionNotPublished
+
+      - name: Docker login
+        # Some tests use testcontainers which pull images from DockerHub.
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Build Java CDK
-        run: ./gradlew --scan :airbyte-cdk:java:airbyte-cdk:cdkBuild
+        uses: burrunan/gradle-cache-action@v1
+        env:
+          CI: true
+        with:
+          read-only: ${{ !(env.DRY_RUN == 'false') }}
+          arguments: --scan :airbyte-cdk:java:airbyte-cdk:cdkBuild
 
       - name: Publish Java Modules to CloudRepo
         if: ${{ env.DRY_RUN == 'false' }}
-        run: ./gradlew --scan :airbyte-cdk:java:airbyte-cdk:cdkPublish
+        uses: burrunan/gradle-cache-action@v1
         env:
+          CI: true
           CLOUDREPO_USER: ${{ secrets.CLOUDREPO_USER }}
           CLOUDREPO_PASSWORD: ${{ secrets.CLOUDREPO_PASSWORD }}
+        with:
+          read-only: true
+          arguments: --scan :airbyte-cdk:java:airbyte-cdk:cdkPublish
 
       - name: Add Success Comment
         if: github.event.inputs.comment-id && success()

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -57,39 +57,10 @@ env:
   CDK_VERSION_FILE_PATH: "./airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties"
 
 jobs:
-  # We are using these runners because they are the same as the one for `publish-command.yml`
-  # One problem we had using `ubuntu-latest` for example is that the user is not root and some commands would fail in
-  # `manage.sh` (specifically `apt-get`)
-  start-publish-docker-image-runner-0:
-    name: Start Build EC2 Runner 0
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@v3
-        with:
-          repository: airbytehq/airbyte
-          ref: master
-      - name: Check PAT rate limits
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
-      - name: Start AWS Runner
-        id: start-ec2-runner
-        uses: ./.github/actions/start-aws-runner
-        with:
-          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          github-token: ${{ env.PAT }}
-          label: ${{ github.run_id }}-publisher
-
   publish-cdk:
     name: Publish Java CDK
-    needs: start-publish-docker-image-runner-0
-    runs-on: ubuntu-latest
+    runs-on: connector-test-xxlarge
+    timeout-minutes: 30
     steps:
       - name: Link comment to workflow run
         if: github.event.inputs.comment-id
@@ -207,33 +178,3 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
-
-  # In case of self-hosted EC2 errors, remove this block.
-  stop-publish-docker-image-runner-0:
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
-    name: Stop Build EC2 Runner
-    needs:
-      - start-publish-docker-image-runner-0 # required to get output from the start-runner job
-      - publish-cdk # required to wait when the main job is done
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-      - name: Checkout Airbyte
-        uses: actions/checkout@v3
-      - name: Check PAT rate limits
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
-      - name: Stop EC2 runner
-        uses: airbytehq/ec2-github-runner@base64v1.1.0
-        with:
-          mode: stop
-          github-token: ${{ env.PAT }}
-          label: ${{ needs.start-publish-docker-image-runner-0.outputs.label }}
-          ec2-instance-id: ${{ needs.start-publish-docker-image-runner-0.outputs.ec2-instance-id }}

--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -8,11 +8,16 @@ allprojects {
     def artifactBaseName = 'airbyte-cdk-' + project.name
     // E.g. airbyte-cdk-core, airbyte-cdk-db-sources, airbyte-cdk-db-destinations, etc.
 
+    var props = new Properties()
+    file("core/src/main/resources/version.properties").withInputStream(props::load)
+    project.version =  props.getProperty('version', 'undefined')
+
     publishing {
         publications {
             main(MavenPublication) {
                 groupId = 'io.airbyte.cdk'
                 artifactId = artifactBaseName
+                version = project.version
                 from components.java
             }
             testFixtures(MavenPublication) {
@@ -54,15 +59,10 @@ tasks.register('cdkPublish').configure {
 }
 tasks.register('assertCdkVersionNotPublished') {
     doLast {
-        var props = new Properties()
-        file("core/src/main/resources/version.properties").withInputStream(props::load)
 
-        var checkGroupId = "io.airbyte.cdk"
-        var checkArtifactId = "airbyte-cdk-core"
-        var checkVersion = props.getProperty('version') ?: 'undefined'
         var repoUrl = "https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars"
-        var groupIdUrl = "${repoUrl}/${checkGroupId.replace('.', '/')}"
-        var artifactUrl = "${groupIdUrl}/${checkArtifactId}/${checkVersion}/${checkArtifactId}-${checkVersion}.pom"
+        var groupIdUrl = "${repoUrl}/io/airbyte/cdk"
+        var artifactUrl = "${groupIdUrl}/airbyte-cdk-core/${project.version}/airbyte-cdk-core-${project.version}.pom"
 
         var connection = artifactUrl.toURL().openConnection() as HttpURLConnection
         connection.setRequestMethod("HEAD")
@@ -71,11 +71,11 @@ tasks.register('assertCdkVersionNotPublished') {
         var responseCode = connection.getResponseCode()
 
         if (responseCode == 200) {
-            throw new GradleException("Java CDK '${checkVersion}' already published at ${groupIdUrl}")
+            throw new GradleException("Java CDK '${project.version}' already published at ${groupIdUrl}")
         } else if (responseCode == 404) {
-            logger.lifecycle("Java CDK '${checkVersion}' not yet published at ${groupIdUrl}")
+            logger.lifecycle("Java CDK '${project.version}' not yet published at ${groupIdUrl}")
         } else {
-            throw new GradleException("Unexpected HTTP response code ${responseCode} from ${artifactUrl}, expected either 200 or 404.")
+            throw new GradleException("Unexpected HTTP response code ${responseCode} from ${artifactUrl} : expected either 200 or 404.")
         }
     }
 }

--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -46,6 +46,12 @@ allprojects {
 
 description = "Airbyte Connector Development Kit (CDK) for Java."
 
+tasks.register('cdkBuild').configure {
+    dependsOn subprojects.collect { it.tasks.named('build') }
+}
+tasks.register('cdkPublish').configure {
+    dependsOn subprojects.collect { it.tasks.named('publish') }
+}
 tasks.register('assertCdkVersionNotPublished') {
     doLast {
         var props = new Properties()

--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -1,3 +1,9 @@
+final var cdkVersion = {
+    var props = new Properties()
+    file("core/src/main/resources/version.properties").withInputStream(props::load)
+    return props.getProperty('version', 'undefined')
+}()
+
 allprojects {
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
@@ -8,9 +14,7 @@ allprojects {
     def artifactBaseName = 'airbyte-cdk-' + project.name
     // E.g. airbyte-cdk-core, airbyte-cdk-db-sources, airbyte-cdk-db-destinations, etc.
 
-    var props = new Properties()
-    file("core/src/main/resources/version.properties").withInputStream(props::load)
-    project.version =  props.getProperty('version', 'undefined')
+    project.version = cdkVersion
 
     publishing {
         publications {

--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -73,7 +73,7 @@ tasks.register('assertCdkVersionNotPublished') {
         if (responseCode == 200) {
             throw new GradleException("Java CDK '${checkVersion}' already published at ${groupIdUrl}")
         } else if (responseCode == 404) {
-            logger.lifecycle("Java CDK '${checkVersion}' not yet published at ${groupIdUrl}.")
+            logger.lifecycle("Java CDK '${checkVersion}' not yet published at ${groupIdUrl}")
         } else {
             throw new GradleException("Unexpected HTTP response code ${responseCode} from ${artifactUrl}, expected either 200 or 404.")
         }


### PR DESCRIPTION
Context: https://airbytehq-team.slack.com/archives/C02TL38U5L7/p1708542793736269

Since I merged https://github.com/airbytehq/airbyte/pull/35307 the java CDK publish workflow has been broken and has effectively done nothing. We haven't published any CDK jars since last weekend.