### PR TITLE
✨Source Amazon Seller Partner: add `GET_VENDOR_FORECASTING_REPORT` streams

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/acceptance-test-config.yml
@@ -99,6 +99,10 @@ acceptance_tests:
             bypass_reason: "Data cannot be seeded in the test account, integration tests added for the stream instead"
           - name: VendorOrders
             bypass_reason: "Data cannot be seeded in the test account, integration tests added for the stream instead"
+          - name: GET_VENDOR_FORECASTING_FRESH_REPORT
+            bypass_reason: "Data cannot be seeded in the test account, integration tests added for the stream instead"
+          - name: GET_VENDOR_FORECASTING_RETAIL_REPORT
+            bypass_reason: "Data cannot be seeded in the test account, integration tests added for the stream instead"
   incremental:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
-  dockerImageTag: 4.0.0
+  dockerImageTag: 4.1.0
   dockerRepository: airbyte/source-amazon-seller-partner
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
   githubIssueLabel: source-amazon-seller-partner

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/pyproject.toml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.0.0"
+version = "4.1.0"
 name = "source-amazon-seller-partner"
 description = "Source implementation for Amazon Seller Partner."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/GET_VENDOR_FORECASTING_FRESH_REPORT.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/GET_VENDOR_FORECASTING_FRESH_REPORT.json
@@ -3,5 +3,5 @@
   "description": "A report with forward looking mean, P70, P80, and P90 weekly customer demand forecasts. Data is reported at the ASIN level for the most recent weekly forecast generation date.",
   "type": "object",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "properties": {"$ref": "GET_VENDOR_FORECASTING_REPORT.json"}
+  "properties": { "$ref": "GET_VENDOR_FORECASTING_REPORT.json" }
 }

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/GET_VENDOR_FORECASTING_FRESH_REPORT.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/GET_VENDOR_FORECASTING_FRESH_REPORT.json
@@ -1,0 +1,7 @@
+{
+  "title": "Vendor Forecasting Fresh Report",
+  "description": "A report with forward looking mean, P70, P80, and P90 weekly customer demand forecasts. Data is reported at the ASIN level for the most recent weekly forecast generation date.",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {"$ref": "GET_VENDOR_FORECASTING_REPORT.json"}
+}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/GET_VENDOR_FORECASTING_RETAIL_REPORT.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/GET_VENDOR_FORECASTING_RETAIL_REPORT.json
@@ -1,0 +1,7 @@
+{
+  "title": "Vendor Forecasting Retail Report",
+  "description": "A report with forward looking mean, P70, P80, and P90 weekly customer demand forecasts. Data is reported at the ASIN level for the most recent weekly forecast generation date.",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {"$ref": "GET_VENDOR_FORECASTING_REPORT.json"}
+}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/GET_VENDOR_FORECASTING_RETAIL_REPORT.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/GET_VENDOR_FORECASTING_RETAIL_REPORT.json
@@ -3,5 +3,5 @@
   "description": "A report with forward looking mean, P70, P80, and P90 weekly customer demand forecasts. Data is reported at the ASIN level for the most recent weekly forecast generation date.",
   "type": "object",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "properties": {"$ref": "GET_VENDOR_FORECASTING_REPORT.json"}
