### PR TITLE
✨ Destination DuckDB: track airbyte integration usage for MotherDuck

### DIFF
--- a/airbyte-integrations/connectors/destination-duckdb/README.md
+++ b/airbyte-integrations/connectors/destination-duckdb/README.md
@@ -54,8 +54,9 @@ cat integration_tests/messages.jsonl| python main.py write --config integration_
 #### Build
 **Via [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) (recommended):**
 ```bash
-airbyte-ci connectors --name=destination-duckdb build
+airbyte-ci connectors --name=destination-duckdb build [--architecture=...]
 ```
+
 
 An image will be built with the tag `airbyte/destination-duckdb:dev`.
 

--- a/airbyte-integrations/connectors/destination-duckdb/destination_duckdb/destination.py
+++ b/airbyte-integrations/connectors/destination-duckdb/destination_duckdb/destination.py
@@ -81,10 +81,13 @@ class DestinationDuckdb(Destination):
 
         # Get and register auth token if applicable
         motherduck_api_key = str(config.get(CONFIG_MOTHERDUCK_API_KEY, ""))
+        duckdb_config = {}
         if motherduck_api_key:
-            os.environ["motherduck_token"] = motherduck_api_key
+            duckdb_config["motherduck_token"] = motherduck_api_key
+            duckdb_config["custom_user_agent"] =  "airbyte"
 
-        con = duckdb.connect(database=path, read_only=False)
+
+        con = duckdb.connect(database=path, read_only=False, config=duckdb_config)
 
         con.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
 
@@ -175,10 +178,13 @@ class DestinationDuckdb(Destination):
                 logger.info(f"Using DuckDB file at {path}")
                 os.makedirs(os.path.dirname(path), exist_ok=True)
 
+            duckdb_config = {}
             if CONFIG_MOTHERDUCK_API_KEY in config:
-                os.environ["motherduck_token"] = str(config[CONFIG_MOTHERDUCK_API_KEY])
+                duckdb_config["motherduck_token"] = str(config[CONFIG_MOTHERDUCK_API_KEY])
+                duckdb_config["custom_user_agent"] =  "airbyte"
 
-            con = duckdb.connect(database=path, read_only=False)
+
+            con = duckdb.connect(database=path, read_only=False, config=duckdb_config)
             con.execute("SELECT 1;")
 
             return AirbyteConnectionStatus(status=Status.SUCCEEDED)

--- a/airbyte-integrations/connectors/destination-duckdb/destination_duckdb/destination.py
+++ b/airbyte-integrations/connectors/destination-duckdb/destination_duckdb/destination.py
@@ -86,7 +86,6 @@ class DestinationDuckdb(Destination):
             duckdb_config["motherduck_token"] = motherduck_api_key
             duckdb_config["custom_user_agent"] =  "airbyte"
 
-
         con = duckdb.connect(database=path, read_only=False, config=duckdb_config)
 
         con.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")

--- a/airbyte-integrations/connectors/destination-duckdb/destination_duckdb/destination.py
+++ b/airbyte-integrations/connectors/destination-duckdb/destination_duckdb/destination.py
@@ -14,7 +14,14 @@ from typing import Any, Iterable, Mapping
 import duckdb
 from airbyte_cdk import AirbyteLogger
 from airbyte_cdk.destinations import Destination
-from airbyte_cdk.models import AirbyteConnectionStatus, AirbyteMessage, ConfiguredAirbyteCatalog, DestinationSyncMode, Status, Type
+from airbyte_cdk.models import (
+    AirbyteConnectionStatus,
+    AirbyteMessage,
+    ConfiguredAirbyteCatalog,
+    DestinationSyncMode,
+    Status,
+    Type,
+)
 
 logger = getLogger("airbyte")
 
@@ -39,7 +46,9 @@ class DestinationDuckdb(Destination):
         Get a normalized version of the destination path.
         Automatically append /local/ to the start of the path
         """
-        if destination_path.startswith("md:") or destination_path.startswith("motherduck:"):
+        if destination_path.startswith("md:") or destination_path.startswith(
+            "motherduck:"
+        ):
             return destination_path
 
         if not destination_path.startswith("/local"):
@@ -48,7 +57,8 @@ class DestinationDuckdb(Destination):
         destination_path = os.path.normpath(destination_path)
         if not destination_path.startswith("/local"):
             raise ValueError(
-                f"destination_path={destination_path} is not a valid path." "A valid path shall start with /local or no / prefix"
+                f"destination_path={destination_path} is not a valid path."
+                "A valid path shall start with /local or no / prefix"
             )
 
         return destination_path
@@ -84,7 +94,7 @@ class DestinationDuckdb(Destination):
         duckdb_config = {}
         if motherduck_api_key:
             duckdb_config["motherduck_token"] = motherduck_api_key
-            duckdb_config["custom_user_agent"] =  "airbyte"
+            duckdb_config["custom_user_agent"] = "airbyte"
 
         con = duckdb.connect(database=path, read_only=False, config=duckdb_config)
 
@@ -132,7 +142,9 @@ class DestinationDuckdb(Destination):
                 data = message.record.data
                 stream = message.record.stream
                 if stream not in streams:
-                    logger.debug(f"Stream {stream} was not present in configured streams, skipping")
+                    logger.debug(
+                        f"Stream {stream} was not present in configured streams, skipping"
+                    )
                     continue
 
                 # add to buffer
@@ -157,7 +169,9 @@ class DestinationDuckdb(Destination):
             con.executemany(query, buffer[stream_name])
             con.commit()
 
-    def check(self, logger: AirbyteLogger, config: Mapping[str, Any]) -> AirbyteConnectionStatus:
+    def check(
+        self, logger: AirbyteLogger, config: Mapping[str, Any]
+    ) -> AirbyteConnectionStatus:
         """
         Tests if the input configuration can be used to successfully connect to the destination with the needed permissions
             e.g: if a provided API token or password can be used to connect and write to the destination.
