### PR TITLE
comment out actual image pushing and stuff that posts to slack for testing

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -269,17 +269,17 @@ jobs:
           cd oss/airbyte-connector-builder-server
           pip install pip-tools
           pip-compile --upgrade
-      - name: Create Pull Request
-        id: create-pull-request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          commit-message: Updating CDK version following release
-          title: Updating CDK version following release
-          body: This is an automatically generated PR triggered by a CDK release
-          branch: automatic-cdk-release
-          base: master
-          delete-branch: true
+#      - name: Create Pull Request
+#        id: create-pull-request
+#        uses: peter-evans/create-pull-request@v6
+#        with:
+#          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+#          commit-message: Updating CDK version following release
+#          title: Updating CDK version following release
+#          body: This is an automatically generated PR triggered by a CDK release
+#          branch: automatic-cdk-release
+#          base: master
+#          delete-branch: true
 #      - name: Post success to Slack channel dev-connectors-extensibility
 #        uses: slackapi/slack-github-action@v1.23.0
 #        continue-on-error: true

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -28,35 +28,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # We are using these runners because they are the same as the one for `publish-command.yml`
-  # One problem we had using `ubuntu-latest` for example is that the user is not root and some commands would fail in
-  # `manage.sh` (specifically `apt-get`)
-  start-publish-docker-image-runner-0:
-    name: Start Build EC2 Runner 0
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@v3
-        with:
-          repository: airbytehq/airbyte
-          ref: master
-      - name: Check PAT rate limits
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
-      - name: Start AWS Runner
-        id: start-ec2-runner
-        uses: ./.github/actions/start-aws-runner
-        with:
-          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          github-token: ${{ env.PAT }}
-          label: ${{ github.run_id }}-publisher
-
   build-cdk:
     runs-on: ubuntu-latest
     steps:
@@ -378,33 +349,3 @@ jobs:
 #            }
 #        env:
 #          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
-
-  # In case of self-hosted EC2 errors, remove this block.
-  stop-publish-docker-image-runner-0:
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
-    name: Stop Build EC2 Runner
-    needs:
-      - start-publish-docker-image-runner-0 # required to get output from the start-runner job
-      - publish-docker-image # required to wait when the main job is done
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-      - name: Checkout Airbyte
-        uses: actions/checkout@v3
-      - name: Check PAT rate limits
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
-      - name: Stop EC2 runner
-        uses: airbytehq/ec2-github-runner@base64v1.1.0
-        with:
-          mode: stop
-          github-token: ${{ env.PAT }}
-          label: ${{ needs.start-publish-docker-image-runner-0.outputs.label }}
-          ec2-instance-id: ${{ needs.start-publish-docker-image-runner-0.outputs.ec2-instance-id }}

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -186,7 +186,7 @@ jobs:
   publish-docker-image:
     timeout-minutes: 240
     needs:
-      - start-publish-docker-image-runner-0
+#      - start-publish-docker-image-runner-0
       - publish-cdk
     runs-on: runner-pool-${{ github.run_id }}
     steps:

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -28,6 +28,35 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # We are using these runners because they are the same as the one for `publish-command.yml`
+  # One problem we had using `ubuntu-latest` for example is that the user is not root and some commands would fail in
+  # `manage.sh` (specifically `apt-get`)
+  start-publish-docker-image-runner-0:
+    name: Start Build EC2 Runner 0
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+        with:
+          repository: airbytehq/airbyte
+          ref: master
+      - name: Check PAT rate limits
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+      - name: Start AWS Runner
+        id: start-ec2-runner
+        uses: ./.github/actions/start-aws-runner
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          github-token: ${{ env.PAT }}
+          label: ${{ github.run_id }}-publisher
+
   build-cdk:
     runs-on: ubuntu-latest
     steps:
@@ -349,3 +378,33 @@ jobs:
 #            }
 #        env:
 #          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+
+  # In case of self-hosted EC2 errors, remove this block.
+  stop-publish-docker-image-runner-0:
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    name: Stop Build EC2 Runner
+    needs:
+      - start-publish-docker-image-runner-0 # required to get output from the start-runner job
+      - publish-docker-image # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+      - name: Check PAT rate limits
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+      - name: Stop EC2 runner
+        uses: airbytehq/ec2-github-runner@base64v1.1.0
+        with:
+          mode: stop
+          github-token: ${{ env.PAT }}
+          label: ${{ needs.start-publish-docker-image-runner-0.outputs.label }}
+          ec2-instance-id: ${{ needs.start-publish-docker-image-runner-0.outputs.ec2-instance-id }}

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -99,13 +99,13 @@ jobs:
           new_version="$(grep -i 'current_version = ' .bumpversion.cfg | sed -e 's/.* = //')"
           awk -v NEW_VERSION="$new_version" -v CHANGELOG_MESSAGE="${{ github.event.inputs.changelog-message }}" 'NR==3{print "## " NEW_VERSION "\n" CHANGELOG_MESSAGE "\n"}1' CHANGELOG.md > tmp && mv tmp CHANGELOG.md
           echo NEW_VERSION=$new_version >> $GITHUB_OUTPUT
