### PR TITLE
source-zoom: reference published version in breaking changes

### DIFF
--- a/airbyte-integrations/connectors/source-zoom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoom/metadata.yaml
@@ -22,7 +22,7 @@ data:
   releaseStage: alpha
   releases:
     breakingChanges:
-      1.0.0:
+      1.1.0:
         message:
           Zoom has deprecated JWT authentication in favor of OAuth. To successfully
           migrate, users will need to create a new server-to-server OAuth app and

--- a/docs/integrations/sources/zoom-migrations.md
+++ b/docs/integrations/sources/zoom-migrations.md
@@ -1,6 +1,6 @@
 # Zoom Migration Guide
 
-## Upgrading to 1.0.0
+## Upgrading to 1.1.0
 
 ### Authentication
 


### PR DESCRIPTION
We want to reference published docker images in the breaking changes table. This will allow the publish to work and OSS users to know which available versions have which behavior