### PR TITLE
Do not add connector header to source and destination index pages

### DIFF
--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -85,7 +85,7 @@ export const HeaderDecoration = ({
         <h1 id={originalId}>
           {isArchived ? (
             <span>
-              {originalTitle} <span style={{ color: "red" }}>[ARCHIVED]</span>
+              {originalTitle} <span style={{ color: "gray" }}>[ARCHIVED]</span>
             </span>
           ) : (
             originalTitle

--- a/docusaurus/src/remark/utils.js
+++ b/docusaurus/src/remark/utils.js
@@ -8,6 +8,11 @@ const isDocsPage = (vfile) => {
     return false;
   }
 
+  // skip the root files in integrations/source and integrations/destinations
+  if (vfile.path.includes("README.md")) {
+    return false;
+  }
+
   if (vfile.path.includes("-migrations.md")) {
     return false;
   }


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/airbytehq/airbyte/pull/34391 which tried to render the connector metadata header on the new connector index pages.  

This PR also makes the `[archived]` less scary. 

<img width="809" alt="Screenshot 2024-02-22 at 11 45 45 AM" src="https://github.com/airbytehq/airbyte/assets/303226/93a3468d-e899-4c16-9033-017928386a24">
