### PR TITLE
Emit record counts in state messages for concurrent streams

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -173,9 +173,6 @@ class AirbyteEntrypoint(object):
             stream_message_count[message_utils.get_stream_descriptor(message)] += 1
 
         elif message.type == Type.STATE:
-            if not message.state.stream:
-                raise ValueError("State message was not in per-stream state format, which is required for record counts.")
-
             stream_descriptor = message_utils.get_stream_descriptor(message)
 
             # Set record count from the counter onto the state message

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -182,12 +182,6 @@ class AirbyteEntrypoint(object):
             message.state.sourceStats = message.state.sourceStats or AirbyteStateStats()
             message.state.sourceStats.recordCount = stream_message_count.get(stream_descriptor, 0)
 
-            # TODO: Logging - remove after pre-release testing
-            stream_name = message.state.stream.stream_descriptor.name
-            stream_state = message.state.stream.stream_state.dict() if message.state.stream.stream_state else {}
-            record_count = message.state.sourceStats.recordCount
-            logger.info(f"Emitting state message for stream '{stream_name}' with count {record_count} and state data: {stream_state}")
-
             # Reset the counter
             stream_message_count[stream_descriptor] = 0
         return message

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -20,8 +20,7 @@ from airbyte_cdk.connector import TConfig
 from airbyte_cdk.exception_handler import init_uncaught_exception_handler
 from airbyte_cdk.logger import init_logger
 from airbyte_cdk.models import AirbyteMessage, FailureType, Status, Type
-from airbyte_cdk.models.airbyte_protocol import ConnectorSpecification  # type: ignore [attr-defined]
-from airbyte_cdk.models.airbyte_protocol import AirbyteStateStats
+from airbyte_cdk.models.airbyte_protocol import AirbyteStateStats, ConnectorSpecification  # type: ignore [attr-defined]
 from airbyte_cdk.sources import Source
 from airbyte_cdk.sources.connector_state_manager import HashableStreamDescriptor
 from airbyte_cdk.sources.utils.schema_helpers import check_config_against_spec_or_exit, split_config

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -156,7 +156,7 @@ class AirbyteEntrypoint(object):
         yield AirbyteMessage(type=Type.CATALOG, catalog=catalog)
 
     def read(
-            self, source_spec: ConnectorSpecification, config: TConfig, catalog: Any, state: Union[list[Any], MutableMapping[str, Any]]
+        self, source_spec: ConnectorSpecification, config: TConfig, catalog: Any, state: Union[list[Any], MutableMapping[str, Any]]
     ) -> Iterable[AirbyteMessage]:
         self.set_up_secret_filter(config, source_spec.connectionSpecification)
         if self.source.check_config_against_spec:

--- a/airbyte-cdk/python/airbyte_cdk/sources/connector_state_manager.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/connector_state_manager.py
@@ -82,7 +82,6 @@ class ConnectorStateManager:
         Generates an AirbyteMessage using the current per-stream state of a specified stream in either the per-stream or legacy format
         :param stream_name: The name of the stream for the message that is being created
         :param namespace: The namespace of the stream for the message that is being created
