### PR TITLE
fix HTML reports

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/templates/test_report.html.j2
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/templates/test_report.html.j2
@@ -178,11 +178,11 @@ function copyToClipBoard(htmlElement) {
       <div class="content-inner">
         {% if step_result.stdout %}
         <span class="std">Standard output(<button onclick="copyToClipBoard(this)">Copy to clipboard</button>):</span>
-        <pre>{{ step_result.stdout }}</pre>
+        <pre>{{ step_result.stdout|e }}</pre>
         {% endif %}
         {% if step_result.stderr %}
         <span class="std">Standard error(<button onclick="copyToClipBoard(this)">Copy to clipboard</button>):</span>
-        <pre>{{ step_result.stderr }}</pre>
+        <pre>{{ step_result.stderr|e }}</pre>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
If the STDOUT or the STDERR of the current step contains the '<' character, it'll be parsed by the browser and break the report. This simply escape all stdout and stderr before appending it to the report