### PR TITLE
🏥Source Google Sheets: add logic to emit stream statuses

### DIFF
--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 71607ba1-c0ac-4799-8049-7f4b90dd50f7
-  dockerImageTag: 0.3.16
+  dockerImageTag: 0.3.17
   dockerRepository: airbyte/source-google-sheets
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-sheets
   githubIssueLabel: source-google-sheets

--- a/airbyte-integrations/connectors/source-google-sheets/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-sheets/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.3.16"
+version = "0.3.17"
 name = "source-google-sheets"
 description = "Source implementation for Google Sheets."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/source.py
+++ b/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/source.py
@@ -14,12 +14,14 @@ from airbyte_cdk.models.airbyte_protocol import (
     AirbyteConnectionStatus,
     AirbyteMessage,
     AirbyteStateMessage,
+    AirbyteStreamStatus,
     ConfiguredAirbyteCatalog,
     Status,
     Type,
 )
 from airbyte_cdk.sources.source import Source
 from airbyte_cdk.utils import AirbyteTracedException
+from airbyte_cdk.utils.stream_status_utils import as_airbyte_message
 from apiclient import errors
 from google.auth import exceptions as google_exceptions
 from requests.status_codes import codes as status_codes
@@ -145,11 +147,11 @@ class SourceGoogleSheets(Source):
         logger: AirbyteLogger,
         config: json,
         catalog: ConfiguredAirbyteCatalog,
-        state: Union[List[AirbyteStateMessage], MutableMapping[str, Any]] = None,
     ) -> Generator[AirbyteMessage, None, None]:
         client = GoogleSheetsClient(self.get_credentials(config))
 
         sheet_to_column_name = Helpers.parse_sheet_and_column_names_from_catalog(catalog)
+        stream_name_to_stream = {stream.stream.name: stream for stream in catalog.streams}
         spreadsheet_id = Helpers.get_spreadsheet_id(config["spreadsheet_id"])
 
         logger.info(f"Starting syncing spreadsheet {spreadsheet_id}")
@@ -162,6 +164,8 @@ class SourceGoogleSheets(Source):
         logger.info(f"Row counts: {sheet_row_counts}")
         for sheet in sheet_to_column_index_to_name.keys():
             logger.info(f"Syncing sheet {sheet}")
+            stream = stream_name_to_stream.get(sheet)
+            yield as_airbyte_message(stream, AirbyteStreamStatus.STARTED)
             # We revalidate the sheet here to avoid errors in case the sheet was changed after the sync started
             is_valid, reason = Helpers.check_sheet_is_valid(client, spreadsheet_id, sheet)
             if is_valid:
@@ -191,11 +195,13 @@ class SourceGoogleSheets(Source):
                     if len(row_values) == 0:
                         break
 
+                    yield as_airbyte_message(stream, AirbyteStreamStatus.RUNNING)
                     for row in row_values:
                         if not Helpers.is_row_empty(row) and Helpers.row_contains_relevant_data(row, column_index_to_name.keys()):
                             yield AirbyteMessage(
                                 type=Type.RECORD, record=Helpers.row_data_to_record_message(sheet, row, column_index_to_name)
                             )
+                yield as_airbyte_message(stream, AirbyteStreamStatus.COMPLETE)
             else:
                 logger.info(f"Skipping syncing sheet {sheet}: {reason}")
 
@@ -208,7 +214,7 @@ class SourceGoogleSheets(Source):
     ) -> Generator[AirbyteMessage, None, None]:
         spreadsheet_id = Helpers.get_spreadsheet_id(config["spreadsheet_id"])
         try:
-            yield from self._read(logger, config, catalog, state)
+            yield from self._read(logger, config, catalog)
         except errors.HttpError as e:
             error_description = exception_description_by_status_code(e.status_code, spreadsheet_id)
 

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -150,7 +150,8 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                           |
-| ------- | ---------- | -------------------------------------------------------- | --------------------------------------------------------------------------------- |
+|---------|------------|----------------------------------------------------------|-----------------------------------------------------------------------------------|
+| 0.3.17  | 2024-02-29 | [35722](https://github.com/airbytehq/airbyte/pull/35722) | Add logic to emit stream statuses                                                 |
 | 0.3.16  | 2024-02-12 | [35136](https://github.com/airbytehq/airbyte/pull/35136) | Fix license in `pyproject.toml`.                                                  |
 | 0.3.15  | 2024-02-07 | [34944](https://github.com/airbytehq/airbyte/pull/34944) | Manage dependencies with Poetry.                                                  |
 | 0.3.14  | 2024-01-23 | [34437](https://github.com/airbytehq/airbyte/pull/34437) | Fix header cells filtering                                                        |

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -142,7 +142,7 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 ### Troubleshooting
 
 * If your sheet is completely empty (no header rows) or deleted, Airbyte will not delete the table in the destination. If this happens, the sync logs will contain a message saying the sheet has been skipped when syncing the full spreadsheet.
-* Connector setup will fail if the speadsheet is not a Google Sheets file. If the file was saved or imported as another file type the setup could fail.
+* Connector setup will fail if the spreadsheet is not a Google Sheets file. If the file was saved or imported as another file type the setup could fail.
 * Check out common troubleshooting issues for the Google Sheets source connector on our [Airbyte Forum](https://github.com/airbytehq/airbyte/discussions).
 
 </details>


### PR DESCRIPTION
## What
Added logic to emit stream statuses (`STARTED`, `RUNNING`, `COMPLETE`)

## Recommended reading order
1. `source.py`
2. `test_stream.py`

## 🚨 User Impact 🚨
No

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>