### PR TITLE
gradle.yml: checkout the repo when not PR trigger

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,6 +27,9 @@ jobs:
       python_cdk: ${{ steps.changes.outputs.python_cdk }}
 
     steps:
+      - name: Checkout Airbyte
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v3
       - id: changes
         uses: dorny/paths-filter@v2
         with:


### PR DESCRIPTION
We have to checkout the repo if the workflow trigger is not a PR, the action can't detect the modified files otherwise.