### PR TITLE
🐛 Install arm64 emulator when building source_declarative_manifest

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -223,7 +223,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: airbytehq/airbyte
-          ref: master
+          ref: ${{ github.event.inputs.gitref }}
       - name: Install Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -245,8 +245,6 @@ jobs:
           command: |
             docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
             ./tools/integrations/manage.sh publish airbyte-cdk/python false
-          attempt_limit: 3
-          attempt_delay: 5000 in # ms
       - name: Post failure to Slack channel dev-connectors-extensibility
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.23.0

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -235,7 +235,9 @@ cmd_publish() {
     do
       echo "building base images for $arch"
       docker buildx build -t airbyte/integration-base:dev --platform $arch --load airbyte-integrations/bases/base
-      docker buildx build -t airbyte/integration-base-java:dev --platform $arch --load airbyte-integrations/bases/base-java
+      if [ "$path" != "airbyte-cdk/python" ]; then
+        docker buildx build -t airbyte/integration-base-java:dev --platform $arch --load airbyte-integrations/bases/base-java
+      fi
 
       # For a short while (https://github.com/airbytehq/airbyte/pull/25034), destinations rely on the normalization image to build
       # Thanks to gradle, destinstaions which need normalization will already have built base-normalization's "build" artifacts

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -238,6 +238,7 @@ cmd_publish() {
     for arch in $(echo $build_arch | sed "s/,/ /g")
     do
       echo "building base images for $arch"
+      # These images aren't needed for the CDK
       if [ "$path" != "airbyte-cdk/python" ]; then
         docker buildx build -t airbyte/integration-base-java:dev --platform $arch --load airbyte-integrations/bases/base-java
         docker buildx build -t airbyte/integration-base:dev --platform $arch --load airbyte-integrations/bases/base

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -231,12 +231,16 @@ cmd_publish() {
     # Alternative local approach @ https://github.com/docker/buildx/issues/301#issuecomment-755164475
     # We need to use the regular docker buildx driver (not docker container) because we need this intermediate contaiers to be available for later build steps
 
+
+    echo Installing arm64 docker emulation
+    docker run --privileged --rm tonistiigi/binfmt --install arm64
+
     for arch in $(echo $build_arch | sed "s/,/ /g")
     do
       echo "building base images for $arch"
-      docker buildx build -t airbyte/integration-base:dev --platform $arch --load airbyte-integrations/bases/base
       if [ "$path" != "airbyte-cdk/python" ]; then
         docker buildx build -t airbyte/integration-base-java:dev --platform $arch --load airbyte-integrations/bases/base-java
+        docker buildx build -t airbyte/integration-base:dev --platform $arch --load airbyte-integrations/bases/base
       fi
 
       # For a short while (https://github.com/airbytehq/airbyte/pull/25034), destinations rely on the normalization image to build

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -237,9 +237,9 @@ cmd_publish() {
 
     for arch in $(echo $build_arch | sed "s/,/ /g")
     do
-      echo "building base images for $arch"
       # These images aren't needed for the CDK
       if [ "$path" != "airbyte-cdk/python" ]; then
+        echo "building base images for $arch"
         docker buildx build -t airbyte/integration-base-java:dev --platform $arch --load airbyte-integrations/bases/base-java
         docker buildx build -t airbyte/integration-base:dev --platform $arch --load airbyte-integrations/bases/base
       fi


### PR DESCRIPTION
## What
* Fix the Python CDK pipeline by installing the arm64 docker emulator
* Stop building `integration-base-java` and `integration-base` when building source_declarative_manifest. They are not needed
* Also prevents the workflow from retrying because it is not idempotent
* Pass the gitref set as workflow param to the checkout action, which was erroneously hardcoded to master

## How
*Describe the solution*

## Recommended reading order
1. `tools/integrations/manage.sh`
2. `.github/workflows/publish-cdk-command-manually.yml`