### PR TITLE
🐛 low-code: remove debug sleep

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_requester.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_requester.py
@@ -456,9 +456,6 @@ class HttpRequester(Requester):
             json=self._request_body_json(stream_state, stream_slice, next_page_token, request_body_json),
             data=self._request_body_data(stream_state, stream_slice, next_page_token, request_body_data),
         )
-        import time
-
-        time.sleep(1)
 
         response = self._send_with_retry(request, log_formatter=log_formatter)
         return self._validate_response(response)


### PR DESCRIPTION
## What
Remove 1.0 second sleep that was accidentally introduced as part of https://github.com/airbytehq/airbyte/commit/f55abc1fdcfed1d857d541b7fbfb8314a2c09941