### PR TITLE
connectors-test: 6H  workflow timeout

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -63,7 +63,7 @@ jobs:
     if: needs.changes.outputs.connectors == 'true'
     name: Connectors CI
     runs-on: connector-test-large
-    timeout-minutes: 1440 # 24 hours
+    timeout-minutes: 360 # 6 hours
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3


### PR DESCRIPTION
Any dagger operation has been given a 5H timeout.
This changes sets a maximum overall workflow duration to 6H.