### PR TITLE
docs: fix or remove broken links

### DIFF
--- a/docs/connector-development/tutorials/the-hard-way/build-a-connector-the-hard-way.md
+++ b/docs/connector-development/tutorials/the-hard-way/build-a-connector-the-hard-way.md
@@ -1249,5 +1249,5 @@ contributor now ;\)
 
 ## Additional guides
 
-- [Building a Python Source](https://docs.airbyte.com/connector-development/tutorials/building-a-python-source.md)
+- [Building a Python Source](https://docs.airbyte.com/connector-development/tutorials/cdk-speedrun)
 - [Building a Java Destination](https://docs.airbyte.com/connector-development/tutorials/building-a-java-destination)

--- a/docs/understanding-airbyte/cdc.md
+++ b/docs/understanding-airbyte/cdc.md
@@ -33,7 +33,7 @@ We add some metadata columns for CDC sources:
 * [Postgres](../integrations/sources/postgres.md) \(For a quick video overview of CDC on Postgres, click [here](https://www.youtube.com/watch?v=NMODvLgZvuE&ab_channel=Airbyte)\)
 * [MySQL](../integrations/sources/mysql.md)
 * [Microsoft SQL Server / MSSQL](../integrations/sources/mssql.md)
-* [MongoDB](../integrations/sources/mongodb-v2.md) \(More information on [Mongodb CDC: How to Sync in Near Real-Time](https://airbyte.com/data-engineering-resources/mongodb-cdc)\)
+* [MongoDB](../integrations/sources/mongodb-v2.md)
 ## Coming Soon
 
 * Oracle DB


### PR DESCRIPTION
I scraped the repo for urls with the word 'airbyte' in them and tested that they didn't return a 4XX code. There were a small handful but these are the only ones which I thought were visible.