### PR TITLE
🐛 Source Shopify: Fixed bug when `start date` was not provided, but the stream was using it

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9da77001-af33-4bcd-be46-6252bf9342b9
-  dockerImageTag: 2.0.0
+  dockerImageTag: 2.0.1
   dockerRepository: airbyte/source-shopify
   documentationUrl: https://docs.airbyte.com/integrations/sources/shopify
   githubIssueLabel: source-shopify

--- a/airbyte-integrations/connectors/source-shopify/pyproject.toml
+++ b/airbyte-integrations/connectors/source-shopify/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.0.0"
+version = "2.0.1"
 name = "source-shopify"
 description = "Source CDK implementation for Shopify."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/config_migrations.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/config_migrations.py
@@ -1,0 +1,93 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+
+from typing import Any, List, Mapping
+
+from airbyte_cdk.config_observation import create_connector_config_control_message
+from airbyte_cdk.entrypoint import AirbyteEntrypoint
+from airbyte_cdk.sources import Source
+from airbyte_cdk.sources.message import InMemoryMessageRepository, MessageRepository
+
+
+class MigrateConfig:
+    """
+    This class stands for migrating the config at runtime,
+    while providing the backward compatibility when falling back to the previous source version.
+
+    Specifically, starting from `2.0.1`, the `start_date` property should be not (None or `None`):
+        > "start_date": "2020-01-01"
+    instead of, in `2.0.0` for some older configs, when the `start_date` was not required:
+        > {...}
+    """
+
+    message_repository: MessageRepository = InMemoryMessageRepository()
+    migrate_key: str = "start_date"
+    # default spec value for the `start_date` is `2020-01-01`
+    default_start_date_value: str = "2020-01-01"
+
+    @classmethod
+    def should_migrate(cls, config: Mapping[str, Any]) -> bool:
+        """
+        This method determines whether the config should be migrated to have the new structure with `start_date`,
+        based on the source spec.
+
+        Returns:
+            > True, if the transformation is necessary
+            > False, otherwise.
+        """
+        # If the config was already migrated, there is no need to do this again.
+        # but if the customer has already switched to the new version,
+        # corrected the old config and switches back to the new version,
+        # we should try to migrate the modified old custom reports.
+        none_values: List[str] = [None, "None"]
+        key_not_present_in_config = cls.migrate_key not in config
+        key_present_in_config_but_invalid = cls.migrate_key in config and config.get(cls.migrate_key) in none_values
+
+        if key_not_present_in_config:
+            return True
+        elif key_present_in_config_but_invalid:
+            return True
+        else:
+            return False
+
+    @classmethod
+    def modify_config(cls, config: Mapping[str, Any], source: Source = None) -> Mapping[str, Any]:
+        config[cls.migrate_key] = cls.default_start_date_value
+        return config
+
+    @classmethod
+    def modify_and_save(cls, config_path: str, source: Source, config: Mapping[str, Any]) -> Mapping[str, Any]:
+        # modify the config
+        migrated_config = cls.modify_config(config, source)
+        # save the config
+        source.write_config(migrated_config, config_path)
+        # return modified config
+        return migrated_config
+
+    @classmethod
+    def emit_control_message(cls, migrated_config: Mapping[str, Any]) -> None:
+        # add the Airbyte Control Message to message repo
+        cls.message_repository.emit_message(create_connector_config_control_message(migrated_config))
+        # emit the Airbyte Control Message from message queue to stdout
+        for message in cls.message_repository._message_queue:
+            print(message.json(exclude_unset=True))
+
+    @classmethod
+    def migrate(cls, args: List[str], source: Source) -> None:
+        """
+        This method checks the input args, should the config be migrated,
+        transform if neccessary and emit the CONTROL message.
+        """
+        # get config path
+        config_path = AirbyteEntrypoint(source).extract_config(args)
+        # proceed only if `--config` arg is provided
+        if config_path:
+            # read the existing config
+            config = source.read_config(config_path)
+            # migration check
+            if cls.should_migrate(config):
+                cls.emit_control_message(
+                    cls.modify_and_save(config_path, source, config),
+                )

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/run.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/run.py
@@ -6,10 +6,14 @@
 import sys
 
 from airbyte_cdk.entrypoint import launch
+from source_shopify.config_migrations import MigrateConfig
 
 from .source import SourceShopify
 
 
-def run():
+def run() -> None:
     source = SourceShopify()
+    # migrate config at runtime
+    MigrateConfig.migrate(sys.argv[1:], source)
+    # run the connector
     launch(source, sys.argv[1:])

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/streams/base_streams.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/streams/base_streams.py
@@ -620,7 +620,7 @@ class IncrementalShopifyGraphQlBulkStream(IncrementalShopifyStream):
     def default_state_comparison_value(self) -> Union[int, str]:
         # certain streams are using `id` field as `cursor_field`, which requires to use `int` type,
         # but many other use `str` values for this, we determine what to use based on `cursor_field` value
