### PR TITLE
airbyte-ci-test.yml: only run if modified internal poetry packages

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -16,7 +16,32 @@ on:
       - reopened
       - synchronize
 jobs:
-  run-airbyte-ci-poetry-ci:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      internal_poetry_packages: ${{ steps.changes.outputs.internal_poetry_packages }}
+
+    steps:
+      - id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          # Note: expressions within a filter are OR'ed
+          filters: |
+            internal_poetry_packages:
+            - airbyte-lib/**
+            - airbyte-ci/connectors/pipelines/**
+            - airbyte-ci/connectors/base_images/**
+            - airbyte-ci/connectors/common_utils/**
+            - airbyte-ci/connectors/connector_ops/**
+            - airbyte-ci/connectors/connectors_qa/**
+            - airbyte-ci/connectors/ci_credentials/**
+            - airbyte-ci/connectors/metadata_service/lib/**
+            - airbyte-ci/connectors/metadata_service/orchestrator/**
+            - airbyte-integrations/bases/connector-acceptance-test/**
+
+  run-tests:
+    needs: changes
+    if: needs.changes.outputs.internal_poetry_packages == 'true'
     #name: Internal Poetry packages CI
     # To rename in a follow up PR
     name: Run Airbyte CI tests


### PR DESCRIPTION
Relates to https://github.com/airbytehq/airbyte-internal-issues/issues/6332

This change is to avoid spawning costly CI runners when a PR is not touching the internal poetry packages.