### PR TITLE
Introduce FinalStateCursor to emit state messages at the end of full refresh syncs

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_source.py
@@ -36,7 +36,7 @@ from airbyte_cdk.sources.file_based.stream.concurrent.adapters import FileBasedS
 from airbyte_cdk.sources.file_based.stream.concurrent.cursor import (
     AbstractConcurrentFileBasedCursor,
     FileBasedConcurrentCursor,
-    FileBasedNoopCursor,
+    FileBasedFinalStateCursor,
 )
 from airbyte_cdk.sources.file_based.stream.cursor import AbstractFileBasedCursor
 from airbyte_cdk.sources.message.repository import InMemoryMessageRepository, MessageRepository
@@ -170,7 +170,9 @@ class FileBasedSource(ConcurrentSourceAdapter, ABC):
                 sync_mode = self._get_sync_mode_from_catalog(stream_config.name)
 
                 if sync_mode == SyncMode.full_refresh and hasattr(self, "_concurrency_level") and self._concurrency_level is not None:
-                    cursor = FileBasedNoopCursor(stream_config)
+                    cursor = FileBasedFinalStateCursor(
+                        stream_config=stream_config, stream_namespace=None, message_repository=self.message_repository
+                    )
                     stream = FileBasedStreamFacade.create_from_stream(
                         self._make_default_stream(stream_config, cursor), self, self.logger, stream_state, cursor
                     )

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py
@@ -83,7 +83,6 @@ class FileBasedStreamFacade(AbstractStreamFacade[DefaultStream], AbstractFileBas
                 cursor_field=cursor_field,
                 logger=logger,
                 namespace=stream.namespace,
-                message_repository=message_repository,
                 cursor=cursor,
             ),
             stream,

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py
@@ -18,7 +18,7 @@ from airbyte_cdk.sources.file_based.config.file_based_stream_config import Prima
 from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.stream import AbstractFileBasedStream
-from airbyte_cdk.sources.file_based.stream.concurrent.cursor import FileBasedNoopCursor
+from airbyte_cdk.sources.file_based.stream.concurrent.cursor import FileBasedFinalStateCursor
 from airbyte_cdk.sources.file_based.stream.cursor import AbstractFileBasedCursor
 from airbyte_cdk.sources.file_based.types import StreamSlice
 from airbyte_cdk.sources.message import MessageRepository
