### PR TITLE
Fix missed PR number in airbyte-ci 4.6.1

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -68,7 +68,8 @@ make tools.airbyte-ci.clean
 
 ## Disabling telemetry
 
-We collect anonymous usage data to help improve the tool. If you would like to disable this, you can set the `AIRBYTE_CI_DISABLE_TELEMETRY` environment variable to `true`.
+We collect anonymous usage data to help improve the tool. If you would like to disable this, you can
+set the `AIRBYTE_CI_DISABLE_TELEMETRY` environment variable to `true`.
 
 ## Installation for development
 
@@ -294,14 +295,14 @@ flowchart TD
 #### Options
 
 | Option                                                  | Multiple | Default value | Description                                                                                                                                                                                              |
-| ------------------------------------------------------- | -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ------------------------------------------------------- | -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `--skip-step/-x`                                        | True     |               | Skip steps by id e.g. `-x unit -x acceptance`                                                                                                                                                            |
 | `--only-step/-k`                                        | True     |               | Only run specific steps by id e.g. `-k unit -k acceptance`                                                                                                                                               |
 | `--fail-fast`                                           | False    | False         | Abort after any tests fail, rather than continuing to run additional tests. Use this setting to confirm a known bug is fixed (or not), or when you only require a pass/fail result.                      |
 | `--code-tests-only`                                     | True     | False         | Skip any tests not directly related to code updates. For instance, metadata checks, version bump checks, changelog verification, etc. Use this setting to help focus on code quality during development. |
 | `--concurrent-cat`                                      | False    | False         | Make CAT tests run concurrently using pytest-xdist. Be careful about source or destination API rate limits.                                                                                              |
 | `--<step-id>.<extra-parameter>=<extra-parameter-value>` | True     |               | You can pass extra parameters for specific test steps. More details in the extra parameters section below                                                                                                |
-| `--ci-requirements`                                     | False    |               |                                                                                                                                                                                                          | Output the CI requirements as a JSON payload. It is used to determine the CI runner to use.
+| `--ci-requirements`                                     | False    |               |                                                                                                                                                                                                          | Output the CI requirements as a JSON payload. It is used to determine the CI runner to use. |
 
 Note:
 
@@ -518,7 +519,6 @@ Make a connector using a Dockerfile migrate to the base image by:
 Migrate source-openweather to use the base image:
 `airbyte-ci connectors --name=source-openweather migrate_to_base_image`
 
-
 ### <a id="connectors-migrate-to-poetry"></a>`connectors migrate-to-poetry` command
 
 Migrate connectors the poetry package manager.
@@ -622,10 +622,13 @@ flowchart TD
 
 ### <a id="tests-command"></a>`tests` command
 
-This command runs the poe tasks declared in the `[tool.airbyte-ci]` section of our internal poetry packages.
-Feel free to checkout this [Pydantic model](https://github.com/airbytehq/airbyte/blob/main/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/models.py#L9) to see the list of available options in `[tool.airbyte-ci]` section.
+This command runs the poe tasks declared in the `[tool.airbyte-ci]` section of our internal poetry
+packages. Feel free to checkout this
+[Pydantic model](https://github.com/airbytehq/airbyte/blob/main/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/models.py#L9)
+to see the list of available options in `[tool.airbyte-ci]` section.
 
-You can find the list of internal packages [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/__init__.py#L1)
+You can find the list of internal packages
+[here](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/__init__.py#L1)
 
 #### Options
 
@@ -636,6 +639,7 @@ You can find the list of internal packages [here](https://github.com/airbytehq/a
 | `--ci-requirements`        | False    | False    | Output the CI requirements as a JSON payload. It is used to determine the CI runner to use. |
 
 #### Examples
+
 You can pass multiple `--poetry-package-path` options to run poe tasks.
 
 E.G.: running Poe tasks on `airbyte-lib` and `airbyte-ci/connectors/pipelines`:
@@ -644,12 +648,11 @@ E.G.: running Poe tasks on `airbyte-lib` and `airbyte-ci/connectors/pipelines`:
 E.G.: running Poe tasks on the modified internal packages of the current branch:
 `airbyte-ci test --modified`
 
-
 ## Changelog
 
 | Version | PR                                                         | Description                                                                                                                |
 | ------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| 4.6.1   | [#0](https://github.com/airbytehq/airbyte/pull/0)          | Fix `ValueError` related to PR number in migrate-to-poetry                                                                 |
+| 4.6.1   | [#36319](https://github.com/airbytehq/airbyte/pull/36319)  | Fix `ValueError` related to PR number in migrate-to-poetry                                                                 |
 | 4.6.0   | [#35583](https://github.com/airbytehq/airbyte/pull/35583)  | Implement the `airbyte-ci connectors migrate-to-poetry` command.                                                           |
 | 4.5.4   | [#36206](https://github.com/airbytehq/airbyte/pull/36206)  | Revert poetry cache removal during nightly builds                                                                          |
 | 4.5.3   | [#34586](https://github.com/airbytehq/airbyte/pull/34586)  | Extract connector changelog modification logic into its own class                                                          |


### PR DESCRIPTION
In #36319, @alafanechere changelog entry missed the PR number — this just puts it back, plus formatting. 