-      - name: Commit and Push Changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          file_pattern: airbyte-cdk/python/setup.py airbyte-cdk/python/.bumpversion.cfg airbyte-cdk/python/CHANGELOG.md airbyte-cdk/python/Dockerfile
-          commit_message: 🤖 Bump ${{ github.event.inputs.release-type }} version of Python CDK
-          commit_user_name: Octavia Squidington III
-          commit_user_email: octavia-squidington-iii@users.noreply.github.com
+#      - name: Commit and Push Changes
+#        uses: stefanzweifel/git-auto-commit-action@v4
+#        with:
+#          file_pattern: airbyte-cdk/python/setup.py airbyte-cdk/python/.bumpversion.cfg airbyte-cdk/python/CHANGELOG.md airbyte-cdk/python/Dockerfile
+#          commit_message: 🤖 Bump ${{ github.event.inputs.release-type }} version of Python CDK
+#          commit_user_name: Octavia Squidington III
+#          commit_user_email: octavia-squidington-iii@users.noreply.github.com
 #      - name: Post failure to Slack channel dev-connectors-extensibility
 #        if: ${{ failure() }}
 #        uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -144,16 +144,16 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
-      - name: Publish Python Package
-        uses: mariamrf/py-package-publish-action@v1.1.0
-        with:
-          # specify the same version as in ~/.python-version
-          python_version: "3.10"
-          pip_version: "23.2"
-          subdir: "airbyte-cdk/python/"
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+#      - name: Publish Python Package
+#        uses: mariamrf/py-package-publish-action@v1.1.0
+#        with:
+#          # specify the same version as in ~/.python-version
+#          python_version: "3.10"
+#          pip_version: "23.2"
+#          subdir: "airbyte-cdk/python/"
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
 #      - name: Post failure to Slack channel dev-connectors-extensibility
 #        if: ${{ failure() }}
 #        uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -74,34 +74,34 @@ jobs:
           ref: ${{ github.event.inputs.gitref }}
       - name: Build CDK Package
         run: (cd airbyte-cdk/python; ./gradlew --no-daemon --no-build-cache :build)
-      - name: Post failure to Slack channel dev-connectors-extensibility
-        if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.23.0
-        continue-on-error: true
-        with:
-          channel-id: C04J1M66D8B
-          payload: |
-            {
-                "text": "Error during `build-cdk` while publishing Python CDK!",
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Error while publishing Python CDK!"
-                        }
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
-                        }
-                    }
-                ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+#      - name: Post failure to Slack channel dev-connectors-extensibility
+#        if: ${{ failure() }}
+#        uses: slackapi/slack-github-action@v1.23.0
+#        continue-on-error: true
+#        with:
+#          channel-id: C04J1M66D8B
+#          payload: |
+#            {
+#                "text": "Error during `build-cdk` while publishing Python CDK!",
+#                "blocks": [
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "Error while publishing Python CDK!"
+#                        }
+#                    },
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+#                        }
+#                    }
+#                ]
+#            }
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
 
   bump-version:
     needs: build-cdk
@@ -135,34 +135,34 @@ jobs:
           commit_message: 🤖 Bump ${{ github.event.inputs.release-type }} version of Python CDK
           commit_user_name: Octavia Squidington III
           commit_user_email: octavia-squidington-iii@users.noreply.github.com
-      - name: Post failure to Slack channel dev-connectors-extensibility
-        if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.23.0
-        continue-on-error: true
-        with:
-          channel-id: C04J1M66D8B
-          payload: |
-            {
-                "text": "Error during `bump-version` while publishing Python CDK!",
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Error while publishing Python CDK!"
-                        }
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
-                        }
-                    }
-                ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+#      - name: Post failure to Slack channel dev-connectors-extensibility
+#        if: ${{ failure() }}
+#        uses: slackapi/slack-github-action@v1.23.0
+#        continue-on-error: true
+#        with:
+#          channel-id: C04J1M66D8B
+#          payload: |
+#            {
+#                "text": "Error during `bump-version` while publishing Python CDK!",
+#                "blocks": [
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "Error while publishing Python CDK!"
+#                        }
+#                    },
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+#                        }
+#                    }
+#                ]
+#            }
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
 
   publish-cdk:
     needs: bump-version