@@ -71,7 +71,7 @@ class FileBasedStreamFacade(AbstractStreamFacade[DefaultStream], AbstractFileBas
                 partition_generator=FileBasedStreamPartitionGenerator(
                     stream,
                     message_repository,
-                    SyncMode.full_refresh if isinstance(cursor, FileBasedNoopCursor) else SyncMode.incremental,
+                    SyncMode.full_refresh if isinstance(cursor, FileBasedFinalStateCursor) else SyncMode.incremental,
                     [cursor_field] if cursor_field is not None else None,
                     state,
                     cursor,
@@ -83,6 +83,7 @@ class FileBasedStreamFacade(AbstractStreamFacade[DefaultStream], AbstractFileBas
                 cursor_field=cursor_field,
                 logger=logger,
                 namespace=stream.namespace,
+                message_repository=message_repository,
                 cursor=cursor,
             ),
             stream,

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/cursor/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/cursor/__init__.py
@@ -1,5 +1,5 @@
 from .abstract_concurrent_file_based_cursor import AbstractConcurrentFileBasedCursor
 from .file_based_concurrent_cursor import FileBasedConcurrentCursor
-from .file_based_noop_cursor import FileBasedNoopCursor
+from .file_based_final_state_cursor import FileBasedFinalStateCursor
 
-__all__ = ["AbstractConcurrentFileBasedCursor", "FileBasedConcurrentCursor", "FileBasedNoopCursor"]
+__all__ = ["AbstractConcurrentFileBasedCursor", "FileBasedConcurrentCursor", "FileBasedFinalStateCursor"]

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/cursor/file_based_final_state_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/cursor/file_based_final_state_cursor.py
@@ -29,6 +29,9 @@ class FileBasedFinalStateCursor(AbstractConcurrentFileBasedCursor):
         self._stream_name = stream_config.name
         self._stream_namespace = stream_namespace
         self._message_repository = message_repository
+        # Normally the connector state manager operates at the source-level. However, we only need it to write the sentinel
+        # state message rather than manage overall source state. This is also only temporary as we move to the resumable
+        # full refresh world where every stream uses a FileBasedConcurrentCursor with incremental state.
         self._connector_state_manager = ConnectorStateManager(stream_instance_map={})
 
     @property

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/cursor/file_based_final_state_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/cursor/file_based_final_state_cursor.py
@@ -4,12 +4,15 @@
 
 import logging
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Iterable, List, MutableMapping
+from typing import TYPE_CHECKING, Any, Iterable, List, MutableMapping, Optional
 
+from airbyte_cdk.sources.connector_state_manager import ConnectorStateManager
 from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from airbyte_cdk.sources.file_based.stream.concurrent.cursor.abstract_concurrent_file_based_cursor import AbstractConcurrentFileBasedCursor
 from airbyte_cdk.sources.file_based.types import StreamState
+from airbyte_cdk.sources.message import MessageRepository
+from airbyte_cdk.sources.streams import FULL_REFRESH_SENTINEL_STATE_KEY
 from airbyte_cdk.sources.streams.concurrent.partitions.partition import Partition
 from airbyte_cdk.sources.streams.concurrent.partitions.record import Record
 
@@ -17,13 +20,20 @@ if TYPE_CHECKING:
     from airbyte_cdk.sources.file_based.stream.concurrent.adapters import FileBasedStreamPartition
 
 
-class FileBasedNoopCursor(AbstractConcurrentFileBasedCursor):
-    def __init__(self, stream_config: FileBasedStreamConfig, **kwargs: Any):
-        pass
+class FileBasedFinalStateCursor(AbstractConcurrentFileBasedCursor):
+    """Cursor that is used to guarantee at least one state message is emitted for a concurrent file-based stream."""
+
+    def __init__(
+        self, stream_config: FileBasedStreamConfig, message_repository: MessageRepository, stream_namespace: Optional[str], **kwargs: Any
+    ):
+        self._stream_name = stream_config.name
+        self._stream_namespace = stream_namespace
+        self._message_repository = message_repository
+        self._connector_state_manager = ConnectorStateManager(stream_instance_map={})
 
     @property
     def state(self) -> MutableMapping[str, Any]:
-        return {}
+        return {FULL_REFRESH_SENTINEL_STATE_KEY: True}
 
     def observe(self, record: Record) -> None:
         pass
@@ -53,4 +63,6 @@ class FileBasedNoopCursor(AbstractConcurrentFileBasedCursor):
         pass
 
     def ensure_at_least_one_state_emitted(self) -> None:
-        pass
+        self._connector_state_manager.update_state_for_stream(self._stream_name, self._stream_namespace, self.state)
+        state_message = self._connector_state_manager.create_state_message(self._stream_name, self._stream_namespace)
+        self._message_repository.emit_message(state_message)

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/adapters.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/adapters.py
@@ -21,7 +21,7 @@ from airbyte_cdk.sources.streams.concurrent.availability_strategy import (
     StreamAvailable,
     StreamUnavailable,
 )
-from airbyte_cdk.sources.streams.concurrent.cursor import Cursor, NoopCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import Cursor, FinalStateCursor
 from airbyte_cdk.sources.streams.concurrent.default_stream import DefaultStream
 from airbyte_cdk.sources.streams.concurrent.exceptions import ExceptionWithDisplayMessage
 from airbyte_cdk.sources.streams.concurrent.helpers import get_cursor_field_from_stream, get_primary_key_from_stream
@@ -77,7 +77,7 @@ class StreamFacade(AbstractStreamFacade[DefaultStream], Stream):
                 partition_generator=StreamPartitionGenerator(
                     stream,
                     message_repository,
-                    SyncMode.full_refresh if isinstance(cursor, NoopCursor) else SyncMode.incremental,
+                    SyncMode.full_refresh if isinstance(cursor, FinalStateCursor) else SyncMode.incremental,
                     [cursor_field] if cursor_field is not None else None,
                     state,
                     cursor,
@@ -89,6 +89,7 @@ class StreamFacade(AbstractStreamFacade[DefaultStream], Stream):
                 primary_key=pk,
                 cursor_field=cursor_field,
                 logger=logger,
+                message_repository=message_repository,
                 cursor=cursor,
             ),
             stream,

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/adapters.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/adapters.py
@@ -89,7 +89,6 @@ class StreamFacade(AbstractStreamFacade[DefaultStream], Stream):
                 primary_key=pk,
                 cursor_field=cursor_field,
                 logger=logger,
-                message_repository=message_repository,
                 cursor=cursor,
             ),
             stream,

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/cursor.py
@@ -93,6 +93,9 @@ class FinalStateCursor(Cursor):
         self._stream_name = stream_name
         self._stream_namespace = stream_namespace
         self._message_repository = message_repository
+        # Normally the connector state manager operates at the source-level. However, we only need it to write the sentinel
+        # state message rather than manage overall source state. This is also only temporary as we move to the resumable
+        # full refresh world where every stream uses a FileBasedConcurrentCursor with incremental state.
         self._connector_state_manager = ConnectorStateManager(stream_instance_map={})
         self._has_closed_at_least_one_slice = False
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/cursor.py
@@ -66,21 +66,6 @@ class Cursor(ABC):
         raise NotImplementedError()
 
 
-class NoopCursor(Cursor):
-    @property
-    def state(self) -> MutableMapping[str, Any]:
-        return {}
-
-    def observe(self, record: Record) -> None:
-        pass
-
-    def close_partition(self, partition: Partition) -> None:
-        pass
-
-    def ensure_at_least_one_state_emitted(self) -> None:
-        pass
-
-
 class FinalStateCursor(Cursor):
     """Cursor that is used to guarantee at least one state message is emitted for a concurrent stream."""
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/default_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/default_stream.py
@@ -7,10 +7,9 @@ from logging import Logger
 from typing import Any, Iterable, List, Mapping, Optional
 
 from airbyte_cdk.models import AirbyteStream, SyncMode
-from airbyte_cdk.sources.message import MessageRepository
 from airbyte_cdk.sources.streams.concurrent.abstract_stream import AbstractStream
 from airbyte_cdk.sources.streams.concurrent.availability_strategy import AbstractAvailabilityStrategy, StreamAvailability
-from airbyte_cdk.sources.streams.concurrent.cursor import Cursor, FinalStateCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import Cursor
 from airbyte_cdk.sources.streams.concurrent.partitions.partition import Partition
 from airbyte_cdk.sources.streams.concurrent.partitions.partition_generator import PartitionGenerator
 
@@ -25,8 +24,7 @@ class DefaultStream(AbstractStream):
         primary_key: List[str],
         cursor_field: Optional[str],
         logger: Logger,
-        cursor: Optional[Cursor],
-        message_repository: MessageRepository,
+        cursor: Cursor,
         namespace: Optional[str] = None,
     ) -> None:
         self._stream_partition_generator = partition_generator
