### PR TITLE
🐛 Source Netsuite: Fix stream builder to check wether incremental cursor field is filterable on Netsuite API

### DIFF
--- a/airbyte-integrations/connectors/source-netsuite/metadata.yaml
+++ b/airbyte-integrations/connectors/source-netsuite/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4f2f093d-ce44-4121-8118-9d13b7bfccd0
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.1.4
   dockerRepository: airbyte/source-netsuite
   documentationUrl: https://docs.airbyte.com/integrations/sources/netsuite
   githubIssueLabel: source-netsuite

--- a/airbyte-integrations/connectors/source-netsuite/source_netsuite/constraints.py
+++ b/airbyte-integrations/connectors/source-netsuite/source_netsuite/constraints.py
@@ -31,6 +31,8 @@ USLESS_SCHEMA_ELEMENTS: list = [
     "nullable",
 ]
 
+FILTERABLE_PROPS_SCHEMA_PATH: str = "x-ns-filterable"
+
 # PREDEFINE SCHEMA HEADER
 SCHEMA_HEADERS: dict = {"Accept": "application/schema+json"}
 

--- a/airbyte-integrations/connectors/source-netsuite/source_netsuite/source.py
+++ b/airbyte-integrations/connectors/source-netsuite/source_netsuite/source.py
@@ -12,7 +12,7 @@ import requests
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from requests_oauthlib import OAuth1
-from source_netsuite.constraints import CUSTOM_INCREMENTAL_CURSOR, INCREMENTAL_CURSOR, META_PATH, RECORD_PATH, SCHEMA_HEADERS
+from source_netsuite.constraints import CUSTOM_INCREMENTAL_CURSOR, FILTERABLE_PROPS_SCHEMA_PATH, INCREMENTAL_CURSOR, META_PATH, RECORD_PATH, SCHEMA_HEADERS
 from source_netsuite.streams import CustomIncrementalNetsuiteStream, IncrementalNetsuiteStream, NetsuiteStream
 
 
@@ -119,11 +119,12 @@ class SourceNetsuite(AbstractSource):
         }
 
         schema = schemas[object_name]
-        schema_props = schema.get("properties")
+        schema_props = schema.get("properties") 
+        schema_filterable_props = schema.get(FILTERABLE_PROPS_SCHEMA_PATH) 
         if schema_props:
-            if INCREMENTAL_CURSOR in schema_props.keys():
+            if INCREMENTAL_CURSOR in schema_props.keys() and INCREMENTAL_CURSOR in schema_filterable_props:
                 return IncrementalNetsuiteStream(**input_args)
-            elif CUSTOM_INCREMENTAL_CURSOR in schema_props.keys():
+            elif CUSTOM_INCREMENTAL_CURSOR in schema_props.keys() and CUSTOM_INCREMENTAL_CURSOR in schema_filterable_props:
                 return CustomIncrementalNetsuiteStream(**input_args)
             else:
                 # all other streams are full_refresh

--- a/docs/integrations/sources/netsuite.md
+++ b/docs/integrations/sources/netsuite.md
@@ -125,6 +125,7 @@ The connector is restricted by Netsuite [Concurrency Limit per Integration](http
 
 | Version | Date       | Pull Request                                             | Subject                     |
 | :------ | :--------- | :------------------------------------------------------- | :-------------------------- |
+| 0.1.4   | 2024-02-25 | [35620](https://github.com/airbytehq/airbyte/pull/35620) | Fix stream builder to check if cursor field is Netsuite filterable |
 | 0.1.3   | 2023-01-20 | [21645](https://github.com/airbytehq/airbyte/pull/21645) | Minor issues fix, Setup Guide corrections for public docs |
 | 0.1.1   | 2022-09-28 | [17304](https://github.com/airbytehq/airbyte/pull/17304) | Migrate to per-stream state |
 | 0.1.0   | 2022-09-15 | [16093](https://github.com/airbytehq/airbyte/pull/16093) | Initial Alpha release       |


### PR DESCRIPTION
## What
* Make sure the incremental cursor is filterable on Netsuite API endpoint to prevent `NONEXISTENT_FIELD` errors
* Fixes #35401 

## How
This source connector choose the sync mode based on the presence of an `INCREMENTAL_CURSOR` filed in the schema properties. Sometimes, this `INCREMENTAL_CURSOR` exists but is not filterable on Netsuite API, resulting in`NONEXISTENT_FIELD` (HTTP 400) errors.   

This fix proposes to make sure that the `INCREMENTAL_CURSOR` field is also present in the `x-ns-filterable` property list exposed in the resource schema. If not, it fallbacks on `full_refresh` sync mode. 

## 🚨 User Impact 🚨
Existing working streams won't be impacted.   
It'll only fix streams presenting `NONEXISTENT_FIELD` errors.

## Pre-merge Actions

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
