### PR TITLE
java-cdk: prettier gradle dependency ordering

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
@@ -17,12 +17,12 @@ dependencies {
 
     implementation 'io.aesy:datasize:1.0.0'
 
-    testImplementation project(':airbyte-cdk:java:airbyte-cdk:typing-deduping')
-
     testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
     testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:dependencies'))
     testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:core')
     testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
     testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:typing-deduping')
     testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:typing-deduping'))
+
+    testImplementation project(':airbyte-cdk:java:airbyte-cdk:typing-deduping')
 }

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
@@ -30,8 +30,6 @@ dependencies {
     api 'org.apache.parquet:parquet-avro:1.13.1'
     runtimeOnly 'com.hadoop.gplcompression:hadoop-lzo:0.4.20'
 
-    testImplementation 'org.mockito:mockito-inline:5.2.0'
-
     testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:dependencies')
     testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:dependencies'))
     testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:core')
@@ -40,4 +38,6 @@ dependencies {
     testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:typing-deduping'))
     testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:db-destinations')
     testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:db-destinations'))
+
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
 }


### PR DESCRIPTION
This just moves stuff around and doesn't functionally change anything at all.