### PR TITLE
airbyte-ci-test.yml: checkout repo for path filters when not on PR

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -22,6 +22,9 @@ jobs:
       internal_poetry_packages: ${{ steps.changes.outputs.internal_poetry_packages }}
 
     steps:
+      - name: Checkout Airbyte
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v3
       - id: changes
         uses: dorny/paths-filter@v2
         with:


### PR DESCRIPTION
We have to checkout the repo when the trigger is not a PR, the filter won't work otherwise