### PR TITLE
Archive connectors already hidden with legacy state

### DIFF
--- a/airbyte-integrations/connectors/source-appstore-singer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appstore-singer/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: false
       # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
       packageName: airbyte-source-appstore-singer
-  registries: # Removed from registries due to LEGACY STATE
+  registries:
     cloud:
       enabled: false
     oss:
@@ -25,5 +25,5 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-  supportLevel: community
+  supportLevel: archived
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-courier/metadata.yaml
+++ b/airbyte-integrations/connectors/source-courier/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-courier
-  registries: # Removed from registries due to LEGACY STATE
+  registries:
     cloud:
       enabled: false
     oss:
@@ -25,5 +25,5 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-  supportLevel: community
+  supportLevel: archived
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dv-360/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dv-360/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-dv-360
-  registries: # Removed from registries due to LEGACY STATE
+  registries:
     cloud:
       enabled: false
     oss:
@@ -24,5 +24,5 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-  supportLevel: community
+  supportLevel: archived
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-kustomer-singer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kustomer-singer/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: false
       # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
       packageName: airbyte-source-kustomer-singer
-  registries: # Removed from registries due to LEGACY STATE
+  registries:
     cloud:
       enabled: false
     oss:
@@ -25,5 +25,5 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-  supportLevel: community
+  supportLevel: archived
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-linnworks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linnworks/metadata.yaml
@@ -16,15 +16,15 @@ data:
   name: Linnworks
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
-      enabled: false
+      enabled: true
   releaseStage: alpha
   remoteRegistries:
     pypi:
       enabled: true
       packageName: airbyte-source-linnworks
-  supportLevel: archived
+  supportLevel: community
   tags:
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-linnworks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linnworks/metadata.yaml
@@ -16,15 +16,15 @@ data:
   name: Linnworks
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
-      enabled: true
+      enabled: false
   releaseStage: alpha
   remoteRegistries:
     pypi:
       enabled: true
       packageName: airbyte-source-linnworks
-  supportLevel: community
+  supportLevel: archived
   tags:
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-recurly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recurly/metadata.yaml
@@ -16,7 +16,7 @@ data:
   name: Recurly
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha
@@ -24,7 +24,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-recurly
-  supportLevel: community
+  supportLevel: archived
   tags:
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-search-metrics/metadata.yaml
+++ b/airbyte-integrations/connectors/source-search-metrics/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-search-metrics
-  registries: # Removed from registries due to LEGACY STATE
+  registries:
     cloud:
       enabled: false
     oss:
@@ -24,5 +24,5 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-  supportLevel: community
+  supportLevel: archived
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-talkdesk-explore/metadata.yaml
+++ b/airbyte-integrations/connectors/source-talkdesk-explore/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-talkdesk-explore
-  registries: # Removed from registries due to LEGACY STATE
+  registries:
     cloud:
       enabled: false
     oss:
@@ -24,5 +24,5 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-  supportLevel: community
+  supportLevel: archived
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zuora/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zuora/metadata.yaml
@@ -16,13 +16,13 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-zuora
-  registries: # Removed from registries due to LEGACY STATE
+  registries:
     cloud:
       enabled: false
     oss:
       enabled: false
   releaseStage: alpha
-  supportLevel: community
+  supportLevel: archived
   tags:
     - language:python
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
These 8 sources are hidden today via LaunchDarkly because they have legacy state

<img width="1682" alt="Screenshot 2024-03-01 at 8 28 10 AM" src="https://github.com/airbytehq/airbyte/assets/303226/b2d7fcec-20a4-4a30-8b78-de5607c7f790">

```
cd42861b-01fc-4658-a8ab-5d11d0510f01 - airbyte/source-recurly
af123bf-0aaf-4e0d-9784-cb497f23741a - airbyte/source-appstore-singer
8d7ef552-2c0f-11ec-8d3d-0242ac130003 - airbyte/source-search-metrics
1356e1d9-977f-4057-ad4b-65f25329cf61 - airbyte/source-dv-360
3dc3037c-5ce8-4661-adc2-f7a9e3c5ece5 - airbyte/source-zuora
0541b2cd-2367-4986-b5f1-b79ff55439e4 -  airbyte/source-courier
cd06e646-31bf-4dc8-af48-cbc6530fcad3 - airbyte/source-kustomer-singer
f00d2cf4-3c28-499a-ba93-b50b6f26359e - airbyte/source-talkdesk-explore
```

However, the LaunchDarkly feature flag only hides connectors from the new source page, but doesn't indicate that it can't be used any more from the docs.  This PR uses our new Archived tooling to formally remove the connector.

Note: source-linworks is also hidden by the feature flag, but we don't want to archive that connector

**TODO**
- [x] PR 1: Set archived=true and remove the connector from the registires
- [x] PR 2: Remove the connector's code and move to https://github.com/airbytehq/connector-archive
- [x] Remove the old `Hide Legacy State Connectors` LaunchDarkly feature flag - it won't be needed any more after PR 1