@@ -183,34 +183,34 @@ jobs:
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-      - name: Post failure to Slack channel dev-connectors-extensibility
-        if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.23.0
-        continue-on-error: true
-        with:
-          channel-id: C04J1M66D8B
-          payload: |
-            {
-                "text": "Error during `publish-cdk` while publishing Python CDK!",
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Error while publishing Python CDK!"
-                        }
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
-                        }
-                    }
-                ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+#      - name: Post failure to Slack channel dev-connectors-extensibility
+#        if: ${{ failure() }}
+#        uses: slackapi/slack-github-action@v1.23.0
+#        continue-on-error: true
+#        with:
+#          channel-id: C04J1M66D8B
+#          payload: |
+#            {
+#                "text": "Error during `publish-cdk` while publishing Python CDK!",
+#                "blocks": [
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "Error while publishing Python CDK!"
+#                        }
+#                    },
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+#                        }
+#                    }
+#                ]
+#            }
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
 
   publish-docker-image:
     timeout-minutes: 240
@@ -245,34 +245,34 @@ jobs:
           command: |
             docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
             ./tools/integrations/manage.sh publish airbyte-cdk/python false
-      - name: Post failure to Slack channel dev-connectors-extensibility
-        if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.23.0
-        continue-on-error: true
-        with:
-          channel-id: C04J1M66D8B
-          payload: |
-            {
-                "text": "Error during `publish-docker-image` while publishing Python CDK!",
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "Error while publishing Docker image following Python CDK release!"
-                        }
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
-                        }
-                    }
-                ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+#      - name: Post failure to Slack channel dev-connectors-extensibility
+#        if: ${{ failure() }}
+#        uses: slackapi/slack-github-action@v1.23.0
+#        continue-on-error: true
+#        with:
+#          channel-id: C04J1M66D8B
+#          payload: |
+#            {
+#                "text": "Error during `publish-docker-image` while publishing Python CDK!",
+#                "blocks": [
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "Error while publishing Docker image following Python CDK release!"
+#                        }
+#                    },
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+#                        }
+#                    }
+#                ]
+#            }
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
 
   update-connector-builder:
     needs:
@@ -309,75 +309,75 @@ jobs:
           branch: automatic-cdk-release
           base: master
           delete-branch: true
-      - name: Post success to Slack channel dev-connectors-extensibility
-        uses: slackapi/slack-github-action@v1.23.0
-        continue-on-error: true
-        with:
-          channel-id: C04J1M66D8B
-          payload: |
-            {
-                "text": "A new version of Python CDK has been released!",
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "A new version of Python CDK has been released with <https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/CHANGELOG.md|changelog>: ${{ github.event.inputs.changelog-message }}\n\n"
-                        }
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "A PR has also been created for the <${{ steps.create-pull-request.outputs.pull-request-url }}|Connector Builder>\n"
-                        }
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
-                        }
-                    }
-                ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
-      - name: Post failure to Slack channel dev-connectors-extensibility
-        if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.23.0
-        continue-on-error: true
-        with:
-          channel-id: C04J1M66D8B
-          payload: |
-            {
-                "text": ":warning: A new version of Python CDK has been released but Connector Builder hasn't been automatically updated",
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "A new version of Python CDK has been released with <https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/CHANGELOG.md|changelog>: ${{ github.event.inputs.changelog-message }}\n\n"
-                        }
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": ":warning: Could not automatically create a PR for Connector Builder>\n"
-                        }
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
-                        }
-                    }
-                ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+#      - name: Post success to Slack channel dev-connectors-extensibility
+#        uses: slackapi/slack-github-action@v1.23.0
+#        continue-on-error: true
+#        with:
+#          channel-id: C04J1M66D8B
+#          payload: |
+#            {
+#                "text": "A new version of Python CDK has been released!",
+#                "blocks": [
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "A new version of Python CDK has been released with <https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/CHANGELOG.md|changelog>: ${{ github.event.inputs.changelog-message }}\n\n"
+#                        }
+#                    },
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "A PR has also been created for the <${{ steps.create-pull-request.outputs.pull-request-url }}|Connector Builder>\n"
+#                        }
+#                    },
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+#                        }
+#                    }
+#                ]
+#            }
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+#      - name: Post failure to Slack channel dev-connectors-extensibility
+#        if: ${{ failure() }}
+#        uses: slackapi/slack-github-action@v1.23.0
+#        continue-on-error: true
+#        with:
+#          channel-id: C04J1M66D8B
+#          payload: |
+#            {
+#                "text": ":warning: A new version of Python CDK has been released but Connector Builder hasn't been automatically updated",
+#                "blocks": [
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "A new version of Python CDK has been released with <https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/CHANGELOG.md|changelog>: ${{ github.event.inputs.changelog-message }}\n\n"
+#                        }
+#                    },
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": ":warning: Could not automatically create a PR for Connector Builder>\n"
+#                        }
+#                    },
+#                    {
+#                        "type": "section",
+#                        "text": {
+#                            "type": "mrkdwn",
+#                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+#                        }
+#                    }
+#                ]
+#            }
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
 
   # In case of self-hosted EC2 errors, remove this block.
   stop-publish-docker-image-runner-0:

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -215,7 +215,7 @@ jobs:
   publish-docker-image:
     timeout-minutes: 240
     needs:
