### PR TITLE
Source S3: temporarily revert concurrency to test performance

### DIFF
--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/source.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/source.py
@@ -21,7 +21,7 @@ _V3_DEPRECATION_FIELD_MAPPING = {
 
 
 class SourceS3(FileBasedSource):
-    _concurrency_level = DEFAULT_CONCURRENCY
+    _concurrency_level = None
 
     @classmethod
     def read_config(cls, config_path: str) -> Mapping[str, Any]:


### PR DESCRIPTION
Temporarily reverting concurrency - creating a prerelease build for investigating a performance issue.