+  "properties": { "$ref": "GET_VENDOR_FORECASTING_REPORT.json" }
 }

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/shared/GET_VENDOR_FORECASTING_REPORT.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/shared/GET_VENDOR_FORECASTING_REPORT.json
@@ -1,0 +1,33 @@
+{
+    "forecastGenerationDate": {
+      "type": ["null", "string"],
+      "format": "date"
+    },
+    "asin": {
+      "type": ["null", "string"]
+    },
+    "startDate": {
+      "type": ["null", "string"],
+      "format": "date"
+    },
+    "endDate": {
+      "type": ["null", "string"],
+      "format": "date"
+    },
+    "meanForecastUnits": {
+      "type": ["null", "number"]
+    },
+    "p70ForecastUnits": {
+      "type": ["null", "number"]
+    },
+    "p80ForecastUnits": {
+      "type": ["null", "number"]
+    },
+    "p90ForecastUnits": {
+      "type": ["null", "number"]
+    },
+    "dataEndTime": {
+      "type": ["null", "string"],
+      "format": "date"
+    }
+}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/shared/GET_VENDOR_FORECASTING_REPORT.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/shared/GET_VENDOR_FORECASTING_REPORT.json
@@ -1,33 +1,33 @@
 {
-    "forecastGenerationDate": {
-      "type": ["null", "string"],
-      "format": "date"
-    },
-    "asin": {
-      "type": ["null", "string"]
-    },
-    "startDate": {
-      "type": ["null", "string"],
-      "format": "date"
-    },
-    "endDate": {
-      "type": ["null", "string"],
-      "format": "date"
-    },
-    "meanForecastUnits": {
-      "type": ["null", "number"]
-    },
-    "p70ForecastUnits": {
-      "type": ["null", "number"]
-    },
-    "p80ForecastUnits": {
-      "type": ["null", "number"]
-    },
-    "p90ForecastUnits": {
-      "type": ["null", "number"]
-    },
-    "dataEndTime": {
-      "type": ["null", "string"],
-      "format": "date"
-    }
+  "forecastGenerationDate": {
+    "type": ["null", "string"],
+    "format": "date"
+  },
+  "asin": {
+    "type": ["null", "string"]
+  },
+  "startDate": {
+    "type": ["null", "string"],
+    "format": "date"
+  },
+  "endDate": {
+    "type": ["null", "string"],
+    "format": "date"
+  },
+  "meanForecastUnits": {
+    "type": ["null", "number"]
+  },
+  "p70ForecastUnits": {
+    "type": ["null", "number"]
+  },
+  "p80ForecastUnits": {
+    "type": ["null", "number"]
+  },
+  "p90ForecastUnits": {
+    "type": ["null", "number"]
+  },
+  "dataEndTime": {
+    "type": ["null", "string"],
+    "format": "date"
+  }
 }

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/source.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/source.py
@@ -3,7 +3,6 @@
 #
 
 
-import traceback
 from os import getenv
 from typing import Any, List, Mapping, Optional, Tuple
 