-        return 0 if self.cursor_field == "id" else (self.config.get("start_date") or "")
+        return 0 if self.cursor_field == "id" else self.config.get("start_date")
 
     # CDK OVERIDES
     @property

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/streams/base_streams.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/streams/base_streams.py
@@ -43,7 +43,7 @@ class ShopifyStream(HttpStream, ABC):
         self._transformer = DataTypeEnforcer(self.get_json_schema())
         self.config = config
         # default value, if the start_date is empty.
-        self.default_start_date = "2018-01-01"
+        self.default_start_date = "2020-01-01"
 
     @property
     @abstractmethod

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/graphql_bulk/test_job.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/graphql_bulk/test_job.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 from source_shopify.shopify_graphql.bulk.exceptions import ShopifyBulkExceptions
 from source_shopify.shopify_graphql.bulk.job import ShopifyBulkStatus
+from source_shopify.streams.base_streams import IncrementalShopifyGraphQlBulkStream
 from source_shopify.streams.streams import (
     Collections,
     CustomerAddress,
@@ -263,3 +264,35 @@ def test_bulk_stream_parse_response(
         assert test_records == [expected_result]
     elif isinstance(expected_result, list):
         assert test_records == expected_result
+
+
+@pytest.mark.parametrize(
+    "stream, stream_state, with_start_date, expected",
+    [
+        (DiscountCodes, {}, True, "updated_at:>='2023-01-01T00:00:00+00:00'"),
+        (DiscountCodes, {}, False, "updated_at:>='2018-01-01T00:00:00+00:00'"),
+        (DiscountCodes, {"updated_at": "2022-01-01T00:00:00Z"}, True, "updated_at:>='2022-01-01T00:00:00+00:00'"),
+        (DiscountCodes, {"updated_at": "2021-01-01T00:00:00Z"}, False, "updated_at:>='2021-01-01T00:00:00+00:00'"),
+    ],
+    ids=[
+        "No State, but Start Date",
+        "No State, No Start Date - should fallback to 2018",
+        "With State, Start Date",
+        "With State, No Start Date",
+    ],
+)
+def test_stream_slices(
+    auth_config,
+    stream, 
+    stream_state, 
+    with_start_date, 
+    expected, 
+) -> None:
+    # simulating `None` for `start_date`
+    if not with_start_date:
+        auth_config.pop("start_date")
+
+    stream = stream(auth_config)
+    test_result = list(stream.stream_slices(stream_state=stream_state))
+    test_query_from_slice = test_result[0].get("query")
+    assert expected in test_query_from_slice

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/graphql_bulk/test_job.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/graphql_bulk/test_job.py
@@ -270,6 +270,7 @@ def test_bulk_stream_parse_response(
     "stream, stream_state, with_start_date, expected",
     [
         (DiscountCodes, {}, True, "updated_at:>='2023-01-01T00:00:00+00:00'"),
+        # here the config migration is applied and the value should be "2020-01-01"
         (DiscountCodes, {}, False, "updated_at:>='2020-01-01T00:00:00+00:00'"),
         (DiscountCodes, {"updated_at": "2022-01-01T00:00:00Z"}, True, "updated_at:>='2022-01-01T00:00:00+00:00'"),
         (DiscountCodes, {"updated_at": "2021-01-01T00:00:00Z"}, False, "updated_at:>='2021-01-01T00:00:00+00:00'"),
@@ -288,9 +289,9 @@ def test_stream_slices(
     with_start_date, 
     expected, 
 ) -> None:
-    # simulating `None` for `start_date`
+    # simulating `None` for `start_date` and `config migration`
     if not with_start_date:
-        auth_config.pop("start_date")
+        auth_config["start_date"] = "2020-01-01"
 
     stream = stream(auth_config)
     test_result = list(stream.stream_slices(stream_state=stream_state))

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/graphql_bulk/test_job.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/graphql_bulk/test_job.py
@@ -270,7 +270,7 @@ def test_bulk_stream_parse_response(
     "stream, stream_state, with_start_date, expected",
     [
         (DiscountCodes, {}, True, "updated_at:>='2023-01-01T00:00:00+00:00'"),
-        (DiscountCodes, {}, False, "updated_at:>='2018-01-01T00:00:00+00:00'"),
+        (DiscountCodes, {}, False, "updated_at:>='2020-01-01T00:00:00+00:00'"),
         (DiscountCodes, {"updated_at": "2022-01-01T00:00:00Z"}, True, "updated_at:>='2022-01-01T00:00:00+00:00'"),
         (DiscountCodes, {"updated_at": "2021-01-01T00:00:00Z"}, False, "updated_at:>='2021-01-01T00:00:00+00:00'"),
     ],

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_migrations/test_config.json
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_migrations/test_config.json
@@ -1,0 +1,8 @@
+{
+  "shop": "airbyte-integration-test",
+  "credentials": {
+    "auth_method": "api_password",
+    "api_password": "__api_password__"
+  },
+  "bulk_window_in_days": 1000
+}

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_migrations/test_config_migrations.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_migrations/test_config_migrations.py
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+
+import json
+from typing import Any, Mapping
+
+from airbyte_cdk.models import OrchestratorType, Type
+from airbyte_cdk.sources import Source
+from source_shopify.config_migrations import MigrateConfig
+from source_shopify.source import SourceShopify
+
+# BASE ARGS
+CMD = "check"
+TEST_CONFIG_PATH = "unit_tests/test_migrations/test_config.json"
+NEW_TEST_CONFIG_PATH = "unit_tests/test_migrations/test_new_config.json"
+SOURCE_INPUT_ARGS = [CMD, "--config", TEST_CONFIG_PATH]
+SOURCE: Source = SourceShopify()
+
+
+# HELPERS
+def load_config(config_path: str = TEST_CONFIG_PATH) -> Mapping[str, Any]:
+    with open(config_path, "r") as config:
+        return json.load(config)
+
+
+def revert_migration(config_path: str = TEST_CONFIG_PATH) -> None:
+    with open(config_path, "r") as test_config:
+        config = json.load(test_config)
+        config.pop("start_date")
+        with open(config_path, "w") as updated_config:
+            config = json.dumps(config)
+            updated_config.write(config)
+
+
+def test_migrate_config() -> None:
+    migration_instance = MigrateConfig()
+    # original_config = load_config()
+    # migrate the test_config
+    migration_instance.migrate(SOURCE_INPUT_ARGS, SOURCE)
+    # load the updated config
+    test_migrated_config = load_config()
+    # check migrated property
+    assert "start_date" in test_migrated_config
+    # check the data type
+    assert isinstance(test_migrated_config["start_date"], str)
+    # check the migration should be skipped, once already done
+    assert not migration_instance.should_migrate(test_migrated_config)
+    # test CONTROL MESSAGE was emitted
+    control_msg = migration_instance.message_repository._message_queue[0]
+    assert control_msg.type == Type.CONTROL
+    assert control_msg.control.type == OrchestratorType.CONNECTOR_CONFIG
+    # check the migrated values
+    assert control_msg.control.connectorConfig.config["start_date"] == "2020-01-01"
+    # revert the test_config to the starting point
+    revert_migration()
+
+
+def test_config_is_reverted():
+    # check the test_config state, it has to be the same as before tests
+    test_config = load_config()
+    # check the config no longer has the migarted property
+    assert "start_date" not in test_config
+
+
+def test_should_not_migrate_new_config():
+    new_config = load_config(NEW_TEST_CONFIG_PATH)
+    migration_instance = MigrateConfig()
+    assert not migration_instance.should_migrate(new_config)

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_migrations/test_new_config.json
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_migrations/test_new_config.json
@@ -1,0 +1,9 @@
+{
+  "start_date": "2020-01-01",
+  "shop": "airbyte-integration-test",
+  "credentials": {
+    "auth_method": "api_password",
+    "api_password": "__api_password__"
+  },
+  "bulk_window_in_days": 1000
+}

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -207,6 +207,7 @@ For all `Shopify GraphQL BULK` api requests these limitations are applied: https
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| 2.0.1   | 2024-03-11 | [35952](https://github.com/airbytehq/airbyte/pull/35952) | Fixed the issue when `start date` is missing but the `stream` required it |
 | 2.0.0   | 2024-02-12 | [32345](https://github.com/airbytehq/airbyte/pull/32345) | Fixed the issue with `state` causing the `substreams` to skip the records, made `metafield_*`: `collections, customers, draft_orders, locations, orders, product_images, product_variants, products`, and `fulfillment_orders, collections, discount_codes, inventory_levels, inventory_items, transactions_graphql, customer_address` streams to use `BULK Operations` instead of `REST`|
 | 1.1.8 | 2024-02-12 | [35166](https://github.com/airbytehq/airbyte/pull/35166) | Manage dependencies with Poetry. |
 | 1.1.7   | 2024-01-19 | [33804](https://github.com/airbytehq/airbyte/pull/33804) | Updated documentation with list of all supported streams |


### PR DESCRIPTION
# What
Resolving:
- https://github.com/airbytehq/oncall/issues/4453

# How
- added additional checks for the `start date` value and `fallback` to the `default_start_date` value of `2018-01-01`, if the `start_date` was not provided in the `config`
- added `config migration` to gracefully migrate the configs with no / bad `start_date` values
- covered the case with `unit_test`