### PR TITLE
[airbyte-cdk] entrypoint wrapper should use per-stream state not legacy format

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/test/entrypoint_wrapper.py
+++ b/airbyte-cdk/python/airbyte_cdk/test/entrypoint_wrapper.py
@@ -74,7 +74,7 @@ class EntrypointOutput:
         state_messages = self._get_message_by_types([Type.STATE])
         if not state_messages:
             raise ValueError("Can't provide most recent state as there are no state messages")
-        return state_messages[-1].state.data
+        return state_messages[-1].state.stream
 
     @property
     def logs(self) -> List[AirbyteMessage]:


### PR DESCRIPTION
After deprecating legacy state from the CDK, I didn't update the CDK mock server test wrapper to refer to the per-stream state format instead of deprecated legacy `data` field. This is blocking updating some of our concurrent connectors that have mocker server tests since we're asserting on a field that is no longer populated.