### PR TITLE
🐛 Source Intercom: Fixed regression for the `conversations` stream 

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.6.2
+  dockerImageTag: 0.6.3
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   githubIssueLabel: source-intercom

--- a/airbyte-integrations/connectors/source-intercom/pyproject.toml
+++ b/airbyte-integrations/connectors/source-intercom/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.6.2"
+version = "0.6.3"
 name = "source-intercom"
 description = "Source implementation for Intercom Yaml."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -294,7 +294,7 @@ definitions:
   conversations:
     $ref: "#/definitions/stream_incremental_search"
     retriever:
-      $ref: "#/definitions/stream_full_refresh/retriever"
+      $ref: "#/definitions/stream_incremental_search/retriever"
       requester:
         $ref: "#/definitions/requester_incremental_search"
         request_headers:

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -74,6 +74,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                  |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------|
+| 0.6.3 | 2024-03-23 | [36414](https://github.com/airbytehq/airbyte/pull/36414) | Fixed `pagination` regression bug for `conversations` stream |
 | 0.6.2 | 2024-03-22 | [36277](https://github.com/airbytehq/airbyte/pull/36277) | Fixed the bug for `conversations` stream failed due to `404 - User Not Found`, when the `2.10` API version is used |
 | 0.6.1 | 2024-03-18 | [36232](https://github.com/airbytehq/airbyte/pull/36232) | Fixed the bug caused the regression when setting the `Intercom-Version` header, updated the source to use the latest CDK version |
 | 0.6.0 | 2024-02-12 | [35176](https://github.com/airbytehq/airbyte/pull/35176) | Update the connector to use `2.10` API version |


### PR DESCRIPTION
## What
Resolving:
- https://github.com/airbytehq/oncall/issues/4646

## What happened
The `manifest` looked at the wrong `$ref`, pointing the Incremental `conversations` stream to the `full-refresh` retriever, which caused the `pagination` regression making the `next_page_token` to be the part of the `url_path`, rather than the `request_body_json` part, as it should be.

Switching the `$refs` resolves the issue.


 