### PR TITLE
Regression testing version comparison

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
@@ -153,6 +153,7 @@ def should_use_remote_secrets(use_remote_secrets: Optional[bool]) -> bool:
         "migrate_to_base_image": "pipelines.airbyte_ci.connectors.migrate_to_base_image.commands.migrate_to_base_image",
         "upgrade_base_image": "pipelines.airbyte_ci.connectors.upgrade_base_image.commands.upgrade_base_image",
         "upgrade_cdk": "pipelines.airbyte_ci.connectors.upgrade_cdk.commands.bump_version",
+        "regression_test": "pipelines.airbyte_ci.connectors.regression_test.commands.regression_test",
     },
 )
 @click.option(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
@@ -23,6 +23,10 @@ class CONNECTOR_TEST_STEP_ID(str, Enum):
     VERSION_INC_CHECK = "version_inc_check"
     TEST_ORCHESTRATOR = "test_orchestrator"
     DEPLOY_ORCHESTRATOR = "deploy_orchestrator"
+    REGRESSION_TEST_BUILD_CONTROL = "regression_test_build_control"
+    REGRESSION_TEST_BUILD_TARGET = "regression_test_build_target"
+    REGRESSION_TEST_CONTROL = "regression_test_control"
+    REGRESSION_TEST_TARGET = "regression_test_target"
 
     def __str__(self) -> str:
         return self.value

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from types import TracebackType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
 
 import yaml  # type: ignore
 from anyio import Path
@@ -68,6 +68,7 @@ class ConnectorContext(PipelineContext):
         concurrent_cat: Optional[bool] = False,
         run_step_options: RunStepOptions = RunStepOptions(),
         targeted_platforms: Sequence[Platform] = BUILD_PLATFORMS,
+        versions_to_test: Optional[Tuple[str, str]] = None,
     ) -> None:
         """Initialize a connector context.
 
@@ -95,6 +96,7 @@ class ConnectorContext(PipelineContext):
             s3_build_cache_secret_key (Optional[str], optional): Gradle S3 Build Cache credentials. Defaults to None.
             concurrent_cat (bool, optional): Whether to run the CAT tests in parallel. Defaults to False.
             targeted_platforms (Optional[Iterable[Platform]], optional): The platforms to build the connector image for. Defaults to BUILD_PLATFORMS.
+            versions_to_test (Optional[Tuple[str, str]]): The control and target version of the connector to be used in regression tests.
         """
 
         self.pipeline_name = pipeline_name
@@ -116,6 +118,7 @@ class ConnectorContext(PipelineContext):
         self.concurrent_cat = concurrent_cat
         self._connector_secrets: Optional[Dict[str, Secret]] = None
         self.targeted_platforms = targeted_platforms
