### PR TITLE
[airbyte-cdk] Increase the maximum parseable field size for CSV files

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-import sys
 import csv
 import json
 import logging

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
@@ -132,20 +132,11 @@ class _CsvReader:
 class CsvParser(FileTypeParser):
     _MAX_BYTES_PER_FILE_FOR_SCHEMA_INFERENCE = 1_000_000
 
-    def __init__(self, csv_reader: Optional[_CsvReader] = None):
+    def __init__(self, csv_reader: Optional[_CsvReader] = None, csv_field_max_bytes: int = 2**31):
         # Increase the maximum length of data that can be parsed in a single CSV field. The default is 128k, which is typically sufficient
-        # but given the use of Airbyte in loading a large variety of data it is best to allow for the maximum field size possible to avoid
+        # but given the use of Airbyte in loading a large variety of data it is best to allow for a larger maximum field size to avoid
         # skipping data on load. https://stackoverflow.com/questions/15063936/csv-error-field-larger-than-field-limit-131072
-        max_int = sys.maxsize
-
-        while True:
-            # decrease the max_int value by factor 10 as long as the OverflowError occurs.
-            try:
-                csv.field_size_limit(max_int)
-                break
-            except OverflowError:
-                max_int = int(max_int/10)
-
+        csv.field_size_limit(csv_field_max_bytes)
         self._csv_reader = csv_reader if csv_reader else _CsvReader()
 
     def check_config(self, config: FileBasedStreamConfig) -> Tuple[bool, Optional[str]]:

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import sys
 import csv
 import json
 import logging
@@ -132,6 +133,19 @@ class CsvParser(FileTypeParser):
     _MAX_BYTES_PER_FILE_FOR_SCHEMA_INFERENCE = 1_000_000
 
     def __init__(self, csv_reader: Optional[_CsvReader] = None):
+        # Increase the maximum length of data that can be parsed in a single CSV field. The default is 128k, which is typically sufficient
+        # but given the use of Airbyte in loading a large variety of data it is best to allow for the maximum field size possible to avoid
+        # skipping data on load. https://stackoverflow.com/questions/15063936/csv-error-field-larger-than-field-limit-131072
+        max_int = sys.maxsize
+
+        while True:
+            # decrease the max_int value by factor 10 as long as the OverflowError occurs.
+            try:
+                csv.field_size_limit(max_int)
+                break
+            except OverflowError:
+                max_int = int(max_int/10)
+
         self._csv_reader = csv_reader if csv_reader else _CsvReader()
 
     def check_config(self, config: FileBasedStreamConfig) -> Tuple[bool, Optional[str]]:

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_csv_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_csv_parser.py
@@ -520,7 +520,6 @@ class CsvReaderTest(unittest.TestCase):
         data_generator = self._read_data()
         assert list(data_generator) == [{"header1": "1", "header2": long_string}]
 
-
     def _read_data(self) -> Generator[Dict[str, str], None, None]:
         data_generator = self._csv_reader.read_data(
             self._config,

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_csv_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_csv_parser.py
@@ -6,7 +6,6 @@ import asyncio
 import csv
 import io
 import logging
-import sys
 import unittest
 from datetime import datetime
 from typing import Any, Dict, Generator, List, Set

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_csv_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_csv_parser.py
@@ -504,7 +504,7 @@ class CsvReaderTest(unittest.TestCase):
 
     def test_parse_field_size_larger_than_default_python_maximum(self) -> None:
         # The field size for the csv module will be set as a side-effect of initializing the CsvParser class.
-        assert csv.field_size_limit() == sys.maxsize
+        assert csv.field_size_limit() == 2**31
         long_string = 130 * 1024 * "a"
         assert len(long_string.encode("utf-8")) > (128 * 1024)
         self._stream_reader.open_file.return_value = (


### PR DESCRIPTION
The Python CSV library defaults to a maximum allowed length of 128k for a given field. This can cause issues when loading files that contain fields exceeding that length. This updates the parser to register the maximum allowable field size based on the runtime system.

Example error from an S3 source connector:
```
2024-03-17 17:35:01 source > Error parsing record. This could be due to a mismatch between the config's file type and the actual file type, or because the file or record is not parseable. stream=raw__edxorg__s3__tables__certificates_generatedcertificate file=edxorg-raw-data/edxorg/raw_data/db_table/certificates_generatedcertificate/prod/MITx-6.041x_1-1T2015/bb970ead7355f6813844e92b66e80d6cbcfbff2dbdbcf49ca4daab5676632eaf.tsv line_no=14534 n_skipped=0
Stack Trace: Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py", line 99, in read_records_from_slice
    for record in parser.parse_records(self.config, file, self.stream_reader, self.logger, schema):
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/file_based/file_types/csv_parser.py", line 194, in parse_records
    for row in data_generator:
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/file_based/file_types/csv_parser.py", line 67, in read_data
    for row in reader:
  File "/usr/local/lib/python3.9/csv.py", line 111, in __next__
    row = next(self.reader)
_csv.Error: field larger than field limit (131072)
```