@@ -36,7 +34,7 @@ class DefaultStream(AbstractStream):
         self._primary_key = primary_key
         self._cursor_field = cursor_field
         self._logger = logger
-        self._cursor = cursor or FinalStateCursor(stream_name=name, stream_namespace=namespace, message_repository=message_repository)
+        self._cursor = cursor
         self._namespace = namespace
 
     def generate_partitions(self) -> Iterable[Partition]:

--- a/airbyte-cdk/python/unit_tests/sources/concurrent_source/test_concurrent_source_adapter.py
+++ b/airbyte-cdk/python/unit_tests/sources/concurrent_source/test_concurrent_source_adapter.py
@@ -20,7 +20,7 @@ from airbyte_cdk.sources.concurrent_source.concurrent_source_adapter import Conc
 from airbyte_cdk.sources.message import InMemoryMessageRepository
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.concurrent.adapters import StreamFacade
-from airbyte_cdk.sources.streams.concurrent.cursor import NoopCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import FinalStateCursor
 
 
 class _MockSource(ConcurrentSourceAdapter):
@@ -36,7 +36,7 @@ class _MockSource(ConcurrentSourceAdapter):
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         return [
-            StreamFacade.create_from_stream(s, self, self._logger, None, NoopCursor()) if is_concurrent else s
+            StreamFacade.create_from_stream(s, self, self._logger, None, FinalStateCursor(stream_name=s.name, stream_namespace=s.namespace, message_repository=InMemoryMessageRepository())) if is_concurrent else s
             for s, is_concurrent in self._streams_to_is_concurrent.items()
         ]
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/stream/concurrent/test_adapters.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/stream/concurrent/test_adapters.py
@@ -23,7 +23,7 @@ from airbyte_cdk.sources.file_based.stream.concurrent.adapters import (
     FileBasedStreamPartition,
     FileBasedStreamPartitionGenerator,
 )
