### PR TITLE
Docs (`ci_credentials`): Add remote install instructions via `pipx`

### DIFF
--- a/airbyte-ci/connectors/ci_credentials/README.md
+++ b/airbyte-ci/connectors/ci_credentials/README.md
@@ -36,8 +36,7 @@ pipx install --editable --force --python=python3.10 airbyte-ci/connectors/ci_cre
 Or install with a link to the default branch of the repo:
 
 ```bash
-pipx install git+https://github.com/airbytehq/airbyte.git#subdirector
-y=airbyte-ci/connectors/ci_credentials
+pipx install git+https://github.com/airbytehq/airbyte.git#subdirectory=airbyte-ci/connectors/ci_credentials
 ```
 
 This command installs `ci_credentials` and makes it globally available in your terminal.

--- a/airbyte-ci/connectors/ci_credentials/README.md
+++ b/airbyte-ci/connectors/ci_credentials/README.md
@@ -33,6 +33,13 @@ Once pyenv and pipx is installed then run the following:
 pipx install --editable --force --python=python3.10 airbyte-ci/connectors/ci_credentials/
 ```
 
+Or install with a link to the default branch of the repo:
+
+```bash
+pipx install git+https://github.com/airbytehq/airbyte.git#subdirector
+y=airbyte-ci/connectors/ci_credentials
+```
+
 This command installs `ci_credentials` and makes it globally available in your terminal.
 
 _Note: `--force` is required to ensure updates are applied on subsequent installs._


### PR DESCRIPTION
Small docs update to install from branch instead of from local path.

Context:

- I am starting to test this with `PyAirbyte` and did not want the version to depend on my `airbyte` branch being up-to-date with `master`.