### PR TITLE
gradle.yml: use XXL runners but only if gradle related files are changed

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,62 +20,52 @@ on:
       - synchronize
 
 jobs:
-  run-check:
-    # The gradle check task which we will run is embarrassingly parallelizable.
-    # We therefore run this on a machine with a maximum number of cores.
-    # We pay per time and per core, so there should be little difference in total cost.
-    # The latency overhead of setting up gradle prior to running the actual task adds up to about a minute.
-    runs-on: connector-test-large
-    name: Gradle Check
-    timeout-minutes: 30
+  changes:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
-      # IMPORTANT! This is necessary to make sure that a status is reported on the PR
-      # even if the workflow is skipped. If we used github actions filters, the workflow
-      # would not be reported as skipped, but instead would be forever pending.
-      #
-      # I KNOW THIS SOUNDS CRAZY, BUT IT IS TRUE.
-      #
-      # Also it gets worse
-      #
-      # IMPORTANT! DO NOT CHANGE THE QUOTES AROUND THE GLOBS. THEY ARE REQUIRED.
-      # MAKE SURE TO TEST ANY SYNTAX CHANGES BEFORE MERGING.
       - name: Get changed files
         uses: tj-actions/changed-files@v39
         id: changes
         with:
-          # Include java connectors and java CDK.
-          # Adding all *.java and *.gradle files gets us most of the way there.
-          # We're take a bit more strict for the java CDK, to make sure that
-          # the tests run when they should, for instance when changing the contents
-          # of a text file used as a resource.
           files_yaml: |
             gradlecheck:
               - '**/*.java'
               - '**/*.gradle'
               - 'airbyte-cdk/java/**/*'
+    outputs:
+      gradle: ${{ steps.changes.outputs.gradlecheck_any_changed }}
 
+  run-check:
+    needs:
+      - changes
+    if: needs.changes.outputs.gradle == 'true'
+    # The gradle check task which we will run is embarrassingly parallelizable.
+    # We therefore run this on a machine with a maximum number of cores.
+    # We pay per time and per core, so there should be little difference in total cost.
+    # The latency overhead of setting up gradle prior to running the actual task adds up to about a minute.
+    runs-on: connector-test-xxlarge
+    name: Gradle Check
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
       - uses: actions/setup-java@v3
-        if: steps.changes.outputs.gradlecheck_any_changed == 'true'
         with:
           distribution: "zulu"
           java-version: "21"
       - name: Install Pip
-        if: steps.changes.outputs.gradlecheck_any_changed == 'true'
         run: curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3
       - name: Install Pyenv
-        if: steps.changes.outputs.gradlecheck_any_changed == 'true'
         run: python3 -m pip install virtualenv --user
       - name: Docker login
-        if: steps.changes.outputs.gradlecheck_any_changed == 'true'
         # Some tests use testcontainers which pull images from DockerHub.
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: Run Gradle Check
-        if: steps.changes.outputs.gradlecheck_any_changed == 'true'
         uses: burrunan/gradle-cache-action@v1
         env:
           CI: true


### PR DESCRIPTION
This change is to only spawn expensive runners when the gradle check has to run.
It works: 
<img width="785" alt="Screenshot 2024-02-22 at 19 00 06" src="https://github.com/airbytehq/airbyte/assets/5551758/19e46d9c-a303-4de4-9bf5-08b359294e3a">