-from airbyte_cdk.sources.file_based.stream.concurrent.cursor import FileBasedNoopCursor
+from airbyte_cdk.sources.file_based.stream.concurrent.cursor import FileBasedFinalStateCursor
 from airbyte_cdk.sources.message import InMemoryMessageRepository
 from airbyte_cdk.sources.streams.concurrent.cursor import Cursor
 from airbyte_cdk.sources.streams.concurrent.exceptions import ExceptionWithDisplayMessage
@@ -36,7 +36,7 @@ _ANY_SYNC_MODE = SyncMode.full_refresh
 _ANY_STATE = {"state_key": "state_value"}
 _ANY_CURSOR_FIELD = ["a", "cursor", "key"]
 _STREAM_NAME = "stream"
-_ANY_CURSOR = Mock(spec=FileBasedNoopCursor)
+_ANY_CURSOR = Mock(spec=FileBasedFinalStateCursor)
 
 
 @pytest.mark.parametrize(
@@ -165,7 +165,7 @@ class StreamFacadeTest(unittest.TestCase):
             supported_sync_modes=[SyncMode.full_refresh],
         )
         self._legacy_stream = DefaultFileBasedStream(
-            cursor=FileBasedNoopCursor(MagicMock()),
+            cursor=FileBasedFinalStateCursor(stream_config=MagicMock(), stream_namespace=None, message_repository=Mock()),
             config=FileBasedStreamConfig(name="stream", format=CsvFormat()),
             catalog_schema={},
             stream_reader=MagicMock(),

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/stream_facade_builder.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/stream_facade_builder.py
@@ -21,7 +21,7 @@ from airbyte_cdk.sources.message import InMemoryMessageRepository, MessageReposi
 from airbyte_cdk.sources.source import TState
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.concurrent.adapters import StreamFacade
-from airbyte_cdk.sources.streams.concurrent.cursor import ConcurrentCursor, CursorField, NoopCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import ConcurrentCursor, CursorField, FinalStateCursor
 from airbyte_cdk.sources.streams.concurrent.state_converters.datetime_stream_state_converter import EpochValueConcurrentStreamStateConverter
 from airbyte_protocol.models import ConfiguredAirbyteStream
 from unit_tests.sources.file_based.scenarios.scenario_builder import SourceBuilder
@@ -83,7 +83,7 @@ class StreamFacadeSource(ConcurrentSourceAdapter):
                     None,
                 )
                 if self._cursor_field
-                else NoopCursor(),
+                else FinalStateCursor(stream_name=stream.name, stream_namespace=stream.namespace, message_repository=self.message_repository),
             )
             for stream, state in zip(self._streams, stream_states)
         ]

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/thread_based_concurrent_stream_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/thread_based_concurrent_stream_scenarios.py
@@ -4,7 +4,6 @@
 import logging
 
 from airbyte_cdk.sources.message import InMemoryMessageRepository
-from airbyte_cdk.sources.streams.concurrent.cursor import FinalStateCursor
 from airbyte_cdk.sources.streams.concurrent.default_stream import DefaultStream
 from airbyte_cdk.sources.streams.concurrent.partitions.record import Record
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/thread_based_concurrent_stream_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/thread_based_concurrent_stream_scenarios.py
@@ -4,7 +4,7 @@
 import logging
 
 from airbyte_cdk.sources.message import InMemoryMessageRepository
-from airbyte_cdk.sources.streams.concurrent.cursor import NoopCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import FinalStateCursor
 from airbyte_cdk.sources.streams.concurrent.default_stream import DefaultStream
 from airbyte_cdk.sources.streams.concurrent.partitions.record import Record
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder
@@ -14,6 +14,8 @@ from unit_tests.sources.streams.concurrent.scenarios.thread_based_concurrent_str
     InMemoryPartition,
     InMemoryPartitionGenerator,
 )
