### PR TITLE
java CDK: add static deserialize*(byte[]) methods to Jsons

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/java/io/airbyte/commons/json/Jsons.java
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/java/io/airbyte/commons/json/Jsons.java
@@ -117,6 +117,22 @@ public class Jsons {
     }
   }
 
+  public static JsonNode deserialize(final byte[] jsonBytes) {
+    try {
+      return OBJECT_MAPPER.readTree(jsonBytes);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static JsonNode deserializeExact(final byte[] jsonBytes) {
+    try {
+      return OBJECT_MAPPER_EXACT.readTree(jsonBytes);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   public static <T> Optional<T> tryDeserialize(final String jsonString, final Class<T> klass) {
     try {
       return Optional.of(OBJECT_MAPPER.readValue(jsonString, klass));


### PR DESCRIPTION
These aren't used anywhere in this PR stack, but it's dumb that these methods don't exist. I want to ship this change in this PR stack's CDK release.