### PR TITLE
Source Monday: fix empty activity logs extractor

### DIFF
--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 80a54ea2-9959-4040-aac1-eee42423ec9b
-  dockerImageTag: 2.0.3
+  dockerImageTag: 2.0.4
   releases:
     breakingChanges:
       2.0.0:

--- a/airbyte-integrations/connectors/source-monday/pyproject.toml
+++ b/airbyte-integrations/connectors/source-monday/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.0.3"
+version = "2.0.4"
 name = "source-monday"
 description = "Source implementation for Monday."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-monday/source_monday/extractor.py
+++ b/airbyte-integrations/connectors/source-monday/source_monday/extractor.py
@@ -41,9 +41,8 @@ class MondayActivityExtractor(RecordExtractor):
             return result
 
         for board_data in response_body["data"]["boards"]:
-            if not isinstance(board_data, dict):
+            if not isinstance(board_data, dict) or not board_data.get("activity_logs"):
                 continue
-
             for record in board_data.get("activity_logs", []):
                 json_data = json.loads(record["data"])
                 new_record = record

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/__init__.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/__init__.py
@@ -1,1 +1,3 @@
 from .teams_requests_builder import TeamsRequestBuilder
+
+__all__ = ["TeamsRequestBuilder"]

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/request_authenticators/__init__.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/request_authenticators/__init__.py
@@ -1,1 +1,3 @@
 from .api_token_authenticator import ApiTokenAuthenticator
+
+__all__ = ["ApiTokenAuthenticator"]

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/request_authenticators/api_token_authenticator.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/request_authenticators/api_token_authenticator.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
-import base64
-
 from .authenticator import Authenticator
 
 

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/__init__.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/__init__.py
@@ -1,2 +1,4 @@
-from .teams_response_builder import TeamsResponseBuilder
 from .error_response_builder import ErrorResponseBuilder
+from .teams_response_builder import TeamsResponseBuilder
+
+__all__ = ["ErrorResponseBuilder", "TeamsResponseBuilder"]

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/records/__init__.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_responses/records/__init__.py
@@ -1,1 +1,3 @@
 from .teams_record_builder import TeamsRecordBuilder
+
+__all__ = ["TeamsRecordBuilder"]

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_teams_stream.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_teams_stream.py
@@ -33,7 +33,7 @@ class TestTeamsStreamFullRefresh(TestCase):
 
         http_mocker.get(
             TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
-            TeamsResponseBuilder.teams_response().with_record(TeamsRecordBuilder.teams_record()).build()
+            TeamsResponseBuilder.teams_response().with_record(TeamsRecordBuilder.teams_record()).build(),
         )
 
         output = read_stream("teams", SyncMode.full_refresh, self._config)
@@ -50,17 +50,18 @@ class TestTeamsStreamFullRefresh(TestCase):
             TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
             [
                 ErrorResponseBuilder.response_with_status(200).build(),
-                TeamsResponseBuilder.teams_response().with_record(TeamsRecordBuilder.teams_record()).build()
-            ]
+                TeamsResponseBuilder.teams_response().with_record(TeamsRecordBuilder.teams_record()).build(),
+            ],
         )
 
-        with patch('time.sleep', return_value=None):
+        with patch("time.sleep", return_value=None):
             output = read_stream("teams", SyncMode.full_refresh, self._config)
 
         assert len(output.records) == 1
 
         error_logs = [
-            error for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
+            error
+            for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
             if f'Response Code: 200, Response Text: {json.dumps({"error_code": "ComplexityException", "status_code": 200})}' in error
         ]
         assert len(error_logs) == 1
@@ -73,17 +74,17 @@ class TestTeamsStreamFullRefresh(TestCase):
         api_token_authenticator = self.get_authenticator(self._config)
 
         http_mocker.get(
-            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
-            ErrorResponseBuilder.response_with_status(200).build()
+            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(), ErrorResponseBuilder.response_with_status(200).build()
         )
 
-        with patch('time.sleep', return_value=None):
+        with patch("time.sleep", return_value=None):
             output = read_stream("teams", SyncMode.full_refresh, self._config)
-        
+
         assert len(output.records) == 0
 
         error_logs = [
-            error for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
+            error
+            for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
             if f'Response Code: 200, Response Text: {json.dumps({"error_code": "ComplexityException", "status_code": 200})}' in error
         ]
         assert len(error_logs) == 5
@@ -96,17 +97,17 @@ class TestTeamsStreamFullRefresh(TestCase):
         api_token_authenticator = self.get_authenticator(self._config)
 
         http_mocker.get(
-            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
-            ErrorResponseBuilder.response_with_status(500).build()
+            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(), ErrorResponseBuilder.response_with_status(500).build()
         )
 
