### PR TITLE
airbyte-ci: set execute timeout on connector test pipelines

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -78,4 +78,5 @@ jobs:
           github_token: ${{ env.PAT }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: "connectors --modified test"
+          # A connector test can't take more than 5 hours to run (5 * 60 * 60 = 18000 seconds)
+          subcommand: "connectors --execute-timeout=18000 --modified  test"


### PR DESCRIPTION
This will effectively make a connector test pipeline fail if the test pipeline takes more than 5 hours.
This is to prevent costly infinite runs.