@@ -179,9 +193,10 @@ class DestinationDuckdb(Destination):
 
             duckdb_config = {}
             if CONFIG_MOTHERDUCK_API_KEY in config:
-                duckdb_config["motherduck_token"] = str(config[CONFIG_MOTHERDUCK_API_KEY])
-                duckdb_config["custom_user_agent"] =  "airbyte"
-
+                duckdb_config["motherduck_token"] = str(
+                    config[CONFIG_MOTHERDUCK_API_KEY]
+                )
+                duckdb_config["custom_user_agent"] = "airbyte"
 
             con = duckdb.connect(database=path, read_only=False, config=duckdb_config)
             con.execute("SELECT 1;")
@@ -189,4 +204,6 @@ class DestinationDuckdb(Destination):
             return AirbyteConnectionStatus(status=Status.SUCCEEDED)
 
         except Exception as e:
-            return AirbyteConnectionStatus(status=Status.FAILED, message=f"An exception occurred: {repr(e)}")
+            return AirbyteConnectionStatus(
+                status=Status.FAILED, message=f"An exception occurred: {repr(e)}"
+            )

--- a/airbyte-integrations/connectors/destination-duckdb/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/destination-duckdb/integration_tests/integration_test.py
@@ -29,6 +29,7 @@ from airbyte_cdk.models import (
     Type,
 )
 from destination_duckdb import DestinationDuckdb
+from destination_duckdb.destination import CONFIG_MOTHERDUCK_API_KEY
 
 CONFIG_PATH = "integration_tests/config.json"
 SECRETS_CONFIG_PATH = "secrets/config.json"  # Should contain a valid MotherDuck API token
