### PR TITLE
gradle.yml: use a smaller runner

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
     # We therefore run this on a machine with a maximum number of cores.
     # We pay per time and per core, so there should be little difference in total cost.
     # The latency overhead of setting up gradle prior to running the actual task adds up to about a minute.
-    runs-on: connector-test-xxlarge
+    runs-on: connector-test-large
     name: Gradle Check
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Downsize the runner used on `gradle.yml` for cost control