### PR TITLE
Source Recurly: bump version to unarchive in Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-recurly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recurly/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: cd42861b-01fc-4658-a8ab-5d11d0510f01
-  dockerImageTag: 1.0.0
+  dockerImageTag: 1.0.1
   dockerRepository: airbyte/source-recurly
   documentationUrl: https://docs.airbyte.com/integrations/sources/recurly
   githubIssueLabel: source-recurly

--- a/airbyte-integrations/connectors/source-recurly/pyproject.toml
+++ b/airbyte-integrations/connectors/source-recurly/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.0.0"
+version = "1.0.1"
 name = "source-recurly"
 description = "Source implementation for Recurly."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/recurly.md
+++ b/docs/integrations/sources/recurly.md
@@ -64,6 +64,7 @@ We recommend creating a restricted, read-only key specifically for Airbyte acces
 
 | Version | Date       | Pull Request                                             | Subject                                                                                  |
 |:--------|:-----------| :--------------------------------------------------------| :--------------------------------------------------------------------------------------- |
+| 1.0.1   | 2024-03-05 | [35828](https://github.com/airbytehq/airbyte/pull/35828) | Bump version to unarchive supportLevel in Cloud productionDB                             |
 | 1.0.0   | 2024-03-01 | [35763](https://github.com/airbytehq/airbyte/pull/35763) | Re-introduce updated connector to catalog from archival repo                             |
 | 0.5.0   | 2024-02-22 | [34622](https://github.com/airbytehq/airbyte/pull/34622) | Republish connector using base image/Poetry, update schemas                              |
 | 0.4.1   | 2022-06-10 | [13685](https://github.com/airbytehq/airbyte/pull/13685) | Add state_checkpoint_interval to Recurly stream                                          |


### PR DESCRIPTION
## What

Bumping the Recurly version to 1.0.1 to try and force Cloud catalog to recognize `supportLevel` as unarchived.