### PR TITLE
[source-mssql] Enable msal4j to unlock access to enterprise MS products

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'io.debezium:debezium-embedded:2.4.0.Final'
     implementation 'io.debezium:debezium-connector-sqlserver:2.4.0.Final'
     implementation 'org.codehaus.plexus:plexus-utils:3.4.2'
-
+    implementation 'com.microsoft.azure:msal4j:1.14.0'
     testFixturesImplementation 'org.testcontainers:mssqlserver:1.19.0'
 
     testImplementation 'org.awaitility:awaitility:4.2.0'

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlCdcHelper.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlCdcHelper.java
@@ -122,7 +122,23 @@ public class MssqlCdcHelper {
     } else {
       props.setProperty("driver.trustServerCertificate", "true");
     }
-
+    
+    if (config.has("auth_method")) {
+      final JsonNode authConfig = config.get("auth_method");
+      final String authMethod = authConfig.get("auth_method").asText();
+      if ("SqlPassword".equals(auth_method)) {
+        props.setProperty("integratedSecurity", "false"); 
+      } else if ("ActiveDirectoryPassword".equals(auth_method)) {
+        props.setProperty("authentication", auth_method);
+      } else if ("ActiveDirectoryIntegrated".equals(auth_method)) {
+        props.setProperty("authentication", auth_method);
+      } else if ("ActiveDirectoryMSI".equals(auth_method)) {
+        props.setProperty("authentication", auth_method);
+      } else if ("ActiveDirectoryInteractive".equals(auth_method)) {
+        props.setProperty("authentication", auth_method);
+      }
+    }
+    
     return props;
   }
 

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -99,6 +99,12 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// I have no idea which of these libraries may be needed, or how Java utilizes these
+import com.microsoft.aad.msal4j.IAuthenticationResult;
+import com.microsoft.aad.msal4j.IClientCredential;
+import com.microsoft.aad.msal4j.IntegratedWindowsAuthenticationParameters;
+import com.microsoft.aad.msal4j.InteractiveRequestParameters;
+
 //TO-DO: I think something may have to be added to this page to pass the authentication property along?? 
 
 public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source {

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -99,6 +99,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+//TO-DO: I think something may have to be added to this page to pass the authentication property along?? 
+
 public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MssqlSource.class);

--- a/airbyte-integrations/connectors/source-mssql/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mssql/src/main/resources/spec.json
@@ -114,13 +114,76 @@
           }
         ]
       },
+      "auth_method": {
+        "title": "Authentication",
+        "type": "object",
+        "description": "The authentication method to connect with the database.",
+        "order": 8,
+        "oneOf": [
+          {
+            "title": "SQL Server Authentication",
+            "description": "Authenticate directly with SQL Server credentials",
+            "required": ["auth_method"],
+            "properties": {
+              "ssl_method": {
+                "type": "string",
+                "const": "SqlPassword"
+              }
+            }
+          },
+          {
+            "title": "Active Directory - Integrated",
+            "description": "Authenticate via Integrated Azure Active Directory",
+            "required": ["auth_method"],
+            "properties": {
+              "ssl_method": {
+                "type": "string",
+                "const": "ActiveDirectoryIntegrated"
+              }
+            }
+          },
+          {
+            "title": "Active Directory - MFA",
+            "description": "Authenticate via Multi Factor Azure Active Directory",
+            "required": ["auth_method"],
+            "properties": {
+              "auth_method": {
+                "type": "string",
+                "const": "ActiveDirectoryInteractive"
+              }
+            }
+          },
+          {
+            "title": "Active Directory - MSI",
+            "description": "Authenticate via MSI Azure Active Directory",
+            "required": ["auth_method"],
+            "properties": {
+              "auth_method": {
+                "type": "string",
+                "const": "ActiveDirectoryMSI"
+              }
+            }
+          },
+          {
+            "title": "Active Directory - Password",
+            "description": "Authenticate via Username and Password from Azure Active Directory",
+            "required": ["auth_method"],
+            "properties": {
+              "auth_method": {
+                "type": "string",
+                "const": "ActiveDirectoryPassword"
+              }
+            }
+          }
+        ]
+      },
       "replication_method": {
         "type": "object",
         "title": "Update Method",
         "description": "Configures how data is extracted from the database.",
         "default": "CDC",
         "display_type": "radio",
-        "order": 8,
+        "order": 9,
         "oneOf": [
           {
             "title": "Read Changes using Change Data Capture (CDC)",


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->
🚨🚨  🚨🚨  🚨🚨 

## What
Currently, the MSSQL Connector does not support Azure AD authentication, which prevents accessing the SQL Server backed of  several MS enterprise applications (i.e. Dynamics 365 CRM). Authentication is a standard parameter accepted by mssql jdbc. Enabling this feature can pave the way for potential connectors to supporting Enterprise MS clients and help drive adoption of Airbyte by enterprise clients that could be potential Airbyte Cloud customers.   

## How
Adding the MSAL4J library, and passing through the finite list of Authentication options to the JDBC Connector. 

## Recommended reading order
1. build.gradle
2. spec.json
3. MssqlSource.java
4. [DBeaver reference documentation](https://github.com/dbeaver/dbeaver) (I referenced this code some to drive the static string names)
5. [MS MSAL4J Documentation](https://learn.microsoft.com/en-us/azure/azure-sql/database/active-directory-interactive-connect-azure-sql-db?view=azuresql)
5. [Gradle Example I used](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/37325ac3b29d97b410ff23c5f8af5a2517b62e3f/LabApiUtilities/build.gradle#L77)
## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*
Yes, the current code I have supplied is untested. However, once exceptions are cleared (if they exist), the changes should not be breaking. Existing connections should be fine without supplying the Authentication parameter (or a default value can be set to whatever is currently occurring). 

I have zero Java developer experience, my background is C#, SQL and Python. I have no means of building/testing Java applications. I have made a good faith effort to steer the ship towards a solution that should be a positive step forward for the MSSQL connector to support expected, native behavior of MSSQL Server connections.


## Pre-merge Actions
*Expand the relevant checklist and delete the others.* 
* Ensure code even runs,
* Make additional changes to ensure the Authentication approach works
* If we need to evaluate the efforts once exceptions have been cleared, I can attempt to test the docker container of the Connector to make contact with a sandbox environment of a SQL Server database that is locked behind Azure AD.
 
