### PR TITLE
🐛 Source MailChimp: Fix incorrect primary key on `list_members` stream

### DIFF
--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b03a9f3e-22a5-11eb-adc1-0242ac120002
-  dockerImageTag: 1.1.2
+  dockerImageTag: 1.2.0
   dockerRepository: airbyte/source-mailchimp
   documentationUrl: https://docs.airbyte.com/integrations/sources/mailchimp
   githubIssueLabel: source-mailchimp

--- a/airbyte-integrations/connectors/source-mailchimp/pyproject.toml
+++ b/airbyte-integrations/connectors/source-mailchimp/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.1.2"
+version = "1.2.0"
 name = "source-mailchimp"
 description = "Source implementation for Mailchimp."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/streams.py
+++ b/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/streams.py
@@ -357,6 +357,7 @@ class ListMembers(MailChimpListSubStream):
 
     cursor_field = "last_changed"
     data_field = "members"
+    primary_key = "contact_id"
 
 
 class Reports(IncrementalMailChimpStream):

--- a/docs/integrations/sources/mailchimp.md
+++ b/docs/integrations/sources/mailchimp.md
@@ -123,6 +123,7 @@ Now that you have set up the Mailchimp source connector, check out the following
 
 | Version | Date       | Pull Request                                             | Subject                                                                    |
 | ------- | ---------- | -------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 1.2.0   | 2024-03-22 | [35092](TODO                                           ) | Fix primary key on `list_members` to preserve emails in multiple lists.    |
 | 1.1.2   | 2024-02-09 | [35092](https://github.com/airbytehq/airbyte/pull/35092) | Manage dependencies with Poetry.                                           |
 | 1.1.1   | 2024-01-11 | [34157](https://github.com/airbytehq/airbyte/pull/34157) | Prepare for airbyte-lib                                                    |
 | 1.1.0   | 2023-12-20 | [32852](https://github.com/airbytehq/airbyte/pull/32852) | Add optional start_date for incremental streams                            |


### PR DESCRIPTION
Resolves #36404

**The issue is that the `list_members` object currently has `primary_key` set to `id`, which is incorrect:**
- In Mailchimp, `members` are associated with `lists`. This means there will be one member record _per list_ they are on.
- `id` is a hash of the member's email address, which is obviously non-unique across lists
- This means that if you do an incremental sync with the current connector, you will only get one record per email—potentially resulting in record loss.

**Either of the following keys would be suitable:**
- `contact_id`, which is a non-email-specific identifier for the member within the list (so is unique across email+list)
- `web_id` is an integer and is also unique to the list+email combination
- `id` and `list_id` could also be used as a compound key with the same effect

**Mailchimp also discourages the use of `members`.`id` in their [docs](https://mailchimp.com/developer/marketing/api/list-members/list-members-info/) (see the `members`.`contact_id` response object), stating:**
>As Mailchimp evolves beyond email, you may eventually have contacts without email addresses. While the `id` is the MD5 hash of their email address, this `contact_id` is agnostic of contact’s inclusion of an email address.

This has been a longstanding issue in the Mailchimp source, but only affects accounts with the same contacts on multiple lists which may be why it's flown under the radar.

**Note:** I would recommend bumping the minor version and including an additional note when released. While this is a non-breaking change, it may introduce unexpected side-effects for existing users using incremental syncs (namely that where previously there was only one record per email address, there will now be multiple if the same contact is on multiple lists). This is correct and consistent with other ETL tools, but may still be unexpected for users who have been using this connector and only receiving unique emails in their destinations.

This change also needs to be addressed appropriately in the currently open PR for the low-code version of this connector, which carries the same bug (I already added a note on that PR): https://github.com/airbytehq/airbyte/pull/35281