-#      - start-publish-docker-image-runner-0
+      - start-publish-docker-image-runner-0
       - publish-cdk
     runs-on: runner-pool-${{ github.run_id }}
     steps:

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -186,9 +186,9 @@ cmd_publish() {
     echo "latest_image $latest_image"
   fi
 
-  # before we start working sanity check that this version has not been published yet, so that we do not spend a lot of
-  # time building, running tests to realize this version is a duplicate.
-  _error_if_tag_exists "$versioned_image"
+#  # before we start working sanity check that this version has not been published yet, so that we do not spend a lot of
+#  # time building, running tests to realize this version is a duplicate.
+#  _error_if_tag_exists "$versioned_image"
 
   # building the connector
   if [ "$path" != "airbyte-cdk/python" ]; then
@@ -196,8 +196,8 @@ cmd_publish() {
     cmd_build "$path" "$run_tests"
   fi
 
-  # in case curing the build / tests someone this version has been published.
-  _error_if_tag_exists "$versioned_image"
+#  # in case curing the build / tests someone this version has been published.
+#  _error_if_tag_exists "$versioned_image"
 
   if [[ "airbyte/normalization" == "${image_name}" ]]; then
     echo "Publishing normalization images (version: $versioned_image)"
@@ -263,13 +263,16 @@ cmd_publish() {
 
     done
 
-    docker manifest push $versioned_image
-    docker manifest rm $versioned_image
+#    docker manifest push $versioned_image
+#    docker manifest rm $versioned_image
+#
+#    if [ "$pre_release" != "true" ]; then
+#      docker manifest push $latest_image
+#      docker manifest rm $latest_image
+#    fi
 
-    if [ "$pre_release" != "true" ]; then
-      docker manifest push $latest_image
-      docker manifest rm $latest_image
-    fi
+
+    echo "TESTING: got to docker push. Did not push"
 
     # delete the temporary image tags made with arch_versioned_image
     sleep 10

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -254,7 +254,7 @@ cmd_publish() {
 
       local arch_versioned_image=$image_name:`echo $arch | sed "s/\//-/g"`-$image_version
       echo "Publishing new version ($arch_versioned_image) from $path"
-      docker buildx build -t $arch_versioned_image --platform $arch --push $path
+      docker buildx build -t $arch_versioned_image --platform $arch
       docker manifest create $versioned_image --amend $arch_versioned_image
 
       if [ "$pre_release" != "true" ]; then

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -254,7 +254,7 @@ cmd_publish() {
 
       local arch_versioned_image=$image_name:`echo $arch | sed "s/\//-/g"`-$image_version
       echo "Publishing new version ($arch_versioned_image) from $path"
-      docker buildx build -t $arch_versioned_image --platform $arch
+      docker buildx build -t $arch_versioned_image --platform $arch --load
       docker manifest create $versioned_image --amend $arch_versioned_image
 
       if [ "$pre_release" != "true" ]; then

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -254,7 +254,7 @@ cmd_publish() {
 
       local arch_versioned_image=$image_name:`echo $arch | sed "s/\//-/g"`-$image_version
       echo "Publishing new version ($arch_versioned_image) from $path"
-      docker buildx build -t $arch_versioned_image --platform $arch --load
+      docker buildx build -t $arch_versioned_image --platform $arch --load $path
       docker manifest create $versioned_image --amend $arch_versioned_image
 
       if [ "$pre_release" != "true" ]; then


### PR DESCRIPTION
comment out actual image pushing and stuff that posts to slack for testing

remove anything about ec2 runners

remove one more potential push

comment out autocommit

comment out pull request creation

remove dependency

comment out publish python package

Revert "remove anything about ec2 runners"

This reverts commit fd9ba6010a77149f01d620d0fada13662f55a623.

bring back dependency

use --load instead of --push in order to not push to remote

add path to command