### PR TITLE
Add stale action for open issues

### DIFF
--- a/.github/workflows/stale-community-issues.yaml
+++ b/.github/workflows/stale-community-issues.yaml
@@ -23,4 +23,4 @@ jobs:
             It's possible it has already been fixed. It is being marked as stale and will be closed in 20 days if there is no activity.
             To keep it open, please comment to let us know why it is important to you and if it is still reproducible on recent versions of Airbyte.
           close-issue-message: "This issue was closed because it has been inactive for 20 days since being marked as stale."
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}

--- a/.github/workflows/stale-community-issues.yaml
+++ b/.github/workflows/stale-community-issues.yaml
@@ -1,7 +1,7 @@
 name: Stale issue action
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "* 9 * * *"
 
 jobs:
   close-issues:

--- a/.github/workflows/stale-community-issues.yaml
+++ b/.github/workflows/stale-community-issues.yaml
@@ -1,0 +1,26 @@
+name: Stale issue action
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          any-of-labels: "community"
+          exempt-issue-labels: "frozen"
+          days-before-issue-stale: 180
+          days-before-issue-close: 20
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            At Airbyte, we seek to be clear about the project priorities and roadmap. 
+            This issue has not had any activity for 180 days, suggesting that it's not as critical as others. 
+            It's possible it has already been fixed. It is being marked as stale and will be closed in 20 days if there is no activity.
+            To keep it open, please comment to let us know why it is important to you and if it is still reproducible on recent versions of Airbyte.
+          close-issue-message: "This issue was closed because it has been inactive for 20 days since being marked as stale."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-routed-issues.yaml
+++ b/.github/workflows/stale-routed-issues.yaml
@@ -1,7 +1,7 @@
 name: Stale issue action
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "* 8 * * *"
 
 jobs:
   close-issues:

--- a/.github/workflows/stale-routed-issues.yaml
+++ b/.github/workflows/stale-routed-issues.yaml
@@ -22,4 +22,4 @@ jobs:
             It's possible it has already been fixed. It is being marked as stale and will be closed in 20 days if there is no activity.
             To keep it open, please comment to let us know why it is important to you and if it is still reproducible on recent versions of Airbyte.
           close-issue-message: "This issue was closed because it has been inactive for 20 days since being marked as stale."
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}

--- a/.github/workflows/stale-routed-issues.yaml
+++ b/.github/workflows/stale-routed-issues.yaml
@@ -12,14 +12,13 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          any-of-labels: "community"
-          exempt-issue-labels: "frozen"
-          days-before-issue-stale: 180
+          any-of-labels: "frozen"
+          days-before-issue-stale: 365
           days-before-issue-close: 20
           stale-issue-label: "stale"
           stale-issue-message: >
             At Airbyte, we seek to be clear about the project priorities and roadmap. 
-            This issue has not had any activity for 180 days, suggesting that it's not as critical as others. 
+            This issue has not had any activity for 365 days, suggesting that it's not as critical as others. 
             It's possible it has already been fixed. It is being marked as stale and will be closed in 20 days if there is no activity.
             To keep it open, please comment to let us know why it is important to you and if it is still reproducible on recent versions of Airbyte.
           close-issue-message: "This issue was closed because it has been inactive for 20 days since being marked as stale."

--- a/.github/workflows/stale-routed-issues.yaml
+++ b/.github/workflows/stale-routed-issues.yaml
@@ -1,0 +1,26 @@
+name: Stale issue action
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          any-of-labels: "community"
+          exempt-issue-labels: "frozen"
+          days-before-issue-stale: 180
+          days-before-issue-close: 20
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            At Airbyte, we seek to be clear about the project priorities and roadmap. 
+            This issue has not had any activity for 180 days, suggesting that it's not as critical as others. 
+            It's possible it has already been fixed. It is being marked as stale and will be closed in 20 days if there is no activity.
+            To keep it open, please comment to let us know why it is important to you and if it is still reproducible on recent versions of Airbyte.
+          close-issue-message: "This issue was closed because it has been inactive for 20 days since being marked as stale."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds 2 stale actions:
* issues without frozen label not updated in 180+ days and close after 20 days ([currently 280 issues](https://github.com/airbytehq/airbyte/issues?q=is%3Aissue+is%3Aopen+label%3Acommunity+updated%3A%3C2023-09-19+-label%3Afrozen))
* issues with frozen label not updated in 365+ days and close after 20 days([currently 0 issues](https://github.com/airbytehq/airbyte/issues?q=is%3Aopen+is%3Aissue+label%3Afrozen+updated%3A%3C2023-03-25))