-        with patch('time.sleep', return_value=None):
+        with patch("time.sleep", return_value=None):
             output = read_stream("teams", SyncMode.full_refresh, self._config)
-        
+
         assert len(output.records) == 0
 
         error_logs = [
-            error for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
+            error
+            for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
             if f'Response Code: 500, Response Text: {json.dumps({"error_message": "Internal server error", "status_code": 500})}' in error
         ]
         assert len(error_logs) == 5
@@ -119,17 +120,17 @@ class TestTeamsStreamFullRefresh(TestCase):
         api_token_authenticator = self.get_authenticator(self._config)
 
         http_mocker.get(
-            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
-            ErrorResponseBuilder.response_with_status(403).build()
+            TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(), ErrorResponseBuilder.response_with_status(403).build()
         )
 
-        with patch('time.sleep', return_value=None):
+        with patch("time.sleep", return_value=None):
             output = read_stream("teams", SyncMode.full_refresh, self._config)
 
         assert len(output.records) == 0
 
         error_logs = [
-            error for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
-            if f'Ignoring response for failed request with error message None' in error
+            error
+            for error in get_log_messages_by_log_level(output.logs, LogLevel.INFO)
+            if "Ignoring response for failed request with error message None" in error
         ]
         assert len(error_logs) == 1

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/utils.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/utils.py
@@ -12,11 +12,7 @@ from source_monday import SourceMonday
 
 
 def read_stream(
-    stream_name: str,
-    sync_mode: SyncMode,
-    config: Dict[str, Any],
-    state: Optional[Dict[str, Any]] = None,
-    expecting_exception: bool = False
+    stream_name: str, sync_mode: SyncMode, config: Dict[str, Any], state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = CatalogBuilder().with_stream(stream_name, sync_mode).build()
     return read(SourceMonday(), config, catalog, state, expecting_exception)

--- a/airbyte-integrations/connectors/source-monday/unit_tests/test_extractor.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/test_extractor.py
@@ -36,6 +36,17 @@ def test_extract_records():
     assert records[0]["created_at_int"] == 1636738688
 
 
+def test_empty_activity_logs_extract_records():
+    response = MagicMock()
+    response_body = {"data": {"boards": [{"activity_logs": None}]}}
+
+    response.json.return_value = response_body
+    extractor = MondayActivityExtractor(parameters={})
+    records = extractor.extract_records(response)
+
+    assert len(records) == 0
+
+
 def test_extract_records_incremental():
     # Mock the response
     response = MagicMock()

--- a/airbyte-integrations/connectors/source-monday/unit_tests/test_extractor.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/test_extractor.py
@@ -11,19 +11,7 @@ def test_extract_records():
     # Mock the response
     response = MagicMock()
     response_body = {
-        "data": {
-            "boards": [
-                {
-                    "activity_logs": [
-                        {
-                            "data": "{\"pulse_id\": 123}",
-                            "entity": "pulse",
-                            "created_at": "16367386880000000"
-                        }
-                    ]
-                }
-            ]
-        }
+        "data": {"boards": [{"activity_logs": [{"data": '{"pulse_id": 123}', "entity": "pulse", "created_at": "16367386880000000"}]}]}
     }
 
     response.json.return_value = response_body
@@ -50,15 +38,7 @@ def test_empty_activity_logs_extract_records():
 def test_extract_records_incremental():
     # Mock the response
     response = MagicMock()
-    response_body = {
-        "data": {
-            "boards": [
-                {
-                    "id": 1
-                }
-            ]
-        }
-    }
+    response_body = {"data": {"boards": [{"id": 1}]}}
 
     response.json.return_value = response_body
     extractor = MondayIncrementalItemsExtractor(
@@ -66,9 +46,9 @@ def test_extract_records_incremental():
         field_path=["data", "ccccc"],
         config=MagicMock(),
         field_path_pagination=["data", "bbbb"],
-        field_path_incremental=["data", "boards", "*"]
+        field_path_incremental=["data", "boards", "*"],
     )
     records = extractor.extract_records(response)
 
     # Assertions
-    assert records == [{'id': 1}]
+    assert records == [{"id": 1}]

--- a/airbyte-integrations/connectors/source-monday/unit_tests/test_graphql_requester.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/test_graphql_requester.py
@@ -105,6 +105,7 @@ def monday_requester():
         nested_limit=InterpolatedString.create("100", parameters={"name": "activity_logs"}),
     )
 
+
 def test_get_schema_root_properties(mocker, monday_requester):
     mock_schema = {
         "properties": {
@@ -113,29 +114,29 @@ def test_get_schema_root_properties(mocker, monday_requester):
             "pulse_id": {"type": "integer"},
             "board_id": {"type": "integer"},
             "other_field": {"type": "string"},
-            "yet_another_field": {"type": "boolean"}
+            "yet_another_field": {"type": "boolean"},
         }
     }
 
