### PR TITLE
airbyte-ci: implement migrate-to-poetry connectors command

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -145,6 +145,7 @@ At this point you can run `airbyte-ci` commands.
 - [`connectors upgrade_cdk` command](#connectors-upgrade_cdk)
 - [`connectors upgrade_base_image` command](#connectors-upgrade_base_image)
 - [`connectors migrate_to_base_image` command](#connectors-migrate_to_base_image)
+- [`connectors migrate-to-poetry` command](#connectors-migrate-to-poetry)
 - [`format` command subgroup](#format-subgroup)
   - [`format check` command](#format-check-command)
   - [`format fix` command](#format-fix-command)
@@ -512,16 +513,20 @@ Make a connector using a Dockerfile migrate to the base image by:
 - Updating its documentation to explain the build process
 - Bumping by a patch version
 
-### Examples
+#### Examples
 
 Migrate source-openweather to use the base image:
 `airbyte-ci connectors --name=source-openweather migrate_to_base_image`
 
-### Arguments
 
-| Argument              | Description                                                 |
-| --------------------- | ----------------------------------------------------------- |
-| `PULL_REQUEST_NUMBER` | The GitHub pull request number, used in the changelog entry |
+### <a id="connectors-migrate-to-poetry"></a>`connectors migrate-to-poetry` command
+
+Migrate connectors the poetry package manager.
+
+#### Examples
+
+Migrate source-openweather to use the base image:
+`airbyte-ci connectors --name=source-openweather migrate-to-poetry`
 
 ### <a id="format-subgroup"></a>`format` command subgroup
 
@@ -644,8 +649,9 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                |
 | ------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| 4.5.4   | [#36206](https://github.com/airbytehq/airbyte/pull/36206) | Revert poetry cache removal during nightly builds                                                                          |
-| 4.5.3   | [#34586](https://github.com/airbytehq/airbyte/pull/34586)  | Extract connector changelog modification logic into its own class                                                       |
+| 4.6.0   | [#35583](https://github.com/airbytehq/airbyte/pull/35583)  | Implement the `airbyte-ci connectors migrate-to-poetry` command.                                                           |
+| 4.5.4   | [#36206](https://github.com/airbytehq/airbyte/pull/36206)  | Revert poetry cache removal during nightly builds                                                                          |
+| 4.5.3   | [#34586](https://github.com/airbytehq/airbyte/pull/34586)  | Extract connector changelog modification logic into its own class                                                          |
 | 4.5.2   | [#35802](https://github.com/airbytehq/airbyte/pull/35802)  | Fix bug with connectors bump_version command                                                                               |
 | 4.5.1   | [#35786](https://github.com/airbytehq/airbyte/pull/35786)  | Declare `live_tests` as an internal poetry package.                                                                        |
 | 4.5.0   | [#35784](https://github.com/airbytehq/airbyte/pull/35784)  | Format command supports kotlin                                                                                             |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
@@ -151,6 +151,7 @@ def should_use_remote_secrets(use_remote_secrets: Optional[bool]) -> bool:
         "publish": "pipelines.airbyte_ci.connectors.publish.commands.publish",
         "bump_version": "pipelines.airbyte_ci.connectors.bump_version.commands.bump_version",
         "migrate_to_base_image": "pipelines.airbyte_ci.connectors.migrate_to_base_image.commands.migrate_to_base_image",
+        "migrate-to-poetry": "pipelines.airbyte_ci.connectors.migrate_to_poetry.commands.migrate_to_poetry",
         "upgrade_base_image": "pipelines.airbyte_ci.connectors.upgrade_base_image.commands.upgrade_base_image",
         "upgrade_cdk": "pipelines.airbyte_ci.connectors.upgrade_cdk.commands.bump_version",
     },

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
@@ -23,6 +23,13 @@ class CONNECTOR_TEST_STEP_ID(str, Enum):
     VERSION_INC_CHECK = "version_inc_check"
     TEST_ORCHESTRATOR = "test_orchestrator"
     DEPLOY_ORCHESTRATOR = "deploy_orchestrator"
+    UPDATE_README = "update_readme"
+    ADD_CHANGELOG_ENTRY = "add_changelog_entry"
+    BUMP_METADATA_VERSION = "bump_metadata_version"
+    REGRESSION_TEST = "regression_test"
+    CHECK_MIGRATION_CANDIDATE = "check_migration_candidate"
+    POETRY_INIT = "poetry_init"
+    DELETE_SETUP_PY = "delete_setup_py"
 
     def __str__(self) -> str:
         return self.value

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/__init__.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/commands.py
@@ -1,0 +1,57 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+
+import asyncclick as click
+from pipelines.airbyte_ci.connectors.context import ConnectorContext
+from pipelines.airbyte_ci.connectors.migrate_to_poetry.pipeline import run_connector_migration_to_poetry_pipeline
+from pipelines.airbyte_ci.connectors.pipeline import run_connectors_pipelines
+from pipelines.cli.dagger_pipeline_command import DaggerPipelineCommand
+
+
+@click.command(
+    cls=DaggerPipelineCommand,
+    short_help="Migrate the selected connectors to poetry.",
+)
+@click.pass_context
+async def migrate_to_poetry(
+    ctx: click.Context,
+) -> bool:
+
+    connectors_contexts = [
+        ConnectorContext(
+            pipeline_name=f"Migrate {connector.technical_name} to Poetry",
+            connector=connector,
+            is_local=ctx.obj["is_local"],
+            git_branch=ctx.obj["git_branch"],
+            git_revision=ctx.obj["git_revision"],
+            ci_report_bucket=ctx.obj["ci_report_bucket_name"],
+            report_output_prefix=ctx.obj["report_output_prefix"],
+            use_remote_secrets=ctx.obj["use_remote_secrets"],
+            gha_workflow_run_url=ctx.obj.get("gha_workflow_run_url"),
+            dagger_logs_url=ctx.obj.get("dagger_logs_url"),
+            pipeline_start_timestamp=ctx.obj.get("pipeline_start_timestamp"),
+            ci_context=ctx.obj.get("ci_context"),
+            ci_gcs_credentials=ctx.obj["ci_gcs_credentials"],
+            ci_git_user=ctx.obj["ci_git_user"],
+            ci_github_access_token=ctx.obj["ci_github_access_token"],
+            enable_report_auto_open=True,
+            docker_hub_username=ctx.obj.get("docker_hub_username"),
+            docker_hub_password=ctx.obj.get("docker_hub_password"),
+            s3_build_cache_access_key_id=ctx.obj.get("s3_build_cache_access_key_id"),
+            s3_build_cache_secret_key=ctx.obj.get("s3_build_cache_secret_key"),
+        )
+        for connector in ctx.obj["selected_connectors_with_modified_files"]
+    ]
+
+    await run_connectors_pipelines(
+        connectors_contexts,
+        run_connector_migration_to_poetry_pipeline,
+        "Migration to poetry pipeline",
+        ctx.obj["concurrency"],
+        ctx.obj["dagger_logs_path"],
+        ctx.obj["execute_timeout"],
+    )
+
+    return True

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
@@ -1,0 +1,487 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import dagger
+import git
+import requests
+import toml
+from connector_ops.utils import ConnectorLanguage  # type: ignore
+from jinja2 import Environment, PackageLoader, select_autoescape
+from pipelines.airbyte_ci.connectors.build_image.steps.python_connectors import BuildConnectorImages
+from pipelines.airbyte_ci.connectors.bump_version.pipeline import AddChangelogEntry, BumpDockerImageTagInMetadata, get_bumped_version
+from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
+from pipelines.airbyte_ci.connectors.context import ConnectorContext, PipelineContext
+from pipelines.airbyte_ci.connectors.reports import ConnectorReport, Report
+from pipelines.consts import LOCAL_BUILD_PLATFORM
+from pipelines.dagger.actions.python.common import with_python_connector_installed
+from pipelines.helpers.execution.run_steps import StepToRun, run_steps
+from pipelines.models.steps import Step, StepResult, StepStatus
+
+if TYPE_CHECKING:
+    from typing import Iterable, List, Optional
+
+    from anyio import Semaphore
+
+PACKAGE_NAME_PATTERN = r"^([a-zA-Z0-9_.\-]+)(?:\[(.*?)\])?([=~><!]=?[a-zA-Z0-9\.]+)?$"
+
+
+class CheckIsMigrationCandidate(Step):
+    """Check if the connector is a candidate for migration to poetry.
+    Candidate conditions:
+    - The connector is a Python connector.
+    - The connector is a source connector.
+    - The connector has a setup.py file.
+    - The connector has a base image defined in the metadata.
+    - The connector has not been migrated to poetry yet.
+    """
+
+    context: ConnectorContext
+
+    title = "Check if the connector is a candidate for migration to poetry."
+    airbyte_repo = git.Repo(search_parent_directories=True)
+
+    async def _run(self) -> StepResult:
+        connector_dir_entries = await (await self.context.get_connector_dir()).entries()
+        if self.context.connector.language not in [ConnectorLanguage.PYTHON, ConnectorLanguage.LOW_CODE]:
+            return StepResult(
+                step=self,
+                status=StepStatus.SKIPPED,
+                stderr="The connector is not a Python connector.",
+            )
+        if self.context.connector.connector_type != "source":
+            return StepResult(
+                step=self,
+                status=StepStatus.SKIPPED,
+                stderr="The connector is not a source connector.",
+            )
+        if "poetry.lock" in connector_dir_entries and "pyproject.toml" in connector_dir_entries:
+            return StepResult(
+                step=self,
+                status=StepStatus.SKIPPED,
+                stderr="The connector has already been migrated to poetry.",
+            )
+        if "setup.py" not in connector_dir_entries:
+            return StepResult(
+                step=self,
+                status=StepStatus.SKIPPED,
+                stderr="The connector can't be migrated to poetry because it does not have a setup.py file.",
+            )
+        if not self.context.connector.metadata.get("connectorBuildOptions", {}).get("baseImage"):
+            return StepResult(
+                step=self,
+                status=StepStatus.SKIPPED,
+                stderr="The connector can't be migrated to poetry because it does not have a base image defined in the metadata.",
+            )
+
+        return StepResult(
+            step=self,
+            status=StepStatus.SUCCESS,
+        )
+
+
+class PoetryInit(Step):
+    context: ConnectorContext
+
+    title = "Generate pyproject.toml and poetry.lock"
+    python_version = "^3.9,<3.12"
+    build_system = {
+        "requires": ["poetry-core>=1.0.0"],
+        "build-backend": "poetry.core.masonry.api",
+    }
+
+    def __init__(self, context: PipelineContext, new_version: str) -> None:
+        super().__init__(context)
+        self.new_version = new_version
+
+    @property
+    def package_name(self) -> str:
+        return self.context.connector.technical_name.replace("-", "_")
+
+    def get_package_info(self, package_info: str) -> dict:
+        package_info_dict = {}
+        for line in package_info.splitlines():
+            # Ignoring locally installed packages
+            if ":" not in line:
+                continue
+            key, value = line.split(": ")
+            package_info_dict[key] = value
+        return {
+            "version": self.context.connector.version,
+            "name": package_info_dict["Name"],
+            "description": package_info_dict["Summary"],
+            "authors": [package_info_dict["Author"] + " <" + package_info_dict["Author-email"] + ">"],
+            "license": self.context.connector.metadata["license"],
+            "readme": "README.md",
+            "documentation": self.context.connector.metadata["documentationUrl"],
+            "homepage": "https://airbyte.com",
+            "repository": "https://github.com/airbytehq/airbyte",
+        }
+
+    def to_poetry_dependencies(self, requirements_style_deps: Iterable[str], latest_dependencies_for_hard_pin: dict) -> dict:
+        dependencies = {}
+        for deps in requirements_style_deps:
+            if "," in deps:
+                deps = deps.split(",")[0]
+            match = re.match(PACKAGE_NAME_PATTERN, deps)
+            assert match, f"Failed to parse package name and version from {deps}"
+            name = match.group(1)
+            extras = match.group(2)
+            version = match.group(3)
+            if extras:
+                extras = extras.split(",")
+            if name in latest_dependencies_for_hard_pin:
+                version = f"=={latest_dependencies_for_hard_pin[name]}"
+            elif "~=" in deps:
+                # We prefer caret (^) over tilde (~) for the version range
+                # See https://python-poetry.org/docs/dependency-specification/
+                version = version.replace("~=", "^")
+            elif "==" not in deps:
+                # The package version is not pinned and not installed in the released connector
+                # It's because it's a test dependency
+                # Poetry requires version to be declared so we should get the latest version from PyPI
+                version = f"^{self.get_latest_version_from_pypi(name)}"
+            if extras:
+                version = {"extras": extras, "version": version}
+            dependencies[name] = version
+        return dependencies
+
+    def get_latest_version_from_pypi(self, package_name: str) -> str:
+        url = f"https://pypi.org/pypi/{package_name}/json"
+
+        # Send GET request to the PyPI API
+        response = requests.get(url)
+        response.raise_for_status()  # Raise an exception for any HTTP error status
+
+        # Parse the JSON response
+        data = response.json()
+
+        # Extract the latest version from the response
+        latest_version = data["info"]["version"]
+
+        return latest_version
+
+    async def get_dependencies(self, connector_container: dagger.Container, groups: Optional[List[str]] = None) -> set[str]:
+        package = "." if not groups else f'.[{",".join(groups)}]'
+        connector_container = await connector_container.with_exec(["pip", "install", package])
+
+        pip_install_dry_run_output = await connector_container.with_exec(["pip", "install", package, "--dry-run"]).stdout()
+
+        non_transitive_deps = []
+        for line in pip_install_dry_run_output.splitlines():
+            if "Requirement already satisfied" in line and "->" not in line:
+                non_transitive_deps.append(line.replace("Requirement already satisfied: ", "").split(" ")[0].replace("_", "-"))
+        return set(non_transitive_deps)
+
+    async def _run(self) -> StepResult:
+        base_image_name = self.context.connector.metadata["connectorBuildOptions"]["baseImage"]
+        base_container = self.dagger_client.container(platform=LOCAL_BUILD_PLATFORM).from_(base_image_name)
+        connector_container = await with_python_connector_installed(
+            self.context,
+            base_container,
+            str(self.context.connector.code_directory),
+        )
+        with_egg_info = await connector_container.with_exec(["python", "setup.py", "egg_info"])
+
+        egg_info_dir = with_egg_info.directory(f"{self.package_name}.egg-info")
+        egg_info_files = {file_path: await egg_info_dir.file(file_path).contents() for file_path in await egg_info_dir.entries()}
+
+        package_info = self.get_package_info(egg_info_files["PKG-INFO"])
+        dependencies = await self.get_dependencies(connector_container)
+        dev_dependencies = await self.get_dependencies(connector_container, groups=["dev", "tests"]) - dependencies
+        latest_pip_freeze = (
+            await self.context.dagger_client.container(platform=LOCAL_BUILD_PLATFORM)
+            .from_(f"{self.context.connector.metadata['dockerRepository']}:latest")
+            .with_exec(["pip", "freeze"], skip_entrypoint=True)
+            .stdout()
+        )
+        latest_dependencies = {
+            name_version.split("==")[0]: name_version.split("==")[1]
+            for name_version in latest_pip_freeze.splitlines()
+            if "==" in name_version
+        }
+        poetry_dependencies = self.to_poetry_dependencies(dependencies, latest_dependencies)
+        poetry_dev_dependencies = self.to_poetry_dependencies(dev_dependencies, latest_dependencies)
+        scripts = {self.context.connector.technical_name: f"{self.package_name}.run:run"}
+
+        pyproject = {
+            "build-system": self.build_system,
+            "tool": {
+                "poetry": {
+                    **package_info,
+                    "packages": [{"include": self.package_name}],
+                    "dependencies": {"python": self.python_version, **poetry_dependencies},
+                    "group": {"dev": {"dependencies": poetry_dev_dependencies}},
+                    "scripts": scripts,
+                }
+            },
+        }
+        toml_string = toml.dumps(pyproject)
+        try:
+            with_poetry_lock = await connector_container.with_new_file("pyproject.toml", contents=toml_string).with_exec(
+                ["poetry", "install"]
+            )
+        except dagger.ExecError as e:
+            return StepResult(
+                step=self,
+                status=StepStatus.FAILURE,
+                stderr=str(e),
+            )
+        with_new_version = await with_poetry_lock.with_exec(["poetry", "version", self.new_version])
+        await with_new_version.file("pyproject.toml").export(f"{self.context.connector.code_directory}/pyproject.toml")
+        self.logger.info(f"Generated pyproject.toml for {self.context.connector.technical_name}")
+        await with_new_version.file("poetry.lock").export(f"{self.context.connector.code_directory}/poetry.lock")
+        self.logger.info(f"Generated poetry.lock for {self.context.connector.technical_name}")
+        return StepResult(step=self, status=StepStatus.SUCCESS, output=(dependencies, dev_dependencies))
+
+
+class DeleteSetUpPy(Step):
+    context: ConnectorContext
+
+    title = "Delete setup.py"
+
+    async def _run(self) -> StepResult:
+        setup_path = self.context.connector.code_directory / "setup.py"
+        original_setup_py = setup_path.read_text()
+        setup_path.unlink()
+        self.logger.info(f"Removed setup.py for {self.context.connector.technical_name}")
+        return StepResult(step=self, status=StepStatus.SUCCESS, output=original_setup_py)
+
+
+class RestoreOriginalState(Step):
+    context: ConnectorContext
+
+    title = "Restore original state"
+
+    def __init__(self, context: ConnectorContext) -> None:
+        super().__init__(context)
+        self.setup_path = context.connector.code_directory / "setup.py"
+        self.metadata_path = context.connector.code_directory / "metadata.yaml"
+        self.pyproject_path = context.connector.code_directory / "pyproject.toml"
+        self.poetry_lock_path = context.connector.code_directory / "poetry.lock"
+        self.readme_path = context.connector.code_directory / "README.md"
+        self.doc_path = context.connector.documentation_file_path
+        self.original_setup_py = self.setup_path.read_text() if self.setup_path.exists() else None
+        self.original_metadata = self.metadata_path.read_text()
+        self.original_docs = self.doc_path.read_text()
+        self.original_readme = self.readme_path.read_text()
+
+    async def _run(self) -> StepResult:
+        if self.original_setup_py:
+            self.setup_path.write_text(self.original_setup_py)
+        self.logger.info(f"Restored setup.py for {self.context.connector.technical_name}")
+        self.metadata_path.write_text(self.original_metadata)
+        self.logger.info(f"Restored metadata.yaml for {self.context.connector.technical_name}")
+        self.doc_path.write_text(self.original_docs)
+        self.logger.info(f"Restored documentation file for {self.context.connector.technical_name}")
+        self.readme_path.write_text(self.original_readme)
+        self.logger.info(f"Restored README.md for {self.context.connector.technical_name}")
+        if self.poetry_lock_path.exists():
+            self.poetry_lock_path.unlink()
+            self.logger.info(f"Removed poetry.lock for {self.context.connector.technical_name}")
+        if self.pyproject_path.exists():
+            self.pyproject_path.unlink()
+            self.logger.info(f"Removed pyproject.toml for {self.context.connector.technical_name}")
+
+        return StepResult(
+            step=self,
+            status=StepStatus.SUCCESS,
+        )
+
+
+class RegressionTest(Step):
+    """Run the regression test for the connector.
+    We test that:
+    - The original dependencies are installed in the new connector image.
+    - The dev dependencies are not installed in the new connector image.
+    - The connector spec command successfully.
+    """
+
+    context: ConnectorContext
+
+    title = "Run regression test"
+
+    async def _run(
+        self, new_connector_container: dagger.Container, original_dependencies: List[str], original_dev_dependencies: List[str]
+    ) -> StepResult:
+        try:
+            await self.check_all_original_deps_are_installed(new_connector_container, original_dependencies, original_dev_dependencies)
+        except (AttributeError, AssertionError) as e:
+            return StepResult(
+                step=self,
+                status=StepStatus.FAILURE,
+                stderr=f"Failed checking if the original dependencies are installed:\n {str(e)}",
+                exc_info=e,
+            )
+
+        try:
+            await new_connector_container.with_exec(["spec"])
+            await new_connector_container.with_mounted_file(
+                "pyproject.toml", (await self.context.get_connector_dir(include=["pyproject.toml"])).file("pyproject.toml")
+            ).with_exec(["poetry", "run", self.context.connector.technical_name, "spec"], skip_entrypoint=True)
+        except dagger.ExecError as e:
+            return StepResult(
+                step=self,
+                status=StepStatus.FAILURE,
+                stderr=str(e),
+            )
+        return StepResult(
+            step=self,
+            status=StepStatus.SUCCESS,
+        )
+
+    async def check_all_original_deps_are_installed(
+        self, new_connector_container: dagger.Container, original_main_dependencies: List[str], original_dev_dependencies: List[str]
+    ) -> None:
+        previous_pip_freeze = (
+            await self.dagger_client.container(platform=LOCAL_BUILD_PLATFORM)
+            .from_(f'{self.context.connector.metadata["dockerRepository"]}:latest')
+            .with_exec(["pip", "freeze"], skip_entrypoint=True)
+            .stdout()
+        ).splitlines()
+        current_pip_freeze = (await new_connector_container.with_exec(["pip", "freeze"], skip_entrypoint=True).stdout()).splitlines()
+        main_dependencies_names = []
+        for dep in original_main_dependencies:
+            match = re.match(PACKAGE_NAME_PATTERN, dep)
+            if match:
+                main_dependencies_names.append(match.group(1))
+
+        dev_dependencies_names = []
+        for dep in original_dev_dependencies:
+            match = re.match(PACKAGE_NAME_PATTERN, dep)
+            if match:
+                dev_dependencies_names.append(match.group(1))
+
+        previous_package_name_version_mapping: dict[str, str] = {}
+        for dep in previous_pip_freeze:
+            if "==" in dep:
+                match = re.match(PACKAGE_NAME_PATTERN, dep)
+                if match:
+                    previous_package_name_version_mapping[match.group(1)] = dep
+
+        current_package_name_version_mapping: dict[str, str] = {}
+        for dep in current_pip_freeze:
+            if "==" in dep:
+                match = re.match(PACKAGE_NAME_PATTERN, dep)
+                if match:
+                    current_package_name_version_mapping[match.group(1)] = dep
+
+        for main_dep in main_dependencies_names:
+            assert main_dep in current_package_name_version_mapping, f"{main_dep} not found in the latest pip freeze"
+            assert (
+                current_package_name_version_mapping[main_dep] == previous_package_name_version_mapping[main_dep]
+            ), f"Poetry installed a different version of {main_dep} than the previous version. Previous: {previous_package_name_version_mapping[main_dep]}, current: {current_package_name_version_mapping[main_dep]}"
+        for dev_dep in dev_dependencies_names:
+            if dev_dep not in main_dependencies_names:
+                assert (
+                    dev_dep not in current_package_name_version_mapping
+                ), f"A dev dependency ({dev_dep}) was installed by poetry in the container image"
+
+
+class UpdateReadMe(Step):
+    context: ConnectorContext
+
+    title = "Update README.md"
+
+    async def _run(self) -> StepResult:
+        readme_path = self.context.connector.code_directory / "README.md"
+        jinja_env = Environment(
+            loader=PackageLoader("pipelines.airbyte_ci.connectors.migrate_to_poetry"),
+            autoescape=select_autoescape(),
+            trim_blocks=False,
+            lstrip_blocks=True,
+        )
+        readme_template = jinja_env.get_template("README.md.j2")
+        updated_readme = readme_template.render(connector=self.context.connector)
+        readme_path.write_text(updated_readme)
+        return StepResult(
+            step=self,
+            status=StepStatus.SUCCESS,
+        )
+
+
+async def run_connector_migration_to_poetry_pipeline(context: ConnectorContext, semaphore: "Semaphore") -> Report:
+    restore_original_state = RestoreOriginalState(context)
+    new_version = get_bumped_version(context.connector.version, "patch")
+    context.targeted_platforms = [LOCAL_BUILD_PLATFORM]
+    steps_to_run: list[StepToRun | list[StepToRun]] = [
+        [StepToRun(id=CONNECTOR_TEST_STEP_ID.CHECK_MIGRATION_CANDIDATE, step=CheckIsMigrationCandidate(context))],
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.POETRY_INIT,
+                step=PoetryInit(context, new_version),
+                depends_on=[CONNECTOR_TEST_STEP_ID.CHECK_MIGRATION_CANDIDATE],
+            )
+        ],
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.DELETE_SETUP_PY, step=DeleteSetUpPy(context), depends_on=[CONNECTOR_TEST_STEP_ID.POETRY_INIT]
+            )
+        ],
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.BUILD, step=BuildConnectorImages(context), depends_on=[CONNECTOR_TEST_STEP_ID.DELETE_SETUP_PY]
+            )
+        ],
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.REGRESSION_TEST,
+                step=RegressionTest(context),
+                depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
+                args=lambda results: {
+                    "new_connector_container": results["BUILD_CONNECTOR_IMAGE"].output[LOCAL_BUILD_PLATFORM],
+                    "original_dependencies": results["POETRY_INIT"].output[0],
+                    "original_dev_dependencies": results["POETRY_INIT"].output[1],
+                },
+            )
+        ],
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.BUMP_METADATA_VERSION,
+                step=BumpDockerImageTagInMetadata(
+                    context, await context.get_repo_dir(include=[str(context.connector.code_directory)]), new_version, export_metadata=True
+                ),
+                depends_on=[CONNECTOR_TEST_STEP_ID.REGRESSION_TEST],
+            )
+        ],
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.ADD_CHANGELOG_ENTRY,
+                step=AddChangelogEntry(
+                    context,
+                    await context.get_repo_dir(include=[str(context.connector.local_connector_documentation_directory)]),
+                    new_version,
+                    "Manage dependencies with Poetry.",
+                    "TBD",
+                    export_docs=True,
+                ),
+                depends_on=[CONNECTOR_TEST_STEP_ID.REGRESSION_TEST],
+            )
+        ],
+        [
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.UPDATE_README, step=UpdateReadMe(context), depends_on=[CONNECTOR_TEST_STEP_ID.REGRESSION_TEST]
+            )
+        ],
+    ]
+    async with semaphore:
+        async with context:
+            try:
+                result_dict = await run_steps(
+                    runnables=steps_to_run,
+                    options=context.run_step_options,
+                )
+            except Exception as e:
+                await restore_original_state.run()
+                raise e
+            results = list(result_dict.values())
+            if any(step_result.status is StepStatus.FAILURE for step_result in results):
+                await restore_original_state.run()
+            report = ConnectorReport(context, steps_results=results, name="TEST RESULTS")
+            context.report = report
+
+    return report

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/templates/README.md.j2
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/templates/README.md.j2
@@ -1,0 +1,91 @@
+# {{ connector.name.title()}} source connector
+
+
+This is the repository for the {{ connector.name.title() }} source connector, written in Python.
+For information about how to use this connector within Airbyte, see [the documentation]({{ connector.metadata['documentationUrl']}}).
+
+## Local development
+
+### Prerequisites
+* Python (~=3.9)
+* Poetry (~=1.7) - installation instructions [here](https://python-poetry.org/docs/#installation)
+
+
+### Installing the connector
+From this connector directory, run:
+```bash
+poetry install --with dev
+```
+
+
+### Create credentials
+**If you are a community contributor**, follow the instructions in the [documentation]({{ connector.metadata['documentationUrl']}})
+to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `{{ connector.technical_name.replace('-', '_')}}/spec.yaml` file.
+Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
+See `sample_files/sample_config.json` for a sample config file.
+
+
+### Locally running the connector
+```
+poetry run {{ connector.technical_name}} spec
+poetry run {{ connector.technical_name}} check --config secrets/config.json
+poetry run {{ connector.technical_name}} discover --config secrets/config.json
+poetry run {{ connector.technical_name}} read --config secrets/config.json --catalog sample_files/configured_catalog.json
+```
+
+### Running unit tests
+To run unit tests locally, from the connector directory run:
+```
+poetry run pytest unit_tests
+```
+
+### Building the docker image
+1. Install [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md)
+2. Run the following command to build the docker image:
+```bash
+airbyte-ci connectors --name={{ connector.technical_name }} build
+```
+
+An image will be available on your host with the tag `airbyte/{{ connector.technical_name}}:dev`.
+
+
+### Running as a docker container
+Then run any of the connector commands as follows:
+```
+docker run --rm airbyte/{{ connector.technical_name }}:dev spec
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/{{ connector.technical_name }}:dev check --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/{{ connector.technical_name }}:dev discover --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/{{ connector.technical_name }}:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
+```
+
+### Running our CI test suite
+You can run our full test suite locally using [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md):
+```bash
+airbyte-ci connectors --name={{ connector.technical_name }} test
+```
+
+### Customizing acceptance Tests
+Customize `acceptance-test-config.yml` file to configure acceptance tests. See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference) for more information.
+If your connector requires to create or destroy resources for use during acceptance tests create fixtures for it and place them inside integration_tests/acceptance.py.
+
+### Dependency Management
+All of your dependencies should be managed via Poetry. 
+To add a new dependency, run:
+```bash
+poetry add <package-name>
+```
+
+Please commit the changes to `pyproject.toml` and `poetry.lock` files.
+
+## Publishing a new version of the connector
+You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
+1. Make sure your changes are passing our test suite: `airbyte-ci connectors --name={{ connector.technical_name }} test`
+2. Bump the connector version (please follow [semantic versioning for connectors](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#semantic-versioning-for-connectors)): 
+    - bump the `dockerImageTag` value in in `metadata.yaml`
+    - bump the `version` value in `pyproject.toml`
+3. Make sure the `metadata.yaml` content is up to date.
+4. Make sure the connector documentation and its changelog is up to date (`{{ connector.documentation_file_path}}`).
+5. Create a Pull Request: use [our PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#pull-request-title-convention).
+6. Pat yourself on the back for being an awesome contributor.
+7. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master.
+8. Once your PR is merged, the new version of the connector will be automatically published to Docker Hub and our connector registry.

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.5.4"
+version = "4.6.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/2903
This PR adds a `migrate-to-poetry` command to `airbyte-ci connectors`  command group.
It was used to migrate our certified connectors to poetry

## How 
The pipeline is composed of the following steps:
1. Check if the connector is a migration candidate: must use our base image and must not already be migrated
2. Generate a `pyproject.toml` and a `poetry.lock` file according to the dependencies declared in `setup.py`. We pin main dependencies to the version used in the previous connector version via a `pip freeze`
3. Delete the `setup.py`
4. Build the poetry based connector version
5. Run a regression test to confirm the main dependencies version match between the previous connector version and the poetry managed one.
6. Revert changes if any step in the process failed

****N.B.**: This code is not in its cleanest form as the migration was mainly an ad-hoc process, we can improve it if this command gets adopted by the community to migrate community connectors to poetry.**
