### PR TITLE
🐛 follow up to #35471: update the cartesian stream slicer

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/cartesian_product_stream_slicer.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/cartesian_product_stream_slicer.py
@@ -104,5 +104,11 @@ class CartesianProductStreamSlicer(StreamSlicer):
         product = itertools.product(*sub_slices)
         for stream_slice_tuple in product:
             partition = dict(ChainMap(*[s.partition for s in stream_slice_tuple]))
-            cursor_slice = dict(ChainMap(*[s.cursor_slice for s in stream_slice_tuple]))
+            cursor_slices = [s.cursor_slice for s in stream_slice_tuple if s.cursor_slice]
+            if len(cursor_slices) > 1:
+                raise ValueError(f"There should only be a single cursor slice. Found {cursor_slices}")
+            if cursor_slices:
+                cursor_slice = cursor_slices[0]
+            else:
+                cursor_slice = {}
             yield StreamSlice(partition=partition, cursor_slice=cursor_slice)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/cartesian_product_stream_slicer.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/cartesian_product_stream_slicer.py
@@ -44,7 +44,7 @@ class CartesianProductStreamSlicer(StreamSlicer):
     ) -> Mapping[str, Any]:
         return dict(
             ChainMap(
-                *[
+                *[  # type: ignore # ChainMap expects a MutableMapping[Never, Never] for reasons
                     s.get_request_params(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
                     for s in self.stream_slicers
                 ]
@@ -60,7 +60,7 @@ class CartesianProductStreamSlicer(StreamSlicer):
     ) -> Mapping[str, Any]:
         return dict(
             ChainMap(
-                *[
+                *[  # type: ignore # ChainMap expects a MutableMapping[Never, Never] for reasons
                     s.get_request_headers(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
                     for s in self.stream_slicers
                 ]
@@ -76,7 +76,7 @@ class CartesianProductStreamSlicer(StreamSlicer):
     ) -> Mapping[str, Any]:
         return dict(
             ChainMap(
-                *[
+                *[  # type: ignore # ChainMap expects a MutableMapping[Never, Never] for reasons
                     s.get_request_body_data(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
                     for s in self.stream_slicers
                 ]
@@ -89,10 +89,10 @@ class CartesianProductStreamSlicer(StreamSlicer):
         stream_state: Optional[StreamState] = None,
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
-    ) -> Optional[Mapping]:
+    ) -> Mapping[str, Any]:
         return dict(
             ChainMap(
-                *[
+                *[  # type: ignore # ChainMap expects a MutableMapping[Never, Never] for reasons
                     s.get_request_body_json(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
                     for s in self.stream_slicers
                 ]
@@ -101,4 +101,8 @@ class CartesianProductStreamSlicer(StreamSlicer):
 
     def stream_slices(self) -> Iterable[StreamSlice]:
         sub_slices = (s.stream_slices() for s in self.stream_slicers)
-        return (dict(ChainMap(*a)) for a in itertools.product(*sub_slices))
+        product = itertools.product(*sub_slices)
+        for stream_slice_tuple in product:
+            partition = dict(ChainMap(*[s.partition for s in stream_slice_tuple]))
+            cursor_slice = dict(ChainMap(*[s.cursor_slice for s in stream_slice_tuple]))
+            yield StreamSlice(partition=partition, cursor_slice=cursor_slice)

--- a/airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py
@@ -75,7 +75,7 @@ from airbyte_cdk.sources.declarative.types import StreamSlice
             [
                 StreamSlice(partition={"owner_resource": "customer"}, cursor_slice={"start_time": "2021-01-01", "end_time": "2021-01-01"}),
                 StreamSlice(partition={"owner_resource": "customer"}, cursor_slice={"start_time": "2021-01-02", "end_time": "2021-01-02"}),
-                StreamSlice(partition={"owner_resource": "customer"}, cursor_slice={ "start_time": "2021-01-03", "end_time": "2021-01-03"}),
+                StreamSlice(partition={"owner_resource": "customer"}, cursor_slice={"start_time": "2021-01-03", "end_time": "2021-01-03"}),
                 StreamSlice(partition={"owner_resource": "store"}, cursor_slice={"start_time": "2021-01-01", "end_time": "2021-01-01"}),
                 StreamSlice(partition={"owner_resource": "store"}, cursor_slice={"start_time": "2021-01-02", "end_time": "2021-01-02"}),
                 StreamSlice(partition={"owner_resource": "store"}, cursor_slice={"start_time": "2021-01-03", "end_time": "2021-01-03"}),

--- a/airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py
@@ -91,6 +91,7 @@ def test_substream_slicer(test_name, stream_slicers, expected_slices):
     slices = [s for s in slicer.stream_slices()]
     assert slices == expected_slices
 
+
 def test_stream_slices_raises_exception_if_multiple_cursor_slice_components():
     stream_slicers = [
         DatetimeBasedCursor(

--- a/airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py
@@ -91,6 +91,33 @@ def test_substream_slicer(test_name, stream_slicers, expected_slices):
     slices = [s for s in slicer.stream_slices()]
     assert slices == expected_slices
 
+def test_stream_slices_raises_exception_if_multiple_cursor_slice_components():
+    stream_slicers = [
+        DatetimeBasedCursor(
+            start_datetime=MinMaxDatetime(datetime="2021-01-01", datetime_format="%Y-%m-%d", parameters={}),
+            end_datetime=MinMaxDatetime(datetime="2021-01-03", datetime_format="%Y-%m-%d", parameters={}),
+            step="P1D",
+            cursor_field=InterpolatedString.create("", parameters={}),
+            datetime_format="%Y-%m-%d",
+            cursor_granularity="P1D",
+            config={},
+            parameters={},
+        ),
+        DatetimeBasedCursor(
+            start_datetime=MinMaxDatetime(datetime="2021-01-01", datetime_format="%Y-%m-%d", parameters={}),
+            end_datetime=MinMaxDatetime(datetime="2021-01-03", datetime_format="%Y-%m-%d", parameters={}),
+            step="P1D",
+            cursor_field=InterpolatedString.create("", parameters={}),
+            datetime_format="%Y-%m-%d",
+            cursor_granularity="P1D",
+            config={},
+            parameters={},
+        ),
+    ]
+    slicer = CartesianProductStreamSlicer(stream_slicers=stream_slicers, parameters={})
+    with pytest.raises(ValueError):
+        list(slicer.stream_slices())
+
 
 @pytest.mark.parametrize(
     "test_name, stream_1_request_option, stream_2_request_option, expected_req_params, expected_headers,expected_body_json, expected_body_data",

--- a/airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py
@@ -9,6 +9,7 @@ from airbyte_cdk.sources.declarative.interpolation.interpolated_string import In
 from airbyte_cdk.sources.declarative.partition_routers.list_partition_router import ListPartitionRouter
 from airbyte_cdk.sources.declarative.requesters.request_option import RequestOption, RequestOptionType
 from airbyte_cdk.sources.declarative.stream_slicers.cartesian_product_stream_slicer import CartesianProductStreamSlicer
+from airbyte_cdk.sources.declarative.types import StreamSlice
 
 
 @pytest.mark.parametrize(
@@ -17,7 +18,9 @@ from airbyte_cdk.sources.declarative.stream_slicers.cartesian_product_stream_sli
         (
             "test_single_stream_slicer",
             [ListPartitionRouter(values=["customer", "store", "subscription"], cursor_field="owner_resource", config={}, parameters={})],
-            [{"owner_resource": "customer"}, {"owner_resource": "store"}, {"owner_resource": "subscription"}],
+            [StreamSlice(partition={"owner_resource": "customer"}, cursor_slice={}),
+             StreamSlice(partition={"owner_resource": "store"}, cursor_slice={}),
+             StreamSlice(partition={"owner_resource": "subscription"}, cursor_slice={})],
         ),
         (
             "test_two_stream_slicers",
@@ -26,13 +29,33 @@ from airbyte_cdk.sources.declarative.stream_slicers.cartesian_product_stream_sli
                 ListPartitionRouter(values=["A", "B"], cursor_field="letter", config={}, parameters={}),
             ],
             [
-                {"owner_resource": "customer", "letter": "A"},
-                {"owner_resource": "customer", "letter": "B"},
-                {"owner_resource": "store", "letter": "A"},
-                {"owner_resource": "store", "letter": "B"},
-                {"owner_resource": "subscription", "letter": "A"},
-                {"owner_resource": "subscription", "letter": "B"},
+                StreamSlice(partition={"owner_resource": "customer", "letter": "A"}, cursor_slice={}),
+                StreamSlice(partition={"owner_resource": "customer", "letter": "B"}, cursor_slice={}),
+                StreamSlice(partition={"owner_resource": "store", "letter": "A"}, cursor_slice={}),
+                StreamSlice(partition={"owner_resource": "store", "letter": "B"}, cursor_slice={}),
+                StreamSlice(partition={"owner_resource": "subscription", "letter": "A"}, cursor_slice={}),
+                StreamSlice(partition={"owner_resource": "subscription", "letter": "B"}, cursor_slice={}),
             ],
+        ),
+        (
+                "test_singledatetime",
+                [
+                    DatetimeBasedCursor(
+                        start_datetime=MinMaxDatetime(datetime="2021-01-01", datetime_format="%Y-%m-%d", parameters={}),
+                        end_datetime=MinMaxDatetime(datetime="2021-01-03", datetime_format="%Y-%m-%d", parameters={}),
+                        step="P1D",
+                        cursor_field=InterpolatedString.create("", parameters={}),
+                        datetime_format="%Y-%m-%d",
+                        cursor_granularity="P1D",
+                        config={},
+                        parameters={},
+                    ),
+                ],
+                [
+                    StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-01", "end_time": "2021-01-01"}),
+                    StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-02", "end_time": "2021-01-02"}),
+                    StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-03", "end_time": "2021-01-03"}),
+                ],
         ),
         (
             "test_list_and_datetime",
@@ -50,15 +73,15 @@ from airbyte_cdk.sources.declarative.stream_slicers.cartesian_product_stream_sli
                 ),
             ],
             [
-                {"owner_resource": "customer", "start_time": "2021-01-01", "end_time": "2021-01-01"},
-                {"owner_resource": "customer", "start_time": "2021-01-02", "end_time": "2021-01-02"},
-                {"owner_resource": "customer", "start_time": "2021-01-03", "end_time": "2021-01-03"},
-                {"owner_resource": "store", "start_time": "2021-01-01", "end_time": "2021-01-01"},
-                {"owner_resource": "store", "start_time": "2021-01-02", "end_time": "2021-01-02"},
-                {"owner_resource": "store", "start_time": "2021-01-03", "end_time": "2021-01-03"},
-                {"owner_resource": "subscription", "start_time": "2021-01-01", "end_time": "2021-01-01"},
-                {"owner_resource": "subscription", "start_time": "2021-01-02", "end_time": "2021-01-02"},
-                {"owner_resource": "subscription", "start_time": "2021-01-03", "end_time": "2021-01-03"},
+                StreamSlice(partition={"owner_resource": "customer"}, cursor_slice={"start_time": "2021-01-01", "end_time": "2021-01-01"}),
+                StreamSlice(partition={"owner_resource": "customer"}, cursor_slice={"start_time": "2021-01-02", "end_time": "2021-01-02"}),
+                StreamSlice(partition={"owner_resource": "customer"}, cursor_slice={ "start_time": "2021-01-03", "end_time": "2021-01-03"}),
+                StreamSlice(partition={"owner_resource": "store"}, cursor_slice={"start_time": "2021-01-01", "end_time": "2021-01-01"}),
+                StreamSlice(partition={"owner_resource": "store"}, cursor_slice={"start_time": "2021-01-02", "end_time": "2021-01-02"}),
+                StreamSlice(partition={"owner_resource": "store"}, cursor_slice={"start_time": "2021-01-03", "end_time": "2021-01-03"}),
+                StreamSlice(partition={"owner_resource": "subscription"}, cursor_slice={"start_time": "2021-01-01", "end_time": "2021-01-01"}),
+                StreamSlice(partition={"owner_resource": "subscription"}, cursor_slice={"start_time": "2021-01-02", "end_time": "2021-01-02"}),
+                StreamSlice(partition={"owner_resource": "subscription"}, cursor_slice={"start_time": "2021-01-03", "end_time": "2021-01-03"}),
             ],
         ),
     ],


### PR DESCRIPTION
## What
* I forgot to update the cartesian stream slicer to return typed StreamSlice in https://github.com/airbytehq/airbyte/pull/35471

This caused connectors to fail because dicts are returned instead of `StreamSlice`s

```
{"type": "TRACE", "trace": {"type": "ERROR", "emitted_at": 1709764005297.951, "error": {"message": "Something went wrong in the connector. See the logs for more details.", "internal_message": "'dict' object has no attribute 'partition'", "stack_trace": "Traceback (most recent call last):\n  File \"/Users/alex/code/airbyte/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py\", line 129, in read\n    yield from self._read_stream(\n  File \"/Users/alex/code/airbyte/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py\", line 229, in _read_stream\n    for record_data_or_message in record_iterator:\n  File \"/Users/alex/code/airbyte/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py\", line 135, in read\n    for _slice in slices:\n  File \"/Users/alex/code/airbyte/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py\", line 74, in stream_slices\n    cursor = self._cursor_per_partition.get(self._to_partition_key(partition.partition))\nAttributeError: 'dict' object has no attribute 'partition'\n", "failure_type": "system_error", "stream_descriptor": {"name": "billable_rates"}}}}
```

## How
* Create a StreamSlice by ChainMapping the partitions and the cursor_slice separately

## Testing
I tested this bugfix with Patrick's harvest low-code connector and confirmed we were able to pull the records without failing
```
{"type": "LOG", "log": {"level": "INFO", "message": "Read 4 records from billable_rates stream"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Marking stream billable_rates as STOPPED"}}
{"type": "TRACE", "trace": {"type": "STREAM_STATUS", "emitted_at": 1709763953537.6611, "stream_status": {"stream_descriptor": {"name": "billable_rates", "namespace": null}, "status": "COMPLETE"}}}
{"type": "LOG", "log": {"level": "INFO", "message": "Finished syncing billable_rates"}}
{"type": "LOG", "log": {"level": "INFO", "message": "SourceHarvest runtimes:\nSyncing stream billable_rates 0:00:08.429028"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Finished syncing SourceHarvest"}
```

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/cartesian_product_stream_slicer.py`
2. `airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py`