### PR TITLE
Fix tab delimiter configuration in CSV file type

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/csv_format.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/csv_format.py
@@ -151,7 +151,7 @@ class CsvFormat(BaseModel):
     @validator("delimiter")
     def validate_delimiter(cls, v: str) -> str:
         if v == r"\t":
-            return v
+            v = "\t"
         if len(v) != 1:
             raise ValueError("delimiter should only be one character")
         if v in {"\r", "\n"}:

--- a/airbyte-cdk/python/unit_tests/sources/file_based/config/test_csv_format.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/config/test_csv_format.py
@@ -30,4 +30,5 @@ class CsvHeaderDefinitionTest(unittest.TestCase):
 
 class CsvDelimiterTest(unittest.TestCase):
     def test_tab_delimter(self):
-        assert CsvFormat(delimiter=r"\t").delimiter == '\\t'
+        assert CsvFormat(delimiter=r"\t").delimiter == '\t'
+        assert len(CsvFormat(delimiter=r"\t").delimiter) == 1


### PR DESCRIPTION
The tab delimiter is only allowed to be a single character long. In the web UI entering a literal tab character (`\t`) yields an escaped tab character (`\\t`) in the stored configuration. This ensures that the escaped tab character is passed through to the call for `csv.register_dialect` as the proper literal tab `\t`.

Run tests for #35901