### PR TITLE
✨ [source-file] implement support for HTTP and FTP protocols

### DIFF
--- a/airbyte-integrations/connectors/source-file/source_file/spec.json
+++ b/airbyte-integrations/connectors/source-file/source_file/spec.json
@@ -72,6 +72,22 @@
             }
           },
           {
+            "title": "HTTP: Public Web",
+            "required": ["storage"],
+            "properties": {
+              "storage": {
+                "type": "string",
+                "const": "HTTP"
+              },
+              "user_agent": {
+                "type": "boolean",
+                "title": "User-Agent",
+                "default": false,
+                "description": "Add User-Agent to request"
+              }
+            }
+          },
+          {
             "title": "GCS: Google Cloud Storage",
             "required": ["storage"],
             "properties": {
@@ -234,6 +250,17 @@
                 "title": "Port",
                 "default": "22",
                 "description": ""
+              }
+            }
+          },
+          {
+            "title": "FTP: Anonymous File Transfer Protocol",
+            "required": ["storage"],
+            "properties": {
+              "storage": {
+                "type": "string",
+                "title": "Storage",
+                "const": "FTP"
               }
             }
           },


### PR DESCRIPTION
### Background
The Airbyte Files source connector currently does not support accessing files via the HTTP and FTP protocols.

### Suggested Changes
Support for the HTTP and FTP `storage` parameters was added to `source_file/spec.json` and the retrieval of files from anonymous FTP servers was implemented in `source_file/client.py`.