### PR TITLE
Docs (PyAirbyte): Add pyairbyte telemetry information and top-level `/telemetry` docs redirect

### DIFF
--- a/docs/operator-guides/telemetry.md
+++ b/docs/operator-guides/telemetry.md
@@ -32,7 +32,7 @@ Also check our [privacy policy](https://airbyte.com/privacy-policy) for more det
     usage data is collected, along with a link to this page for more information.
 
     Anonymous usage tracking ("telemetry") helps us understand how PyAirbyte is being used,
-    including which connectors are working well, which connectors are frequently failing. This helps
+    including which connectors are working well and which connectors are frequently failing. This helps
     us to prioritize product improvements which benefit users of PyAirbyte as well as Airbyte Cloud,
     OSS, and Enterprise.
 

--- a/docs/operator-guides/telemetry.md
+++ b/docs/operator-guides/telemetry.md
@@ -27,4 +27,20 @@ Also check our [privacy policy](https://airbyte.com/privacy-policy) for more det
 
     Server side telemetry collection can't be changed using Airbyte Cloud.
   </TabItem>
+  <TabItem value="pyairbyte" label="PyAirbyte">
+    When running [PyAirbyte](https://docs.airbyte.com/pyairbyte) for the first time on a new machine, you'll be informed that anonymous
+    usage data is collected, along with a link to this page for more information.
+
+    Anonymous usage tracking ("telemetry") helps us understand how PyAirbyte is being used,
+    including which connectors are working well, which connectors are frequently failing. This helps
+    us to prioritize product improvements which benefit users of PyAirbyte as well as Airbyte Cloud,
+    OSS, and Enterprise.
+
+    We will _never_ collect any information which could be considered PII (personally identifiable
+    information) or sensitive data. We _do not_ collect IP addresses, hostnames, or any other
+    information that could be used to identify you or your organization.
+
+    You can opt-out of anonymous usage reporting by setting the environment variable `DO_NOT_TRACK`
+    to any value.
+  </TabItem>
 </Tabs>

--- a/docusaurus/redirects.yml
+++ b/docusaurus/redirects.yml
@@ -96,3 +96,6 @@
 - from:
     - /pyairbyte
   to: /using-airbyte/pyairbyte/getting-started
+- from:
+    - /telemetry
+  to: /operator-guides/telemetry


### PR DESCRIPTION
This PR adds PyAirbyte to the `telemetry` landing page. It also adds a redirect so that `http://docs.airbyte.com/telemetry` will redirect automatically to `https://docs.airbyte.com/operator-guides/telemetry`

Pairs with the URL fix in the LangChain Telemetry PR:

- https://github.com/airbytehq/PyAirbyte/pull/125
