### PR TITLE
Source Recurly: update archived flag in metadata

### DIFF
--- a/airbyte-integrations/connectors/source-recurly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recurly/metadata.yaml
@@ -31,7 +31,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-recurly
-  supportLevel: archived
+  supportLevel: community
   tags:
     - language:python
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Source Recurly was just added back to the main repo from the archived-connectors repo, but I missed the "archived" flag in the metadata, and it does not currently appear in the catalog.