### PR TITLE
Disable Google Workspace Admin Reports in registries

### DIFF
--- a/airbyte-integrations/connectors/source-google-workspace-admin-reports/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-workspace-admin-reports/metadata.yaml
@@ -16,9 +16,9 @@ data:
   registries:
     cloud:
       dockerImageTag: 0.1.4
-      enabled: true
+      enabled: false
     oss:
-      enabled: true
+      enabled: false
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-workspace-admin-reports
   tags:


### PR DESCRIPTION
Google Workspace Admin Reports is being archived due to emitting legacy state. This PR disables it in the registries so the code can be migrated to the archived-connectors repo. Once this PR is merged, #35967 will remove the connector code from the main repo.