### PR TITLE
Docs index pages are not really docs pages

### DIFF
--- a/docusaurus/src/remark/utils.js
+++ b/docusaurus/src/remark/utils.js
@@ -11,8 +11,9 @@ const isDocsPage = (vfile) => {
   let response = { isDocsPage: false, isTrueDocsPage: false };
 
   if (
-    vfile.path.includes("integrations/sources") ||
-    vfile.path.includes("integrations/destinations")
+    (vfile.path.includes("integrations/sources") ||
+      vfile.path.includes("integrations/destinations")) &&
+    !vfile.path.toLowerCase().includes("readme.md")
   ) {
     response.isDocsPage = true;
     response.isTrueDocsPage = true;


### PR DESCRIPTION
Fixes this bug - the source/destination connectors index pages shouldn't have the metadata badge

<img width="754" alt="Screenshot 2024-02-28 at 9 08 41 AM" src="https://github.com/airbytehq/airbyte/assets/303226/673e9c73-d4e8-4b85-9db6-9d58dfc41268">
