### PR TITLE
Base datetime cursor state off latest observed record

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
@@ -38,14 +38,14 @@ class Cursor(ABC, StreamSlicer):
     def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
         """
         Update state based on the stream slice and the latest record. Note that `stream_slice.cursor_slice` and
-        `last_record.associated_slice` are expected to be the same but we make it explicit here that `stream_slice` should be leveraged to
+        `most_recent_record.associated_slice` are expected to be the same but we make it explicit here that `stream_slice` should be leveraged to
         update the state.
 
         :param stream_slice: slice to close
-        :param last_record: the latest record we have received for the slice. This is important to consider because even if the cursor emits
-          a slice, some APIs are not able to enforce the upper boundary. The outcome is that the last_record might have a higher cursor
-          value than the slice upper boundary and if we want to reduce the duplication as much as possible, we need to consider the highest
-          value between the internal cursor, the stream slice upper boundary and the record cursor value.
+        :param most_recent_record: the latest record we have received for the slice. This is important to consider because even if the
+          cursor emits a slice, some APIs are not able to enforce the upper boundary. The outcome is that the last_record might have a
+          higher cursor value than the slice upper boundary and if we want to reduce the duplication as much as possible, we need to
+          consider the highest value between the internal cursor, the stream slice upper boundary and the record cursor value.
         """
 
     @abstractmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
@@ -24,6 +24,16 @@ class Cursor(ABC, StreamSlicer):
         :param stream_state: The state of the stream as returned by get_stream_state
         """
 
+    def observe(self, stream_slice: StreamSlice, record: Record) -> None:
+        """
+        Register a record with the cursor; the cursor instance can then use it to manage the state of the in-progress stream read.
+
+        :param stream_slice: The current slice, which may or may not contain the most recently observed record
+        :param record: the most recently-read record, which the cursor can use to update the stream state. Outwardly-visible changes to the
+          stream state may need to be deferred depending on whether the source reliably orders records by the cursor field.
+        """
+        pass
+
     @abstractmethod
     def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -119,6 +119,10 @@ class DatetimeBasedCursor(Cursor):
           stream state may need to be deferred depending on whether the source reliably orders records by the cursor field.
         """
         record_cursor_value = record.get(self.cursor_field.eval(self.config))
+        # if the current record has no cursor value, we cannot meaningfully update the state based on it, so there is nothing more to do
+        if not record_cursor_value:
+            return
+
         start_field = self.partition_field_start.eval(self.config)
         end_field = self.partition_field_end.eval(self.config)
         is_highest_observed_cursor_value = not self._highest_observed_cursor_field_value or record_cursor_value > self._highest_observed_cursor_field_value

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -52,7 +52,8 @@ class DatetimeBasedCursor(Cursor):
     datetime_format: str
     config: Config
     parameters: InitVar[Mapping[str, Any]]
-    _cursor: Optional[str] = field(repr=False, default=None)  # tracks current datetime
+    _highest_observed_cursor_field_value: Optional[str] = field(repr=False, default=None)  # tracks the latest observed datetime, which may not be safe to emit in the case of out-of-order records
+    _cursor: Optional[str] = field(repr=False, default=None)  # tracks the latest observed datetime that is appropriate to emit as stream state
     end_datetime: Optional[Union[MinMaxDatetime, str]] = None
     step: Optional[Union[InterpolatedString, str]] = None
     cursor_granularity: Optional[str] = None
