### PR TITLE
airbyte-ci format: run a runner with more disk space

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -12,7 +12,7 @@ jobs:
   format-check:
     # IMPORTANT: This name must match the require check name on the branch protection settings
     name: "Check for formatting errors"
-    runs-on: ubuntu-latest
+    runs-on: tooling-test-small
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3


### PR DESCRIPTION
Mitigate https://github.com/airbytehq/airbyte-internal-issues/issues/6439

Make the `format_check.yml` workflow use a runner with more disk space (150GB vs 16GB).