### PR TITLE
Attempt to fix Connector Builder release

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -300,7 +300,7 @@ jobs:
           pip-compile --upgrade
       - name: Create Pull Request
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           commit-message: Updating CDK version following release


### PR DESCRIPTION
## What
The automatic PR creation in the Connector Builder is failing with 

## How
Based on [this](https://github.com/peter-evans/create-pull-request/issues/2790#issuecomment-1967972220), GitHub API had a breaking change and we need to update so we will up the version to the one that supports this new API

## 🚨 User Impact 🚨
Hopefully, automatic PR creation should not fail anymore (I haven't check if the GitHub action had breaking changes in the YAML but I'm willing to bet that it did not and fix the pipeline again when the new error occurs)