@@ -63,9 +62,9 @@ from source_amazon_seller_partner.streams import (
     SellerFeedbackReports,
     StrandedInventoryUiReport,
     VendorDirectFulfillmentShipping,
-    VendorInventoryReports,
     VendorForecastingFreshReport,
     VendorForecastingRetailReport,
+    VendorInventoryReports,
     VendorOrders,
     VendorSalesReports,
     VendorTrafficReport,

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/source.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/source.py
@@ -64,6 +64,8 @@ from source_amazon_seller_partner.streams import (
     StrandedInventoryUiReport,
     VendorDirectFulfillmentShipping,
     VendorInventoryReports,
+    VendorForecastingFreshReport,
+    VendorForecastingRetailReport,
     VendorOrders,
     VendorSalesReports,
     VendorTrafficReport,
@@ -184,6 +186,8 @@ class SourceAmazonSellerPartner(AbstractSource):
             LedgerSummaryViewReport,
             FbaReimbursementsReports,
             VendorOrders,
+            VendorForecastingFreshReport,
+            VendorForecastingRetailReport,
         ]
 
         # TODO: Remove after Brand Analytics will be enabled in CLOUD: https://github.com/airbytehq/airbyte/issues/32353

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
@@ -409,13 +409,13 @@ class ReportsAmazonSPStream(HttpStream, ABC):
                 logging.error(f"Failed to retrieve the report result document for stream '{self.name}'. Exception: {e}")
                 error_response = "Failed to retrieve the report result document."
 
-            raise AirbyteTracedException(
-                internal_message=(
-                    f"Failed to retrieve the report '{self.name}' for period "
-                    f"{stream_slice['dataStartTime']}-{stream_slice['dataEndTime']}. "
+            exception_message = f"Failed to retrieve the report '{self.name}'"
+            if stream_slice and "dataStartTime" in stream_slice:
+                exception_message += (
+                    f" for period {stream_slice['dataStartTime']}-{stream_slice['dataEndTime']}. "
                     f"This will be read during the next sync. Error: {error_response}"
                 )
-            )
+            raise AirbyteTracedException(internal_message=exception_message)
         elif processing_status == ReportProcessingStatus.CANCELLED:
             logger.warning(f"The report for stream '{self.name}' was cancelled or there is no data to return.")
         else:

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
@@ -891,6 +891,52 @@ class VendorSalesReports(IncrementalAnalyticsStream):
     availability_sla_days = 4  # Data is only available after 4 days
 
 
+class VendorForecastingReport(AnalyticsStream, ABC):
+    """
+    Field definitions:
+    https://github.com/amzn/selling-partner-api-models/blob/main/schemas/reports/vendorForecastingReport.json
+    Docs: https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports
+    """
+
+    result_key = "forecastByAsin"
+
+    @property
+    @abstractmethod
+    def selling_program(self) -> str:
+        pass
+
+    @property
+    def name(self) -> str:
+        return f"GET_VENDOR_FORECASTING_{self.selling_program}_REPORT"
+
+    def stream_slices(
+        self, sync_mode: SyncMode, cursor_field: List[str] = None, stream_state: Mapping[str, Any] = None
+    ) -> Iterable[Optional[Mapping[str, Any]]]:
+        return [None]
+
+    def _report_data(
+        self,
+        sync_mode: SyncMode,
+        cursor_field: List[str] = None,
+        stream_slice: Mapping[str, Any] = None,
+        stream_state: Mapping[str, Any] = None,
+    ) -> Mapping[str, Any]:
+        # This report supports the `sellingProgram` parameter only
+        return {
+            "reportType": "GET_VENDOR_FORECASTING_REPORT",
+            "marketplaceIds": [self.marketplace_id],
+            "reportOptions": {"sellingProgram": self.selling_program},
+        }
+
+
+class VendorForecastingFreshReport(VendorForecastingReport):
+    selling_program = "FRESH"
+
+
+class VendorForecastingRetailReport(VendorForecastingReport):
+    selling_program = "RETAIL"
+
+
 class SellerFeedbackReports(IncrementalReportsAmazonSPStream):
     """
     Field definitions: https://sellercentral.amazon.com/help/hub/reference/G202125660

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/integration/test_report_based_streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/integration/test_report_based_streams.py
@@ -4,6 +4,7 @@
 
 
 import gzip
+import json
 from http import HTTPStatus
 from typing import List, Optional
 
@@ -170,7 +171,6 @@ class TestFullRefresh:
     @HttpMocker()
     def test_given_report_when_read_then_return_records(self, stream_name: str, data_format: str, http_mocker: HttpMocker) -> None:
         mock_auth(http_mocker)
-
         http_mocker.post(_create_report_request(stream_name).build(), _create_report_response(_REPORT_ID))
         http_mocker.get(
             _check_report_status_request(_REPORT_ID).build(),
@@ -194,7 +194,6 @@ class TestFullRefresh:
         self, stream_name: str, data_format: str, http_mocker: HttpMocker
     ) -> None:
         mock_auth(http_mocker)
-
         http_mocker.post(_create_report_request(stream_name).build(), _create_report_response(_REPORT_ID))
         http_mocker.get(
             _check_report_status_request(_REPORT_ID).build(),
@@ -513,3 +512,313 @@ class TestIncremental:
         cursor_value_from_state_message = output.most_recent_state.get(stream_name, {}).get(cursor_field)
         cursor_value_from_latest_record = output.records[-1].record.data.get(cursor_field)
         assert cursor_value_from_state_message == cursor_value_from_latest_record
+
+
+@freezegun.freeze_time(NOW.isoformat())
+class TestVendorSalesReportsFullRefresh:
+    data_format = "json"
+    selling_program = ("RETAIL", "FRESH")
+
+    @staticmethod
+    def _read(stream_name: str, config_: ConfigBuilder, expecting_exception: bool = False) -> EntrypointOutput:
+        return read_output(
+            config_builder=config_,
+            stream_name=stream_name,
+            sync_mode=SyncMode.full_refresh,
+            expecting_exception=expecting_exception,
+        )
+
+    @staticmethod
+    def _get_stream_name(selling_program: str) -> str:
+        return f"GET_VENDOR_FORECASTING_{selling_program}_REPORT"
+
+    @staticmethod
+    def _get_report_request_body(selling_program: str) -> str:
+        return json.dumps(
+            {
+                "reportType": "GET_VENDOR_FORECASTING_REPORT",
+                "marketplaceIds": [MARKETPLACE_ID],
+                "reportOptions": {"sellingProgram": selling_program},
+            }
+        )
+
+    @pytest.mark.parametrize("selling_program", selling_program)
+    @HttpMocker()
+    def test_given_report_when_read_then_return_records(self, selling_program: str, http_mocker: HttpMocker) -> None:
+        mock_auth(http_mocker)
+        stream_name = self._get_stream_name(selling_program)
+        create_report_request_body = self._get_report_request_body(selling_program)
+        http_mocker.post(
+            _create_report_request(stream_name).with_body(create_report_request_body).build(),
+            _create_report_response(_REPORT_ID),
+        )
+        http_mocker.get(
+            _check_report_status_request(_REPORT_ID).build(),
+            _check_report_status_response(stream_name, report_document_id=_REPORT_DOCUMENT_ID),
+        )
+        http_mocker.get(
+            _get_document_download_url_request(_REPORT_DOCUMENT_ID).build(),
+            _get_document_download_url_response(_DOCUMENT_DOWNLOAD_URL, _REPORT_DOCUMENT_ID),
+        )
+        http_mocker.get(
+            _download_document_request(_DOCUMENT_DOWNLOAD_URL).build(),
+            _download_document_response(stream_name, data_format=self.data_format),
+        )
+
+        output = self._read(stream_name, config())
+        assert len(output.records) == DEFAULT_EXPECTED_NUMBER_OF_RECORDS
+
+    @pytest.mark.parametrize("selling_program", selling_program)
+    @HttpMocker()
+    def test_given_compressed_report_when_read_then_return_records(
+        self, selling_program: str, http_mocker: HttpMocker
+    ) -> None:
+        mock_auth(http_mocker)
+        stream_name = self._get_stream_name(selling_program)
+        create_report_request_body = self._get_report_request_body(selling_program)
+        http_mocker.post(
+            _create_report_request(stream_name).with_body(create_report_request_body).build(),
+            _create_report_response(_REPORT_ID),
+        )
+        http_mocker.get(
+            _check_report_status_request(_REPORT_ID).build(),
+            _check_report_status_response(stream_name, report_document_id=_REPORT_DOCUMENT_ID),
+        )
+        http_mocker.get(
+            _get_document_download_url_request(_REPORT_DOCUMENT_ID).build(),
+            _get_document_download_url_response(_DOCUMENT_DOWNLOAD_URL, _REPORT_DOCUMENT_ID, compressed=True),
+        )
+
+        # a workaround to pass compressed document to the mocked response
+        document_request = _download_document_request(_DOCUMENT_DOWNLOAD_URL).build()
+        document_response = _download_document_response(stream_name, data_format=self.data_format, compressed=True)
+        document_request_matcher = HttpRequestMatcher(document_request, minimum_number_of_expected_match=1)
+        http_mocker._matchers.append(document_request_matcher)
+
+        http_mocker._mocker.get(
+            requests_mock.ANY,
+            additional_matcher=http_mocker._matches_wrapper(document_request_matcher),
+            response_list=[{"content": document_response.body, "status_code": document_response.status_code}],
+        )
+
+        output = self._read(stream_name, config())
+        assert len(output.records) == DEFAULT_EXPECTED_NUMBER_OF_RECORDS
+
+    @pytest.mark.parametrize("selling_program", selling_program)
+    @HttpMocker()
+    def test_given_http_status_500_then_200_when_create_report_then_retry_and_return_records(
+        self, selling_program: str, http_mocker: HttpMocker
+    ) -> None:
+        mock_auth(http_mocker)
+        stream_name = self._get_stream_name(selling_program)
+        create_report_request_body = self._get_report_request_body(selling_program)
+        http_mocker.post(
+            _create_report_request(stream_name).with_body(create_report_request_body).build(),
+            [response_with_status(status_code=HTTPStatus.INTERNAL_SERVER_ERROR), _create_report_response(_REPORT_ID)],
+        )
+        http_mocker.get(
+            _check_report_status_request(_REPORT_ID).build(),
+            _check_report_status_response(stream_name, report_document_id=_REPORT_DOCUMENT_ID),
+        )
+        http_mocker.get(
+            _get_document_download_url_request(_REPORT_DOCUMENT_ID).build(),
+            _get_document_download_url_response(_DOCUMENT_DOWNLOAD_URL, _REPORT_DOCUMENT_ID),
+        )
+        http_mocker.get(
+            _download_document_request(_DOCUMENT_DOWNLOAD_URL).build(),
+            _download_document_response(stream_name, data_format=self.data_format),
+        )
+
+        output = self._read(stream_name, config())
+        assert len(output.records) == DEFAULT_EXPECTED_NUMBER_OF_RECORDS
+
+    @pytest.mark.parametrize("selling_program", selling_program)
+    @HttpMocker()
+    def test_given_http_status_500_then_200_when_retrieve_report_then_retry_and_return_records(
+        self, selling_program: str, http_mocker: HttpMocker
+    ) -> None:
+        mock_auth(http_mocker)
+        stream_name = self._get_stream_name(selling_program)
+        create_report_request_body = self._get_report_request_body(selling_program)
+        http_mocker.post(
+            _create_report_request(stream_name).with_body(create_report_request_body).build(),
+            _create_report_response(_REPORT_ID),
+        )
+        http_mocker.get(
+            _check_report_status_request(_REPORT_ID).build(),
+            [
+                response_with_status(status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+                _check_report_status_response(stream_name, report_document_id=_REPORT_DOCUMENT_ID),
+            ],
+        )
+        http_mocker.get(
+            _get_document_download_url_request(_REPORT_DOCUMENT_ID).build(),
+            _get_document_download_url_response(_DOCUMENT_DOWNLOAD_URL, _REPORT_DOCUMENT_ID),
+        )
+        http_mocker.get(
+            _download_document_request(_DOCUMENT_DOWNLOAD_URL).build(),
+            _download_document_response(stream_name, data_format=self.data_format),
+        )
+
+        output = self._read(stream_name, config())
+        assert len(output.records) == DEFAULT_EXPECTED_NUMBER_OF_RECORDS
+
+    @pytest.mark.parametrize("selling_program", selling_program)
+    @HttpMocker()
+    def test_given_http_status_500_then_200_when_get_document_url_then_retry_and_return_records(
+        self, selling_program: str, http_mocker: HttpMocker
+    ) -> None:
+        mock_auth(http_mocker)
+        stream_name = self._get_stream_name(selling_program)
+        create_report_request_body = self._get_report_request_body(selling_program)
+        http_mocker.post(
+            _create_report_request(stream_name).with_body(create_report_request_body).build(),
+            _create_report_response(_REPORT_ID),
+        )
+        http_mocker.get(
+            _check_report_status_request(_REPORT_ID).build(),
+            _check_report_status_response(stream_name, report_document_id=_REPORT_DOCUMENT_ID),
+        )
+        http_mocker.get(
+            _get_document_download_url_request(_REPORT_DOCUMENT_ID).build(),
+            [
+                response_with_status(status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+                _get_document_download_url_response(_DOCUMENT_DOWNLOAD_URL, _REPORT_DOCUMENT_ID),
+            ],
+        )
+        http_mocker.get(
+            _download_document_request(_DOCUMENT_DOWNLOAD_URL).build(),
+            _download_document_response(stream_name, data_format=self.data_format),
+        )
+
+        output = self._read(stream_name, config())
+        assert len(output.records) == DEFAULT_EXPECTED_NUMBER_OF_RECORDS
+
+    @pytest.mark.parametrize("selling_program", selling_program)
+    @HttpMocker()
+    def test_given_http_status_500_then_200_when_download_document_then_retry_and_return_records(
+        self, selling_program: str, http_mocker: HttpMocker
+    ) -> None:
+        mock_auth(http_mocker)
+        stream_name = self._get_stream_name(selling_program)
+        create_report_request_body = self._get_report_request_body(selling_program)
+        http_mocker.post(
+            _create_report_request(stream_name).with_body(create_report_request_body).build(),
+            _create_report_response(_REPORT_ID),
+        )
+        http_mocker.get(
+            _check_report_status_request(_REPORT_ID).build(),
+            _check_report_status_response(stream_name, report_document_id=_REPORT_DOCUMENT_ID),
+        )
+        http_mocker.get(
+            _get_document_download_url_request(_REPORT_DOCUMENT_ID).build(),
+            _get_document_download_url_response(_DOCUMENT_DOWNLOAD_URL, _REPORT_DOCUMENT_ID),
+        )
+        http_mocker.get(
+            _download_document_request(_DOCUMENT_DOWNLOAD_URL).build(),
+            [
+                response_with_status(status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+                _download_document_response(stream_name, data_format=self.data_format),
+            ],
+        )
+
+        output = self._read(stream_name, config())
+        assert len(output.records) == DEFAULT_EXPECTED_NUMBER_OF_RECORDS
+
+    @pytest.mark.parametrize("selling_program", selling_program)
+    @HttpMocker()
+    def test_given_report_access_forbidden_when_read_then_no_records_and_error_logged(
+        self, selling_program: str, http_mocker: HttpMocker
+    ) -> None:
+        mock_auth(http_mocker)
+        stream_name = self._get_stream_name(selling_program)
+        create_report_request_body = self._get_report_request_body(selling_program)
+        http_mocker.post(
+            _create_report_request(stream_name).with_body(create_report_request_body).build(),
+            response_with_status(status_code=HTTPStatus.FORBIDDEN),
+        )
+
+        output = self._read(stream_name, config())
+        message_on_access_forbidden = (
+            "This is most likely due to insufficient permissions on the credentials in use. "
+            "Try to grant required permissions/scopes or re-authenticate."
+        )
+        assert_message_in_log_output(message_on_access_forbidden, output)
+        assert len(output.records) == 0
+
+    @pytest.mark.parametrize("selling_program", selling_program)
+    @HttpMocker()
+    def test_given_report_status_cancelled_when_read_then_stream_completed_successfully_and_warn_about_cancellation(
+        self, selling_program: str, http_mocker: HttpMocker
+    ) -> None:
+        mock_auth(http_mocker)
+        stream_name = self._get_stream_name(selling_program)
+        create_report_request_body = self._get_report_request_body(selling_program)
+        http_mocker.post(
+            _create_report_request(stream_name).with_body(create_report_request_body).build(),
+            _create_report_response(_REPORT_ID),
+        )
+        http_mocker.get(
+            _check_report_status_request(_REPORT_ID).build(),
+            _check_report_status_response(stream_name, processing_status=ReportProcessingStatus.CANCELLED),
+        )
+
+        message_on_report_cancelled = f"The report for stream '{stream_name}' was cancelled or there is no data to return."
+
+        output = self._read(stream_name, config())
+        assert_message_in_log_output(message_on_report_cancelled, output)
+        assert len(output.records) == 0
+
+    @pytest.mark.parametrize("selling_program", selling_program)
+    @HttpMocker()
+    def test_given_report_status_fatal_when_read_then_exception_raised(
+        self, selling_program: str, http_mocker: HttpMocker
+    ) -> None:
+        mock_auth(http_mocker)
+        stream_name = self._get_stream_name(selling_program)
+        create_report_request_body = self._get_report_request_body(selling_program)
+        http_mocker.post(
+            _create_report_request(stream_name).with_body(create_report_request_body).build(),
+            _create_report_response(_REPORT_ID),
+        )
+        http_mocker.get(
+            _check_report_status_request(_REPORT_ID).build(),
+            _check_report_status_response(
+                stream_name, processing_status=ReportProcessingStatus.FATAL, report_document_id=_REPORT_DOCUMENT_ID
+            ),
+        )
+
+        http_mocker.get(
+            _get_document_download_url_request(_REPORT_DOCUMENT_ID).build(),
+            _get_document_download_url_response(_DOCUMENT_DOWNLOAD_URL, _REPORT_DOCUMENT_ID),
+        )
+        http_mocker.get(
+            _download_document_request(_DOCUMENT_DOWNLOAD_URL).build(),
+            [
+                response_with_status(status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+                _download_document_error_response(),
+            ],
+        )
+
+        output = self._read(stream_name, config(), expecting_exception=True)
+        assert output.errors[-1].trace.error.failure_type == FailureType.config_error
+        assert f"Failed to retrieve the report '{stream_name}'" in output.errors[-1].trace.error.message
+
+    @pytest.mark.parametrize("selling_program", selling_program)
+    @HttpMocker()
+    def test_given_http_error_500_on_create_report_when_read_then_no_records_and_error_logged(
+        self, selling_program: str, http_mocker: HttpMocker
+    ) -> None:
+        mock_auth(http_mocker)
+        stream_name = self._get_stream_name(selling_program)
+        create_report_request_body = self._get_report_request_body(selling_program)
+        http_mocker.post(
+            _create_report_request(stream_name).with_body(create_report_request_body).build(),
+            response_with_status(status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+        )
+
+        message_on_backoff_exception = f"The report for stream '{stream_name}' was cancelled due to several failed retry attempts."
+
+        output = self._read(stream_name, config())
+        assert_message_in_log_output(message_on_backoff_exception, output)
+        assert len(output.records) == 0

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/GET_VENDOR_FORECASTING_FRESH_REPORT.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/GET_VENDOR_FORECASTING_FRESH_REPORT.json
@@ -1,0 +1,31 @@
+{
+  "reportSpecification": {
+    "reportType": "GET_VENDOR_FORECASTING_REPORT",
+    "reportOptions": {
+      "sellingProgram": "FRESH"
+    },
+    "marketplaceIds": ["ATVPDKIKX0DER"]
+  },
+  "forecastByAsin": [
+    {
+      "forecastGenerationDate": "2021-06-06",
+      "asin": "B123456789",
+      "startDate": "2021-06-06",
+      "endDate": "2021-06-12",
+      "meanForecastUnits": 3.1,
+      "p70ForecastUnits": 3.9,
+      "p80ForecastUnits": 30.3,
+      "p90ForecastUnits": 300.7
+    },
+    {
+      "forecastGenerationDate": "2021-06-06",
+      "asin": "B123456789",
+      "startDate": "2021-06-13",
+      "endDate": "2021-06-19",
+      "meanForecastUnits": 3.1,
+      "p70ForecastUnits": 3.9,
+      "p80ForecastUnits": 30.3,
+      "p90ForecastUnits": 300.7
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/GET_VENDOR_FORECASTING_RETAIL_REPORT.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/GET_VENDOR_FORECASTING_RETAIL_REPORT.json
@@ -1,0 +1,31 @@
+{
+  "reportSpecification": {
+    "reportType": "GET_VENDOR_FORECASTING_REPORT",
+    "reportOptions": {
+      "sellingProgram": "RETAIL"
+    },
+    "marketplaceIds": ["ATVPDKIKX0DER"]
+  },
+  "forecastByAsin": [
+    {
+      "forecastGenerationDate": "2021-06-06",
+      "asin": "B123456789",
+      "startDate": "2021-06-06",
+      "endDate": "2021-06-12",
+      "meanForecastUnits": 3.1,
+      "p70ForecastUnits": 3.9,
+      "p80ForecastUnits": 30.3,
+      "p90ForecastUnits": 300.7
+    },
+    {
+      "forecastGenerationDate": "2021-06-06",
+      "asin": "B123456789",
+      "startDate": "2021-06-13",
+      "endDate": "2021-06-19",
+      "meanForecastUnits": 3.1,
+      "p70ForecastUnits": 3.9,
+      "p80ForecastUnits": 30.3,
+      "p90ForecastUnits": 300.7
+    }
+  ]
+}

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -135,10 +135,11 @@ The Amazon Seller Partner source connector supports the following [sync modes](h
 - [Unshipped Orders Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-order#order-reports) \(incremental\)
 - [Vendor Direct Fulfillment Shipping](https://developer-docs.amazon.com/sp-api/docs/vendor-direct-fulfillment-shipping-api-v1-reference) \(incremental\)
 - [Vendor Inventory Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(incremental\)
+- [Vendor Forecasting Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(incremental\)
+- [Vendor Orders](https://developer-docs.amazon.com/sp-api/docs/vendor-orders-api-v1-reference#get-vendorordersv1purchaseorders) \(incremental\)
 - [Vendor Sales Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(incremental\)
 - [Vendor Traffic Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(incremental\)
 - [XML Orders By Order Date Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-order#order-tracking-reports) \(incremental\)
-- [Vendor Orders](https://developer-docs.amazon.com/sp-api/docs/vendor-orders-api-v1-reference#get-vendorordersv1purchaseorders) \(incremental\)
 
 ## Report options
 

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -135,7 +135,7 @@ The Amazon Seller Partner source connector supports the following [sync modes](h
 - [Unshipped Orders Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-order#order-reports) \(incremental\)
 - [Vendor Direct Fulfillment Shipping](https://developer-docs.amazon.com/sp-api/docs/vendor-direct-fulfillment-shipping-api-v1-reference) \(incremental\)
 - [Vendor Inventory Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(incremental\)
-- [Vendor Forecasting Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(incremental\)
+- [Vendor Forecasting Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(full-refresh\)
 - [Vendor Orders](https://developer-docs.amazon.com/sp-api/docs/vendor-orders-api-v1-reference#get-vendorordersv1purchaseorders) \(incremental\)
 - [Vendor Sales Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(incremental\)
 - [Vendor Traffic Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(incremental\)
@@ -149,6 +149,9 @@ For the full list, refer to Amazon’s report type values [documentation](https:
 Certain report types have required parameters that must be defined.
 For `GET_AMAZON_FULFILLED_SHIPMENTS_DATA_GENERAL` and `GET_FLAT_FILE_RETURNS_DATA_BY_RETURN_DATE` streams maximum value for `period_in_days` 30 days and 60 days.
 So, for any value that exceeds the limit, the `period_in_days` will be automatically reduced to the limit for the stream.
+
+For the Vendor Forecasting Report, we have two streams - `GET_VENDOR_FORECASTING_FRESH_REPORT` and `GET_VENDOR_FORECASTING_RETAIL_REPORT` which use the same `GET_VENDOR_FORECASTING_REPORT` Amazon's report,
+but with different options for the `sellingProgram` parameter - `FRESH` and `RETAIL` respectively.
 
 ## Performance considerations
 
@@ -169,6 +172,7 @@ Information about rate limits you may find [here](https://developer-docs.amazon.
 
 | Version  | Date       | Pull Request                                                | Subject                                                                                                                                                                             |
 |:---------|:-----------|:------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `4.1.0`  | 2024-03-12 | [\#35954](https://github.com/airbytehq/airbyte/pull/35954)  | Add `GET_VENDOR_FORECASTING_FRESH_REPORT` and `GET_VENDOR_FORECASTING_RETAIL_REPORT` streams                                                                                        |
 | `4.0.0`  | 2024-02-23 | [\#35439](https://github.com/airbytehq/airbyte/pull/35439)  | Update schema for the `GET_FBA_STORAGE_FEE_CHARGES_DATA` stream                                                                                                                     |
 | `3.5.0`  | 2024-02-09 | [\#35331](https://github.com/airbytehq/airbyte/pull/35331)  | Fix check for Vendor accounts. Add failed report result message                                                                                                                     |
 | `3.4.0`  | 2024-02-15 | [\#35273](https://github.com/airbytehq/airbyte/pull/35273)  | Add `VendorOrders` stream                                                                                                                                                           |


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/oncall/issues/4397

## How
Add streams `GET_VENDOR_FORECASTING_FRESH_REPORT` and `GET_VENDOR_FORECASTING_RETAIL_REPORT` which take data from the [`VENDOR_FORECASTING_FRESH_REPORT`](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports)

## Recommended reading order
1. `streams.py`
2. `source.py`

## 🚨 User Impact 🚨
No

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>