@@ -109,20 +110,30 @@ class DatetimeBasedCursor(Cursor):
         """
         self._cursor = stream_state.get(self._cursor_field.eval(self.config)) if stream_state else None
 
-    def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
+    def observe(self, stream_slice: StreamSlice, record: Record) -> None:
+        """
+        Register a record with the cursor; the cursor instance can then use it to manage the state of the in-progress stream read.
+
+        :param stream_slice: The current slice, which may or may not contain the most recently observed record
+        :param record: the most recently-read record, which the cursor can use to update the stream state. Outwardly-visible changes to the
+          stream state may need to be deferred depending on whether the source reliably orders records by the cursor field.
+        """
+        record_cursor_value = record.get(self.cursor_field.eval(self.config))
+        start_field = self.partition_field_start.eval(self.config)
+        end_field = self.partition_field_end.eval(self.config)
+        is_highest_observed_cursor_value = not self._highest_observed_cursor_field_value or record_cursor_value > self._highest_observed_cursor_field_value
+        if self._is_within_daterange_boundaries(record, stream_slice.get(start_field), stream_slice.get(end_field)) and is_highest_observed_cursor_value:
+            self._highest_observed_cursor_field_value = record_cursor_value
+
+    def close_slice(self, stream_slice: StreamSlice, _most_recent_record: Optional[Record]) -> None:
         if stream_slice.partition:
             raise ValueError(f"Stream slice {stream_slice} should not have a partition. Got {stream_slice.partition}.")
-        last_record_cursor_value = most_recent_record.get(self._cursor_field.eval(self.config)) if most_recent_record else None
-        stream_slice_value_end = stream_slice.get(self._partition_field_end.eval(self.config))
-        potential_cursor_values = [
-            cursor_value for cursor_value in [self._cursor, last_record_cursor_value, stream_slice_value_end] if cursor_value
-        ]
         cursor_value_str_by_cursor_value_datetime = dict(
             map(
                 # we need to ensure the cursor value is preserved as is in the state else the CATs might complain of something like
                 # 2023-01-04T17:30:19.000Z' <= '2023-01-04T17:30:19.000000Z'
                 lambda datetime_str: (self.parse_date(datetime_str), datetime_str),
-                potential_cursor_values,
+                filter(lambda item: item, [self._cursor, self._highest_observed_cursor_field_value]),
             )
         )
         self._cursor = (
@@ -279,10 +290,18 @@ class DatetimeBasedCursor(Cursor):
                 f"Could not find cursor field `{cursor_field}` in record. The incremental sync will assume it needs to be synced",
             )
             return True
-
         latest_possible_cursor_value = self._select_best_end_datetime()
         earliest_possible_cursor_value = self._calculate_earliest_possible_value(latest_possible_cursor_value)
-        return earliest_possible_cursor_value <= self.parse_date(record_cursor_value) <= latest_possible_cursor_value
+        return self._is_within_daterange_boundaries(record, earliest_possible_cursor_value, latest_possible_cursor_value)
+
+    def _is_within_daterange_boundaries(self, record: Record, start_datetime_boundary: Union[MinMaxDatetime, str], end_datetime_boundary: Union[MinMaxDatetime, str]) -> bool:
+        cursor_field = self.cursor_field.eval(self.config)
+        record_cursor_value = record.get(cursor_field)
+        if isinstance(start_datetime_boundary, str):
+            start_datetime_boundary = self.parse_date(start_datetime_boundary)
+        if isinstance(end_datetime_boundary, str):
+            end_datetime_boundary = self.parse_date(end_datetime_boundary)
+        return start_datetime_boundary <= self.parse_date(record_cursor_value) <= end_datetime_boundary
 
     def _send_log(self, level: Level, message: str) -> None:
         if self.message_repository:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -118,13 +118,13 @@ class DatetimeBasedCursor(Cursor):
         :param record: the most recently-read record, which the cursor can use to update the stream state. Outwardly-visible changes to the
           stream state may need to be deferred depending on whether the source reliably orders records by the cursor field.
         """
-        record_cursor_value = record.get(self.cursor_field.eval(self.config))
+        record_cursor_value = record.get(self._cursor_field.eval(self.config))
         # if the current record has no cursor value, we cannot meaningfully update the state based on it, so there is nothing more to do
         if not record_cursor_value:
             return
 
