### PR TITLE
CI: Run `format_fix.yml` workflow without creds

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
           fetch-depth: 1
       - name: Run airbyte-ci format check [MASTER]
         id: airbyte_ci_format_check_all_master
@@ -28,11 +27,6 @@ jobs:
         with:
           context: "master"
           dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_2 }}
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           subcommand: "format check all"
 
       - name: Run airbyte-ci format check [PULL REQUEST]
@@ -43,11 +37,6 @@ jobs:
         with:
           context: "pull_request"
           dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_2 }}
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           subcommand: "format check all"
 
       - name: Run airbyte-ci format check [WORKFLOW DISPATCH]
@@ -58,11 +47,6 @@ jobs:
         with:
           context: "manual"
           dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_2 }}
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           subcommand: "format check all"
 
       - name: Match GitHub User to Slack User [MASTER]

--- a/.github/workflows/format_fix.yml
+++ b/.github/workflows/format_fix.yml
@@ -17,21 +17,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
-          # Important that this is set so that CI checks are triggered again
-          # Without this we would be forever waiting on required checks to pass
-          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
 
       - name: Run airbyte-ci format fix all
         uses: ./.github/actions/run-airbyte-ci
         continue-on-error: true
         with:
           context: "manual"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_2 }}
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           subcommand: "format fix all"
 
       # This is helpful in the case that we change a previously committed generated file to be ignored by git.


### PR DESCRIPTION
**Note: This is set to auto-merge on approval+requirements met. CI is green, so I think we're good. But wanted to call out.**

---

This works on our main repo.

Commit was cherry-picked from this PR:

- #36367

That PR has the CI workflow job here:

- https://github.com/airbytehq/airbyte/actions/runs/8381613692/job/22953550096

The above fails in the check step, due to formatting errors, instead of during hte checkout step, which was happening on the users' fork.

This doesn't prove yet that it'll actually run in a fork, but at least it still works in our repo.

---

Related to:

- #36370 