+        self.versions_to_test = versions_to_test
 
         super().__init__(
             pipeline_name=pipeline_name,

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/regression_test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/regression_test/commands.py
@@ -1,0 +1,116 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+from typing import Dict, List
+
+import asyncclick as click
+from pipelines import main_logger
+from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
+from pipelines.airbyte_ci.connectors.context import ConnectorContext
+from pipelines.airbyte_ci.connectors.pipeline import run_connectors_pipelines
+from pipelines.airbyte_ci.connectors.regression_test.pipeline import run_connector_regression_test_pipeline
+from pipelines.cli.click_decorators import click_ci_requirements_option
+from pipelines.cli.dagger_pipeline_command import DaggerPipelineCommand
+from pipelines.consts import LOCAL_BUILD_PLATFORM, ContextState
+from pipelines.helpers.execution import argument_parsing
+from pipelines.helpers.execution.run_steps import RunStepOptions
+from pipelines.helpers.github import update_global_commit_status_check_for_tests
+from pipelines.helpers.utils import fail_if_missing_docker_hub_creds
+from pipelines.models.steps import STEP_PARAMS
+
+
+@click.command(
+    cls=DaggerPipelineCommand,
+    help="Test all the selected connectors.",
+    context_settings=dict(
+        ignore_unknown_options=True,
+    ),
+)
+@click_ci_requirements_option()
+@click.option(
+    "--control-version",
+    help=(
+        "Control version of the connector to be tested. Records will be downloaded from this container and used as expected records for the target version."
+    ),
+    default="latest",
+    type=str,
+)
+@click.option(
+    "--target-version",
+    help=("Target version of the connector being tested."),
+    default="dev",
+    type=str,
+)
+@click.option(
+    "--fail-fast",
+    help="When enabled, tests will fail fast.",
+    default=False,
+    type=bool,
+    is_flag=True,
+)
+@click.pass_context
+async def regression_test(ctx: click.Context, control_version: str, target_version: str, fail_fast: bool) -> bool:
+    """
+    Runs a regression test pipeline for the selected connectors.
+    """
+    if ctx.obj["is_ci"]:
+        fail_if_missing_docker_hub_creds(ctx)
+
+    if ctx.obj["selected_connectors_with_modified_files"]:
+        update_global_commit_status_check_for_tests(ctx.obj, "pending")
+    else:
+        main_logger.warn("No connector were selected for testing.")
+        update_global_commit_status_check_for_tests(ctx.obj, "success")
+        return True
+
+    run_step_options = RunStepOptions(fail_fast=fail_fast)
+    connectors_tests_contexts = []
+    for connector in ctx.obj["selected_connectors_with_modified_files"]:
+        if control_version in ("dev", "latest"):
+            control_version = f"airbyte/{connector.technical_name}:{control_version}"
+
+        if target_version in ("dev", "latest"):
+            target_version = f"airbyte/{connector.technical_name}:{target_version}"
+
+        connectors_tests_contexts.append(
+            ConnectorContext(
+                pipeline_name=f"Testing connector {connector.technical_name}",
+                connector=connector,
+                is_local=ctx.obj["is_local"],
+                git_branch=ctx.obj["git_branch"],
+                git_revision=ctx.obj["git_revision"],
+                ci_report_bucket=ctx.obj["ci_report_bucket_name"],
+                report_output_prefix=ctx.obj["report_output_prefix"],
+                use_remote_secrets=ctx.obj["use_remote_secrets"],
+                gha_workflow_run_url=ctx.obj.get("gha_workflow_run_url"),
+                dagger_logs_url=ctx.obj.get("dagger_logs_url"),
+                pipeline_start_timestamp=ctx.obj.get("pipeline_start_timestamp"),
+                ci_context=ctx.obj.get("ci_context"),
+                pull_request=ctx.obj.get("pull_request"),
+                ci_gcs_credentials=ctx.obj["ci_gcs_credentials"],
+                use_local_cdk=ctx.obj.get("use_local_cdk"),
+                s3_build_cache_access_key_id=ctx.obj.get("s3_build_cache_access_key_id"),
+                s3_build_cache_secret_key=ctx.obj.get("s3_build_cache_secret_key"),
+                docker_hub_username=ctx.obj.get("docker_hub_username"),
+                docker_hub_password=ctx.obj.get("docker_hub_password"),
+                run_step_options=run_step_options,
+                targeted_platforms=[LOCAL_BUILD_PLATFORM],
+                versions_to_test=(control_version, target_version),
+            )
+        )
+
+    try:
+        await run_connectors_pipelines(
+            [connector_context for connector_context in connectors_tests_contexts],
+            run_connector_regression_test_pipeline,
+            "Regression Test Pipeline",
+            ctx.obj["concurrency"],
+            ctx.obj["dagger_logs_path"],
+            ctx.obj["execute_timeout"],
+        )
+    except Exception as e:
+        main_logger.error("An error occurred while running the regression test pipeline", exc_info=e)
+        return False
+
+    return True

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/regression_test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/regression_test/pipeline.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+"""This module groups factory like functions to dispatch tests steps according to the connector under test language."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import anyio
+from connector_ops.utils import ConnectorLanguage  # type: ignore
+from pipelines.airbyte_ci.connectors.context import ConnectorContext
+from pipelines.airbyte_ci.connectors.regression_test.steps.regression_cats import get_test_steps
+from pipelines.airbyte_ci.connectors.reports import ConnectorReport
+from pipelines.helpers.execution.run_steps import StepToRun, run_steps
+
+if TYPE_CHECKING:
+
+    from pipelines.helpers.execution.run_steps import STEP_TREE
+
+
+async def run_connector_regression_test_pipeline(context: ConnectorContext, semaphore: anyio.Semaphore) -> ConnectorReport:
+    """
+    Compute the steps to run for a connector test pipeline.
+    """
+    steps_to_run: STEP_TREE = get_test_steps(context)
+
+    async with semaphore:
+        async with context:
+            result_dict = await run_steps(
+                runnables=steps_to_run,
+                options=context.run_step_options,
+            )
+
+            results = list(result_dict.values())
+            report = ConnectorReport(context, steps_results=results, name="TEST RESULTS")
+            context.report = report
+
+    return report

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/regression_test/steps/regression_cats.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/regression_test/steps/regression_cats.py
@@ -1,0 +1,193 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+"""This module groups steps made to run regression tests for any Source connector."""
+
+import sys
+from typing import List
+
+import dagger
+from dagger import Container, Directory
+from pipelines import hacks
+from pipelines.airbyte_ci.connectors.build_image.steps.python_connectors import BuildConnectorImages
+from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
+from pipelines.airbyte_ci.connectors.context import ConnectorContext
+from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests
+from pipelines.consts import LOCAL_BUILD_PLATFORM
+from pipelines.helpers.execution.run_steps import STEP_TREE, StepToRun
+from pipelines.models.steps import StepResult, StepStatus
+
+_BASE_CONTAINER_DIRECTORY = "/tmp"
+_CONTAINER_TEST_OUTPUT_DIRECTORY = f"{_BASE_CONTAINER_DIRECTORY}/test_output"
+_CONTAINER_EXPECTED_RECORDS_DIRECTORY = f"{_CONTAINER_TEST_OUTPUT_DIRECTORY}/expected_records"
+_CONTAINER_ACCEPTANCE_TEST_CONFIG_FILEPATH = f"{_BASE_CONTAINER_DIRECTORY}/updated-acceptance-test-config.yml"
+_HOST_TEST_OUTPUT_DIRECTORY = "/tmp/test_dir"
+_REGRESSION_TEST_DIRECTORY = "/app/connector_acceptance_test/utils/regression_test.py"
+
+
+class BuildConnectorImagesControl(BuildConnectorImages):
+    @property
+    def title(self):
+        return f"{super().title}: Control Container ({self.docker_image_name})"
+
+
+class BuildConnectorImagesTarget(BuildConnectorImages):
+    @property
+    def title(self):
+        return f"{super().title}: Target Container ({self.docker_image_name})"
+
+
+class RegressionTestsControl(AcceptanceTests):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._container_id_filepath = f"{_BASE_CONTAINER_DIRECTORY}/control_container_id.txt"
+
+    @property
+    def title(self):
+        return f"Regression Tests: Control Container ({self.context.versions_to_test[0]})"
+
+    async def get_cat_command(self, connector_dir: Directory) -> List[str]:
+        return await super().get_cat_command(connector_dir) + [
+            "--store-expected-records",
+            _CONTAINER_EXPECTED_RECORDS_DIRECTORY,
+            "--container-id-filepath",
+            self._container_id_filepath,
+        ]
+
+    async def _run(self, connector_under_test_container: Container) -> StepResult:
+        """Run the first phase of the regression test suite on a connector image.
+
+        This phase runs connector acceptance tests on the connector and stores the output records which will
+        be passed to the target container for expected record validation.
+
+        Args:
+            connector_under_test_container (Container): The container holding the connector under test image.
+
+        Returns:
+            StepResult: Failure or success of the acceptances tests with stdout and stderr.
+        """
+        if not self.context.connector.acceptance_test_config:
+            return StepResult(step=self, status=StepStatus.SKIPPED)
+
+        connector_dir = await self.context.get_connector_dir()
+        cat_container = await self._build_connector_acceptance_test(connector_under_test_container, connector_dir)
+        cat_command = await self.get_cat_command(connector_dir)
+
+        # Execute CATs and prepare for the target run by exporting output to a directory on the host
+        cat_container = await cat_container.with_(hacks.never_fail_exec(cat_command))
+        await cat_container.directory(_BASE_CONTAINER_DIRECTORY).export(_HOST_TEST_OUTPUT_DIRECTORY)
+
+        await self._update_secrets_dir(cat_container)
+        return await self.get_step_result(cat_container)
+
+
+class RegressionTestsTarget(AcceptanceTests):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._container_id_filepath = f"{_BASE_CONTAINER_DIRECTORY}/target_container_id.txt"
+
+    @property
+    def title(self):
+        return f"Regression Tests: Target Container ({self.context.versions_to_test[1]})"
+
+    async def get_cat_command(self, connector_dir: Directory) -> List[str]:
+        return await super().get_cat_command(connector_dir) + [
+            "--acceptance-test-config-filepath",
+            _CONTAINER_ACCEPTANCE_TEST_CONFIG_FILEPATH,
+            "--container-id-filepath",
+            self._container_id_filepath,
+        ]
+
+    async def _run(self, connector_under_test_container: Container) -> StepResult:
+        """Run the second phase of the regression test suite on a connector image.
+
+        This phase runs connector acceptance tests on the connector, using the records output by the run of the
+         control container as expected records.
+
+        Args:
+            connector_under_test_container (Container): The container holding the connector under test image.
+
+        Returns:
+            StepResult: Failure or success of the acceptances tests with stdout and stderr.
+        """
+        if not self.context.connector.acceptance_test_config:
+            return StepResult(step=self, status=StepStatus.SKIPPED)
+
+        connector_dir = await self.context.get_connector_dir()
+        cat_container = await self._build_connector_acceptance_test(connector_under_test_container, connector_dir)
+        cat_command = await self.get_cat_command(connector_dir)
+
+        # Prepare the host container with an acceptance-test-config.yml whose expected records location points to the
+        # mounted directory containing the records output from the control run.
+        prep_container = await self._prepare_regression_test(cat_container)
+        await prep_container.directory(_BASE_CONTAINER_DIRECTORY).export(_HOST_TEST_OUTPUT_DIRECTORY)
+        prep_result = await self.get_step_result(prep_container)
+        if not prep_result.success:
+            return prep_result
+
+        async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+            # Give the target container access to the output from the RegressionTestsControl phase and then execute CATs
+            temp_dir = client.host().directory(_HOST_TEST_OUTPUT_DIRECTORY)
+            cat_container = await cat_container.with_directory(_BASE_CONTAINER_DIRECTORY, temp_dir)
+            cat_container = cat_container.with_(hacks.never_fail_exec(cat_command))
+
+        await self._update_secrets_dir(cat_container)
+        return await self.get_step_result(cat_container)
+
+    async def _prepare_regression_test(self, cat_container: Container) -> Container:
+        rewrite_config_command = [
+            "python",
+            _REGRESSION_TEST_DIRECTORY,
+            ".",
+            _CONTAINER_ACCEPTANCE_TEST_CONFIG_FILEPATH,
+            _CONTAINER_EXPECTED_RECORDS_DIRECTORY,
+        ]
+        return await cat_container.with_(hacks.never_fail_exec(rewrite_config_command))
+
+
+def get_test_steps(context: ConnectorContext) -> STEP_TREE:
+    """
+    Get all the tests steps for running regression tests.
+    """
+    control_image, target_image = context.versions_to_test
+
+    return [
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.REGRESSION_TEST_BUILD_CONTROL,
+                step=BuildConnectorImagesControl(context, docker_image_name=control_image),
+            ),
+        ],
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.REGRESSION_TEST_CONTROL,
+                step=RegressionTestsControl(context, context.concurrent_cat),
+                args=lambda results: {
+                    "connector_under_test_container": results[CONNECTOR_TEST_STEP_ID.REGRESSION_TEST_BUILD_CONTROL].output_artifact[
+                        LOCAL_BUILD_PLATFORM
+                    ]
+                },
+                depends_on=[CONNECTOR_TEST_STEP_ID.REGRESSION_TEST_BUILD_CONTROL],
+            ),
+        ],
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.REGRESSION_TEST_BUILD_TARGET,
+                step=BuildConnectorImagesTarget(context, docker_image_name=target_image),
+                depends_on=[CONNECTOR_TEST_STEP_ID.REGRESSION_TEST_CONTROL],
+            )
+        ],
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.REGRESSION_TEST_TARGET,
+                step=RegressionTestsTarget(context, context.concurrent_cat),
+                args=lambda results: {
+                    "connector_under_test_container": results[CONNECTOR_TEST_STEP_ID.REGRESSION_TEST_BUILD_TARGET].output_artifact[
+                        LOCAL_BUILD_PLATFORM
+                    ]
+                },
+                depends_on=[CONNECTOR_TEST_STEP_ID.REGRESSION_TEST_BUILD_TARGET, CONNECTOR_TEST_STEP_ID.REGRESSION_TEST_CONTROL],
+            )
+        ],
+    ]

--- a/airbyte-ci/connectors/pipelines/tests/test_regression_tests/test_regression_cats.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_regression_tests/test_regression_cats.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from typing import Type
+from unittest.mock import AsyncMock
+
+import dagger
+import pytest
+from pipelines.airbyte_ci.connectors.context import ConnectorContext
+from pipelines.airbyte_ci.connectors.regression_test.steps.regression_cats import RegressionTestsControl, RegressionTestsTarget
+from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests
+from pipelines.helpers.connectors.modifed import ConnectorWithModifiedFiles
+from pipelines.models.steps import StepStatus
+
+pytestmark = [
+    pytest.mark.anyio,
+]
+
+
+class TestRegressionTests:
+    @staticmethod
+    def get_dummy_cat_container(dagger_client: dagger.Client, test_cls: Type[AcceptanceTests], stdout: str, stderr: str):
+        container = (
+            dagger_client.container()
+            .from_("bash:latest")
+            .with_exec(["mkdir", "-p", test_cls.CONTAINER_TEST_INPUT_DIRECTORY])
+            .with_exec(["mkdir", "-p", test_cls.CONTAINER_SECRETS_DIRECTORY])
+        )
+        return container.with_new_file("/stupid_bash_script.sh", contents=f"echo {stdout}; echo {stderr} >&2; exit 0")
+
+    @pytest.fixture
+    def test_context_ci(self, current_platform, dagger_client):
+        context = ConnectorContext(
+            pipeline_name="test",
+            connector=ConnectorWithModifiedFiles("source-faker", frozenset()),
+            git_branch="test",
+            git_revision="test",
+            report_output_prefix="test",
+            is_local=False,
+            use_remote_secrets=True,
+            targeted_platforms=[current_platform],
+            versions_to_test=("latest", "dev"),
+        )
+        context.dagger_client = dagger_client
+        return context
+
+    @pytest.fixture
+    def dummy_connector_under_test_container(self, dagger_client) -> dagger.Container:
+        return dagger_client.container().from_("airbyte/source-faker:latest")
+
+    @pytest.mark.asyncio
+    async def test_regression_tests_control(self, test_context_ci, mocker):
+        """Test the behavior of the run function for RegressionTestsControl using a dummy container."""
+        cat_container = self.get_dummy_cat_container(test_context_ci.dagger_client, RegressionTestsControl, stdout="hello", stderr="world")
+        prep_container = self.get_dummy_cat_container(test_context_ci.dagger_client, RegressionTestsControl, stdout="hello", stderr="world")
+        mock_prepare = AsyncMock(return_value=prep_container)
+        mock_export = AsyncMock()
+
+        mocker.patch.object(RegressionTestsControl, "_build_connector_acceptance_test", side_effect=AsyncMock(return_value=cat_container))
+        mocker.patch.object(RegressionTestsControl, "get_cat_command", return_value=["bash", "/stupid_bash_script.sh"])
+        RegressionTestsControl._prepare_regression_test = mock_prepare
+        RegressionTestsControl._export_control_output = mock_export
+        test_context_ci.get_connector_dir = mocker.AsyncMock(return_value=".")
+        acceptance_test_step = RegressionTestsControl(test_context_ci)
+        step_result = await acceptance_test_step._run(None)
+        assert step_result.status == StepStatus.SUCCESS
+        mock_prepare.assert_awaited_once()
+        mock_export.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_regression_tests_target(self, test_context_ci, mocker):
+        """Test the behavior of the run function for RegressionTestsTarget using a dummy container."""
+        cat_container = self.get_dummy_cat_container(test_context_ci.dagger_client, RegressionTestsTarget, stdout="hello", stderr="world")
+        mocker.patch.object(RegressionTestsTarget, "_build_connector_acceptance_test", side_effect=AsyncMock(return_value=cat_container))
+        mocker.patch.object(RegressionTestsTarget, "get_cat_command", return_value=["bash", "/stupid_bash_script.sh"])
+        test_context_ci.get_connector_dir = mocker.AsyncMock(return_value=".")
+        acceptance_test_step = RegressionTestsTarget(test_context_ci)
+        step_result = await acceptance_test_step._run(None)
+        assert step_result.status == StepStatus.SUCCESS

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
@@ -21,7 +21,7 @@ configured_catalog_path: Optional[str] = Field(default=None, description="Path t
 timeout_seconds: int = Field(default=None, description="Test execution timeout_seconds", ge=0)
 deployment_mode: Optional[str] = Field(default=None, description="Deployment mode to run the test in", regex=r"^(cloud|oss)$")
 
-SEMVER_REGEX = r"(0|(?:[1-9]\d*))(?:\.(0|(?:[1-9]\d*))(?:\.(0|(?:[1-9]\d*)))?(?:\-([\w][\w\.\-_]*))?)?"
+SEMVER_REGEX = r"^(latest|(0|(?:[1-9]\d*))(?:\.(0|(?:[1-9]\d*))(?:\.(0|(?:[1-9]\d*)))?(?:\-([\w][\w\.\-_]*))?)?)$"
 ALLOW_LEGACY_CONFIG = True
 
 

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/common.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/common.py
@@ -4,9 +4,10 @@
 
 import json
 import logging
+import os
 from collections import UserDict
 from pathlib import Path
-from typing import Iterable, List, MutableMapping, Set, Union
+from typing import Iterable, List, MutableMapping, Optional, Set, Union
 
 import pytest
 from yaml import load
@@ -27,15 +28,22 @@ from airbyte_protocol.models import (
 from connector_acceptance_test.config import Config, EmptyStreamConfiguration
 
 
-def load_config(path: str) -> Config:
+def load_config(path: str, config_file_override: Optional[str] = None) -> Config:
     """Function to load test config, avoid duplication of code in places where we can't use fixture"""
-    path = Path(path) / "acceptance-test-config.yml"
+    path = _get_path_from_filepath(config_file_override) or Path(path) / "acceptance-test-config.yml"
     if not path.exists():
         pytest.fail(f"config file {path.absolute()} does not exist")
 
     with open(str(path), "r") as file:
         data = load(file, Loader=Loader)
         return Config.parse_obj(data)
+
+
+def _get_path_from_filepath(filepath: str) -> Optional[Path]:
+    if filepath:
+        directory, filename = os.path.split(filepath)
+        return Path(directory) / filepath
+    return None
 
 
 def full_refresh_only_catalog(configured_catalog: ConfiguredAirbyteCatalog) -> ConfiguredAirbyteCatalog:

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/regression_test.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/regression_test.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+"""
+This file contains utilities for regression tests.
+
+Regression tests store the output records from one CAT run, for use as expected records in a CAT
+run for a new version of the connector.
+"""
+
+import json
+import sys
+
+import yaml
+from connector_acceptance_test.config import Config
+from connector_acceptance_test.utils.common import load_config
+
+
+def update_config_expected_records_path(config: Config, test_output_dir: str, new_config_path: str):
+    for test in config.acceptance_tests.basic_read.tests:
+        test.expect_records.path = f"{test_output_dir}/{test.expect_records.path}"
+    _write_new_config(config, new_config_path)
+
+
+def _write_new_config(config: Config, new_config_path: str):
+    with open(new_config_path, "w") as f:
+        yaml.dump(json.loads(config.json()), f)
+
+
+if __name__ == "__main__":
+    original_config_filepath, updated_acceptance_test_config_file_path, test_output_directory = sys.argv[1:]
+    orig_config = load_config(original_config_filepath)
+    update_config_expected_records_path(orig_config, test_output_directory, updated_acceptance_test_config_file_path)

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/conftest.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/conftest.py
@@ -5,9 +5,12 @@
 import json
 import sys
 from contextlib import contextmanager
+from unittest.mock import MagicMock
 
 import dagger
 import pytest
+from connector_acceptance_test.tests.test_core import TestBasicRead
+from connector_acceptance_test.utils import regression_test
 
 
 @pytest.fixture
@@ -41,3 +44,7 @@ async def dagger_client():
 @pytest.fixture(scope="module")
 async def source_faker_container(dagger_client):
     return await dagger_client.container().from_("airbyte/source-faker:latest")
+
+
+TestBasicRead._store_records = MagicMock()
+regression_test._write_new_config = MagicMock()

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_regression_test_utils.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_regression_test_utils.py
@@ -1,0 +1,103 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import pytest
+import yaml
+from connector_acceptance_test.config import Config
+from connector_acceptance_test.utils.regression_test import update_config_expected_records_path
+
+
+@pytest.mark.parametrize(
+    "config_before, output_dir, config_after",
+    [
+        pytest.param(
+            """
+            connector_image: my-image
+            base_path: my-base-path
+            acceptance_tests:
+              basic_read:
+                config_path: my-test-read-config-path
+                tests:
+                  - config_path: secrets/config.json
+                    expect_records:
+                      path: integration_tests/expected_records.jsonl
+            """,
+            "/new_test_dir",
+            """
+            connector_image: my-image
+            base_path: my-base-path
+            acceptance_tests:
+              basic_read:
+                config_path: my-test-read-config-path
+                tests:
+                  - config_path: secrets/config.json
+                    expect_records:
+                      path: /new_test_dir/integration_tests/expected_records.jsonl
+            """,
+            id="update single test path"
+        ),
+        pytest.param(
+            """
+            connector_image: my-image
+            base_path: my-base-path
+            acceptance_tests:
+              basic_read:
+              config_path: my-test-read-config-path
+              tests:
+                - config_path: secrets/config1.json
+                  expect_records:
+                    path: integration_tests/expected_records1.jsonl
+                - config_path: secrets/config2.json
+                  expect_records:
+                    path: integration_tests/expected_records2.jsonl
+            """,
+            "/new_test_dir",
+            """
+            connector_image: my-image
+            base_path: my-base-path
+            acceptance_tests:
+              basic_read:
+                config_path: my-test-read-config-path
+                tests:
+                  - config_path: secrets/config1.json
+                    expect_records:
+                      path: /new_test_dir/integration_tests/expected_records1.jsonl
+                  - config_path: secrets/config2.json
+                    expect_records:
+                      path: /new_test_dir/integration_tests/expected_records2.jsonl
+            """,
+            id="update multiple test paths",
+        ),
+        pytest.param(
+            """
+            connector_image: my-image
+            base_path: my-base-path
+            acceptance_tests:
+              basic_read:
+                config_path: my-test-read-config-path
+                tests: []
+            """,
+            "/new_test_dir",
+            """
+            connector_image: my-image
+            base_path: my-base-path
+            acceptance_tests:
+            basic_read:
+              config_path: my-test-read-config-path
+              tests: []
+            """,
+            id="no tests in basic read",
+        )
+    ],
+)
+async def test_all_supported_file_types_present(config_before, output_dir, config_after):
+    config = Config.parse_obj(yaml.safe_load(config_before))
+    update_config_expected_records_path(config, output_dir, "dummy_new_config_path")
+    expected_config = Config.parse_obj(yaml.safe_load(config_after))
+
+    # Convert the paths in the config object to strings for comparison
+    for test in expected_config.acceptance_tests.basic_read.tests:
+        test.expect_records.path = str(test.expect_records.path)
+
+    assert config.dict() == expected_config.dict()

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_utils.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_utils.py
@@ -366,3 +366,18 @@ def test_build_configured_catalog_from_custom_catalog(mocker, custom_configured_
         common.logging.info.assert_called_once()
     else:
         common.pytest.fail.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "path, expected_path_name",
+    [
+        pytest.param("fake", "fake", id="no path separator returns Path"),
+        pytest.param("fake/file.json", "file.json", id="no path separator returns Path"),
+        pytest.param("", False, id="no path None"),
+    ]
+)
+def test_get_config_filepath(path, expected_path_name):
+    if expected_path_name:
+        assert common._get_path_from_filepath(path).name == expected_path_name
+    else:
+        assert common._get_path_from_filepath(path) is None


### PR DESCRIPTION
### What
Introduces the first phase of regression tests, which allows us to compare two arbitrary versions of a connector against each other. 

The regression test run can be invoked with the following:
```
airbyte-ci connectors --name=<connector_name> regression_test
                     [--control-version=<version>]  # where version is a docker image name & tag, e.g. airbyte/source-faker:0.1.1
                     [--target-version=<version>]
                     [--fail-fast]
```

### Implementation
At a high level, we are using the airbyte-ci framework to do 2 CAT runs:
1) A "control" run, which runs CATs against an input version of the container (intended to be a trusted version). During this run we write the records to a file and skip the expected record check.
2) A "target" run, which runs CATs against an input version of the container (the version to be tested), whose records are compared against the stored records from 1.

