### PR TITLE
Update cloud path in cdk publish pipeline

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -292,7 +292,7 @@ jobs:
         run: |
           PREVIOUS_VERSION=$(cat oss/airbyte-connector-builder-resources/CDK_VERSION)
           sed -i "s/${PREVIOUS_VERSION}/${{needs.bump-version.outputs.new_cdk_version}}/g" oss/airbyte-connector-builder-server/Dockerfile
-          sed -i "s/${PREVIOUS_VERSION}/${{needs.bump-version.outputs.new_cdk_version}}/g" airbyte-connector-builder-server-wrapped/Dockerfile
+          sed -i "s/${PREVIOUS_VERSION}/${{needs.bump-version.outputs.new_cdk_version}}/g" cloud/airbyte-connector-builder-server-wrapped/Dockerfile
           sed -i "s/airbyte-cdk==${PREVIOUS_VERSION}/airbyte-cdk==${{needs.bump-version.outputs.new_cdk_version}}/g" oss/airbyte-connector-builder-server/requirements.in
           echo ${{needs.bump-version.outputs.new_cdk_version}} > oss/airbyte-connector-builder-resources/CDK_VERSION
           cd oss/airbyte-connector-builder-server


### PR DESCRIPTION
## What
The path to the cloud project was updated from the root to `/cloud`.

This PR updates the path to the wrapped connector builder server's file in the CDK publish pipeline