-        start_field = self.partition_field_start.eval(self.config)
-        end_field = self.partition_field_end.eval(self.config)
+        start_field = self._partition_field_start.eval(self.config)
+        end_field = self._partition_field_end.eval(self.config)
         is_highest_observed_cursor_value = not self._highest_observed_cursor_field_value or self.parse_date(record_cursor_value) > self.parse_date(self._highest_observed_cursor_field_value)
         if self._is_within_daterange_boundaries(record, stream_slice.get(start_field), stream_slice.get(end_field)) and is_highest_observed_cursor_value:
             self._highest_observed_cursor_field_value = record_cursor_value
@@ -299,7 +299,7 @@ class DatetimeBasedCursor(Cursor):
         return self._is_within_daterange_boundaries(record, earliest_possible_cursor_value, latest_possible_cursor_value)
 
     def _is_within_daterange_boundaries(self, record: Record, start_datetime_boundary: Union[MinMaxDatetime, str], end_datetime_boundary: Union[MinMaxDatetime, str]) -> bool:
-        cursor_field = self.cursor_field.eval(self.config)
+        cursor_field = self._cursor_field.eval(self.config)
         record_cursor_value = record.get(cursor_field)
         if isinstance(start_datetime_boundary, str):
             start_datetime_boundary = self.parse_date(start_datetime_boundary)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -125,7 +125,7 @@ class DatetimeBasedCursor(Cursor):
 
         start_field = self.partition_field_start.eval(self.config)
         end_field = self.partition_field_end.eval(self.config)
-        is_highest_observed_cursor_value = not self._highest_observed_cursor_field_value or record_cursor_value > self._highest_observed_cursor_field_value
+        is_highest_observed_cursor_value = not self._highest_observed_cursor_field_value or self.parse_date(record_cursor_value) > self.parse_date(self._highest_observed_cursor_field_value)
         if self._is_within_daterange_boundaries(record, stream_slice.get(start_field), stream_slice.get(end_field)) and is_highest_observed_cursor_value:
             self._highest_observed_cursor_field_value = record_cursor_value
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -146,7 +146,6 @@ class DatetimeBasedCursor(Cursor):
             else None
         )
 
-
     def stream_slices(self) -> Iterable[StreamSlice]:
         """
         Partition the daterange into slices of size = step.

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -52,8 +52,12 @@ class DatetimeBasedCursor(Cursor):
     datetime_format: str
     config: Config
     parameters: InitVar[Mapping[str, Any]]
-    _highest_observed_cursor_field_value: Optional[str] = field(repr=False, default=None)  # tracks the latest observed datetime, which may not be safe to emit in the case of out-of-order records
-    _cursor: Optional[str] = field(repr=False, default=None)  # tracks the latest observed datetime that is appropriate to emit as stream state
+    _highest_observed_cursor_field_value: Optional[str] = field(
+        repr=False, default=None
+    )  # tracks the latest observed datetime, which may not be safe to emit in the case of out-of-order records
+    _cursor: Optional[str] = field(
+        repr=False, default=None
+    )  # tracks the latest observed datetime that is appropriate to emit as stream state
     end_datetime: Optional[Union[MinMaxDatetime, str]] = None
     step: Optional[Union[InterpolatedString, str]] = None
     cursor_granularity: Optional[str] = None
@@ -125,8 +129,13 @@ class DatetimeBasedCursor(Cursor):
 
         start_field = self._partition_field_start.eval(self.config)
         end_field = self._partition_field_end.eval(self.config)
-        is_highest_observed_cursor_value = not self._highest_observed_cursor_field_value or self.parse_date(record_cursor_value) > self.parse_date(self._highest_observed_cursor_field_value)
-        if self._is_within_daterange_boundaries(record, stream_slice.get(start_field), stream_slice.get(end_field)) and is_highest_observed_cursor_value:
+        is_highest_observed_cursor_value = not self._highest_observed_cursor_field_value or self.parse_date(
+            record_cursor_value
+        ) > self.parse_date(self._highest_observed_cursor_field_value)
+        if (
+            self._is_within_daterange_boundaries(record, stream_slice.get(start_field), stream_slice.get(end_field))
+            and is_highest_observed_cursor_value
+        ):
             self._highest_observed_cursor_field_value = record_cursor_value
 
     def close_slice(self, stream_slice: StreamSlice, _most_recent_record: Optional[Record]) -> None:
@@ -298,7 +307,9 @@ class DatetimeBasedCursor(Cursor):
         earliest_possible_cursor_value = self._calculate_earliest_possible_value(latest_possible_cursor_value)
         return self._is_within_daterange_boundaries(record, earliest_possible_cursor_value, latest_possible_cursor_value)
 
-    def _is_within_daterange_boundaries(self, record: Record, start_datetime_boundary: Union[MinMaxDatetime, str], end_datetime_boundary: Union[MinMaxDatetime, str]) -> bool:
+    def _is_within_daterange_boundaries(
+        self, record: Record, start_datetime_boundary: Union[MinMaxDatetime, str], end_datetime_boundary: Union[MinMaxDatetime, str]
+    ) -> bool:
         cursor_field = self._cursor_field.eval(self.config)
         record_cursor_value = record.get(cursor_field)
         if isinstance(start_datetime_boundary, str):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -146,6 +146,7 @@ class DatetimeBasedCursor(Cursor):
             else None
         )
 
+
     def stream_slices(self) -> Iterable[StreamSlice]:
         """
         Partition the daterange into slices of size = step.

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -86,6 +86,9 @@ class PerPartitionCursor(Cursor):
         for state in stream_state["states"]:
             self._cursor_per_partition[self._to_partition_key(state["partition"])] = self._create_cursor(state["cursor"])
 
