### PR TITLE
fix connector changelogs

### DIFF
--- a/docs/integrations/destinations/astra.md
+++ b/docs/integrations/destinations/astra.md
@@ -36,6 +36,7 @@ This page contains the setup guide and reference information for the destination
 | Incremental - Append + Deduped | Yes                  |       |
 
 ## Changelog
+
 | Version | Date       | Pull Request                                             | Subject                     |
 | :------ | :--------- | :------------------------------------------------------- | :-------------------------- |
 | 0.1.1   | 2024-01-26 |                                                          | DS Branding Update          |

--- a/docs/integrations/sources/adjust.md
+++ b/docs/integrations/sources/adjust.md
@@ -36,6 +36,6 @@ The source connector supports the following [sync modes](https://docs.airbyte.co
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Description      |
+| Version | Date       | Pull Request                                             | Subject          |
 |---------|------------|----------------------------------------------------------|------------------|
 | 0.1.0   | 2022-08-26 | [16051](https://github.com/airbytehq/airbyte/pull/16051) | Initial version. |

--- a/docs/integrations/sources/commcare.md
+++ b/docs/integrations/sources/commcare.md
@@ -36,4 +36,5 @@ The Commcare source connector supports the following streams:
 ## Changelog
 
 | Version | Date | Pull Request | Subject |
+|---------|------|--------------|---------|
 | 0.1.0   | 2022-11-08 | [20220](https://github.com/airbytehq/airbyte/pull/20220)   | Commcare Source Connector |

--- a/docs/integrations/sources/e2e-test-cloud.md
+++ b/docs/integrations/sources/e2e-test-cloud.md
@@ -28,9 +28,9 @@ Here is its configuration:
 
 The OSS and Cloud variants have the same version number. The Cloud variant was initially released at version `1.0.0`.
 
-| Version | Date       | Pull request                                             | Notes                                               |
+| Version | Date       | Pull request                                             | Subject                                             |
 |---------|------------|----------------------------------------------------------|-----------------------------------------------------|
-| 2.2.1   | 2024-02-13 | [35231](https://github.com/airbytehq/airbyte/pull/35231)           | Adopt JDK 0.20.4.                                                                                     |
+| 2.2.1   | 2024-02-13 | [35231](https://github.com/airbytehq/airbyte/pull/35231) | Adopt JDK 0.20.4.                                   |
 | 2.1.5   | 2023-10-06 | [31092](https://github.com/airbytehq/airbyte/pull/31092) | Bring in changes from oss                           |
 | 2.1.4   | 2023-03-01 | [23656](https://github.com/airbytehq/airbyte/pull/23656) | Fix inheritance between e2e-test and e2e-test-cloud |
 | 0.1.0   | 2021-07-23 | [9720](https://github.com/airbytehq/airbyte/pull/9720)   | Initial release.                                    |

--- a/docs/integrations/sources/e2e-test.md
+++ b/docs/integrations/sources/e2e-test.md
@@ -70,7 +70,7 @@ This mode is also excluded from the Cloud variant of this connector.
 
 The OSS and Cloud variants have the same version number. The Cloud variant was initially released at version `1.0.0`.
 
-| Version | Date       | Pull request                                                       | Notes                                                                                                 |
+| Version | Date       | Pull request                                                       | Subject                                                                                               |
 |---------|------------| ------------------------------------------------------------------ |-------------------------------------------------------------------------------------------------------|
 | 2.2.1   | 2024-02-13 | [35231](https://github.com/airbytehq/airbyte/pull/35231)           | Adopt JDK 0.20.4.                                                                                     |
 | 2.2.0   | 2023-12-18 | [33485](https://github.com/airbytehq/airbyte/pull/33485)           | Remove LEGACY state                                                                                   |

--- a/docs/integrations/sources/genesys.md
+++ b/docs/integrations/sources/genesys.md
@@ -22,6 +22,7 @@ You can follow the documentation on [API credentials](https://developer.genesys.
 - [Users](https://developer.genesys.cloud/useragentman/users/)
 
 ## Changelog
+
 | Version | Date       | Pull Request                                             | Subject                     |
 | :------ | :--------- | :------------------------------------------------------- | :-------------------------- |
 | 0.1.1   | 2023-04-27 | [25598](https://github.com/airbytehq/airbyte/pull/25598) | Use region specific API server |

--- a/docs/integrations/sources/ip2whois.md
+++ b/docs/integrations/sources/ip2whois.md
@@ -28,6 +28,7 @@ Ip2whois APIs allows you to query up to 500 WHOIS domain name per month.
 
 
 ## Changelog
+
 | Version | Date       | Pull Request                                              | Subject                                    |
 | :------ | :--------- | :-------------------------------------------------------- | :----------------------------------------- |
 | 0.1.0   | 2022-10-29 | [#18651](https://github.com/airbytehq/airbyte/pull/18651) | 🎉 New source: Ip2whois [low-code SDK]|

--- a/docs/integrations/sources/kyriba.md
+++ b/docs/integrations/sources/kyriba.md
@@ -61,6 +61,7 @@ The Kyriba connector should not run into API limitations under normal usage. [Cr
 </details>
 
 ## Changelog
+
 | Version | Date       | Pull Request                                             | Subject                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------- |
 | 0.1.1   | 2024-01-30 | [34545](https://github.com/airbytehq/airbyte/pull/34545) | Updates CDK, Base image migration: remove Dockerfile and use the python-connector-base image                  |

--- a/docs/integrations/sources/kyve.md
+++ b/docs/integrations/sources/kyve.md
@@ -23,7 +23,7 @@ You can fetch with one source configuration more than one pool simultaneously. Y
 
 ## Changelog
 
-| Version | Date     | Subject                                             |
-| :------ |:---------|:----------------------------------------------------|
-| 0.1.0   | 25-05-23 |  Initial release of KYVE source connector            |
-| 0.2.0   | 10-11-23 | Update KYVE source to support to Mainnet and Testnet|
+| Version | Date     | Pull Request | Subject                                             |
+| :------ |:---------|:-------------|:----------------------------------------------------|
+| 0.2.0   | 2023-11-10 | | Update KYVE source to support to Mainnet and Testnet|
+| 0.1.0   | 2023-05-25 | | Initial release of KYVE source connector            |

--- a/docs/integrations/sources/rocket-chat.md
+++ b/docs/integrations/sources/rocket-chat.md
@@ -37,5 +37,5 @@ You need to setup a personal access token within the Rocket.chat workspace, see 
 ## Changelog
 
 | Version | Date       | Pull Request                                              | Subject                                       |
-| :-----* | :--------* | :-------------------------------------------------------* | :----------------------------------------*    |
+| :------ | :--------- | :-------------------------------------------------------- | :-----------------------------------------    |
 | 0.1.0   | 2022-10-29 | [#18635](https://github.com/airbytehq/airbyte/pull/18635) | 🎉 New Source: Rocket.chat API [low-code CDK] |

--- a/docs/integrations/sources/surveycto.md
+++ b/docs/integrations/sources/surveycto.md
@@ -48,6 +48,7 @@ The SurveyCTO source connector supports the following streams:
 ## Changelog
 
 | Version | Date | Pull Request | Subject |
+|---------|------|--------------|---------|
 | 0.1.2 | 2023-07-27 | [28512](https://github.com/airbytehq/airbyte/pull/28512) | Added Check Connection |
 | 0.1.1 | 2023-04-25 | [24784](https://github.com/airbytehq/airbyte/pull/24784) | Fix incremental sync |
 | 0.1.0 | 2022-11-16 | [19371](https://github.com/airbytehq/airbyte/pull/19371) | SurveyCTO Source Connector |

--- a/docs/integrations/sources/talkdesk-explore.md
+++ b/docs/integrations/sources/talkdesk-explore.md
@@ -64,5 +64,6 @@ Please refer to the [getting started with the API](https://docs.talkdesk.com/doc
 ## Changelog
 
 | Version | Date | Pull Request | Subject |
+|---------|------|--------------|---------|
 | 0.1.0 | 2022-02-07 | | New Source: Talkdesk Explore
 | :--- | :--- | :--- | :--- |


### PR DESCRIPTION
As we're trying to automate changelog editing, we need to make sure it's following a common format. Most connectors are OK except the ones here.
Issus include:
Missing a line before the changelog table (as required per markdown)
missing a header separator (as required by makdown)
having weird characters in the header separator
Wrong headers
missing column