### PR TITLE
update support level metadata

### DIFF
--- a/airbyte-integrations/connectors/source-recurly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recurly/metadata.yaml
@@ -31,7 +31,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-recurly
-  supportLevel: archived
+  supportLevel: community
   tags:
     - language:python
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Source Recurly was migrated back to the catalog from the "archived-connectors" repo in #35763, but I missed updating the supportLevel metadata tag from "archived" to "community" so it's still flagged as archived in our docs.