### PR TITLE
airbyte-cdk [python]: re-enable tests in CI

### DIFF
--- a/.github/workflows/python_cdk_tests.yml
+++ b/.github/workflows/python_cdk_tests.yml
@@ -62,7 +62,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: cd airbyte-cdk/python
         run: cd airbyte-cdk/python
-      - name: Run Gradle Check
+      - name: Run Gradle Check on Python CDK
         uses: burrunan/gradle-cache-action@v1
         env:
           CI: true

--- a/.github/workflows/python_cdk_tests.yml
+++ b/.github/workflows/python_cdk_tests.yml
@@ -54,12 +54,6 @@ jobs:
         run: curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3
       - name: Install Pyenv
         run: python3 -m pip install virtualenv --user
-      - name: Docker login
-        # Some tests use testcontainers which pull images from DockerHub.
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: cd airbyte-cdk/python
         run: cd airbyte-cdk/python
       - name: Run Gradle Check on Python CDK

--- a/.github/workflows/python_cdk_tests.yml
+++ b/.github/workflows/python_cdk_tests.yml
@@ -1,4 +1,5 @@
-name: Connector Ops CI - Gradle Check
+# THIS WORKFLOW SHOULD BE REPLACED BY A CLEANER ONE ONCE THE PYTHON CDK TESTS CAN BE RUN WITH POETRY
+name: Python CDK Tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,29 +24,24 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      java: ${{ steps.changes.outputs.java }}
-
+      python_cdk: ${{ steps.changes.outputs.python_cdk }}
     steps:
+      - name: Checkout Airbyte
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v3
       - id: changes
         uses: dorny/paths-filter@v2
         with:
           # Note: expressions within a filter are OR'ed
           filters: |
-            java:
-              - '**/*.java'
-              - '**/*.gradle'
-              - 'airbyte-cdk/java/**/*'
-
-  run-check:
+            python_cdk:
+              - 'airbyte-cdk/python/**/*'
+  run-python-cdk-check:
     needs:
       - changes
-    if: needs.changes.outputs.java == 'true'
-    # The gradle check task which we will run is embarrassingly parallelizable.
-    # We therefore run this on a machine with a maximum number of cores.
-    # We pay per time and per core, so there should be little difference in total cost.
-    # The latency overhead of setting up gradle prior to running the actual task adds up to about a minute.
-    runs-on: connector-test-xxlarge
-    name: Gradle Check
+    if: needs.changes.outputs.python_cdk == 'true'
+    runs-on: connector-test-large
+    name: Python CDK Tests
     timeout-minutes: 30
     steps:
       - name: Checkout Airbyte
@@ -64,6 +60,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: cd airbyte-cdk/python
+        run: cd airbyte-cdk/python
       - name: Run Gradle Check
         uses: burrunan/gradle-cache-action@v1
         env:
@@ -80,7 +78,7 @@ jobs:
     name: Create Instatus Incident on Failure
     runs-on: ubuntu-latest
     needs:
-      - run-check
+      - run-python-cdk-check
     if: ${{ failure() && github.ref == 'refs/heads/master' }}
     steps:
       - name: Call Instatus Webhook
@@ -93,7 +91,7 @@ jobs:
     name: Create Instatus Incident on Success
     runs-on: ubuntu-latest
     needs:
-      - run-check
+      - run-python-cdk-check
     if: ${{ success() && github.ref == 'refs/heads/master' }}
     steps:
       - name: Call Instatus Webhook
@@ -106,7 +104,7 @@ jobs:
     name: "Notify Slack Channel on Build Failures"
     runs-on: ubuntu-latest
     needs:
-      - run-check
+      - run-python-cdk-check
     if: ${{ failure() && github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout Airbyte
@@ -135,7 +133,7 @@ jobs:
     name: "Notify Slack Channel on Build Fixes"
     runs-on: ubuntu-latest
     needs:
-      - run-check
+      - run-python-cdk-check
     if: success()
     steps:
       - name: Get Previous Workflow Status

--- a/.github/workflows/python_cdk_tests.yml
+++ b/.github/workflows/python_cdk_tests.yml
@@ -65,8 +65,7 @@ jobs:
           read-only: ${{ github.ref != 'refs/heads/master' }}
           gradle-distribution-sha-256-sum-warning: false
           concurrent: true
-          # TODO: be able to remove the skipSlowTests property
-          arguments: --scan check -DskipSlowTests=true
+          arguments: --scan build
 
   set-instatus-incident-on-failure:
     name: Create Instatus Incident on Failure

--- a/.github/workflows/python_cdk_tests.yml
+++ b/.github/workflows/python_cdk_tests.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           CI: true
         with:
-          job-id: gradle-check
+          job-id: python-cdk-check
           read-only: ${{ github.ref != 'refs/heads/master' }}
           gradle-distribution-sha-256-sum-warning: false
           concurrent: true


### PR DESCRIPTION
`gradle.yml` is not running the python cdk test anymore as the python cdk is now an independant (and soon retired) gradle project. This PR introduces a new workflow which should specifically run `gradle check` on the python cdk.

## TODO:
* We can't test this workflow until it has reached master, so merge and test...
* Make the "Python CDK Tests" a required check if we want to disallow merges when they fail (GH branch protection rules settings)