-        :param send_per_stream_state: Decides which state format the message should be generated as
         :return: The Airbyte state message to be emitted by the connector during a sync
         """
         hashable_descriptor = HashableStreamDescriptor(name=stream_name, namespace=namespace)

--- a/airbyte-cdk/python/airbyte_cdk/utils/message_utils.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/message_utils.py
@@ -8,6 +8,8 @@ def get_stream_descriptor(message: AirbyteMessage) -> HashableStreamDescriptor:
     if message.type == Type.RECORD:
         return HashableStreamDescriptor(name=message.record.stream, namespace=message.record.namespace)
     elif message.type == Type.STATE:
+        if not message.state.stream or not message.state.stream.stream_descriptor:
+            raise ValueError("State message was not in per-stream state format, which is required for record counts.")
         return HashableStreamDescriptor(
             name=message.state.stream.stream_descriptor.name, namespace=message.state.stream.stream_descriptor.namespace
         )

--- a/airbyte-cdk/python/airbyte_cdk/utils/message_utils.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/message_utils.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
 from airbyte_cdk.sources.connector_state_manager import HashableStreamDescriptor
-from airbyte_protocol.models import AirbyteMessage
+from airbyte_protocol.models import AirbyteMessage, Type
 
 
 def get_stream_descriptor(message: AirbyteMessage) -> HashableStreamDescriptor:
-    if message.record:
+    if message.type == Type.RECORD:
         return HashableStreamDescriptor(name=message.record.stream, namespace=message.record.namespace)
-    elif message.state:
+    elif message.type == Type.STATE:
         return HashableStreamDescriptor(
             name=message.state.stream.stream_descriptor.name, namespace=message.state.stream.stream_descriptor.namespace
         )

--- a/airbyte-cdk/python/airbyte_cdk/utils/message_utils.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/message_utils.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from airbyte_cdk.sources.connector_state_manager import HashableStreamDescriptor
+from airbyte_protocol.models import AirbyteMessage
+
+
+def get_stream_descriptor(message: AirbyteMessage) -> HashableStreamDescriptor:
+    if message.record:
+        return HashableStreamDescriptor(name=message.record.stream, namespace=message.record.namespace)
+    elif message.state:
+        return HashableStreamDescriptor(
+            name=message.state.stream.stream_descriptor.name, namespace=message.state.stream.stream_descriptor.namespace
+        )
+    else:
+        raise ValueError("Message format does not contain a stream descriptor.")

--- a/airbyte-cdk/python/airbyte_cdk/utils/message_utils.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/message_utils.py
@@ -12,4 +12,4 @@ def get_stream_descriptor(message: AirbyteMessage) -> HashableStreamDescriptor:
             name=message.state.stream.stream_descriptor.name, namespace=message.state.stream.stream_descriptor.namespace
         )
     else:
-        raise ValueError("Message format does not contain a stream descriptor.")
+        raise NotImplementedError(f"get_stream_descriptor is not implemented for message type '{message.type}'.")

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -71,7 +71,7 @@ def assert_exception(expected_exception: type[BaseException], output: Entrypoint
 
 
 def _verify_read_output(output: EntrypointOutput, scenario: TestScenario[AbstractSource]) -> None:
-    records, log_messages = output.records_and_state_messages, output.logs
+    records_and_state_messages, log_messages = output.records_and_state_messages, output.logs
     logs = [message.log for message in log_messages if message.log.level.value in scenario.log_levels]
     if scenario.expected_records is None:
         return
@@ -85,7 +85,7 @@ def _verify_read_output(output: EntrypointOutput, scenario: TestScenario[Abstrac
         ),
     )
     sorted_records = sorted(
-        filter(lambda r: r.record, records),
+        filter(lambda r: r.record, records_and_state_messages),
         key=lambda record: ",".join(
             f"{k}={v}" for k, v in sorted(record.record.data.items(), key=lambda items: (items[0], items[1])) if k != "emitted_at"
         ),
@@ -104,8 +104,9 @@ def _verify_read_output(output: EntrypointOutput, scenario: TestScenario[Abstrac
             assert actual.record.stream == expected["stream"]
 
     expected_states = list(filter(lambda e: "data" not in e, expected_records))
-    states = list(filter(lambda r: r.state, records))
+    states = list(filter(lambda r: r.state, records_and_state_messages))
     assert len(states) > 0, "No state messages emitted. Successful syncs should emit at least one stream state."
+    _verify_state_record_counts(sorted_records, states)
 
     if hasattr(scenario.source, "cursor_cls") and issubclass(scenario.source.cursor_cls, AbstractConcurrentFileBasedCursor):
         # Only check the last state emitted because we don't know the order the others will be in.
@@ -114,13 +115,6 @@ def _verify_read_output(output: EntrypointOutput, scenario: TestScenario[Abstrac
     else:
         for actual, expected in zip(states, expected_states):  # states should be emitted in sorted order
             assert actual.state.stream.stream_state.dict() == expected
-
-    # TODO: probably split this up per stream
-    for stream in set([record.record.stream for record in sorted_records]):
-        # Deal with namespaces here for the comparison
-        total_state_message_record_count_for_stream = sum([state_message.state.sourceStats.recordCount for state_message in states if state_message.state.stream.stream_descriptor.name == stream])
-        num_records_for_stream = len([record for record in sorted_records if record.record.stream == stream])
-        assert total_state_message_record_count_for_stream == num_records_for_stream
 
     if scenario.expected_logs:
         read_logs = scenario.expected_logs.get("read")
@@ -133,9 +127,31 @@ def _verify_read_output(output: EntrypointOutput, scenario: TestScenario[Abstrac
         _verify_analytics(analytics, scenario.expected_analytics)
 
 
+def _verify_state_record_counts(records: List[AirbyteMessage], states: List[AirbyteMessage]) -> None:
+    # TODO: Use HashableStreamDescriptor here
+    record_streams = {record.record.stream for record in records}
+    actual_record_counts = {stream: 0 for stream in record_streams}
+    for record in records:
+        actual_record_counts[record.record.stream] += 1
+
+    state_message_streams = {state.state.stream.stream_descriptor.name for state in states}
+    state_record_count_sums = {stream: 0 for stream in state_message_streams}
+    for state in states:
+        state_record_count_sums[state.state.stream.stream_descriptor.name] += state.state.sourceStats.recordCount
+
+    for stream, actual_count in actual_record_counts.items():
+        assert state_record_count_sums.get(stream) == actual_count
+
+    # We can have extra keys in state_record_count_sums if we processed a stream and reported 0 records
+    extra_keys = state_record_count_sums.keys() - actual_record_counts.keys()
+    for stream in extra_keys:
+        assert state_record_count_sums[stream] == 0
+
+
 def _verify_analytics(analytics: List[AirbyteMessage], expected_analytics: Optional[List[AirbyteAnalyticsTraceMessage]]) -> None:
     if expected_analytics:
-        assert len(analytics) == len(expected_analytics), \
+        assert len(analytics) == len(
+            expected_analytics), \
             f"Number of actual analytics messages ({len(analytics)}) did not match expected ({len(expected_analytics)})"
         for actual, expected in zip(analytics, expected_analytics):
             actual_type, actual_value = actual.trace.analytics.type, actual.trace.analytics.value

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -115,6 +115,13 @@ def _verify_read_output(output: EntrypointOutput, scenario: TestScenario[Abstrac
         for actual, expected in zip(states, expected_states):  # states should be emitted in sorted order
             assert actual.state.stream.stream_state.dict() == expected
 
+    # TODO: probably split this up per stream
+    for stream in set([record.record.stream for record in sorted_records]):
+        # Deal with namespaces here for the comparison
+        total_state_message_record_count_for_stream = sum([state_message.state.sourceStats.recordCount for state_message in states if state_message.state.stream.stream_descriptor.name == stream])
+        num_records_for_stream = len([record for record in sorted_records if record.record.stream == stream])
+        assert total_state_message_record_count_for_stream == num_records_for_stream
+
     if scenario.expected_logs:
         read_logs = scenario.expected_logs.get("read")
         assert len(logs) == (len(read_logs) if read_logs else 0)

--- a/airbyte-cdk/python/unit_tests/sources/mock_server_tests/test_mock_server_abstract_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/mock_server_tests/test_mock_server_abstract_source.py
@@ -205,6 +205,7 @@ class FullRefreshStreamTest(TestCase):
         validate_message_order([Type.RECORD, Type.RECORD, Type.STATE], actual_messages.records_and_state_messages)
         assert actual_messages.state_messages[0].state.stream.stream_descriptor.name == "users"
         assert actual_messages.state_messages[0].state.stream.stream_state == {"__ab_full_refresh_state_message": True}
+        assert actual_messages.state_messages[0].state.sourceStats.recordCount == 2
 
     @HttpMocker()
     def test_full_refresh_with_slices(self, http_mocker):
@@ -232,6 +233,7 @@ class FullRefreshStreamTest(TestCase):
         validate_message_order([Type.RECORD, Type.RECORD, Type.RECORD, Type.RECORD, Type.STATE], actual_messages.records_and_state_messages)
         assert actual_messages.state_messages[0].state.stream.stream_descriptor.name == "dividers"
         assert actual_messages.state_messages[0].state.stream.stream_state == {"__ab_full_refresh_state_message": True}
+        assert actual_messages.state_messages[0].state.sourceStats.recordCount == 4
 
 
 @freezegun.freeze_time(_NOW)
@@ -264,8 +266,10 @@ class IncrementalStreamTest(TestCase):
         validate_message_order([Type.RECORD, Type.RECORD, Type.RECORD, Type.STATE, Type.RECORD, Type.RECORD, Type.STATE], actual_messages.records_and_state_messages)
         assert actual_messages.state_messages[0].state.stream.stream_descriptor.name == "planets"
         assert actual_messages.state_messages[0].state.stream.stream_state == {"created_at": last_record_date_0}
+        assert actual_messages.state_messages[0].state.sourceStats.recordCount == 3
         assert actual_messages.state_messages[1].state.stream.stream_descriptor.name == "planets"
         assert actual_messages.state_messages[1].state.stream.stream_state == {"created_at": last_record_date_1}
+        assert actual_messages.state_messages[1].state.sourceStats.recordCount == 2
 
     @HttpMocker()
     def test_incremental_running_as_full_refresh(self, http_mocker):
@@ -295,6 +299,7 @@ class IncrementalStreamTest(TestCase):
         validate_message_order([Type.RECORD, Type.RECORD, Type.RECORD, Type.RECORD, Type.RECORD, Type.STATE], actual_messages.records_and_state_messages)
         assert actual_messages.state_messages[0].state.stream.stream_descriptor.name == "planets"
         assert actual_messages.state_messages[0].state.stream.stream_state == {"created_at": last_record_date_1}
+        assert actual_messages.state_messages[0].state.sourceStats.recordCount == 5
 
     @HttpMocker()
     def test_legacy_incremental_sync(self, http_mocker):
@@ -324,8 +329,10 @@ class IncrementalStreamTest(TestCase):
         validate_message_order([Type.RECORD, Type.RECORD, Type.RECORD, Type.STATE, Type.RECORD, Type.RECORD, Type.STATE], actual_messages.records_and_state_messages)
         assert actual_messages.state_messages[0].state.stream.stream_descriptor.name == "legacies"
         assert actual_messages.state_messages[0].state.stream.stream_state == {"created_at": last_record_date_0}
+        assert actual_messages.state_messages[0].state.sourceStats.recordCount == 3
         assert actual_messages.state_messages[1].state.stream.stream_descriptor.name == "legacies"
         assert actual_messages.state_messages[1].state.stream.stream_state == {"created_at": last_record_date_1}
+        assert actual_messages.state_messages[1].state.sourceStats.recordCount == 2
 
 
 @freezegun.freeze_time(_NOW)
@@ -395,12 +402,16 @@ class MultipleStreamTest(TestCase):
         ], actual_messages.records_and_state_messages)
         assert actual_messages.state_messages[0].state.stream.stream_descriptor.name == "users"
         assert actual_messages.state_messages[0].state.stream.stream_state == {"__ab_full_refresh_state_message": True}
+        assert actual_messages.state_messages[0].state.sourceStats.recordCount == 2
         assert actual_messages.state_messages[1].state.stream.stream_descriptor.name == "planets"
         assert actual_messages.state_messages[1].state.stream.stream_state == {"created_at": last_record_date_0}
+        assert actual_messages.state_messages[1].state.sourceStats.recordCount == 3
         assert actual_messages.state_messages[2].state.stream.stream_descriptor.name == "planets"
         assert actual_messages.state_messages[2].state.stream.stream_state == {"created_at": last_record_date_1}
+        assert actual_messages.state_messages[2].state.sourceStats.recordCount == 2
         assert actual_messages.state_messages[3].state.stream.stream_descriptor.name == "dividers"
         assert actual_messages.state_messages[3].state.stream.stream_state == {"__ab_full_refresh_state_message": True}
+        assert actual_messages.state_messages[3].state.sourceStats.recordCount == 4
 
 
 def emits_successful_sync_status_messages(status_messages: List[AirbyteStreamStatus]) -> bool:

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/thread_based_concurrent_stream_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/scenarios/thread_based_concurrent_stream_scenarios.py
@@ -255,7 +255,7 @@ test_concurrent_cdk_multiple_streams = (
                     primary_key=[],
                     cursor_field=None,
                     logger=logging.getLogger("test_logger"),
-                    cursor=FinalStateCursor(stream_name="stream1", stream_namespace=None, message_repository=_message_repository),
+                    cursor=FinalStateCursor(stream_name="stream2", stream_namespace=None, message_repository=_message_repository),
                 ),
             ]
         )

--- a/airbyte-cdk/python/unit_tests/test_entrypoint.py
+++ b/airbyte-cdk/python/unit_tests/test_entrypoint.py
@@ -106,14 +106,14 @@ def test_airbyte_entrypoint_init(mocker):
         ("check", {"config": "config_path"}, {"command": "check", "config": "config_path", "debug": False}),
         ("discover", {"config": "config_path", "debug": ""}, {"command": "discover", "config": "config_path", "debug": True}),
         (
-            "read",
-            {"config": "config_path", "catalog": "catalog_path", "state": "None"},
-            {"command": "read", "config": "config_path", "catalog": "catalog_path", "state": "None", "debug": False},
+                "read",
+                {"config": "config_path", "catalog": "catalog_path", "state": "None"},
+                {"command": "read", "config": "config_path", "catalog": "catalog_path", "state": "None", "debug": False},
         ),
         (
-            "read",
-            {"config": "config_path", "catalog": "catalog_path", "state": "state_path", "debug": ""},
-            {"command": "read", "config": "config_path", "catalog": "catalog_path", "state": "state_path", "debug": True},
+                "read",
+                {"config": "config_path", "catalog": "catalog_path", "state": "state_path", "debug": ""},
+                {"command": "read", "config": "config_path", "catalog": "catalog_path", "state": "state_path", "debug": True},
         ),
     ],
 )
@@ -181,9 +181,9 @@ def config_mock(mocker, request):
         ({"username": "fake"}, {"type": "object", "properties": {"user": {"type": "string"}}}, True),
         ({"username": "fake"}, {"type": "object", "properties": {"user": {"type": "string", "airbyte_secret": True}}}, True),
         (
-            {"username": "fake", "_limit": 22},
-            {"type": "object", "properties": {"username": {"type": "string"}}, "additionalProperties": False},
-            True,
+                {"username": "fake", "_limit": 22},
+                {"type": "object", "properties": {"username": {"type": "string"}}, "additionalProperties": False},
+                True,
         ),
     ],
     indirect=["config_mock"],
@@ -260,7 +260,7 @@ def test_run_read(entrypoint: AirbyteEntrypoint, mocker, spec_mock, config_mock)
 
 
 def test_given_message_emitted_during_config_when_read_then_emit_message_before_next_steps(
-    entrypoint: AirbyteEntrypoint, mocker, spec_mock, config_mock
+        entrypoint: AirbyteEntrypoint, mocker, spec_mock, config_mock
 ):
     parsed_args = Namespace(command="read", config="config_path", state="statepath", catalog="catalogpath")
     mocker.patch.object(MockSource, "read_catalog", side_effect=ValueError)
@@ -334,9 +334,12 @@ def test_filter_internal_requests(deployment_mode, url, expected_error):
             id="test_handle_record_message",
         ),
         pytest.param(
-            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(stream_descriptor=StreamDescriptor(name="customers"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")))),
+            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="customers"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")))),
             {HashableStreamDescriptor(name="customers"): 100},
-            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(stream_descriptor=StreamDescriptor(name="customers"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")), sourceStats=AirbyteStateStats(recordCount=100.0))),
+            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="customers"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")),
+                                                                      sourceStats=AirbyteStateStats(recordCount=100.0))),
             {HashableStreamDescriptor(name="customers"): 0},
             id="test_handle_state_message",
         ),
@@ -348,9 +351,15 @@ def test_filter_internal_requests(deployment_mode, url, expected_error):
             id="test_handle_first_record_message",
         ),
         pytest.param(
-            AirbyteMessage(type=Type.TRACE, trace=AirbyteTraceMessage(type=TraceType.STREAM_STATUS, stream_status=AirbyteStreamStatusTraceMessage(stream_descriptor=StreamDescriptor(name="customers"), status=AirbyteStreamStatus.COMPLETE), emitted_at=1)),
+            AirbyteMessage(type=Type.TRACE, trace=AirbyteTraceMessage(type=TraceType.STREAM_STATUS,
+                                                                      stream_status=AirbyteStreamStatusTraceMessage(
+                                                                          stream_descriptor=StreamDescriptor(name="customers"),
+                                                                          status=AirbyteStreamStatus.COMPLETE), emitted_at=1)),
             {HashableStreamDescriptor(name="customers"): 5},
-            AirbyteMessage(type=Type.TRACE, trace=AirbyteTraceMessage(type=TraceType.STREAM_STATUS, stream_status=AirbyteStreamStatusTraceMessage(stream_descriptor=StreamDescriptor(name="customers"), status=AirbyteStreamStatus.COMPLETE), emitted_at=1)),
+            AirbyteMessage(type=Type.TRACE, trace=AirbyteTraceMessage(type=TraceType.STREAM_STATUS,
+                                                                      stream_status=AirbyteStreamStatusTraceMessage(
+                                                                          stream_descriptor=StreamDescriptor(name="customers"),
+                                                                          status=AirbyteStreamStatus.COMPLETE), emitted_at=1)),
             {HashableStreamDescriptor(name="customers"): 5},
             id="test_handle_other_message_type",
         ),
@@ -362,31 +371,45 @@ def test_filter_internal_requests(deployment_mode, url, expected_error):
             id="test_handle_record_message_for_other_stream",
         ),
         pytest.param(
-            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(stream_descriptor=StreamDescriptor(name="others"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")))),
+            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="others"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")))),
             {HashableStreamDescriptor(name="customers"): 100, HashableStreamDescriptor(name="others"): 27},
-            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(stream_descriptor=StreamDescriptor(name="others"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")),sourceStats=AirbyteStateStats(recordCount=27.0))),
+            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="others"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")),
+                                                                      sourceStats=AirbyteStateStats(recordCount=27.0))),
             {HashableStreamDescriptor(name="customers"): 100, HashableStreamDescriptor(name="others"): 0},
             id="test_handle_state_message_for_other_stream",
         ),
         pytest.param(
-            AirbyteMessage(type=Type.RECORD, record=AirbyteRecordMessage(stream="customers", namespace="public", data={"id": "12345"}, emitted_at=1)),
+            AirbyteMessage(type=Type.RECORD,
+                           record=AirbyteRecordMessage(stream="customers", namespace="public", data={"id": "12345"}, emitted_at=1)),
             {HashableStreamDescriptor(name="customers", namespace="public"): 100},
-            AirbyteMessage(type=Type.RECORD, record=AirbyteRecordMessage(stream="customers", namespace="public", data={"id": "12345"}, emitted_at=1)),
+            AirbyteMessage(type=Type.RECORD,
+                           record=AirbyteRecordMessage(stream="customers", namespace="public", data={"id": "12345"}, emitted_at=1)),
             {HashableStreamDescriptor(name="customers", namespace="public"): 101},
             id="test_handle_record_message_with_descriptor",
         ),
         pytest.param(
-            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(stream_descriptor=StreamDescriptor(name="customers", namespace="public"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")))),
+            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="customers", namespace="public"),
+                stream_state=AirbyteStateBlob(updated_at="2024-02-02")))),
             {HashableStreamDescriptor(name="customers", namespace="public"): 100},
-            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(stream_descriptor=StreamDescriptor(name="customers", namespace="public"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")),sourceStats=AirbyteStateStats(recordCount=100.0))),
+            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="customers", namespace="public"),
+                stream_state=AirbyteStateBlob(updated_at="2024-02-02")), sourceStats=AirbyteStateStats(recordCount=100.0))),
             {HashableStreamDescriptor(name="customers", namespace="public"): 0},
             id="test_handle_state_message_with_descriptor",
         ),
         pytest.param(
-            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(stream_descriptor=StreamDescriptor(name="others", namespace="public"),stream_state=AirbyteStateBlob(updated_at="2024-02-02")))),
+            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="others", namespace="public"),
+                stream_state=AirbyteStateBlob(updated_at="2024-02-02")))),
             {HashableStreamDescriptor(name="customers", namespace="public"): 100},
-            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(stream_descriptor=StreamDescriptor(name="others", namespace="public"), stream_state=AirbyteStateBlob(updated_at="2024-02-02")), sourceStats=AirbyteStateStats(recordCount=0.0))),
-            {HashableStreamDescriptor(name="customers", namespace="public"): 100, HashableStreamDescriptor(name="others", namespace="public"): 0},
+            AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(type=AirbyteStateType.STREAM, stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="others", namespace="public"),
+                stream_state=AirbyteStateBlob(updated_at="2024-02-02")), sourceStats=AirbyteStateStats(recordCount=0.0))),
+            {HashableStreamDescriptor(name="customers", namespace="public"): 100,
+             HashableStreamDescriptor(name="others", namespace="public"): 0},
             id="test_handle_state_message_no_records",
         ),
     ]

--- a/airbyte-cdk/python/unit_tests/utils/test_message_utils.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_message_utils.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+import pytest
+from airbyte_cdk.sources.connector_state_manager import HashableStreamDescriptor
+from airbyte_cdk.utils.message_utils import get_stream_descriptor
+from airbyte_protocol.models import (
+    AirbyteControlConnectorConfigMessage,
+    AirbyteControlMessage,
+    AirbyteMessage,
+    AirbyteRecordMessage,
+    AirbyteStateBlob,
+    AirbyteStateMessage,
+    AirbyteStateStats,
+    AirbyteStateType,
+    AirbyteStreamState,
+    OrchestratorType,
+    StreamDescriptor,
+    Type,
+)
+
+
+def test_get_record_message_stream_descriptor():
+    message = AirbyteMessage(
+        type=Type.RECORD,
+        record=AirbyteRecordMessage(
+            stream="test_stream",
+            namespace="test_namespace",
+            data={"id": "12345"},
+            emitted_at=1,
+        ),
+    )
+    expected_descriptor = HashableStreamDescriptor(name="test_stream", namespace="test_namespace")
+    assert get_stream_descriptor(message) == expected_descriptor
+
+
+def test_get_record_message_stream_descriptor_no_namespace():
+    message = AirbyteMessage(
+        type=Type.RECORD,
+        record=AirbyteRecordMessage(
+            stream="test_stream", data={"id": "12345"}, emitted_at=1
+        ),
+    )
+    expected_descriptor = HashableStreamDescriptor(name="test_stream", namespace=None)
+    assert get_stream_descriptor(message) == expected_descriptor
+
+
+def test_get_state_message_stream_descriptor():
+    message = AirbyteMessage(
+        type=Type.STATE,
+        state=AirbyteStateMessage(
+            type=AirbyteStateType.STREAM,
+            stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(
+                    name="test_stream", namespace="test_namespace"
+                ),
+                stream_state=AirbyteStateBlob(updated_at="2024-02-02"),
+            ),
+            sourceStats=AirbyteStateStats(recordCount=27.0),
+        ),
+    )
+    expected_descriptor = HashableStreamDescriptor(name="test_stream", namespace="test_namespace")
+    assert get_stream_descriptor(message) == expected_descriptor
+
+
+def test_get_state_message_stream_descriptor_no_namespace():
+    message = AirbyteMessage(
+        type=Type.STATE,
+        state=AirbyteStateMessage(
+            type=AirbyteStateType.STREAM,
+            stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="test_stream"),
+                stream_state=AirbyteStateBlob(updated_at="2024-02-02"),
+            ),
+            sourceStats=AirbyteStateStats(recordCount=27.0),
+        ),
+    )
+    expected_descriptor = HashableStreamDescriptor(name="test_stream", namespace=None)
+    assert get_stream_descriptor(message) == expected_descriptor
+
+
+def test_get_other_message_stream_descriptor_fails():
+    message = AirbyteMessage(
+    type=Type.CONTROL,
+    control=AirbyteControlMessage(
+        type=OrchestratorType.CONNECTOR_CONFIG,
+        emitted_at=10,
+        connectorConfig=AirbyteControlConnectorConfigMessage(config={"any config": "a config value"}),
+    ))
+    with pytest.raises(ValueError):
+        get_stream_descriptor(message)

--- a/airbyte-cdk/python/unit_tests/utils/test_message_utils.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_message_utils.py
@@ -86,5 +86,5 @@ def test_get_other_message_stream_descriptor_fails():
         emitted_at=10,
         connectorConfig=AirbyteControlConnectorConfigMessage(config={"any config": "a config value"}),
     ))
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         get_stream_descriptor(message)

--- a/airbyte-cdk/python/unit_tests/utils/test_message_utils.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_message_utils.py
@@ -80,11 +80,12 @@ def test_get_state_message_stream_descriptor_no_namespace():
 
 def test_get_other_message_stream_descriptor_fails():
     message = AirbyteMessage(
-    type=Type.CONTROL,
-    control=AirbyteControlMessage(
-        type=OrchestratorType.CONNECTOR_CONFIG,
-        emitted_at=10,
-        connectorConfig=AirbyteControlConnectorConfigMessage(config={"any config": "a config value"}),
-    ))
+        type=Type.CONTROL,
+        control=AirbyteControlMessage(
+            type=OrchestratorType.CONNECTOR_CONFIG,
+            emitted_at=10,
+            connectorConfig=AirbyteControlConnectorConfigMessage(config={"any config": "a config value"}),
+        ),
+    )
     with pytest.raises(NotImplementedError):
         get_stream_descriptor(message)

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -20,7 +20,7 @@ from airbyte_cdk.sources.source import TState
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.call_rate import AbstractAPIBudget, HttpAPIBudget, HttpRequestMatcher, MovingWindowCallRatePolicy, Rate
 from airbyte_cdk.sources.streams.concurrent.adapters import StreamFacade
-from airbyte_cdk.sources.streams.concurrent.cursor import Comparable, ConcurrentCursor, CursorField, FinalStateCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import Comparable, ConcurrentCursor, CursorField, NoopCursor
 from airbyte_cdk.sources.streams.concurrent.state_converters.datetime_stream_state_converter import EpochValueConcurrentStreamStateConverter
 from airbyte_cdk.sources.streams.http.auth import TokenAuthenticator
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
@@ -524,13 +524,7 @@ class SourceStripe(ConcurrentSourceAdapter):
 
     def _to_concurrent(self, stream: Stream, fallback_start, state_manager: ConnectorStateManager) -> Stream:
         if stream.name in self._streams_configured_as_full_refresh:
-            return StreamFacade.create_from_stream(
-                stream,
-                self,
-                entrypoint_logger,
-                self._create_empty_state(),
-                FinalStateCursor(stream_name=stream.name, stream_namespace=stream.namespace, message_repository=self.message_repository),
-            )
+            return StreamFacade.create_from_stream(stream, self, entrypoint_logger, self._create_empty_state(), NoopCursor())
 
         state = state_manager.get_stream_state(stream.name, stream.namespace)
         slice_boundary_fields = self._SLICE_BOUNDARY_FIELDS_BY_IMPLEMENTATION.get(type(stream))


### PR DESCRIPTION
* Closes https://github.com/airbytehq/airbyte-internal-issues/issues/2936
* Closes https://github.com/airbytehq/airbyte-internal-issues/issues/6451

Description by @brianjlai 

## What

For each outbound state message, the record count of record emitted since the prior state message is now appended. An example state message looks like:
```
AirbyteMessage(
  type=Type.STATE,
  state=AirbyteStateMessage(
    type=AirbyteStateType.STREAM,
    stream=AirbyteStreamState(
      stream_descriptor=StreamDescriptor(name="others", namespace="public"),
      stream_state=AirbyteStateBlob(updated_at="2024-02-02")
    ),
    sourceStats=AirbyteStateStats(recordCount=50.0)
  )
)
```

## How

By placing it in the `entrypoint.py` around where all messages are read from, we're closer to the platform and less chance that we count incorrectly and emit the wrong value. This also allows for much simpler code w/ less branching code paths and "it just works" for every flavor of the CDK. 

One part to note is that this does not automagically upgrade `source-stripe` and `source-salesforce` because we didn't do a straight replace of `NoopCursor` and `FinalStateCursor`. @brianjlai has tested this on Cloud and will handle those two upgrades

## Recommended reading order
1. `entrypoint.py`
2. `test_entrypoint.py`
3. `test_mock_server_abstract_source`
