### PR TITLE
Salesforce: retry on download_data and create_stream_job

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b117307c-14b6-41aa-9422-947e34922962
-  dockerImageTag: 2.4.0
+  dockerImageTag: 2.4.1
   dockerRepository: airbyte/source-salesforce
   documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce
   githubIssueLabel: source-salesforce

--- a/airbyte-integrations/connectors/source-salesforce/pyproject.toml
+++ b/airbyte-integrations/connectors/source-salesforce/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.4.0"
+version = "2.4.1"
 name = "source-salesforce"
 description = "Source implementation for Salesforce."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
@@ -6,6 +6,7 @@ import concurrent.futures
 import logging
 from typing import Any, List, Mapping, Optional, Tuple
 
+import backoff
 import requests  # type: ignore[import]
 from airbyte_cdk.models import ConfiguredAirbyteCatalog
 from airbyte_cdk.utils import AirbyteTracedException
@@ -300,7 +301,7 @@ class Salesforce:
         validated_streams = [stream_name for stream_name in stream_names if self.filter_streams(stream_name)]
         return {stream_name: sobject_options for stream_name, sobject_options in stream_objects.items() if stream_name in validated_streams}
 
-    @default_backoff_handler(max_tries=5, factor=5)
+    @default_backoff_handler(max_tries=5, backoff_method=backoff.expo, backoff_params={"factor": 5})
     def _make_request(
         self, http_method: str, url: str, headers: dict = None, body: dict = None, stream: bool = False, params: dict = None
     ) -> requests.models.Response:

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
@@ -26,7 +26,7 @@ TRANSIENT_EXCEPTIONS = (
     exceptions.JSONDecodeError,
 )
 