+    def observe(self, stream_slice: StreamSlice, record: Record) -> None:
+        self._cursor_per_partition[self._to_partition_key(stream_slice.partition)].observe(stream_slice.cursor_slice, record)
+
     def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
         try:
             cursor_most_recent_record = (

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -87,7 +87,9 @@ class PerPartitionCursor(Cursor):
             self._cursor_per_partition[self._to_partition_key(state["partition"])] = self._create_cursor(state["cursor"])
 
     def observe(self, stream_slice: StreamSlice, record: Record) -> None:
-        self._cursor_per_partition[self._to_partition_key(stream_slice.partition)].observe(stream_slice.cursor_slice, record)
+        self._cursor_per_partition[self._to_partition_key(stream_slice.partition)].observe(
+            StreamSlice(partition={}, cursor_slice=stream_slice.cursor_slice), record
+        )
 
     def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
         try:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -322,6 +322,11 @@ class SimpleRetriever(Retriever):
             records_schema=records_schema,
         )
         for stream_data in self._read_pages(record_generator, self.state, _slice):
+            if self.cursor:
+                self.cursor.observe(stream_slice, stream_data)
+
+            # TODO this is just the most recent record *read*, not necessarily the most recent record *within slice boundaries*; once all
+            # cursors implement a meaningful `observe` method, it can be removed, both from here and the `Cursor.close_slice` method args
             most_recent_record_from_slice = self._get_most_recent_record(most_recent_record_from_slice, stream_data, _slice)
             yield stream_data
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -322,12 +322,13 @@ class SimpleRetriever(Retriever):
             records_schema=records_schema,
         )
         for stream_data in self._read_pages(record_generator, self.state, _slice):
-            if self.cursor:
-                self.cursor.observe(stream_slice, stream_data)
+            current_record = self._extract_record(stream_data, _slice)
+            if self.cursor and current_record:
+                self.cursor.observe(_slice, current_record)
 
             # TODO this is just the most recent record *read*, not necessarily the most recent record *within slice boundaries*; once all
             # cursors implement a meaningful `observe` method, it can be removed, both from here and the `Cursor.close_slice` method args