-    mocker.patch.object(JsonFileSchemaLoader, 'get_json_schema', return_value=mock_schema)
+    mocker.patch.object(JsonFileSchemaLoader, "get_json_schema", return_value=mock_schema)
     requester = monday_requester
     result_schema = requester._get_schema_root_properties()
 
-    assert result_schema == { 
-        "other_field": { "type": "string" },
-        "yet_another_field": { "type": "boolean" }
-    }
+    assert result_schema == {"other_field": {"type": "string"}, "yet_another_field": {"type": "boolean"}}
 
 
 def test_build_activity_query(mocker, monday_requester):
 
-    mock_stream_state = { "updated_at_int": 1636738688 }
-    object_arguments = { "stream_state": mock_stream_state }
-    mocker.patch.object(MondayGraphqlRequester, '_get_object_arguments', return_value="stream_state:{{ stream_state['updated_at_int'] }}")
+    mock_stream_state = {"updated_at_int": 1636738688}
+    object_arguments = {"stream_state": mock_stream_state}
+    mocker.patch.object(MondayGraphqlRequester, "_get_object_arguments", return_value="stream_state:{{ stream_state['updated_at_int'] }}")
     requester = monday_requester
 
     result = requester._build_activity_query(object_name="activity_logs", field_schema={}, sub_page=None, **object_arguments)
-    assert result == "boards(stream_state:{{ stream_state['updated_at_int'] }}){activity_logs(stream_state:{{ stream_state['updated_at_int'] }}){}}"
+    assert (
+        result
+        == "boards(stream_state:{{ stream_state['updated_at_int'] }}){activity_logs(stream_state:{{ stream_state['updated_at_int'] }}){}}"
+    )
 
 
 def test_build_items_incremental_query(monday_requester):
@@ -149,11 +150,11 @@ def test_build_items_incremental_query(monday_requester):
 
     built_query = monday_requester._build_items_incremental_query(object_name, field_schema, stream_slice)
 
-    assert built_query == 'items(limit:100,ids:[1, 2, 3]){id,name}'
+    assert built_query == "items(limit:100,ids:[1, 2, 3]){id,name}"
 
 
 def test_get_request_headers(monday_requester):
 
     headers = monday_requester.get_request_headers()
 
-    assert headers == {'API-Version': '2024-01'}
+    assert headers == {"API-Version": "2024-01"}

--- a/airbyte-integrations/connectors/source-monday/unit_tests/test_item_pagination_strategy.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/test_item_pagination_strategy.py
@@ -41,19 +41,20 @@ def test_item_pagination_strategy(response_json, last_records, expected):
 
     assert strategy.next_page_token(response, last_records) == expected
 
+
 @pytest.mark.parametrize(
     ("response_json", "last_records", "expected"),
     [
         pytest.param(
-            {"data": {"boards": [{"items_page": {"cursor": "bla", "items":[{"id": "1"}]}}]}},
+            {"data": {"boards": [{"items_page": {"cursor": "bla", "items": [{"id": "1"}]}}]}},
             [],
-            (1, 'bla'),
+            (1, "bla"),
             id="test_cursor_in_first_request",
         ),
         pytest.param(
-            {"data": {"next_items_page": {"cursor": "bla2", "items":[{"id": "1"}]}}},
+            {"data": {"next_items_page": {"cursor": "bla2", "items": [{"id": "1"}]}}},
             [],
-            (1, 'bla2'),
+            (1, "bla2"),
             id="test_cursor_in_next_page",
         ),
         pytest.param(

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -74,6 +74,7 @@ The Monday connector should not run into Monday API limitations under normal usa
 
 | Version | Date       | Pull Request                                              | Subject                                                                 |
 |:--------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------|
+| 2.0.4   | 2024-02-28 | [35696](https://github.com/airbytehq/airbyte/pull/35696)  | Fix extraction for `null` value in stream `Activity logs`               |
 | 2.0.3   | 2024-02-21 | [35506](https://github.com/airbytehq/airbyte/pull/35506)  | Support for column values of the mirror type for the `Items` stream.    |
 | 2.0.2   | 2024-02-12 | [35146](https://github.com/airbytehq/airbyte/pull/35146)  | Manage dependencies with Poetry.                                        |
 | 2.0.1   | 2024-02-08 | [35016](https://github.com/airbytehq/airbyte/pull/35016)  | Migrated to the latest airbyte cdk                                      |


### PR DESCRIPTION
## What

Resolve https://github.com/airbytehq/oncall/issues/4395

## How

pass if `activity_logs` value is `null`

## Recommended reading order
1. `airbyte-integrations/connectors/source-monday/source_monday/extractor.py`

## 🚨 User Impact 🚨

no breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