-_RETRYABLE_400_STATUS_CODE = {
+_RETRYABLE_400_STATUS_CODES = {
     # Using debug mode and breakpointing on the issue, we were able to validate that there issues are retryable. We've also opened a case
     # with Salesforce to try to understand what is causing that as the response does not have a body.
     406,
@@ -50,7 +50,7 @@ def default_backoff_handler(max_tries: int, backoff_method={"method": backoff.ex
     def should_give_up(exc):
         give_up = (
             exc.response is not None
-            and exc.response.status_code not in _RETRYABLE_400_STATUS_CODE
+            and exc.response.status_code not in _RETRYABLE_400_STATUS_CODES
             and 400 <= exc.response.status_code < 500
         )
 

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
@@ -8,6 +8,8 @@ import sys
 import backoff
 from airbyte_cdk.sources.streams.http.exceptions import DefaultBackoffException
 from requests import codes, exceptions  # type: ignore[import]
+from http.client import IncompleteRead
+
 
 TRANSIENT_EXCEPTIONS = (
     DefaultBackoffException,
@@ -15,6 +17,9 @@ TRANSIENT_EXCEPTIONS = (
     exceptions.ReadTimeout,
     exceptions.ConnectionError,
     exceptions.HTTPError,
+    # We've had a customer on a self-managed instance which got this issue. The error occurred during `BulkSalesforceStream.download_data`.
+    # Without much more information, we will make it retryable hoping that performing the same request will work.
+    IncompleteRead,
 )
 
 logger = logging.getLogger("airbyte")

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
@@ -29,7 +29,7 @@ TRANSIENT_EXCEPTIONS = (
 logger = logging.getLogger("airbyte")
 
 
-def default_backoff_handler(max_tries: int, factor: int, **kwargs):
+def default_backoff_handler(max_tries: int, backoff_method={"method": backoff.expo, "params": {"factor": 15}}, **kwargs):
     def log_retry_attempt(details):
         _, exc, _ = sys.exc_info()
         logger.info(str(exc))
@@ -49,12 +49,11 @@ def default_backoff_handler(max_tries: int, factor: int, **kwargs):
         return give_up
 
     return backoff.on_exception(
-        backoff.expo,
+        backoff_method["method"],
         TRANSIENT_EXCEPTIONS,
         jitter=None,
         on_backoff=log_retry_attempt,
         giveup=should_give_up,
         max_tries=max_tries,
-        factor=factor,
-        **kwargs,
+        **backoff_method["params"],
     )

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
@@ -9,7 +9,6 @@ import backoff
 from airbyte_cdk.sources.streams.http.exceptions import DefaultBackoffException
 from requests import codes, exceptions  # type: ignore[import]
 
-
 TRANSIENT_EXCEPTIONS = (
     DefaultBackoffException,
     exceptions.ConnectTimeout,

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
@@ -48,7 +48,11 @@ def default_backoff_handler(max_tries: int, backoff_method={"method": backoff.ex
         logger.info(f"Caught retryable error after {details['tries']} tries. Waiting {details['wait']} seconds then retrying...")
 
     def should_give_up(exc):
-        give_up = exc.response is not None and exc.response.status_code not in _RETRYABLE_400_STATUS_CODE and 400 <= exc.response.status_code < 500
+        give_up = (
+            exc.response is not None
+            and exc.response.status_code not in _RETRYABLE_400_STATUS_CODE
+            and 400 <= exc.response.status_code < 500
+        )
 
         # Salesforce can return an error with a limit using a 403 code error.
         if exc.response is not None and exc.response.status_code == codes.forbidden:

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
@@ -4,12 +4,11 @@
 
 import logging
 import sys
+from http.client import IncompleteRead
 
 import backoff
 from airbyte_cdk.sources.streams.http.exceptions import DefaultBackoffException
 from requests import codes, exceptions  # type: ignore[import]
-from http.client import IncompleteRead
-
 
 TRANSIENT_EXCEPTIONS = (
     DefaultBackoffException,

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -11,7 +11,7 @@ import urllib.parse
 import uuid
 from abc import ABC
 from contextlib import closing
-from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Type, Union, Dict
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Type, Union
 
 import backoff
 import pandas as pd
@@ -41,7 +41,6 @@ csv.field_size_limit(CSV_FIELD_SIZE_LIMIT)
 DEFAULT_ENCODING = "utf-8"
 LOOKBACK_SECONDS = 600  # based on https://trailhead.salesforce.com/trailblazer-community/feed/0D54V00007T48TASAZ
 _JOB_TRANSIENT_ERRORS_MAX_RETRY = 1
-
 
 
 class SalesforceStream(HttpStream, ABC):
@@ -493,7 +492,9 @@ class BulkSalesforceStream(SalesforceStream):
         except exceptions.JSONDecodeError:
             self.logger.warning(f"The response for `{response.request.url}` is not a JSON but was `{response.content}`")
         except IndexError:
-            self.logger.warning(f"The response for `{response.request.url}` was expected to be a list with at least one element but was `{response.content}`")
+            self.logger.warning(
+                f"The response for `{response.request.url}` was expected to be a list with at least one element but was `{response.content}`"
+            )
 
         return None, ""
 

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -354,7 +354,7 @@ class BulkSalesforceStream(SalesforceStream):
 
     transformer = TypeTransformer(TransformConfig.CustomSchemaNormalization | TransformConfig.DefaultSchemaNormalization)
 
-    @default_backoff_handler(max_tries=5, backoff_method={"method": backoff.expo, "params": {"factor": 15}})
+    @default_backoff_handler(max_tries=5, backoff_method=backoff.expo, backoff_params={"factor": 15})
     def _send_http_request(self, method: str, url: str, json: dict = None, headers: dict = None, stream: bool = False):
         """
         This method should be used when you don't have to read data from the HTTP body. Else, you will have to retry when you actually read
@@ -370,7 +370,7 @@ class BulkSalesforceStream(SalesforceStream):
         response.raise_for_status()
         return response
 
-    @default_backoff_handler(max_tries=5, backoff_method={"method": backoff.expo, "params": {"factor": 15}})
+    @default_backoff_handler(max_tries=5, backoff_method=backoff.expo, backoff_params={"factor": 15})
     def _create_stream_job(self, query: str, url: str) -> Optional[str]:
         json = {"operation": "queryAll", "query": query, "contentType": "CSV", "columnDelimiter": "COMMA", "lineEnding": "LF"}
         response = self._non_retryable_send_http_request("POST", url, json=json)
@@ -544,7 +544,7 @@ class BulkSalesforceStream(SalesforceStream):
 
         return self.encoding
 
-    @default_backoff_handler(max_tries=5, backoff_method={"method": backoff.constant, "params": {"interval": 5}})
+    @default_backoff_handler(max_tries=5, backoff_method=backoff.constant, backoff_params={"interval": 5})
     def download_data(self, url: str, chunk_size: int = 1024) -> tuple[str, str, dict]:
         """
         Retrieves binary data result from successfully `executed_job`, using chunks, to avoid local memory limitations.

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -360,8 +360,6 @@ class BulkSalesforceStream(SalesforceStream):
         return self._non_retryable_send_http_request(method, url, json, headers, stream)
 
     def _non_retryable_send_http_request(self, method: str, url: str, json: dict = None, headers: dict = None, stream: bool = False):
-        """
-        """
         headers = self.authenticator.get_auth_header() if not headers else headers | self.authenticator.get_auth_header()
         response = self._session.request(method, url=url, headers=headers, json=json, stream=stream)
         if response.status_code not in [200, 204]:

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/conftest.py
@@ -3,6 +3,7 @@
 #
 
 import json
+import pathlib
 from typing import List
 from unittest.mock import Mock
 
@@ -22,14 +23,14 @@ def time_sleep_mock(mocker):
 
 @pytest.fixture(scope="module")
 def bulk_catalog():
-    with open("unit_tests/bulk_catalog.json") as f:
+    with (pathlib.Path(__file__).parent / "bulk_catalog.json").open() as f:
         data = json.loads(f.read())
     return ConfiguredAirbyteCatalog.parse_obj(data)
 
 
 @pytest.fixture(scope="module")
 def rest_catalog():
-    with open("unit_tests/rest_catalog.json") as f:
+    with (pathlib.Path(__file__).parent / "rest_catalog.json").open() as f:
         data = json.loads(f.read())
     return ConfiguredAirbyteCatalog.parse_obj(data)
 

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -193,7 +193,7 @@ Now that you have set up the Salesforce source connector, check out the followin
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| 2.4.1   | 2024-03-22 | [36385](https://github.com/airbytehq/airbyte/pull/36385) | Retry HTTP requests on IncompleteRead                                                                                                |
+| 2.4.1   | 2024-03-22 | [36385](https://github.com/airbytehq/airbyte/pull/36385) | Retry HTTP requests and jobs on various cases                                                                                        |
 | 2.4.0   | 2024-03-12 | [35978](https://github.com/airbytehq/airbyte/pull/35978)  | Upgrade CDK to start emitting record counts with state and full refresh state                                                        |
 | 2.3.3   | 2024-03-04 | [35791](https://github.com/airbytehq/airbyte/pull/35791) | Fix memory leak (OOM)                                                                                                                |
 | 2.3.2   | 2024-02-19 | [35421](https://github.com/airbytehq/airbyte/pull/35421) | Add Stream Slice Step option to specification                                                                                        |

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -193,7 +193,7 @@ Now that you have set up the Salesforce source connector, check out the followin
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| 2.4.1   | 2024-03-22 | [36385](https://github.com/airbytehq/airbyte/pull/36385) | Retry HTTP requests and jobs on various cases                                                                                        |
+| 2.4.1   | 2024-04-03 | [36385](https://github.com/airbytehq/airbyte/pull/36385) | Retry HTTP requests and jobs on various cases                                                                                        |
 | 2.4.0   | 2024-03-12 | [35978](https://github.com/airbytehq/airbyte/pull/35978)  | Upgrade CDK to start emitting record counts with state and full refresh state                                                        |
 | 2.3.3   | 2024-03-04 | [35791](https://github.com/airbytehq/airbyte/pull/35791) | Fix memory leak (OOM)                                                                                                                |
 | 2.3.2   | 2024-02-19 | [35421](https://github.com/airbytehq/airbyte/pull/35421) | Add Stream Slice Step option to specification                                                                                        |

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -193,7 +193,8 @@ Now that you have set up the Salesforce source connector, check out the followin
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| 2.4.0   | 2024-03-12 | [35978](https://github.com/airbytehq/airbyte/pull/35978)  | Upgrade CDK to start emitting record counts with state and full refresh state                                                                                                                                                 |
+| 2.4.1   | 2024-03-22 | [36385](https://github.com/airbytehq/airbyte/pull/36385) | Retry HTTP requests on IncompleteRead                                                                                                |
+| 2.4.0   | 2024-03-12 | [35978](https://github.com/airbytehq/airbyte/pull/35978)  | Upgrade CDK to start emitting record counts with state and full refresh state                                                        |
 | 2.3.3   | 2024-03-04 | [35791](https://github.com/airbytehq/airbyte/pull/35791) | Fix memory leak (OOM)                                                                                                                |
 | 2.3.2   | 2024-02-19 | [35421](https://github.com/airbytehq/airbyte/pull/35421) | Add Stream Slice Step option to specification                                                                                        |
 | 2.3.1   | 2024-02-12 | [35147](https://github.com/airbytehq/airbyte/pull/35147) | Manage dependencies with Poetry.                                                                                                     |


### PR DESCRIPTION
## What

A self-managed customer has had [issues syncing a very big Salesforce sync](https://airbytehq-team.slack.com/archives/C0570DE7TC6/p1710345601286679). We are seeing a lot of connector errors in the sync namely TimeoutError. However, the one that makes the sync crash is an `IncompleteRead`/`ChunkedEncodingError`. I can't observe a `IncompleteRead` in our cloud platform for the past 7 days as [this query](https://console.cloud.google.com/logs/query;query=%22IncompleteRead%22;summaryFields=:false:32:beginning;cursorTimestamp=2024-03-22T13:01:25.189441966Z;duration=P7D?project=prod-ab-cloud-proj&pli=1) yields no result (note that I've got weird infinite loading on Google Logs Explorer this morning so I would like someone to confirm that as well).

There are other `ChunkedEncodingError` as shown by https://github.com/airbytehq/airbyte-internal-issues/issues/6860 so we will try to tackle all of them at the same time. The issue is that they occur not on the actual HTTP query but when we try to read the response. As such, the retry should encapsulate `.json()` and `.iter_content(<...>)`

Other fixes were adding as they were follow up to fully resolve the customer issues, namely:
* JSON parsing: https://github.com/airbytehq/airbyte-internal-issues/issues/6887
* 406 HTTP status: https://github.com/airbytehq/airbyte-internal-issues/issues/6886
* 420 HTTP status: https://github.com/airbytehq/airbyte-internal-issues/issues/6855

## Solution

We have no good reasons to believe it will work but for now, we will set this exception as retryable, make sure the backoff are not only on `self._session.send(<...>)` but also on `.json()` and `.iter_content(<...>)` and will monitor the situation.