### PR TITLE
Attempt to fix transient nightly build errors: Remove poetry cache

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Sequence
 from dagger import Container, Directory
 from pipelines import hacks
 from pipelines.airbyte_ci.connectors.context import ConnectorContext, PipelineContext
-from pipelines.dagger.containers.python import with_pip_cache, with_poetry_cache, with_python_base, with_testing_dependencies
+from pipelines.dagger.containers.python import with_pip_cache, with_python_base, with_testing_dependencies
 from pipelines.helpers.utils import check_path_in_workdir, get_file_contents
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
@@ -211,6 +211,9 @@ async def with_installed_python_package(
     has_pyproject_toml = await check_path_in_workdir(container, "pyproject.toml")
 
     if has_pyproject_toml:
+        # This is a temporary change in order to scope an issue. There should be following action items once we have more information.
+        # maxi297 has an action item on his calendar for 2024-03-21 to review this
+        # container = with_poetry_cache(container, context.dagger_client)
         container = _install_python_dependencies_from_poetry(container, additional_dependency_groups, install_root_package)
     elif has_setup_py:
         container = with_pip_cache(container, context.dagger_client)

--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
@@ -211,7 +211,6 @@ async def with_installed_python_package(
     has_pyproject_toml = await check_path_in_workdir(container, "pyproject.toml")
 
     if has_pyproject_toml:
-        container = with_poetry_cache(container, context.dagger_client)
         container = _install_python_dependencies_from_poetry(container, additional_dependency_groups, install_root_package)
     elif has_setup_py:
         container = with_pip_cache(container, context.dagger_client)


### PR DESCRIPTION
## What
We have seen transient errors on the build phase of the nighty build. The errors are somewhat all over the places but always link to Poetry. The goal would be to scope the issue.

Here are a couple of examples (not sharing the links because they are not sharable as they expire):

### source-s3 2024-02-29 nightly build
```
The following error occurred when trying to handle this error:


  EnvCommandError

  Command ['/usr/local/bin/python', '-m', 'pip', 'uninstall', 'charset-normalizer', '-y'] errored with the following return code 1
  
  Output:
  Traceback (most recent call last):
    File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
      return _run_code(code, main_globals, None,
    File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
      exec(code, run_globals)
    File "/usr/local/lib/python3.9/site-packages/pip/__main__.py", line 22, in <module>
      from pip._internal.cli.main import main as _main
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/cli/main.py", line 10, in <module>
      from pip._internal.cli.autocompletion import autocomplete
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/cli/autocompletion.py", line 10, in <module>
      from pip._internal.cli.main_parser import create_main_parser
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/cli/main_parser.py", line 9, in <module>
      from pip._internal.build_env import get_runnable_pip
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/build_env.py", line 19, in <module>
      from pip._internal.cli.spinners import open_spinner
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/cli/spinners.py", line 9, in <module>
      from pip._internal.utils.logging import get_indentation
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/utils/logging.py", line 13, in <module>
      from pip._vendor.rich.console import (
    File "/usr/local/lib/python3.9/site-packages/pip/_vendor/rich/console.py", line 60, in <module>
      from .pretty import Pretty, is_expandable
    File "/usr/local/lib/python3.9/site-packages/pip/_vendor/rich/pretty.py", line 31, in <module>
      import attr as _attr_module
    File "/usr/local/lib/python3.9/site-packages/attr/__init__.py", line 10, in <module>
      from . import converters, exceptions, filters, setters, validators
    File "/usr/local/lib/python3.9/site-packages/attr/converters.py", line 11, in <module>
      from ._make import NOTHING, Factory, pipe
    File "/usr/local/lib/python3.9/site-packages/attr/_make.py", line 53, in <module>
      _ng_default_on_setattr = setters.pipe(setters.convert, setters.validate)
  AttributeError: module 'attr.setters' has no attribute 'pipe'
```

### source-sentry 2024-02-28 nightly build

```
The following error occurred when trying to handle this error:


  EnvCommandError

  Command ['/usr/local/bin/python', '-m', 'pip', 'uninstall', 'attrs', '-y'] errored with the following return code 2
  
  Output:
  Found existing installation: attrs 23.1.0
  Uninstalling attrs-23.1.0:
  ERROR: Exception:
  Traceback (most recent call last):
    File "/usr/local/lib/python3.9/shutil.py", line 825, in move
      os.rename(src, real_dst)
  OSError: [Errno 18] Invalid cross-device link: '/usr/local/lib/python3.9/site-packages/attr/' -> '/usr/local/lib/python3.9/site-packages/~ttr'
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 180, in exc_logging_wrapper
      status = run_func(*args)
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/commands/uninstall.py", line 105, in run
      uninstall_pathset = req.uninstall(
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/req/req_install.py", line 687, in uninstall
      uninstalled_pathset.remove(auto_confirm, verbose)
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/req/req_uninstall.py", line 381, in remove
      moved.stash(path)
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/req/req_uninstall.py", line 272, in stash
      renames(path, new_path)
    File "/usr/local/lib/python3.9/site-packages/pip/_internal/utils/misc.py", line 315, in renames
      shutil.move(old, new)
    File "/usr/local/lib/python3.9/shutil.py", line 843, in move
      rmtree(src)
    File "/usr/local/lib/python3.9/shutil.py", line 740, in rmtree
      onerror(os.rmdir, path, sys.exc_info())
    File "/usr/local/lib/python3.9/shutil.py", line 738, in rmtree
      os.rmdir(path)
  OSError: [Errno 39] Directory not empty: '/usr/local/lib/python3.9/site-packages/attr/'
```


## How
As we don't seem to see this in CI checks, we assume this is something specific to nightly builds (even though, it could be because there is more volume on nightly build and statistically this is where we see the issue). Poetry cache is not used on CI checks but it is on nightly builds. Remove the poetry cache will help us scope the issue.


## 🚨 User Impact 🚨
We expect more network traffic and longer nightly builds but less flaky ones.