-            most_recent_record_from_slice = self._get_most_recent_record(most_recent_record_from_slice, stream_data, _slice)
+            most_recent_record_from_slice = self._get_most_recent_record(most_recent_record_from_slice, current_record, _slice)
             yield stream_data
 
         if self.cursor:
@@ -335,13 +336,13 @@ class SimpleRetriever(Retriever):
         return
 
     def _get_most_recent_record(
-        self, current_most_recent: Optional[Record], stream_data: StreamData, stream_slice: StreamSlice
+        self, current_most_recent: Optional[Record], current_record: Optional[Record], stream_slice: StreamSlice
     ) -> Optional[Record]:
-        if self.cursor and (record := self._extract_record(stream_data, stream_slice)):
+        if self.cursor and current_record:
             if not current_most_recent:
-                return record
+                return current_record
             else:
-                return current_most_recent if self.cursor.is_greater_than_or_equal(current_most_recent, record) else record
+                return current_most_recent if self.cursor.is_greater_than_or_equal(current_most_recent, current_record) else current_record
         else:
             return None
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
@@ -338,46 +338,81 @@ def test_stream_slices(
 
 
 @pytest.mark.parametrize(
-    "test_name, previous_cursor, stream_slice, latest_record_data, expected_state",
+    "test_name, previous_cursor, stream_slice, observed_records, expected_state",
     [
         (
             "test_close_slice_previous_cursor_is_highest",
             "2023-01-01",
-            StreamSlice(partition={}, cursor_slice={"end_time": "2022-01-01"}),
-            {cursor_field: "2021-01-01"},
+            StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2022-01-01"}),
+            [{cursor_field: "2021-01-01"}],
             {cursor_field: "2023-01-01"},
         ),
         (
             "test_close_slice_stream_slice_partition_end_is_highest",
             "2020-01-01",
-            StreamSlice(partition={}, cursor_slice={"end_time": "2023-01-01"}),
-            {cursor_field: "2021-01-01"},
+            StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2023-01-01"}),
+            [{cursor_field: "2021-01-01"}],
             {cursor_field: "2021-01-01"},
         ),
         (
-            "test_close_slice_latest_record_cursor_value_is_highest",
+            "test_close_slice_latest_record_cursor_value_is_higher_than_slice_end",
             "2021-01-01",
-            StreamSlice(partition={}, cursor_slice={"end_time": "2022-01-01"}),
-            {cursor_field: "2023-01-01"},
+            StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2022-01-01"}),
+            [{cursor_field: "2023-01-01"}],
+            {cursor_field: "2021-01-01"},
+        ),
+        (
+            "test_close_slice_with_no_records_observed",
+            "2021-01-01",
+            StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2022-01-01"}),
+            [],
+            {cursor_field: "2021-01-01"},
+        ),
+        (
+            "test_close_slice_with_no_records_observed_and_no_previous_state",
+            None,
+            StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2022-01-01"}),
+            [],
+            {},
+        ),
+        (
+            "test_close_slice_without_previous_cursor",
+            None,
+            StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2023-01-01"}),
+            [{cursor_field: "2022-01-01"}],
             {cursor_field: "2022-01-01"},
         ),
         (
-            "test_close_slice_without_latest_record",
+            "test_close_slice_with_out_of_order_records",
             "2021-01-01",
-            StreamSlice(partition={}, cursor_slice={"end_time": "2022-01-01"}),
-            None,
-            {cursor_field: "2022-01-01"},
+            StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2022-01-01"}),
+            [{cursor_field: "2021-04-01"}, {cursor_field: "2021-02-01"}, {cursor_field: "2021-03-01"}],
+            {cursor_field: "2021-04-01"},
         ),
         (
-            "test_close_slice_without_cursor",
+            "test_close_slice_with_some_records_out_of_slice_boundaries",
+            "2021-01-01",
+            StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2022-01-01"}),
+            [{cursor_field: "2021-02-01"}, {cursor_field: "2021-03-01"}, {cursor_field: "2023-01-01"}],
+            {cursor_field: "2021-03-01"},
+        ),
+        (
+            "test_close_slice_with_all_records_out_of_slice_boundaries",
+            "2021-01-01",
+            StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2022-01-01"}),
+            [{cursor_field: "2023-01-01"}],
+            {cursor_field: "2021-01-01"},
+        ),
+        (
+            "test_close_slice_with_all_records_out_of_slice_and_no_previous_cursor",
             None,
-            StreamSlice(partition={}, cursor_slice={"end_time": "2022-01-01"}),
-            {cursor_field: "2023-01-01"},
-            {cursor_field: "2023-01-01"},
+            StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2022-01-01"}),
+            [{cursor_field: "2023-01-01"}],
+            {},
         ),
     ],
 )
-def test_close_slice(test_name, previous_cursor, stream_slice, latest_record_data, expected_state):
+def test_close_slice(test_name, previous_cursor, stream_slice, observed_records, expected_state):
     cursor = DatetimeBasedCursor(
         start_datetime=MinMaxDatetime(datetime="2021-01-01T00:00:00.000000+0000", parameters={}),
         cursor_field=InterpolatedString(string=cursor_field, parameters={}),
@@ -387,15 +422,12 @@ def test_close_slice(test_name, previous_cursor, stream_slice, latest_record_dat
         partition_field_start="start_time",
         partition_field_end="end_time",
     )
-    cursor._cursor = previous_cursor
-    stream_slice = {
-        "start_time": "2021-01-01",
-        "end_time": stream_slice["end_time"]
-    }
-    if latest_record_data:
-        record = Record(latest_record_data, stream_slice)
+    cursor.set_initial_state({cursor_field: previous_cursor})
+    for record_data in observed_records:
+        record = Record(record_data, stream_slice)
         cursor.observe(stream_slice, record)
-    cursor.close_slice(stream_slice, Record(latest_record_data, stream_slice) if latest_record_data else None)
+    last_record = observed_records[-1] if observed_records else None
+    cursor.close_slice(stream_slice, Record(last_record, stream_slice) if last_record else None)
     updated_state = cursor.get_stream_state()
     assert updated_state == expected_state
 
@@ -413,7 +445,26 @@ def test_close_slice_fails_if_slice_has_a_partition():
         cursor.close_slice(stream_slice, Record({"id": 1}, stream_slice))
 
 
-def test_given_different_format_and_slice_is_highest_when_close_slice_then_slice_datetime_format():
+def test_compares_cursor_values_by_chronological_order():
+    cursor = DatetimeBasedCursor(
+        start_datetime=MinMaxDatetime(datetime="2021-01-01T00:00:00.000000+0000", parameters={}),
+        cursor_field=cursor_field,
+        datetime_format="%d-%m-%Y",
+        config=config,
+        parameters={},
+    )
+
+    _slice = StreamSlice(partition={}, cursor_slice={"start_time": "01-01-2023", "end_time": "01-04-2023"})
+    first_record = Record({cursor_field: "21-02-2023"}, _slice)
+    cursor.observe(_slice, first_record)
+    second_record = Record({cursor_field: "01-03-2023"}, _slice)
+    cursor.observe(_slice, second_record)
+    cursor.close_slice(_slice, second_record)
+
+    assert cursor.get_stream_state()[cursor_field] == "01-03-2023"
+
+
+def test_given_different_format_and_slice_is_highest_when_close_slice_then_state_uses_record_format():
     cursor = DatetimeBasedCursor(
         start_datetime=MinMaxDatetime(datetime="2021-01-01T00:00:00.000000+0000", parameters={}),
         cursor_field=cursor_field,
@@ -423,27 +474,13 @@ def test_given_different_format_and_slice_is_highest_when_close_slice_then_slice
         parameters={},
     )
 
-    _slice = StreamSlice(partition={}, cursor_slice={"end_time": "2023-01-04T17:30:19.000Z"})
+    _slice = StreamSlice(partition={}, cursor_slice={"start_time": "2023-01-01T17:30:19.000Z", "end_time": "2023-01-04T17:30:19.000Z"})
     record_cursor_value = "2023-01-03"
-    cursor.close_slice(_slice, Record({cursor_field: record_cursor_value}, _slice))
+    record = Record({cursor_field: record_cursor_value}, _slice)
+    cursor.observe(_slice, record)
+    cursor.close_slice(_slice, record)
 
-    assert cursor.get_stream_state()[cursor_field] == "2023-01-04T17:30:19.000Z"
-
-
-def test_given_partition_end_is_specified_and_greater_than_record_when_close_slice_then_use_partition_end():
-    partition_field_end = "partition_field_end"
-    cursor = DatetimeBasedCursor(
-        start_datetime=MinMaxDatetime(datetime="2021-01-01T00:00:00.000000+0000", parameters={}),
-        cursor_field=InterpolatedString(string=cursor_field, parameters={}),
-        datetime_format="%Y-%m-%d",
-        partition_field_end=partition_field_end,
-        config=config,
-        parameters={},
-    )
-    stream_slice = StreamSlice(partition={}, cursor_slice={partition_field_end: "2025-01-01"})
-    cursor.close_slice(stream_slice, Record({cursor_field: "2020-01-01"}, stream_slice))
-    updated_state = cursor.get_stream_state()
-    assert {cursor_field: "2025-01-01"} == updated_state
+    assert cursor.get_stream_state()[cursor_field] == "2023-01-03"
 
 
 @pytest.mark.parametrize(

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
@@ -349,17 +349,17 @@ def test_stream_slices(
         ),
         (
             "test_close_slice_stream_slice_partition_end_is_highest",
-            "2021-01-01",
+            "2020-01-01",
             StreamSlice(partition={}, cursor_slice={"end_time": "2023-01-01"}),
             {cursor_field: "2021-01-01"},
-            {cursor_field: "2023-01-01"},
+            {cursor_field: "2021-01-01"},
         ),
         (
             "test_close_slice_latest_record_cursor_value_is_highest",
             "2021-01-01",
             StreamSlice(partition={}, cursor_slice={"end_time": "2022-01-01"}),
             {cursor_field: "2023-01-01"},
-            {cursor_field: "2023-01-01"},
+            {cursor_field: "2022-01-01"},
         ),
         (
             "test_close_slice_without_latest_record",
@@ -384,8 +384,17 @@ def test_close_slice(test_name, previous_cursor, stream_slice, latest_record_dat
         datetime_format="%Y-%m-%d",
         config=config,
         parameters={},
+        partition_field_start="start_time",
+        partition_field_end="end_time",
     )
     cursor._cursor = previous_cursor
+    stream_slice = {
+        "start_time": "2021-01-01",
+        "end_time": stream_slice["end_time"]
+    }
+    if latest_record_data:
+        record = Record(latest_record_data, stream_slice)
+        cursor.observe(stream_slice, record)
     cursor.close_slice(stream_slice, Record(latest_record_data, stream_slice) if latest_record_data else None)
     updated_state = cursor.get_stream_state()
     assert updated_state == expected_state

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_per_partition_cursor_integration.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_per_partition_cursor_integration.py
@@ -200,7 +200,7 @@ def test_given_record_for_partition_when_read_then_update_state():
         "states": [
             {
                 "partition": {"partition_field": "1"},
-                "cursor": {CURSOR_FIELD: "2022-01-31"},
+                "cursor": {CURSOR_FIELD: "2022-01-15"},
             }
         ]
     }

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_per_partition_cursor_integration.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_per_partition_cursor_integration.py
@@ -207,7 +207,7 @@ def test_given_record_for_partition_when_read_then_update_state():
 
 
 def test_substream_without_input_state():
-    source = ManifestDeclarativeSource(
+    test_source = ManifestDeclarativeSource(
         source_config=ManifestBuilder()
         .with_substream_partition_router("AnotherStream")
         .with_incremental_sync(
@@ -231,20 +231,24 @@ def test_substream_without_input_state():
         .build()
     )
 
-    stream_instance = source.streams({})[1]
+    stream_instance = test_source.streams({})[1]
 
     stream_slice = StreamSlice(partition={"parent_id": "1"},
                                cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"})
 
     with patch.object(
             SimpleRetriever, "_read_pages", side_effect=[[Record({"id": "1", CURSOR_FIELD: "2022-01-15"}, stream_slice)],
-                                                         Record({"id": "2", CURSOR_FIELD: "2022-01-15"}, stream_slice)]
+                                                         [Record({"id": "2", CURSOR_FIELD: "2022-01-15"}, stream_slice)]]
     ):
         slices = list(stream_instance.stream_slices(sync_mode=SYNC_MODE))
         assert list(slices) == [
             StreamSlice(partition={"parent_id": "1", "parent_slice": {}, },
                         cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"}),
             StreamSlice(partition={"parent_id": "1", "parent_slice": {}, },
+                        cursor_slice={"start_time": "2022-02-01", "end_time": "2022-02-28"}),
+            StreamSlice(partition={"parent_id": "2", "parent_slice": {}, },
+                        cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"}),
+            StreamSlice(partition={"parent_id": "2", "parent_slice": {}, },
                         cursor_slice={"start_time": "2022-02-01", "end_time": "2022-02-28"}),
         ]
 
@@ -307,7 +311,7 @@ def test_substream_with_legacy_input_state():
     with patch.object(
             SimpleRetriever, "_read_pages", side_effect=[
                 [Record({"id": "1", CURSOR_FIELD: "2022-01-15"}, stream_slice)],
-                [Record({"parent_id": "1"}, stream_slice)],
+                [Record({"parent_id": "1", CURSOR_FIELD: "2022-01-15"}, stream_slice)],
                 [Record({"id": "2", CURSOR_FIELD: "2022-01-15"}, stream_slice)],
                 [Record({"parent_id": "2", CURSOR_FIELD: "2022-01-15"}, stream_slice)]
             ]
@@ -319,7 +323,7 @@ def test_substream_with_legacy_input_state():
         expected_state = {"states": [
             {
                 "cursor": {
-                    "cursor_field": "2022-01-31"
+                    CURSOR_FIELD: "2022-01-15"
                 },
                 "partition": {"parent_id": "1", "parent_slice": {}}
             }

--- a/airbyte-cdk/python/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
@@ -477,6 +477,7 @@ def test_given_stream_data_is_not_record_when_read_records_then_update_slice_wit
         side_effect=retriever_read_pages,
     ):
         list(retriever.read_records(stream_slice=stream_slice, records_schema={}))
+        cursor.observe.assert_not_called()
         cursor.close_slice.assert_called_once_with(stream_slice, None)
 
 


### PR DESCRIPTION
## What
Writing the code before the description, so watch this space for updates; part 1/3 for closing https://github.com/airbytehq/airbyte-internal-issues/issues/6314

- Part 1 (this PR): add the new `Cursor.observe` method and update `DatetimeBasedCursor` to use it for more less lossy state messages; preserve the old interface to limit the blast radius of required changes to just `DatetimeBasedCursor` and `PerPartitionCursor` (which needs to correctly delegate `per_slice_cursor.observe` calls inside `PerPartitionCursor.observe`). This appears to be done and working already.
- Part 2: Update the `Cursor.close_slice` method to force all `Cursor` subclasses to use `observe` for state tracking. These changes could perhaps be merged into this PR instead.
- Part 3: Update the greenhouse and chargebee source's custom cursor implementations to use the new interface. This cannot be merged with earlier PRs since the already-published CDK version is used to validate connector changes.

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