+
+_message_repository = InMemoryMessageRepository()
 
 _id_only_stream = DefaultStream(
     partition_generator=InMemoryPartitionGenerator(
@@ -30,7 +32,8 @@ _id_only_stream = DefaultStream(
     primary_key=[],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    cursor=NoopCursor(),
+    message_repository=_message_repository,
+    cursor=None,
 )
 
 _id_only_stream_with_slice_logger = DefaultStream(
@@ -48,7 +51,8 @@ _id_only_stream_with_slice_logger = DefaultStream(
     primary_key=[],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    cursor=NoopCursor(),
+    message_repository=_message_repository,
+    cursor=None,
 )
 
 _id_only_stream_with_primary_key = DefaultStream(
@@ -66,7 +70,8 @@ _id_only_stream_with_primary_key = DefaultStream(
     primary_key=["id"],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    cursor=NoopCursor(),
+    message_repository=_message_repository,
+    cursor=None,
 )
 
 _id_only_stream_multiple_partitions = DefaultStream(
@@ -87,7 +92,8 @@ _id_only_stream_multiple_partitions = DefaultStream(
     primary_key=[],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    cursor=NoopCursor(),
+    message_repository=_message_repository,
+    cursor=None,
 )
 
 _id_only_stream_multiple_partitions_concurrency_level_two = DefaultStream(
@@ -108,7 +114,8 @@ _id_only_stream_multiple_partitions_concurrency_level_two = DefaultStream(
     primary_key=[],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    cursor=NoopCursor(),
+    message_repository=_message_repository,
+    cursor=None,
 )
 
 _stream_raising_exception = DefaultStream(
@@ -126,7 +133,8 @@ _stream_raising_exception = DefaultStream(
     primary_key=[],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    cursor=NoopCursor(),
+    message_repository=_message_repository,
+    cursor=None,
 )
 
 test_concurrent_cdk_single_stream = (
@@ -140,7 +148,7 @@ test_concurrent_cdk_single_stream = (
                 _id_only_stream,
             ]
         )
-        .set_message_repository(InMemoryMessageRepository())
+        .set_message_repository(_message_repository)
     )
     .set_expected_records(
         [
@@ -193,7 +201,7 @@ test_concurrent_cdk_single_stream_with_primary_key = (
                 _id_only_stream_with_primary_key,
             ]
         )
-        .set_message_repository(InMemoryMessageRepository())
+        .set_message_repository(_message_repository)
     )
     .set_expected_records(
         [
@@ -253,11 +261,12 @@ test_concurrent_cdk_multiple_streams = (
                     primary_key=[],
                     cursor_field=None,
                     logger=logging.getLogger("test_logger"),
-                    cursor=NoopCursor(),
+                    message_repository=_message_repository,
+                    cursor=None,
                 ),
             ]
         )
-        .set_message_repository(InMemoryMessageRepository())
+        .set_message_repository(_message_repository)
     )
     .set_expected_records(
         [
@@ -308,7 +317,7 @@ test_concurrent_cdk_partition_raises_exception = (
                 _stream_raising_exception,
             ]
         )
-        .set_message_repository(InMemoryMessageRepository())
+        .set_message_repository(_message_repository)
     )
     .set_expected_records(
         [
@@ -346,7 +355,7 @@ test_concurrent_cdk_single_stream_multiple_partitions = (
                 _id_only_stream_multiple_partitions,
             ]
         )
-        .set_message_repository(InMemoryMessageRepository())
+        .set_message_repository(_message_repository)
     )
     .set_expected_records(
         [
@@ -386,7 +395,7 @@ test_concurrent_cdk_single_stream_multiple_partitions_concurrency_level_two = (
                 _id_only_stream_multiple_partitions_concurrency_level_two,
             ]
         )
-        .set_message_repository(InMemoryMessageRepository())
+        .set_message_repository(_message_repository)
     )
     .set_expected_records(
         [

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/thread_based_concurrent_stream_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/thread_based_concurrent_stream_scenarios.py
@@ -4,6 +4,7 @@
 import logging
 
 from airbyte_cdk.sources.message import InMemoryMessageRepository
+from airbyte_cdk.sources.streams.concurrent.cursor import FinalStateCursor
 from airbyte_cdk.sources.streams.concurrent.default_stream import DefaultStream
 from airbyte_cdk.sources.streams.concurrent.partitions.record import Record
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder
@@ -31,8 +32,7 @@ _id_only_stream = DefaultStream(
     primary_key=[],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    message_repository=_message_repository,
-    cursor=None,
+    cursor=FinalStateCursor(stream_name="stream1", stream_namespace=None, message_repository=_message_repository),
 )
 
 _id_only_stream_with_slice_logger = DefaultStream(
@@ -50,8 +50,7 @@ _id_only_stream_with_slice_logger = DefaultStream(
     primary_key=[],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    message_repository=_message_repository,
-    cursor=None,
+    cursor=FinalStateCursor(stream_name="stream1", stream_namespace=None, message_repository=_message_repository),
 )
 
 _id_only_stream_with_primary_key = DefaultStream(
@@ -69,8 +68,7 @@ _id_only_stream_with_primary_key = DefaultStream(
     primary_key=["id"],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    message_repository=_message_repository,
-    cursor=None,
+    cursor=FinalStateCursor(stream_name="stream1", stream_namespace=None, message_repository=_message_repository),
 )
 
 _id_only_stream_multiple_partitions = DefaultStream(
@@ -91,8 +89,7 @@ _id_only_stream_multiple_partitions = DefaultStream(
     primary_key=[],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    message_repository=_message_repository,
-    cursor=None,
+    cursor=FinalStateCursor(stream_name="stream1", stream_namespace=None, message_repository=_message_repository),
 )
 
 _id_only_stream_multiple_partitions_concurrency_level_two = DefaultStream(
@@ -113,8 +110,7 @@ _id_only_stream_multiple_partitions_concurrency_level_two = DefaultStream(
     primary_key=[],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    message_repository=_message_repository,
-    cursor=None,
+    cursor=FinalStateCursor(stream_name="stream1", stream_namespace=None, message_repository=_message_repository),
 )
 
 _stream_raising_exception = DefaultStream(
@@ -132,8 +128,7 @@ _stream_raising_exception = DefaultStream(
     primary_key=[],
     cursor_field=None,
     logger=logging.getLogger("test_logger"),
-    message_repository=_message_repository,
-    cursor=None,
+    cursor=FinalStateCursor(stream_name="stream1", stream_namespace=None, message_repository=_message_repository),
 )
 
 test_concurrent_cdk_single_stream = (
@@ -260,8 +255,7 @@ test_concurrent_cdk_multiple_streams = (
                     primary_key=[],
                     cursor_field=None,
                     logger=logging.getLogger("test_logger"),
-                    message_repository=_message_repository,
-                    cursor=None,
+                    cursor=FinalStateCursor(stream_name="stream1", stream_namespace=None, message_repository=_message_repository),
                 ),
             ]
         )

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/thread_based_concurrent_stream_source_builder.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/thread_based_concurrent_stream_source_builder.py
@@ -8,11 +8,11 @@ from typing import Any, Iterable, List, Mapping, Optional, Tuple, Union
 from airbyte_cdk.models import ConfiguredAirbyteCatalog, ConnectorSpecification, DestinationSyncMode, SyncMode
 from airbyte_cdk.sources.concurrent_source.concurrent_source import ConcurrentSource
 from airbyte_cdk.sources.concurrent_source.concurrent_source_adapter import ConcurrentSourceAdapter
-from airbyte_cdk.sources.message import MessageRepository
+from airbyte_cdk.sources.message import InMemoryMessageRepository, MessageRepository
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.concurrent.adapters import StreamFacade
 from airbyte_cdk.sources.streams.concurrent.availability_strategy import AbstractAvailabilityStrategy, StreamAvailability, StreamAvailable
-from airbyte_cdk.sources.streams.concurrent.cursor import FinalStateCursor, NoopCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import FinalStateCursor
 from airbyte_cdk.sources.streams.concurrent.default_stream import DefaultStream
 from airbyte_cdk.sources.streams.concurrent.partitions.partition import Partition
 from airbyte_cdk.sources.streams.concurrent.partitions.partition_generator import PartitionGenerator
@@ -58,7 +58,7 @@ class ConcurrentCdkSource(ConcurrentSourceAdapter):
         return ConfiguredAirbyteCatalog(
             streams=[
                 ConfiguredAirbyteStream(
-                    stream=StreamFacade(s, LegacyStream(), NoopCursor(), NeverLogSliceLogger(), s._logger).as_airbyte_stream(),
+                    stream=StreamFacade(s, LegacyStream(), FinalStateCursor(stream_name=s.name, stream_namespace=s.namespace, message_repository=InMemoryMessageRepository()), NeverLogSliceLogger(), s._logger).as_airbyte_stream(),
                     sync_mode=SyncMode.full_refresh,
                     destination_sync_mode=DestinationSyncMode.overwrite,
                 )

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import Mock
 
 from airbyte_cdk.models import AirbyteStream, SyncMode
+from airbyte_cdk.sources.message import InMemoryMessageRepository
 from airbyte_cdk.sources.streams.concurrent.availability_strategy import STREAM_AVAILABLE
 from airbyte_cdk.sources.streams.concurrent.cursor import Cursor, NoopCursor
 from airbyte_cdk.sources.streams.concurrent.default_stream import DefaultStream
@@ -29,6 +30,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._cursor_field,
             self._logger,
             NoopCursor(),
+            InMemoryMessageRepository(),
         )
 
     def test_get_json_schema(self):
@@ -90,6 +92,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._cursor_field,
             self._logger,
             NoopCursor(),
+            InMemoryMessageRepository(),
         )
 
         expected_airbyte_stream = AirbyteStream(
@@ -122,6 +125,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._cursor_field,
             self._logger,
             NoopCursor(),
+            InMemoryMessageRepository(),
         )
 
         expected_airbyte_stream = AirbyteStream(
@@ -154,6 +158,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             "date",
             self._logger,
             NoopCursor(),
+            InMemoryMessageRepository()
         )
 
         expected_airbyte_stream = AirbyteStream(
@@ -179,6 +184,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._cursor_field,
             self._logger,
             NoopCursor(),
+            InMemoryMessageRepository(),
             namespace="test",
         )
         expected_airbyte_stream = AirbyteStream(

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 from airbyte_cdk.models import AirbyteStream, SyncMode
 from airbyte_cdk.sources.message import InMemoryMessageRepository
 from airbyte_cdk.sources.streams.concurrent.availability_strategy import STREAM_AVAILABLE
-from airbyte_cdk.sources.streams.concurrent.cursor import Cursor, NoopCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import Cursor, FinalStateCursor
 from airbyte_cdk.sources.streams.concurrent.default_stream import DefaultStream
 
 
@@ -21,6 +21,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
         self._cursor_field = None
         self._logger = Mock()
         self._cursor = Mock(spec=Cursor)
+        self._message_repository = InMemoryMessageRepository()
         self._stream = DefaultStream(
             self._partition_generator,
             self._name,
@@ -29,8 +30,8 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._primary_key,
             self._cursor_field,
             self._logger,
-            NoopCursor(),
-            InMemoryMessageRepository(),
+            FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
+            self._message_repository,
         )
 
     def test_get_json_schema(self):
@@ -91,8 +92,8 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             ["id"],
             self._cursor_field,
             self._logger,
-            NoopCursor(),
-            InMemoryMessageRepository(),
+            FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
+            self._message_repository,
         )
 
         expected_airbyte_stream = AirbyteStream(
@@ -124,7 +125,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             ["id_a", "id_b"],
             self._cursor_field,
             self._logger,
-            NoopCursor(),
+            FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
             InMemoryMessageRepository(),
         )
 
@@ -157,8 +158,8 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._primary_key,
             "date",
             self._logger,
-            NoopCursor(),
-            InMemoryMessageRepository()
+            FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
+            self._message_repository,
         )
 
         expected_airbyte_stream = AirbyteStream(
@@ -183,8 +184,8 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._primary_key,
             self._cursor_field,
             self._logger,
-            NoopCursor(),
-            InMemoryMessageRepository(),
+            FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
+            self._message_repository,
             namespace="test",
         )
         expected_airbyte_stream = AirbyteStream(

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
@@ -31,7 +31,6 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._cursor_field,
             self._logger,
             FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
-            self._message_repository,
         )
 
     def test_get_json_schema(self):
@@ -93,7 +92,6 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._cursor_field,
             self._logger,
             FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
-            self._message_repository,
         )
 
         expected_airbyte_stream = AirbyteStream(
@@ -126,7 +124,6 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._cursor_field,
             self._logger,
             FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
-            InMemoryMessageRepository(),
         )
 
         expected_airbyte_stream = AirbyteStream(
@@ -159,7 +156,6 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             "date",
             self._logger,
             FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
-            self._message_repository,
         )
 
         expected_airbyte_stream = AirbyteStream(
@@ -185,7 +181,6 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._cursor_field,
             self._logger,
             FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
-            self._message_repository,
             namespace="test",
         )
         expected_airbyte_stream = AirbyteStream(

--- a/airbyte-cdk/python/unit_tests/sources/streams/test_stream_read.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/test_stream_read.py
@@ -26,7 +26,7 @@ from airbyte_cdk.sources.connector_state_manager import ConnectorStateManager
 from airbyte_cdk.sources.message import InMemoryMessageRepository, MessageRepository
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.concurrent.adapters import StreamFacade
-from airbyte_cdk.sources.streams.concurrent.cursor import Cursor, NoopCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import Cursor, FinalStateCursor
 from airbyte_cdk.sources.streams.concurrent.partitions.partition import Partition
 from airbyte_cdk.sources.streams.concurrent.partitions.record import Record
 from airbyte_cdk.sources.streams.core import StreamData
@@ -105,8 +105,9 @@ def _stream(slice_to_partition_mapping, slice_logger, logger, message_repository
     return _MockStream(slice_to_partition_mapping)
 
 
-def _concurrent_stream(slice_to_partition_mapping, slice_logger, logger, message_repository, cursor: Cursor = NoopCursor()):
+def _concurrent_stream(slice_to_partition_mapping, slice_logger, logger, message_repository, cursor: Optional[Cursor] = None):
     stream = _stream(slice_to_partition_mapping, slice_logger, logger, message_repository)
+    cursor = cursor or FinalStateCursor(stream_name=stream.name, stream_namespace=stream.namespace, message_repository=message_repository)
     source = Mock()
     source._slice_logger = slice_logger
     source.message_repository = message_repository

--- a/airbyte-cdk/python/unit_tests/sources/test_source_read.py
+++ b/airbyte-cdk/python/unit_tests/sources/test_source_read.py
@@ -27,7 +27,7 @@ from airbyte_cdk.sources.concurrent_source.concurrent_source_adapter import Conc
 from airbyte_cdk.sources.message import InMemoryMessageRepository
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.concurrent.adapters import StreamFacade
-from airbyte_cdk.sources.streams.concurrent.cursor import NoopCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import FinalStateCursor
 from airbyte_cdk.sources.streams.core import StreamData
 from airbyte_cdk.utils import AirbyteTracedException
 from unit_tests.sources.streams.concurrent.scenarios.thread_based_concurrent_stream_source_builder import NeverLogSliceLogger
@@ -409,9 +409,8 @@ def _init_sources(stream_slice_to_partitions, state, logger):
 
 
 def _init_source(stream_slice_to_partitions, state, logger, source):
-    cursor = NoopCursor()
     streams = [
-        StreamFacade.create_from_stream(_MockStream(stream_slices, f"stream{i}"), source, logger, state, cursor)
+        StreamFacade.create_from_stream(_MockStream(stream_slices, f"stream{i}"), source, logger, state, FinalStateCursor(stream_name=f"stream{i}", stream_namespace=None, message_repository=InMemoryMessageRepository()))
         for i, stream_slices in enumerate(stream_slice_to_partitions)
     ]
     source.set_streams(streams)


### PR DESCRIPTION
❗ Note: We decided to split apart the PR into a graphite stack when there were some prerequisites to support the record count. @brianjlai wrote this code and the below description, so we need another reviewer!

## What

Concurrent and concurrent file-based connectors didn't support emitting a state message at the end of a full refresh sync. As part of record counts we want to align behavior so all syncs emit at least one successful state upon completion.

## How

The state emission flow in the concurrent CDK is consolidated regardless of sync type and it is solely the responsibility of the cursor implementation to handle state emission. Previously, full refresh syncs implemented a Noop cursor, but we've reworked this for concurrent sources to have a cursor that implements `ensure_at_least_one_state_emitted()` to always ensure a last state message.

Concurrent:
- We kept the `NoopCursor` because this is technically exposed as a public facing component that concurrent sources implement (see Stripe).
- We introduced the new `FinalStateCursor` which is responsible for just emitting the last state at the end of the sync. It will be added to Stripe and Salesforce replacing NoopCursor for full refresh syncs

File based concurrent:
- The `NoopCursor` isn't being used anywhere on a per-source basis so we're in a better state to just replace this one for file-based sources.

This has been tested against S3 and Stripe as pre-release versions

A note on testing:
There a lot of swapping and sharing of the InMemoryMessageRepository. Because the cursor needs a repository to emit messages, we need them to be shared between streams creation which includes creating the cursor. Other than that, most was account for new test behavior

## Recommended reading order

1. `cursor.py`
2. `default_stream.py`
3. `file_based_final_state_cursor.py`
4. `file_based_source.py`
5. `adapters.py` (2)
