### PR TITLE
Airbyte CDK (low code): add refresh_token_error handler to `DeclarativeOauth2Authenticator`

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -905,7 +905,7 @@ definitions:
               - ["credentials", "token_expiry_date"]
           refresh_token_error_status_codes:
             title: Refresh Token Error Status Codes
-            description: Status Codes to Identify refresh token error in response (Refresh Token Error Key and Refresh Token Error Values should be also specified).
+            description: Status Codes to Identify refresh token error in response (Refresh Token Error Key and Refresh Token Error Values should be also specified). Responses with one of the error status code and containing an error value will be flagged as a config error
             type: array
             items:
               type: integer

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -903,6 +903,31 @@ definitions:
             default: ["credentials", "token_expiry_date"]
             examples:
               - ["credentials", "token_expiry_date"]
+          refresh_token_error_status_codes:
+            title: Refresh Token Error Status Codes
+            description: Status Codes to Identify refresh token error in response.
+            type: array
+            items:
+              type: integer
+            default: []
+            examples:
+              - [ 400, 500 ]
+          refresh_token_error_key:
+            title: Refresh Token Error Key
+            description: Key to Identify refresh token error in response.
+            type: string
+            default: ""
+            examples:
+              - "error"
+          refresh_token_error_values:
+            title: Refresh Token Error Values
+            description: List of values to check for refresh token error in response.
+            type: array
+            items:
+              type: string
+            default: [ ]
+            examples:
+              - [ "invalid_grant", "invalid_permissions" ]
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -911,7 +911,7 @@ definitions:
               type: integer
             default: []
             examples:
-              - [ 400, 500 ]
+              - [400, 500]
           refresh_token_error_key:
             title: Refresh Token Error Key
             description: Key to Identify refresh token error in response.
@@ -925,9 +925,9 @@ definitions:
             type: array
             items:
               type: string
-            default: [ ]
+            default: []
             examples:
-              - [ "invalid_grant", "invalid_permissions" ]
+              - ["invalid_grant", "invalid_permissions"]
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -905,7 +905,7 @@ definitions:
               - ["credentials", "token_expiry_date"]
           refresh_token_error_status_codes:
             title: Refresh Token Error Status Codes
-            description: Status Codes to Identify refresh token error in response.
+            description: Status Codes to Identify refresh token error in response (Refresh Token Error Key and Refresh Token Error Values should be also specified).
             type: array
             items:
               type: integer
@@ -914,14 +914,14 @@ definitions:
               - [400, 500]
           refresh_token_error_key:
             title: Refresh Token Error Key
-            description: Key to Identify refresh token error in response.
+            description: Key to Identify refresh token error in response (Refresh Token Error Status Codes and Refresh Token Error Values should be also specified).
             type: string
             default: ""
             examples:
               - "error"
           refresh_token_error_values:
             title: Refresh Token Error Values
-            description: 'List of values to check for exception during token refresh process. Used to check if the error found in the response matches the key from the Refresh Token Error Key field (e.g. response={"error": "invalid_grant"}). Raised AirbyteTracedException configuration error.'
+            description: 'List of values to check for exception during token refresh process. Used to check if the error found in the response matches the key from the Refresh Token Error Key field (e.g. response={"error": "invalid_grant"}). Only responses with one of the error status code and containing an error value will be flagged as a config error'
             type: array
             items:
               type: string

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -921,7 +921,7 @@ definitions:
               - "error"
           refresh_token_error_values:
             title: Refresh Token Error Values
-            description: List of values to check for refresh token error in response.
+            description: 'List of values to check for exception during token refresh process. Used to check if the error found in the response matches the key from the Refresh Token Error Key field (e.g. response={"error": "invalid_grant"}). Raised AirbyteTracedException configuration error.'
             type: array
             items:
               type: string

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -261,7 +261,7 @@ class RefreshTokenUpdater(BaseModel):
     )
     refresh_token_error_values: Optional[List[str]] = Field(
         [],
-        description='List of values to check for refresh token error in response.',
+        description='List of values to check for exception during token refresh process. Used to check if the error found in the response matches the key from the Refresh Token Error Key field (e.g. response={"error": "invalid_grant"}). Raised AirbyteTracedException configuration error.',
         examples=[['invalid_grant', 'invalid_permissions']],
         title='Refresh Token Error Values',
     )

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -247,6 +247,24 @@ class RefreshTokenUpdater(BaseModel):
         examples=[['credentials', 'token_expiry_date']],
         title='Config Path To Expiry Date',
     )
