### PR TITLE
🐛 Source Orb: fix window request for `credit_ledger_entries`

### DIFF
--- a/airbyte-integrations/connectors/source-orb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orb/metadata.yaml
@@ -4,7 +4,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 7f0455fb-4518-4ec0-b7a3-d808bf8081cc
-  dockerImageTag: 1.1.1
+  dockerImageTag: 1.1.2
   dockerRepository: airbyte/source-orb
   githubIssueLabel: source-orb
   icon: orb.svg

--- a/airbyte-integrations/connectors/source-orb/pyproject.toml
+++ b/airbyte-integrations/connectors/source-orb/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.1.1"
+version = "1.1.2"
 name = "source-orb"
 description = "Source implementation for Orb."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/orb.md
+++ b/docs/integrations/sources/orb.md
@@ -38,6 +38,10 @@ In order to capture data that has been updated after creation, please run a peri
 
 The Orb connector should not run into Orb API limitations under normal usage. Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
 
+:::warning
+The `credit_ledger_entries` stream will now include `events` data. This upgrade uses the `created_at` timestamps from the `credits` to establish a 30-day timeframe, with the earliest `created_at` as the starting point. This restriction is set by the Orb API.
+:::
+
 ## Getting started
 
 ### Requirements
@@ -54,6 +58,7 @@ an Orb Account and API Key.
 
 | Version | Date       | Pull Request                                             | Subject |
 | --- |------------|----------------------------------------------------------| --- |
+| 1.1.2 | 2024-03-13 | [x](https://github.com/airbytehq/airbyte/pull/x)         | Fix window to 30 days for events query timesframe start and query |
 | 1.1.1 | 2024-02-07 | [35005](https://github.com/airbytehq/airbyte/pull/35005) | Pass timeframe_start, timeframe_end to events query |
 | 1.1.0 | 2023-03-03 | [24567](https://github.com/airbytehq/airbyte/pull/24567) | Add Invoices incremental stream merged from [#24737](https://github.com/airbytehq/airbyte/pull/24737) |
 | 1.0.0 | 2023-02-02 | [21951](https://github.com/airbytehq/airbyte/pull/21951) | Add SubscriptionUsage stream, and made `start_date` a required field |


### PR DESCRIPTION
Fix `credit_ledger_entries` previous version was building request with larger than 30 days. As the Orb API throws errors for these request:
> “Cannot search for events in a time range greater than 30 days.”

Now the connector will create a fixed-window of 30 days based on the `created_at` field inside the `credit_ledger_entry` record, our best shot to get data from the event.

I was able to run a mock test using a single customer and also I added more information whatever the code fails now giving better idea what need to be improved.