### PR TITLE
fix junit versionning mess

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,23 +145,24 @@ allprojects {
         testFixturesAnnotationProcessor lombok
 
         // JUnit dependencies.
-        def vAssertJ = "3.21.0"
-        def vJUnit = "5.9.1"
-        def vJUnitJupiter = "5.10.0"
-        def vJUnitPioneer = "1.7.1"
+        def vAssertJ = "3.25.3"
+        def vJUnit = "5.10.2"
+        def vJUnitJupiter = "5.11.0"
 
+
+        testFixturesImplementation platform("org.junit:junit-bom:${vJUnit}")
         testFixturesImplementation "org.junit.jupiter:junit-jupiter-api:${vJUnit}"
         testFixturesImplementation "org.junit.jupiter:junit-jupiter-params:${vJUnit}"
         testFixturesImplementation "org.mockito:mockito-junit-jupiter:${vJUnitJupiter}"
         testFixturesImplementation "org.assertj:assertj-core:${vAssertJ}"
-        testFixturesImplementation "org.junit-pioneer:junit-pioneer:${vJUnitPioneer}"
 
+        testImplementation platform("org.junit:junit-bom:${vJUnit}")
         testImplementation "org.junit.jupiter:junit-jupiter-api:${vJUnit}"
         testImplementation "org.junit.jupiter:junit-jupiter-params:${vJUnit}"
         testImplementation "org.mockito:mockito-junit-jupiter:${vJUnitJupiter}"
         testImplementation "org.assertj:assertj-core:${vAssertJ}"
-        testImplementation  "org.junit-pioneer:junit-pioneer:${vJUnitPioneer}"
 
+        testRuntimeOnly platform("org.junit:junit-bom:${vJUnit}")
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${vJUnit}"
 
         // Spotbugs dependencies.

--- a/deps.toml
+++ b/deps.toml
@@ -9,7 +9,7 @@ glassfish_version = "2.31"
 hikaricp = "5.0.1"
 jmh = "1.36"
 jooq = "3.13.4"
-junit-jupiter = "5.9.1"
+junit-bom = "5.10.1"
 kotlin = "1.9.0"
 log4j = "2.21.1"
 lombok = "1.18.30"
@@ -19,6 +19,7 @@ segment = "2.1.1"
 slf4j = "2.0.9"
 temporal = "1.17.0"
 debezium = "2.4.0.Final"
+mockito-version = "5.11.0"
 
 [libraries]
 airbyte-protocol = { module = "io.airbyte.airbyte-protocol:protocol-models", version.ref = "airbyte-protocol" }
@@ -70,11 +71,7 @@ jooq = { module = "org.jooq:jooq", version.ref = "jooq" }
 jooq-codegen = { module = "org.jooq:jooq-codegen", version.ref = "jooq" }
 jooq-meta = { module = "org.jooq:jooq-meta", version.ref = "jooq" }
 jul-to-slf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "slf4j" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
-junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
 junit-jupiter-system-stubs = { module = "uk.org.webcompere:system-stubs-jupiter", version = "2.0.1" }
-junit-pioneer = { module = "org.junit-pioneer:junit-pioneer", version = "1.7.1" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version = "5.1.0" }
 kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli", version = "0.3.5" }
 kotlinx-cli-jvm = { module = "org.jetbrains.kotlinx:kotlinx-cli-jvm", version = "0.3.5" }
@@ -87,7 +84,6 @@ log4j-over-slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "slf4j
 log4j-web = { module = "org.apache.logging.log4j:log4j-web", version.ref = "log4j" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 micrometer-statsd = { module = "io.micrometer:micrometer-registry-statsd", version = "1.9.3" }
-mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version = "5.10.0" }
 mockk = { module = "io.mockk:mockk", version = "1.13.3" }
 mongo-driver-sync = { module = "org.mongodb:mongodb-driver-sync", version = "4.10.2" }
 otel-bom = { module = "io.opentelemetry:opentelemetry-bom", version = "1.14.0" }
@@ -117,7 +113,6 @@ debezium-postgres = { module = "io.debezium:debezium-connector-postgres", versio
 apache = ["apache-commons", "apache-commons-lang"]
 datadog = ["datadog-trace-api", "datadog-trace-ot"]
 jackson = ["jackson-databind", "jackson-annotations", "jackson-dataformat", "jackson-datatype"]
-junit = ["junit-jupiter-api", "junit-jupiter-params", "mockito-junit-jupiter"]
 log4j = ["log4j-api", "log4j-core", "log4j-slf4j-impl", "log4j-slf4j2-impl", "log4j-web"]
 slf4j = ["jul-to-slf4j", "jcl-over-slf4j", "log4j-over-slf4j"]
 temporal = ["temporal-sdk", "temporal-serviceclient"]


### PR DESCRIPTION
When executing some tests, Gireesh ran into an IllegalAccessException. We tracked it down to one junit jar being 5.10.1, calling to a function that ended up being in 5.9.1, where it was still declared as private. Using the BOM mostly allows us to force upgrade of transitive dependencies that are declared in tha BOM (mostly, because sometimes, there's another BOM that declares another version, in which case we're stuck with different versions...)