### PR TITLE
Revert "Use a separate concurrency group for Java CDK GH workflow."

### DIFF
--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -35,7 +35,7 @@ on:
         required: false
 
 concurrency:
-  group: publish-java-cdk
+  group: publish-airbyte-cdk
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
Reverts airbytehq/airbyte#35758