### PR TITLE
Install Command Update, External Secret Management & Kubernetes Secrets

### DIFF
--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -69,7 +69,7 @@ kubectl create namespace airbyte
 
 ### Configure Kubernetes Secrets
 
-Sensitive credentials such as AWS access keys are required to be made available in Kubernetes Secrets during deployment. The Kubernetes secret store and secret keys are referenced in your `values.yml` file. We recommend ensuring all required secrets are configured before deploying Airbyte Self-Managed Enterprise.
+Sensitive credentials such as AWS access keys are required to be made available in Kubernetes Secrets during deployment. The Kubernetes secret store and secret keys are referenced in your `values.yml` file. Ensure all required secrets are configured before deploying Airbyte Self-Managed Enterprise.
 
 You may apply your Kubernetes secrets by applying the example manifests below to your cluster, or using `kubectl` directly. If your Kubernetes cluster already has permissions to make requests to an external entity via an instance profile, credentials are not required. For example, if your Amazon EKS cluster has been assigned a sufficient AWS IAM role to make requests to AWS S3, you do not need to specify access keys.
 

--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -553,10 +553,6 @@ airbyte-enterprise \
 airbyte/airbyte
 ```
 
-helm install --namespace airbyte --values ./airbyte.yml --set-file airbyteYml="./airbyte.yml" --set keycloak-setup.env_vars.KEYCLOAK_RESET_REALM=true  airbyte-enterprise airbyte/airbyte 
-
-The default release name is `airbyte-enterprise`. You can change this by modifying the above `helm upgrade` command.
-
 ## Updating Self-Managed Enterprise
 
 Upgrade Airbyte Self-Managed Enterprise by:


### PR DESCRIPTION
* updates install / update command
* adds section on aws secrets manager
* adds prerequisite sections on kubernetes secrets
* moves bucket policies to prerequisites
* documents `edition: enterprise`
* splits out license file (airbyte.yml) from values file

see here: https://airbyte-docs-git-alexcuoci-docs-cleanup-airbyte-growth.vercel.app/enterprise-setup/implementation-guide