To make this work, we pass the control CAT run flag instructing it to store records at a specific location; when run via airbyte-ci/dagger, the records are then exported to the host machine. After the control CATs are complete, we prepare the the target run by writing a new acceptance test config file, which uses the new location for expected records; when run via airbyte-ci/dagger, the new config file and the control's records are mounted to the target CAT container.

High-level overview ([source](https://whimsical.com/regression-tests-FnkpJaGt7VSiCqieDW25A8)):
<img width="1200" alt="image" src="https://github.com/airbytehq/airbyte/assets/5257313/98062de7-f364-43ee-9c5d-e861f03a0816">

CAT modifications:
- `--acceptance-test-config-filepath`: Path to an acceptance test config yml, to override the acceptance-test-config.yml in the default location.
- `--connector-version`: The image tag for the version of the connector to test. If not set, we use the connector version in acceptance-test-config.yml.
- `--store-expected-records`: Folder to store expected records, e.g. for inspection or use in a subsequent test. If not set records will not be stored.
- `--container-id-filepath`: Path to the container ID, when one is present and differs from the default (/tmp/container_id.txt).

airbyte-ci `regression_test` subcommand:
- `--control-version`: Control version of the connector to be tested. If not set, defaults to the latest version.
- `--target-version`: Target version of the connector being tested. If not set, defaults to a dev version.
- `--fail-fast`: When enabled, tests will fail fast.

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/2855.