### PR TITLE
CDK: upgrade pyarrow

### DIFF
--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 avro_dependency = "avro~=1.11.2"
 fastavro_dependency = "fastavro~=1.8.0"
-pyarrow_dependency = "pyarrow==12.0.1"
+pyarrow_dependency = "pyarrow~=15.0.0"
 
 langchain_dependency = "langchain==0.0.271"
 openai_dependency = "openai[embeddings]==0.27.9"


### PR DESCRIPTION
Upgrades pyarrow to the latest version, to avoid possible exposure to a vulnerability described [here](https://nvd.nist.gov/vuln/detail/CVE-2023-47248).