### PR TITLE
destination-duckdb: fix formatting

### DIFF
--- a/airbyte-integrations/connectors/destination-duckdb/destination_duckdb/destination.py
+++ b/airbyte-integrations/connectors/destination-duckdb/destination_duckdb/destination.py
@@ -14,14 +14,7 @@ from typing import Any, Iterable, Mapping
 import duckdb
 from airbyte_cdk import AirbyteLogger
 from airbyte_cdk.destinations import Destination
-from airbyte_cdk.models import (
-    AirbyteConnectionStatus,
-    AirbyteMessage,
-    ConfiguredAirbyteCatalog,
-    DestinationSyncMode,
-    Status,
-    Type,
-)
+from airbyte_cdk.models import AirbyteConnectionStatus, AirbyteMessage, ConfiguredAirbyteCatalog, DestinationSyncMode, Status, Type
 
 logger = getLogger("airbyte")
 
@@ -46,9 +39,7 @@ class DestinationDuckdb(Destination):
         Get a normalized version of the destination path.
         Automatically append /local/ to the start of the path
         """
-        if destination_path.startswith("md:") or destination_path.startswith(
-            "motherduck:"
-        ):
+        if destination_path.startswith("md:") or destination_path.startswith("motherduck:"):
             return destination_path
 
         if not destination_path.startswith("/local"):
@@ -57,8 +48,7 @@ class DestinationDuckdb(Destination):
         destination_path = os.path.normpath(destination_path)
         if not destination_path.startswith("/local"):
             raise ValueError(
-                f"destination_path={destination_path} is not a valid path."
-                "A valid path shall start with /local or no / prefix"
+                f"destination_path={destination_path} is not a valid path." "A valid path shall start with /local or no / prefix"
             )
 
         return destination_path
@@ -142,9 +132,7 @@ class DestinationDuckdb(Destination):
                 data = message.record.data
                 stream = message.record.stream
                 if stream not in streams:
-                    logger.debug(
-                        f"Stream {stream} was not present in configured streams, skipping"
-                    )
+                    logger.debug(f"Stream {stream} was not present in configured streams, skipping")
                     continue
 
                 # add to buffer
@@ -169,9 +157,7 @@ class DestinationDuckdb(Destination):
             con.executemany(query, buffer[stream_name])
             con.commit()
 
-    def check(
-        self, logger: AirbyteLogger, config: Mapping[str, Any]
-    ) -> AirbyteConnectionStatus:
+    def check(self, logger: AirbyteLogger, config: Mapping[str, Any]) -> AirbyteConnectionStatus:
         """
         Tests if the input configuration can be used to successfully connect to the destination with the needed permissions
             e.g: if a provided API token or password can be used to connect and write to the destination.
@@ -193,9 +179,7 @@ class DestinationDuckdb(Destination):
 
             duckdb_config = {}
             if CONFIG_MOTHERDUCK_API_KEY in config:
-                duckdb_config["motherduck_token"] = str(
-                    config[CONFIG_MOTHERDUCK_API_KEY]
-                )
+                duckdb_config["motherduck_token"] = str(config[CONFIG_MOTHERDUCK_API_KEY])
                 duckdb_config["custom_user_agent"] = "airbyte"
 
             con = duckdb.connect(database=path, read_only=False, config=duckdb_config)
@@ -204,6 +188,4 @@ class DestinationDuckdb(Destination):
             return AirbyteConnectionStatus(status=Status.SUCCEEDED)
 
         except Exception as e:
-            return AirbyteConnectionStatus(
-                status=Status.FAILED, message=f"An exception occurred: {repr(e)}"
-            )
+            return AirbyteConnectionStatus(status=Status.FAILED, message=f"An exception occurred: {repr(e)}")


### PR DESCRIPTION
## What
fix the formatting by running `airbyte-ci format fix python`. Looks like it didn't block https://github.com/airbytehq/airbyte/pull/36353

Follow ups:
1. Aggregate all connector development docs in a single guide as a follow up so it's easier to know how to fix the formatting
2. Potentially block merging PRs on the formatting check