### PR TITLE
Use a separate concurrency group for Java CDK GH workflow.

### DIFF
--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -35,7 +35,7 @@ on:
         required: false
 
 concurrency:
-  group: publish-airbyte-cdk
+  group: publish-java-cdk
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
Use a different concurrency group for java-cdk
## What
Java CDK publish is sharing concurrency group with python cdk publish. Separate it out. 
