### PR TITLE
✨ [source-slack] Support syncing from private channels

### DIFF
--- a/airbyte-integrations/connectors/source-slack/source_slack/source.py
+++ b/airbyte-integrations/connectors/source-slack/source_slack/source.py
@@ -156,7 +156,7 @@ class Channels(ChanneledStream):
 
     def request_params(self, **kwargs) -> MutableMapping[str, Any]:
         params = super().request_params(**kwargs)
-        params["types"] = "public_channel"
+        params["types"] = "public_channel,private_channel"
         return params
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[MutableMapping]:


### PR DESCRIPTION
Airbyte's Slack source connector hard-codes the channel types to public channels only.  This makes no sense, because the authorized user or app must be intentionally added to private channels, and then you would expect Airbyte to sync those as well.  This PR updates the default to include private channels.