### PR TITLE
Microsoft Entra ID for Self-Managed Enterprise

### DIFF
--- a/docs/access-management/sso-providers/azure-entra-id.md
+++ b/docs/access-management/sso-providers/azure-entra-id.md
@@ -1,21 +1,24 @@
 ---
-sidebar_label: Azure Entra ID
-products: cloud-teams
+sidebar_label: Microsoft Entra ID
+products: cloud-teams, oss-enterprise
 ---
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# Setup Single Sign-On via Azure Entra ID
+# Setup Single Sign-On via Microsoft Entra ID
 
-This page guides you through setting up [Single Sign-On](../sso.md) with Airbyte using **Microsoft Azure Entra ID** (formerly known as **Azure Active Directory**).
+This page guides you through setting up [Single Sign-On](../sso.md) with Airbyte using **Microsoft Entra ID** (formerly known as **Azure ActiveDirectory**).
 
 Airbyte will communicate with your Entra ID using OpenID Connect (OIDC).
+
+<Tabs groupId="cloud-hosted">
+<TabItem value="Cloud" label="Cloud">
 
 ## Creating an Entra ID app for Airbyte
 
 :::info
-The following steps need to be executed by an administrator of your company's Azure Entra ID account.
+The following steps need to be executed by an administrator of your company's Microsoft Entra ID account.
 :::
 
 You'll require to know your **Company Identifier** to create your application. You receive this
