### PR TITLE
connectors-ci: early exit when no connector changes

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -22,7 +22,45 @@ on:
       - opened
       - synchronize
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      connectors: ${{ steps.changes.outputs.connectors }}
+    permissions:
+      statuses: write
+    steps:
+      - name: Checkout Airbyte
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v3
+      - id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          # Note: expressions within a filter are OR'ed
+          filters: |
+            connectors:
+              - '*'
+              - 'airbyte-ci/**/*'
+              - 'airbyte-integrations/connectors/**/*'
+              - 'airbyte-cdk/**/*'
+              - 'buildSrc/**/*'
+      # The Connector CI Tests is a status check emitted by airbyte-ci
+      # We make it pass once we have determined that there are no changes to the connectors
+      - name: "Skip Connectors CI tests"
+        if: steps.changes.outputs.connectors != 'true' && github.event_name == 'pull_request'
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --data '{
+            "state": "success",
+            "context": "Connectors CI tests",
+            "target_url": "${{ github.event.workflow_run.html_url }}"
+            }' \
+
   connectors_ci:
+    needs: changes
+    if: needs.changes.outputs.connectors == 'true'
     name: Connectors CI
     runs-on: connector-test-large
     timeout-minutes: 1440 # 24 hours


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Relates to https://github.com/airbytehq/airbyte-internal-issues/issues/6332
We don't want to spawn a costly instance if the PR changes are not likely touching a connector.

## How 
This changes creates an initial job run (running on cheap  `ubuntu:latest` runner) in the workflow to determine if the PR has connector changes.
If it does not we can:
* Set the required "Connectors CI Tests" status check to success
* Skip the run of the connector ci job

I validated the behavior on a connector PR [here](https://github.com/airbytehq/airbyte/pull/35579)
