### PR TITLE
source-intercom: add string as possible type for height and width fields in conversation streams

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/conversation_parts.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/conversation_parts.json
@@ -43,10 +43,10 @@
             "type": ["null", "integer"]
           },
           "height": {
-            "type": ["null", "integer"]
+            "type": ["null", "integer", "string"]
           },
           "width": {
-            "type": ["null", "integer"]
+            "type": ["null", "integer", "string"]
           }
         }
       }

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/conversations.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/conversations.json
@@ -151,10 +151,10 @@
                     "type": ["null", "integer"]
                   },
                   "height": {
-                    "type": ["null", "integer"]
+                    "type": ["null", "integer", "string"]
                   },
                   "width": {
-                    "type": ["null", "integer"]
+                    "type": ["null", "integer", "string"]
                   }
                 }
               }


### PR DESCRIPTION
## What
* `height` field in `conversation_parts` stream can be returned as string by intercom api. This PR adds `string` as possible type in the json schema for this field.

```
jsonschema.exceptions.ValidationError: '421' is not of type 'null', 'integer'
Failed validating 'type' in schema['properties']['attachments']['items']['properties']['height']: {'type': ['null', 'integer']}
```
* Also added `string` as possible type for `width` field. Anticipate that this could also be an issue in the `conversation` stream so we added these changes there too. 
* linked issue: https://github.com/airbytehq/airbyte/issues/35729

## How
* update json schemas for `conversation_parts` and `conversation` streams

## Recommended reading order
1. `conversation_parts.json`
2. `conversation.json`

## 🚨 User Impact 🚨
None


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
