### PR TITLE
java CDK: improve kotlin support

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -58,12 +58,30 @@ allprojects {
             compilerOptions {
                 jvmTarget = JvmTarget.JVM_21
                 languageVersion = KotlinVersion.KOTLIN_1_9
+                allWarningsAsErrors = true
+            }
+            dependsOn {
+                tasks.matching { it.name == 'generate' }
             }
         }
         compileTestKotlin {
             compilerOptions {
                 jvmTarget = JvmTarget.JVM_21
                 languageVersion = KotlinVersion.KOTLIN_1_9
+                allWarningsAsErrors = true
+            }
+            dependsOn {
+                tasks.matching { it.name == 'generate' }
+            }
+        }
+        compileTestFixturesKotlin {
+            compilerOptions {
+                jvmTarget = JvmTarget.JVM_21
+                languageVersion = KotlinVersion.KOTLIN_1_9
+                allWarningsAsErrors = true
+            }
+            dependsOn {
+                tasks.matching { it.name == 'generate' }
             }
         }
     }

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
@@ -26,6 +26,10 @@ jsonSchema2Pojo {
     includeSetters = true
 }
 
+tasks.register('generate').configure {
+    dependsOn tasks.named('generateJsonSchema2Pojo')
+}
+
 dependencies {
 
     implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/migrators/MinimumDestinationState.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/migrators/MinimumDestinationState.kt
@@ -40,6 +40,7 @@ interface MinimumDestinationState {
             return needsSoftReset
         }
 
+        @Suppress("UNCHECKED_CAST")
         override fun <T : MinimumDestinationState> withSoftReset(needsSoftReset: Boolean): T {
             return copy(needsSoftReset = true) as T
         }


### PR DESCRIPTION
This fixes a missing gradle task dependency related to generated code (`jsonSchema2Pojo` isn't aware of kotlin) and makes the kotlin compiler choke on warnings in the CDK.