+    refresh_token_error_status_codes: Optional[List[int]] = Field(
+        [],
+        description='Status Codes to Identify refresh token error in response.',
+        examples=[[400, 500]],
+        title='Refresh Token Error Status Codes',
+    )
+    refresh_token_error_key: Optional[str] = Field(
+        '',
+        description='Key to Identify refresh token error in response.',
+        examples=['error'],
+        title='Refresh Token Error Key',
+    )
+    refresh_token_error_values: Optional[List[str]] = Field(
+        [],
+        description='List of values to check for refresh token error in response.',
+        examples=[['invalid_grant', 'invalid_permissions']],
+        title='Refresh Token Error Values',
+    )
 
 
 class OAuthAuthenticator(BaseModel):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -249,7 +249,7 @@ class RefreshTokenUpdater(BaseModel):
     )
     refresh_token_error_status_codes: Optional[List[int]] = Field(
         [],
-        description='Status Codes to Identify refresh token error in response (Refresh Token Error Key and Refresh Token Error Values should be also specified).',
+        description='Status Codes to Identify refresh token error in response (Refresh Token Error Key and Refresh Token Error Values should be also specified). Responses with one of the error status code and containing an error value will be flagged as a config error',
         examples=[[400, 500]],
         title='Refresh Token Error Status Codes',
     )

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -249,19 +249,19 @@ class RefreshTokenUpdater(BaseModel):
     )
     refresh_token_error_status_codes: Optional[List[int]] = Field(
         [],
-        description='Status Codes to Identify refresh token error in response.',
+        description='Status Codes to Identify refresh token error in response (Refresh Token Error Key and Refresh Token Error Values should be also specified).',
         examples=[[400, 500]],
         title='Refresh Token Error Status Codes',
     )
     refresh_token_error_key: Optional[str] = Field(
         '',
-        description='Key to Identify refresh token error in response.',
+        description='Key to Identify refresh token error in response (Refresh Token Error Status Codes and Refresh Token Error Values should be also specified).',
         examples=['error'],
         title='Refresh Token Error Key',
     )
     refresh_token_error_values: Optional[List[str]] = Field(
         [],
-        description='List of values to check for exception during token refresh process. Used to check if the error found in the response matches the key from the Refresh Token Error Key field (e.g. response={"error": "invalid_grant"}). Raised AirbyteTracedException configuration error.',
+        description='List of values to check for exception during token refresh process. Used to check if the error found in the response matches the key from the Refresh Token Error Key field (e.g. response={"error": "invalid_grant"}). Only responses with one of the error status code and containing an error value will be flagged as a config error',
         examples=[['invalid_grant', 'invalid_permissions']],
         title='Refresh Token Error Values',
     )

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -806,7 +806,7 @@ class ModelToComponentFactory:
 
     def create_oauth_authenticator(self, model: OAuthAuthenticatorModel, config: Config, **kwargs: Any) -> DeclarativeOauth2Authenticator:
         if model.refresh_token_updater:
-            # ignore type error beause fixing it would have a lot of dependencies, revisit later
+            # ignore type error because fixing it would have a lot of dependencies, revisit later
             return DeclarativeSingleUseRefreshTokenOauth2Authenticator(  # type: ignore
                 config,
                 InterpolatedString.create(model.token_refresh_endpoint, parameters=model.parameters or {}).eval(config),
@@ -827,6 +827,9 @@ class ModelToComponentFactory:
                 scopes=model.scopes,
                 token_expiry_date_format=model.token_expiry_date_format,
                 message_repository=self._message_repository,
+                refresh_token_error_status_codes=model.refresh_token_updater.refresh_token_error_status_codes,
+                refresh_token_error_key=model.refresh_token_updater.refresh_token_error_key,
+                refresh_token_error_values=model.refresh_token_updater.refresh_token_error_values,
             )
         # ignore type error because fixing it would have a lot of dependencies, revisit later
         return DeclarativeOauth2Authenticator(  # type: ignore

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -356,6 +356,9 @@ def test_single_use_oauth_branch():
         interpolated_body_field: "{{ config['apikey'] }}"
       refresh_token_updater:
         refresh_token_name: "the_refresh_token"
+        refresh_token_error_status_codes: [400]
+        refresh_token_error_key: "error"
+        refresh_token_error_values: ["invalid_grant"]
         refresh_token_config_path:
           - apikey
     """
@@ -378,6 +381,9 @@ def test_single_use_oauth_branch():
     # default values
     assert authenticator._access_token_config_path == ["credentials", "access_token"]
     assert authenticator._token_expiry_date_config_path == ["credentials", "token_expiry_date"]
+    assert authenticator._refresh_token_error_status_codes == [400]
+    assert authenticator._refresh_token_error_key == "error"
+    assert authenticator._refresh_token_error_values == ["invalid_grant"]
 
 
 def test_list_based_stream_slicer_with_values_refd():


### PR DESCRIPTION
## What

Resolve https://github.com/airbytehq/airbyte-internal-issues/issues/6571

## How

add refresh_token_error handler to low code `DeclarativeSingleUseRefreshTokenOauth2Authenticator`

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml`
2. `airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py`
3. `airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py`

## 🚨 User Impact 🚨

no breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

