### PR TITLE
Add extensibility team to python connector approvers

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -10,7 +10,7 @@ from connector_ops import utils
 BACKWARD_COMPATIBILITY_REVIEWERS = {"connector-extensibility"}
 TEST_STRICTNESS_LEVEL_REVIEWERS = {"connector-extensibility"}
 BYPASS_REASON_REVIEWERS = {"connector-extensibility"}
-STRATEGIC_PYTHON_CONNECTOR_REVIEWERS = {"gl-python"}
+STRATEGIC_PYTHON_CONNECTOR_REVIEWERS = {"gl-python", "connector-extensibility"}
 BREAKING_CHANGE_REVIEWERS = {"breaking-change-reviewers"}
 REVIEW_REQUIREMENTS_FILE_PATH = ".github/connector_org_review_requirements.yaml"
 


### PR DESCRIPTION
Allow Extensibility team to also approve strategic python connector changes.