### PR TITLE
.github: remove python references CDK from gradle.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,8 +39,7 @@ jobs:
               - '**/*.java'
               - '**/*.gradle'
               - 'airbyte-cdk/java/**/*'
-            python_cdk:
-              - 'airbyte-cdk/python/**/*'
+
   run-check:
     needs:
       - changes


### PR DESCRIPTION
The gradle at the root of the repo can't run those tests anyway. The python CDK has its own, completely distinct gradle structure.