### PR TITLE
gradle: add kotlin support in all projects, warnings as errors

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -1,8 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
-}
 
 final var cdkVersion = {
     var props = new Properties()
@@ -10,13 +5,9 @@ final var cdkVersion = {
     return props.getProperty('version', 'undefined')
 }()
 
-
-
 allprojects {
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
-    apply plugin: 'java-test-fixtures'
-    apply plugin: 'org.jetbrains.kotlin.jvm'
 
     group 'io.airbyte.cdk'
 
@@ -51,19 +42,6 @@ allprojects {
                     username System.getenv('CLOUDREPO_USER')
                     password System.getenv('CLOUDREPO_PASSWORD')
                 }
-            }
-        }
-
-        compileKotlin {
-            compilerOptions {
-                jvmTarget = JvmTarget.JVM_21
-                languageVersion = KotlinVersion.KOTLIN_1_9
-            }
-        }
-        compileTestKotlin {
-            compilerOptions {
-                jvmTarget = JvmTarget.JVM_21
-                languageVersion = KotlinVersion.KOTLIN_1_9
             }
         }
     }

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
@@ -26,6 +26,10 @@ jsonSchema2Pojo {
     includeSetters = true
 }
 
+tasks.register('generate').configure {
+    dependsOn tasks.named('generateJsonSchema2Pojo')
+}
+
 dependencies {
 
     implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/migrators/MinimumDestinationState.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/migrators/MinimumDestinationState.kt
@@ -40,6 +40,7 @@ interface MinimumDestinationState {
             return needsSoftReset
         }
 
+        @Suppress("UNCHECKED_CAST")
         override fun <T : MinimumDestinationState> withSoftReset(needsSoftReset: Boolean): T {
             return copy(needsSoftReset = true) as T
         }

--- a/airbyte-integrations/connectors/destination-bigquery/build.gradle
+++ b/airbyte-integrations/connectors/destination-bigquery/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'airbyte-java-connector'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
 }
 
 airbyteJavaConnector {

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'airbyte-java-connector'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
 }
 
 airbyteJavaConnector {

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'airbyte-java-connector'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
 }
 
 airbyteJavaConnector {

--- a/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresState.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresState.kt
@@ -11,6 +11,7 @@ data class PostgresState(val needsSoftReset: Boolean) : MinimumDestinationState 
         return needsSoftReset
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun <T : MinimumDestinationState> withSoftReset(needsSoftReset: Boolean): T {
         return copy(needsSoftReset = needsSoftReset) as T
     }

--- a/airbyte-integrations/connectors/destination-redshift/build.gradle
+++ b/airbyte-integrations/connectors/destination-redshift/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'application'
     id 'airbyte-java-connector'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
 }
 
 airbyteJavaConnector {

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/typing_deduping/RedshiftState.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/typing_deduping/RedshiftState.kt
@@ -11,6 +11,7 @@ data class RedshiftState(val needsSoftReset: Boolean) : MinimumDestinationState 
         return needsSoftReset
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun <T : MinimumDestinationState> withSoftReset(needsSoftReset: Boolean): T {
         return copy(needsSoftReset = needsSoftReset) as T
     }

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'airbyte-java-connector'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
 }
 
 airbyteJavaConnector {

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/migrations/SnowflakeState.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/migrations/SnowflakeState.kt
@@ -13,6 +13,7 @@ data class SnowflakeState(val needsSoftReset: Boolean) : MinimumDestinationState
         return needsSoftReset
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun <T : MinimumDestinationState> withSoftReset(needsSoftReset: Boolean): T {
         return copy(needsSoftReset = needsSoftReset) as T
     }

--- a/airbyte-integrations/connectors/source-mongodb-v2/build.gradle
+++ b/airbyte-integrations/connectors/source-mongodb-v2/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'airbyte-java-connector'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
 }
 
 airbyteJavaConnector {

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
 import com.github.spotbugs.snom.Confidence
 import com.github.spotbugs.snom.Effort
 import com.github.spotbugs.snom.SpotBugsTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     id 'base'
-    id 'com.github.spotbugs' version '6.0.7'
+    id 'com.github.spotbugs' version '6.0.7' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.9.22' apply false
 }
 
 allprojects {
@@ -12,6 +15,7 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'java-test-fixtures'
     apply plugin: 'com.github.spotbugs'
+    apply plugin: 'org.jetbrains.kotlin.jvm'
 
     // By default gradle uses directory as the project name. That works very well in a single project environment but
     // projects clobber each other in an environments with subprojects when projects are in directories named identically.
@@ -55,6 +59,40 @@ allprojects {
         compileTestFixturesJava {
             //rawtypes and unchecked are necessary for mockito
             options.compilerArgs += ["-Werror", "-Xlint:all,-serial,-processing,-rawtypes,-unchecked"]
+        }
+    }
+
+    compileKotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_21
+            languageVersion = KotlinVersion.KOTLIN_1_9
+            allWarningsAsErrors = true
+            freeCompilerArgs = ["-Xjvm-default=all"]
+        }
+        dependsOn {
+            tasks.matching { it.name == 'generate' }
+        }
+    }
+    compileTestKotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_21
+            languageVersion = KotlinVersion.KOTLIN_1_9
+            allWarningsAsErrors = true
+            freeCompilerArgs = ["-Xjvm-default=all"]
+        }
+        dependsOn {
+            tasks.matching { it.name == 'generate' }
+        }
+    }
+    compileTestFixturesKotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_21
+            languageVersion = KotlinVersion.KOTLIN_1_9
+            allWarningsAsErrors = true
+            freeCompilerArgs = ["-Xjvm-default=all"]
+        }
+        dependsOn {
+            tasks.matching { it.name == 'generate' }
         }
     }
 


### PR DESCRIPTION
Gradle sometimes whines that the kotlin plugin is being applied separately in the java cdk and in the connectors and that bad things might happen. This PR fixes this to make for a good clean build. 

The kotlin compiler is set up slightly differently to before:
- `-Xjvm-default=all` allows compiling concrete methods in kotlin interfaces as default methods in java interfaces; this is useful for java interop.
- `allWarningsAsErrors = true` makes the compilation fail on warnings just like we do for java.
- Support test fixtures.

This required adding a few annotations in some connectors. None of these changes warrant a CDK or a connector release.