@@ -179,8 +180,11 @@ def test_write(
 
     result = list(generator)
     assert len(result) == 1
-
-    con = duckdb.connect(database=config.get("destination_path"), read_only=False)
+    motherduck_api_key = str(config.get(CONFIG_MOTHERDUCK_API_KEY, ""))
+    duckdb_config = {}
+    duckdb_config["motherduck_token"] = motherduck_api_key
+    duckdb_config["custom_user_agent"] =  "airbyte_intg_test"
+    con = duckdb.connect(database=config.get("destination_path"), config=duckdb_config,read_only=False)
     with con:
         cursor = con.execute(
             "SELECT _airbyte_ab_id, _airbyte_emitted_at, _airbyte_data "

--- a/airbyte-integrations/connectors/destination-duckdb/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/destination-duckdb/integration_tests/integration_test.py
@@ -66,7 +66,6 @@ def config(request, test_schema_name: str) -> Dict[str, str]:
     elif request.param == "motherduck_config":
         config_dict = json.loads(Path(SECRETS_CONFIG_PATH).read_text())
         config_dict["schema"] = test_schema_name
-        print(config_dict)
         yield config_dict
 
     else:

--- a/airbyte-integrations/connectors/destination-duckdb/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/destination-duckdb/integration_tests/integration_test.py
@@ -32,7 +32,9 @@ from destination_duckdb import DestinationDuckdb
 from destination_duckdb.destination import CONFIG_MOTHERDUCK_API_KEY
 
 CONFIG_PATH = "integration_tests/config.json"
-SECRETS_CONFIG_PATH = "secrets/config.json"  # Should contain a valid MotherDuck API token
+SECRETS_CONFIG_PATH = (
+    "secrets/config.json"  # Should contain a valid MotherDuck API token
+)
 
 
 def pytest_generate_tests(metafunc):
@@ -43,7 +45,9 @@ def pytest_generate_tests(metafunc):
     if Path(SECRETS_CONFIG_PATH).is_file():
         configs.append("motherduck_config")
     else:
-        print(f"Skipping MotherDuck tests because config file not found at: {SECRETS_CONFIG_PATH}")
+        print(
+            f"Skipping MotherDuck tests because config file not found at: {SECRETS_CONFIG_PATH}"
+        )
 
     # for test_name in ["test_check_succeeds", "test_write"]:
     metafunc.parametrize("config", configs, indirect=True)
@@ -99,7 +103,9 @@ def table_schema() -> str:
 
 
 @pytest.fixture
-def configured_catalogue(test_table_name: str, table_schema: str) -> ConfiguredAirbyteCatalog:
+def configured_catalogue(
+    test_table_name: str, table_schema: str
+) -> ConfiguredAirbyteCatalog:
     append_stream = ConfiguredAirbyteStream(
         stream=AirbyteStream(
             name=test_table_name,
@@ -138,7 +144,9 @@ def airbyte_message2(test_table_name: str):
 
 @pytest.fixture
 def airbyte_message3():
-    return AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(data={"state": "1"}))
+    return AirbyteMessage(
+        type=Type.STATE, state=AirbyteStateMessage(data={"state": "1"})
+    )
 
 
 @pytest.mark.disable_autouse
@@ -184,8 +192,10 @@ def test_write(
     duckdb_config = {}
     if motherduck_api_key:
         duckdb_config["motherduck_token"] = motherduck_api_key
-        duckdb_config["custom_user_agent"] =  "airbyte_intg_test"
-    con = duckdb.connect(database=config.get("destination_path"),read_only=False, config=duckdb_config)
+        duckdb_config["custom_user_agent"] = "airbyte_intg_test"
+    con = duckdb.connect(
+        database=config.get("destination_path"), read_only=False, config=duckdb_config
+    )
     with con:
         cursor = con.execute(
             "SELECT _airbyte_ab_id, _airbyte_emitted_at, _airbyte_data "

--- a/airbyte-integrations/connectors/destination-duckdb/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/destination-duckdb/integration_tests/integration_test.py
@@ -66,6 +66,7 @@ def config(request, test_schema_name: str) -> Dict[str, str]:
     elif request.param == "motherduck_config":
         config_dict = json.loads(Path(SECRETS_CONFIG_PATH).read_text())
         config_dict["schema"] = test_schema_name
+        print(config_dict)
         yield config_dict
 
     else:
@@ -182,9 +183,10 @@ def test_write(
     assert len(result) == 1
     motherduck_api_key = str(config.get(CONFIG_MOTHERDUCK_API_KEY, ""))
     duckdb_config = {}
-    duckdb_config["motherduck_token"] = motherduck_api_key
-    duckdb_config["custom_user_agent"] =  "airbyte_intg_test"
-    con = duckdb.connect(database=config.get("destination_path"), config=duckdb_config,read_only=False)
+    if motherduck_api_key:
+        duckdb_config["motherduck_token"] = motherduck_api_key
+        duckdb_config["custom_user_agent"] =  "airbyte_intg_test"
+    con = duckdb.connect(database=config.get("destination_path"),read_only=False, config=duckdb_config)
     with con:
         cursor = con.execute(
             "SELECT _airbyte_ab_id, _airbyte_emitted_at, _airbyte_data "

--- a/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
@@ -4,7 +4,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 94bd199c-2ff0-4aa2-b98e-17f0acb72610
-  dockerImageTag: 0.3.1
+  dockerImageTag: 0.3.2
   dockerRepository: airbyte/destination-duckdb
   githubIssueLabel: destination-duckdb
   icon: duckdb.svg

--- a/airbyte-integrations/connectors/destination-duckdb/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-duckdb/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "destination-duckdb"
-version = "0.3.0"
+version = "0.3.1"
 description = "Destination implementation for Duckdb."
 authors = ["Simon Späti, Airbyte"]
 license = "MIT"

--- a/airbyte-integrations/connectors/destination-duckdb/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-duckdb/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "destination-duckdb"
-version = "0.3.1"
+version = "0.3.2"
 description = "Destination implementation for Duckdb."
 authors = ["Simon Späti, Airbyte"]
 license = "MIT"

--- a/docs/integrations/destinations/duckdb.md
+++ b/docs/integrations/destinations/duckdb.md
@@ -106,6 +106,7 @@ Note: If you are running Airbyte on Windows with Docker backed by WSL2, you have
 
 | Version | Date       | Pull Request                                             | Subject                |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------- |
+| 0.3.2   | 2024-03-20 | [#32635](https://github.com/airbytehq/airbyte/pull/32635) | Instrument custom_user_agent to identify Airbyte-Motherduck connector usage.  |
 | 0.3.1   | 2023-11-18 | [#32635](https://github.com/airbytehq/airbyte/pull/32635) | Upgrade DuckDB version to [`v0.9.2`](https://github.com/duckdb/duckdb/releases/tag/v0.9.2). |
 | 0.3.0   | 2022-10-23 | [#31744](https://github.com/airbytehq/airbyte/pull/31744) | Upgrade DuckDB version to [`v0.9.1`](https://github.com/duckdb/duckdb/releases/tag/v0.9.1). **Required update for all MotherDuck users.** Note, this is a **BREAKING CHANGE** for users who may have other connections using versions of DuckDB prior to 0.9.x. See the [0.9.0 release notes](https://github.com/duckdb/duckdb/releases/tag/v0.9.0) for more information and for upgrade instructions. |
 | 0.2.1   | 2022-10-20 | [#30600](https://github.com/airbytehq/airbyte/pull/30600) | Fix: schema name mapping |


### PR DESCRIPTION
# What
Add a connection parameter to enable us to track airbyte integration usage for MotherDuck

# How
Set parameter custom_user_agent=airbyte when connecting to MotherDuck.

# User Impact
none