### PR TITLE
✨ File-based CDK: Add `skip_wrong_number_of_fields_error` parameter for CSV parser

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/csv_format.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/csv_format.py
@@ -147,6 +147,11 @@ class CsvFormat(BaseModel):
         description="How to infer the types of the columns. If none, inference default to strings.",
         airbyte_hidden=True,
     )
+    skip_wrong_number_of_fields_error: bool = Field(
+        title="Skip Wrong Number of Fields Error",
+        default=False,
+        description="Whether to skip the error when the number of fields in the CSV does not match the number of columns in the schema.",
+    )
 
     @validator("delimiter")
     def validate_delimiter(cls, v: str) -> str:

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/csv_format.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/csv_format.py
@@ -147,10 +147,10 @@ class CsvFormat(BaseModel):
         description="How to infer the types of the columns. If none, inference default to strings.",
         airbyte_hidden=True,
     )
-    skip_wrong_number_of_fields_error: bool = Field(
-        title="Skip Wrong Number of Fields Error",
+    ignore_errors_on_fields_mismatch: bool = Field(
+        title="Ignore errors on field mismatch",
         default=False,
-        description="Whether to skip the error when the number of fields in the CSV does not match the number of columns in the schema.",
+        description="Whether to ignore errors that occur when the number of fields in the CSV does not match the number of columns in the schema.",
     )
 
     @validator("delimiter")

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
@@ -70,13 +70,21 @@ class _CsvReader:
                     # The row was not properly parsed if any of the values are None. This will most likely occur if there are more columns
                     # than headers or more headers dans columns
                     if None in row:
-                        raise RecordParseError(
-                            FileBasedSourceError.ERROR_PARSING_RECORD_MISMATCHED_COLUMNS,
-                            filename=file.uri,
-                            lineno=lineno,
-                        )
+                        if config_format.skip_wrong_number_of_fields_error:
+                            logger.error(f"Skipping record in line {lineno} of file {file.uri} due to mismatched columns.")
+                        else:
+                            raise RecordParseError(
+                                FileBasedSourceError.ERROR_PARSING_RECORD_MISMATCHED_COLUMNS,
+                                filename=file.uri,
+                                lineno=lineno,
+                            )
                     if None in row.values():
-                        raise RecordParseError(FileBasedSourceError.ERROR_PARSING_RECORD_MISMATCHED_ROWS, filename=file.uri, lineno=lineno)
+                        if config_format.skip_wrong_number_of_fields_error:
+                            logger.error(f"Skipping record in line {lineno} of file {file.uri} due to mismatched rows.")
+                        else:
+                            raise RecordParseError(
+                                FileBasedSourceError.ERROR_PARSING_RECORD_MISMATCHED_ROWS, filename=file.uri, lineno=lineno
+                            )
                     yield row
             finally:
                 # due to RecordParseError or GeneratorExit

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
@@ -71,7 +71,7 @@ class _CsvReader:
                     # than headers or more headers dans columns
                     if None in row:
                         if config_format.skip_wrong_number_of_fields_error:
-                            logger.error(f"Skipping record in line {lineno} of file {file.uri} due to mismatched columns.")
+                            logger.error(f"Skipping record in line {lineno} of file {file.uri}; invalid CSV row with missing column.")
                         else:
                             raise RecordParseError(
                                 FileBasedSourceError.ERROR_PARSING_RECORD_MISMATCHED_COLUMNS,
@@ -80,7 +80,7 @@ class _CsvReader:
                             )
                     if None in row.values():
                         if config_format.skip_wrong_number_of_fields_error:
-                            logger.error(f"Skipping record in line {lineno} of file {file.uri} due to mismatched rows.")
+                            logger.error(f"Skipping record in line {lineno} of file {file.uri}; invalid CSV row with extra column.")
                         else:
                             raise RecordParseError(
                                 FileBasedSourceError.ERROR_PARSING_RECORD_MISMATCHED_ROWS, filename=file.uri, lineno=lineno

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
@@ -70,7 +70,7 @@ class _CsvReader:
                     # The row was not properly parsed if any of the values are None. This will most likely occur if there are more columns
                     # than headers or more headers dans columns
                     if None in row:
-                        if config_format.skip_wrong_number_of_fields_error:
+                        if config_format.ignore_errors_on_fields_mismatch:
                             logger.error(f"Skipping record in line {lineno} of file {file.uri}; invalid CSV row with missing column.")
                         else:
                             raise RecordParseError(
@@ -79,7 +79,7 @@ class _CsvReader:
                                 lineno=lineno,
                             )
                     if None in row.values():
-                        if config_format.skip_wrong_number_of_fields_error:
+                        if config_format.ignore_errors_on_fields_mismatch:
                             logger.error(f"Skipping record in line {lineno} of file {file.uri}; invalid CSV row with extra column.")
                         else:
                             raise RecordParseError(

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -265,11 +265,11 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                                     "airbyte_hidden": True,
                                                     "enum": ["None", "Primitive Types Only"],
                                                 },
-                                                "skip_wrong_number_of_fields_error": {
+                                                "ignore_errors_on_fields_mismatch": {
                                                     "type": "boolean",
-                                                    "title": "Skip Wrong Number of Fields Error",
+                                                    "title": "Ignore errors on field mismatch",
                                                     "default": False,
-                                                    "description": "Whether to skip the error when the number of fields in the CSV does not match the number of columns in the schema.",
+                                                    "description": "Whether to ignore errors that occur when the number of fields in the CSV does not match the number of columns in the schema.",
                                                 },
                                             },
                                             "required": ["filetype"],

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -265,6 +265,12 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                                     "airbyte_hidden": True,
                                                     "enum": ["None", "Primitive Types Only"],
                                                 },
+                                                "skip_wrong_number_of_fields_error": {
+                                                    "type": "boolean",
+                                                    "title": "Skip Wrong Number of Fields Error",
+                                                    "default": False,
+                                                    "description": "Whether to skip the error when the number of fields in the CSV does not match the number of columns in the schema.",
+                                                },
                                             },
                                             "required": ["filetype"],
                                         },


### PR DESCRIPTION
## What
Add new parameter `skip_wrong_number_of_fields_error` for CSV parser to skip errors with the mismatched number of fields. Implements: https://github.com/airbytehq/airbyte-internal-issues/issues/2621. Partially resolves: https://github.com/airbytehq/oncall/issues/4148