@@ -25,7 +28,7 @@ from your contact at Airbyte.
 
 You will need to create a new Entra ID application for Airbyte. Log into the [Azure Portal](https://portal.azure.com/) and search for the Entra ID service.
 
-On the Overview of Entra ID press **Add** > **App registration** on the top of the screen.
+From the overview page of Entra ID, press **Add** > **App registration** on the top of the screen.
 
 Specify any name you want (e.g. "Airbyte") and configure a **Redirect URI** of type **Web** with the following value:
 
@@ -39,13 +42,13 @@ Hit **Register** to create the application.
 
 To create Client credentials for Airbyte to talk to your application head to **Certificates & Secrets** on the detail screen of your application and select the **Client secrets** tab.
 
-Click **New client secret**, specify any Description you want and any Expire date you want. 
+Click **New client secret**, specify any Description you want and any expiry date you want. 
 
 :::tip
-We recommend to chose an expiry date of at least 12 months. You'll need to pass the new Client Secret to use every time the old one expires, to continue being able to log in via Entra ID.
+We recommend to chose an expiry date of at least 12 months. You'll need to pass in the new client secret every time the old one expires to continue being able to log in via Entra ID.
 :::
 
-Copy the **Value** (the Client Secret itself) immediately after creation. You won't be able to view this later on again.
+Copy the **Value** (the Client Secret itself) immediately after creation. You won't be able to view this later on.
 
 ### Setup information needed
 
@@ -56,3 +59,46 @@ You'll need to pass your Airbyte contact the following information of the create
 * **OpenID Connect metadata document**: You'll find this in the **Endpoints** panel, that you can open from the top bar on the **Overview** page
 
 Once we've received this information from you, We'll setup SSO for you and let you know once it's ready to be used.
+
+</TabItem>
+<TabItem value="Self-Managed" label="Self-Managed">
+
+## Creating an Entra ID app for Airbyte
+
+:::info
+The following steps need to be executed by an administrator of your company's Azure Entra ID account.
+:::
+
+### Create application
+
+You will need to create a new Entra ID application for Airbyte. Log into the [Azure Portal](https://portal.azure.com/) and search for the Entra ID service.
+
+From the overview page of Entra ID, press **Add** > **App registration** on the top of the screen. The name you select is your app integration name. Once chosen, configure a **Redirect URI** of type **Web** with the following value:
+
+```
+<your-airbyte-domain>/auth/realms/airbyte/broker/<app-integration-name>/endpoint
+```
+
+Hit **Register** to create the application.
+
+### Create client credentials
+
+To create client credentials for Airbyte to interface with your application, head to **Certificates & Secrets** on the detail screen of your application and select the **Client secrets** tab. Then:
+1. Click **New client secret**, and enter the expiry date of your choosing. You'll need to pass in the new client secret every time the old one expires to continue being able to log in via Entra ID.
+2. Copy the **Value** (the client secret itself) immediately after creation. You won't be able to view this later on.
+
+### Setup information needed
+
+Once your Microsoft Entra ID app is set up, you're ready to deploy Airbyte Self-Managed Enterprise with SSO. Take note of the following configuration values, as you will need them to configure Airbyte to use your new Okta SSO app integration:
+
+    * OpenID Connect metadata document: You'll find this in the list of endpoints found in the **Endpoints** panel, which you can open from the top bar of the **Overview** page. This will be used to populate the `Domain` field in your `airbyte.yml`.
+    * App Integration Name: The name of the Entra ID application created in the first step.
+    * Client ID: You'll find this in the **Essentials** section on the **Overview** page of the application you created.
+    * Client Secret: The client secret you copied in the previous step.
+
+Use this information to configure the auth details of your `airbyte.yml` for your Self-Managed Enterprise deployment. To learn more on deploying Self-Managed Enterprise, see our [implementation guide](/enterprise-setup/implementation-guide).
+
+</TabItem>
+</Tabs>
+
+

--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -80,11 +80,14 @@ cp configs/airbyte.sample.yml configs/airbyte.yml
 
 3. Add your Airbyte Self-Managed Enterprise license key to your `airbyte.yml`. 
 
-4. Add your [auth details](/enterprise-setup/sso) to your `airbyte.yml`. Auth configurations aren't easy to modify after Airbyte is installed, so please double check them to make sure they're accurate before proceeding.
+4. Add your [auth details](/access-management/sso) to your `airbyte.yml`.  
 
 <details>
     <summary>Configuring auth in your airbyte.yml file</summary>
 
+
+<Tabs>
+<TabItem value="Okta" label="Okta">
 To configure SSO with Okta, add the following at the end of your `airbyte.yml` file:
 
 ```yaml
@@ -97,7 +100,31 @@ auth:
             client-secret: $OKTA_CLIENT_SECRET
 ```
 
+See the [following guide](/access-management/sso-providers/okta) on how to collect this information for Okta.
+
+</TabItem>
+<TabItem value="Other" label="Other">
+
+To configure SSO with any identity provider via [OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/), such as Azure Entra ID (formerly ActiveDirectory), add the following at the end of your `airbyte.yml` file:
+
+```yaml
+auth:   
+    identity-providers:
+        -   type: oidc
+            domain: $DOMAIN
+            app-name: $APP_INTEGRATION_NAME
+            client-id: $CLIENT_ID
+            client-secret: $CLIENT_SECRET
+```
+
+See the [following guide](/access-management/sso-providers/azure-entra-id) on how to collect this information for Azure Entra ID (formerly ActiveDirectory).
+
+</TabItem>
+</Tabs>
+
 To configure basic auth (deploy without SSO), remove the entire `auth:` section from your airbyte.yml config file. You will authenticate with the instance admin user and password included in the your `airbyte.yml`.
+
+To modify auth configurations after Airbyte is installed, you will need to redeploy Airbyte with the additional environment variable `RESET_KEYCLOAK_REALM=TRUE`. As this also resets the list of Airbyte users and permissions, please use this with caution.
 
 </details>
 

--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -124,7 +124,7 @@ See the [following guide](/access-management/sso-providers/azure-entra-id) on ho
 
 To configure basic auth (deploy without SSO), remove the entire `auth:` section from your airbyte.yml config file. You will authenticate with the instance admin user and password included in the your `airbyte.yml`.
 
-To modify auth configurations after Airbyte is installed, you will need to redeploy Airbyte with the additional environment variable `RESET_KEYCLOAK_REALM=TRUE`. As this also resets the list of Airbyte users and permissions, please use this with caution.
+To modify auth configurations after Airbyte is installed, you will need to redeploy Airbyte with the additional environment variable `KEYCLOAK_RESET_REALM=TRUE`. As this also resets the list of Airbyte users and permissions, please use this with caution.
 
 </details>
 


### PR DESCRIPTION
* Adds a 'Self-Managed' section to the Microsoft Entra ID instructions
* Adds an 'Other' section to the auth config in the Self-Managed Enterprise implementation guide

Previews:
* https://airbyte-docs-git-alexcuoci-ad-oidc-instructions-airbyte-growth.vercel.app/access-management/sso-providers/azure-entra-id
* https://airbyte-docs-git-alexcuoci-ad-oidc-instructions-airbyte-growth.vercel.app/enterprise-setup/implementation-guide#clone--configure-airbyte