### PR TITLE
java-cdk: add component abstraction

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/components/ComponentRunner.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/components/ComponentRunner.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.components
+
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicReference
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * [ComponentRunner] orchestrates [ProducerComponent] and [ConsumerComponent] instances to collect
+ * records and states.
+ *
+ * Constructor args:
+ * - [name] is decorative-only and is used to name the threads spawned by this object;
+ * - [producerBuilder] is used to instantiate [ProducerComponent];
+ * - [consumerBuilder] is used to instantiate [ConsumerComponent];
+ * - [maxTime] is the global timeout for a [collect] method call;
+ * - [comparator] is used by [collectRepeatedly] to compare relative progress between two states.
+ */
+class ComponentRunner<R, S>(
+    val name: String,
+    val producerBuilder: ProducerComponent.Builder<R, S>,
+    val consumerBuilder: ConsumerComponent.Builder<R>,
+    val maxTime: Duration,
+    val comparator: Comparator<S>,
+) {
+
+    /**
+     * [collect] instantiates a [ProducerComponent] with a [ConsumerComponent] and uses them to
+     * collect records until a stopping criterion is met.
+     *
+     * The [input] argument determines the records emitted by the producer. Either the producer
+     * itself triggers a stop or the [maxTime] timeout does, after which we return:
+     * - all records produced and consumed, with [ConsumerComponent.flush],
+     * - the final state of the producer, with [ProducerComponent.finalState].
+     */
+    fun collect(input: S): Pair<Sequence<R>, S> {
+        val consumer: ConsumerComponent<R> = consumerBuilder.build()
+        val sentinel = Runnable {
+            try {
+                Thread.sleep(maxTime.toMillis())
+                log.debug("$name timed out.")
+            } catch (e: InterruptedException) {
+                log.debug("$name was notified to stop before timing out.", e)
+            } catch (e: Throwable) {
+                log.warn("$name sentinel threw an error or an exception", e)
+            }
+        }
+        val sentinelThread = Thread(sentinel, "$name-closer-sentinel")
+        val producer: ProducerComponent<S> =
+            producerBuilder.build(input, consumer, sentinelThread::interrupt)
+        val producerThread = Thread(producer, "$name-producer")
+        val closer = Runnable {
+            try {
+                sentinelThread.join()
+                log.debug("$name timed out, closing...")
+            } catch (e: InterruptedException) {
+                log.debug("$name was notified to stop before timing out, closing...", e)
+            }
+            try {
+                producer.close()
+                log.debug("$name closed")
+            } catch (e: Throwable) {
+                log.warn("$name producer close() threw an exception", e)
+                throw e
+            }
+        }
+        val closerThread = Thread(closer, "$name-closer")
+        val thrown = AtomicReference<Throwable>()
+        log.debug("$name is running")
+        sentinelThread.start()
+        producerThread.setUncaughtExceptionHandler { _, e: Throwable ->
+            thrown.set(e)
+            sentinelThread.interrupt()
+            closerThread.interrupt()
+            log.warn("$name producer run() threw an exception, interrupted other $name threads", e)
+        }
+        producerThread.start()
+        closerThread.start()
+        try {
+            closerThread.join()
+            producerThread.join()
+            sentinelThread.join()
+        } catch (e: InterruptedException) {
+            log.debug("$name was interrupted", e)
+        }
+        thrown.get()?.run { throw this }
+        log.debug("$name is done")
+        return Pair(consumer.flush(), producer.finalState())
+    }
+
+    /**
+     * Calls [collect] repeatedly until:
+     * - either the state has reached or exceeded its upper bound,
+     * - or there is no more forward progress from one state to the next.
+     *
+     * It does this lazily.
+     */
+    fun collectRepeatedly(initialState: S, upperBound: S): Sequence<Pair<Sequence<R>, S>> =
+        Sequence {
+            object : Iterator<Pair<Sequence<R>, S>> {
+
+                var nextValue: Pair<Sequence<R>, S>? = collect(initialState)
+
+                override fun hasNext(): Boolean = nextValue != null
+
+                override fun next(): Pair<Sequence<R>, S> {
+                    val currentValue = nextValue ?: throw NoSuchElementException()
+                    val (_, currentState) = currentValue
+                    val hasReachedUpperBound = comparator.compare(currentState, upperBound) >= 0
+                    if (hasReachedUpperBound) {
+                        nextValue = null
+                    } else {
+                        // Compute the successor output ahead of time for the next iteration.
+                        val (successorOutput, successorState) = collect(currentState)
+                        // Stop when reaching a fixed point.
+                        val hasProgress = comparator.compare(currentState, successorState) < 0
+                        nextValue = if (hasProgress) Pair(successorOutput, successorState) else null
+                    }
+                    return currentValue
+                }
+            }
+        }
+
+    companion object {
+        val log: Logger = LoggerFactory.getLogger(ComponentRunner::class.java)
+    }
+}

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/components/ConsumerComponent.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/components/ConsumerComponent.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.components
+
+import java.util.function.Consumer
+
+/**
+ * [ConsumerComponent] collects records of type [R] produced by [ProducerComponent]. It's this
+ * object's responsibility to tell the [ProducerComponent] that it has collected enough records.
+ *
+ * All implementations must be thread-safe. The [Consumer.accept] and [shouldCheckpoint] methods may
+ * be called concurrently from multiple threads.
+ */
+interface ConsumerComponent<R> : Consumer<R> {
+
+    /**
+     * Returns true if the records held by this [ConsumerComponent] should be flushed ASAP. This
+     * method is called by the [ProducerComponent] bound to this [ConsumerComponent].
+     */
+    fun shouldCheckpoint(): Boolean
+
+    /**
+     * Returns all the records accepted by the [ConsumerComponent]. This method is called
+     * exclusively, and at most once, by [ComponentRunner.collect].
+     */
+    fun flush(): Sequence<R>
+
+    fun interface Builder<R> {
+
+        /**
+         * Deterministically instantiates a new [ConsumerComponent] instance. May be called multiple
+         * times. Called exclusively by [ComponentRunner].
+         */
+        fun build(): ConsumerComponent<R>
+    }
+}

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/components/ProducerComponent.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/components/ProducerComponent.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.components
+
+/**
+ * [ProducerComponent] is a [Runnable] which runs indefinitely to produce records and pass them to a
+ * [ConsumerComponent]. [Runnable.run] only stops after [AutoCloseable.close] is called.
+ * [AutoCloseable.close] will be called exactly once and not before [Runnable.run].
+ *
+ * All implementations must be thread-safe. All methods will be called in different threads and
+ * exclusively by the [ComponentRunner].
+ */
+interface ProducerComponent<S> : Runnable, AutoCloseable {
+
+    /**
+     * Returns the final state of the producer. Starting a new producer using this state as its
+     * initial state will resume production where it left off. This method will be called after the
+     * call to [Runnable.run] completes.
+     */
+    fun finalState(): S
+
+    fun interface Builder<R, S> {
+
+        /**
+         * Deterministically instantiates a new [ProducerComponent] instance:
+         * - [input] is the initial state of the producer and determines which records of type [R]
+         * will be produced;
+         * - [consumer] is the consumer to pass the records to via [ConsumerComponent.accept];
+         * - [notifyStop] is the callback that the producer will call when it thinks that it should
+         * stop producing, typically when [ConsumerComponent.shouldCheckpoint] returns true.
+         *
+         * May be called multiple times. Called exclusively by [ComponentRunner].
+         */
+        fun build(
+            input: S,
+            consumer: ConsumerComponent<R>,
+            notifyStop: () -> Unit,
+        ): ProducerComponent<S>
+    }
+}

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/kotlin/io/airbyte/cdk/components/ComponentRunnerTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/kotlin/io/airbyte/cdk/components/ComponentRunnerTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.components
+
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class ComponentRunnerTest {
+
+    /**
+     * Test implementation of [ConsumerComponent]. Thread-safe, as per contract. Records are
+     * characters, which are accumulated into a string.
+     */
+    class TestConsumerComponent(val maxRecords: Int) : ConsumerComponent<Char> {
+
+        private val sb = StringBuilder()
+
+        override fun shouldCheckpoint(): Boolean = synchronized(sb) { sb.length >= maxRecords }
+
+        override fun flush(): Sequence<Char> = synchronized(sb) { sb.toString() }.asSequence()
+
+        override fun accept(c: Char) {
+            synchronized(sb) { sb.append(c) }
+        }
+    }
+
+    /**
+     * Test implementation of [ProducerComponent]. Thread-safe, as per contract. Emits the
+     * characters in [DATASET] in an infinite loop, until a latch reaches zero.
+     *
+     * In one less-realistic variant where [isCloseSynchronized] is true, [close] is synchronized
+     * with [notifyStop] and the producer stops immediately. This makes for more predictable output.
+     * Otherwise, the loop exits only once the [ComponentRunner] comes around to calling [close].
+     */
+    class TestProducerComponent(
+        initialState: Int,
+        val upperBound: Int,
+        val isCloseSynchronized: Boolean,
+        val notifyStop: () -> Unit,
+        val consumer: ConsumerComponent<Char>,
+    ) : ProducerComponent<Int> {
+
+        private val state = AtomicInteger(initialState)
+        private val latch = CountDownLatch(1)
+
+        override fun finalState(): Int = state.get()
+
+        override fun run() {
+            while (latch.count > 0) {
+                consumer.accept(DATASET[state.getAndIncrement().mod(DATASET.length)])
+                if (consumer.shouldCheckpoint() || state.get() >= upperBound) {
+                    notifyStop()
+                    if (isCloseSynchronized) {
+                        // Wait until the notification registers.
+                        // This helps to make the test as deterministic as possible.
+                        latch.await(maxTime.toMillis(), TimeUnit.MILLISECONDS)
+                    }
+                }
+            }
+        }
+
+        override fun close() {
+            latch.countDown()
+        }
+    }
+
+    companion object {
+        const val DATASET = "The Quick Brown Fox Jumped Over The Lazy Dog. "
+        val log: Logger = LoggerFactory.getLogger(ComponentRunnerTest::class.java)
+        // Adjust this upwards if the test starts to flake.
+        val maxTime: Duration = Duration.ofMillis(100)
+    }
+
+    @Test
+    fun testNoCheckpointing() {
+        doTestCases(DATASET, TestCase())
+        doTestCases("Brown Fox Jumped Over The Lazy Dog. ", TestCase(initialState = 10))
+    }
+
+    @Test
+    fun testCheckpointing() {
+        doTestCases(
+            "Bro|wn |Fox| Ju|mpe|d O|ver| Th|e L|azy| Do|g. ",
+            TestCase(maxRecords = 3, initialState = 10)
+        )
+    }
+
+    @Test
+    fun testCheckpointingWithUpperBound() {
+        doTestCases("Brow|n Fo|x ", TestCase(maxRecords = 4, initialState = 10, upperBound = 20))
+    }
+
+    fun doTestCases(
+        expectedLiteral: String,
+        tc: TestCase,
+    ) {
+        Assertions.assertEquals(expectedLiteral, tc.expected())
+        log.info("running {}", tc)
+        log.info("expected value is '{}'", tc.expected())
+        doTestCase(tc, isCloseSynchronized = false)
+        doTestCase(tc, isCloseSynchronized = true)
+    }
+
+    data class TestCase(
+        val maxRecords: Int = 1_000,
+        val initialState: Int = 0,
+        val upperBound: Int = DATASET.length
+    ) {
+        fun expected(): String =
+            DATASET.repeat(1 + upperBound / DATASET.length)
+                .take(upperBound)
+                .drop(initialState)
+                .flatMapIndexed { idx, c ->
+                    if (0 == (idx + 1).mod(maxRecords)) listOf(c, '|') else listOf(c)
+                }
+                .dropLastWhile { it == '|' }
+                .joinToString(separator = "")
+    }
+
+    fun doTestCase(
+        tc: TestCase,
+        isCloseSynchronized: Boolean,
+    ) {
+        val expected: String = tc.expected()
+        val actual: String = collectRepeatedly(tc, isCloseSynchronized)
+        log.info("actual value with isCloseSynchronized = {} is '{}'", isCloseSynchronized, actual)
+        if (isCloseSynchronized) {
+            Assertions.assertEquals(
+                tc.expected(),
+                actual,
+                "when producer close() is synchronized, '$actual' should equal '$expected'"
+            )
+        } else {
+            // In this case, when notifyStop fires, the producer doesn't immediately stop
+            // producing. Instead. the ComponentRunner shuts the producer thread down.
+            // These testing conditions are more realistic, but less deterministic, so we relax
+            // the assertions.
+            Assertions.assertTrue(
+                actual.replace("|", "").startsWith(expected.replace("|", "")),
+                "when producer close() is not synchronized, " +
+                    "'$actual' should start with '$expected', minus the '|' characters"
+            )
+        }
+    }
+
+    fun collectRepeatedly(
+        tc: TestCase,
+        isCloseSynchronized: Boolean,
+    ): String {
+        val consumerBuilder = ConsumerComponent.Builder { TestConsumerComponent(tc.maxRecords) }
+        val producerBuilder =
+            ProducerComponent.Builder { input: Int, consumer: ConsumerComponent<Char>, notifyStop ->
+                TestProducerComponent(
+                    input,
+                    tc.upperBound,
+                    isCloseSynchronized,
+                    notifyStop,
+                    consumer
+                )
+            }
+        val runner =
+            ComponentRunner(
+                name = "test",
+                producerBuilder,
+                consumerBuilder,
+                maxTime,
+                Comparator.naturalOrder()
+            )
+        val output: Sequence<Pair<Sequence<Char>, Int>> =
+            runner.collectRepeatedly(tc.initialState, tc.upperBound)
+        val collectedChunks: Sequence<String> =
+            output.map { (records, _) -> records.joinToString(separator = "") { it.toString() } }
+        return collectedChunks.joinToString(separator = "|")
+    }
+}


### PR DESCRIPTION
A generic abstraction for handling records and state in a source connector. Implemented for debezium in #36154 which is the next PR in the stack.

ComponentRunner requires a lot more tests to validate that the thread logic actually works, especially in the face of exceptions and timeouts.