### PR TITLE
force-publish java CDK on push to master

### DIFF
--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -1,3 +1,5 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
 # Usage: This workflow can be invoked manually or by a slash command.
 #
 # To invoke via GitHub UI, go to Actions tab, select the workflow, and click "Run workflow".
@@ -8,6 +10,11 @@
 #    /publish-java-cdk force=true     # Force-publish if needing to replace an already published version
 name: Publish Java CDK
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - "./airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties"
   workflow_dispatch:
     inputs:
       repo:
@@ -41,7 +48,7 @@ concurrency:
 env:
   # Use the provided GITREF or default to the branch triggering the workflow.
   GITREF: ${{ github.event.inputs.gitref || github.ref }}
-  FORCE: "${{ github.event.inputs.force == null && 'false' || github.event.inputs.force }}"
+  FORCE: "${{ github.event_name == 'push' || github.event.inputs.force == null && 'false' ||  github.event.inputs.force }}"
   DRY_RUN: "${{ github.event.inputs.dry-run == null && 'true' || github.event.inputs.dry-run }}"
   CDK_VERSION_FILE_PATH: "./airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties"
   S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
@@ -101,7 +108,8 @@ jobs:
           arguments: --scan :airbyte-cdk:java:airbyte-cdk:cdkBuild
 
       - name: Check for Existing Version
-        if: ${{ !(env.FORCE == 'true') }}
+        # we only check existing version if it's a manual trigger and FORCE is set to false
+        if: ${{ (env.FORCE != 'true') }}
         uses: burrunan/gradle-cache-action@v1
         env:
           CI: true


### PR DESCRIPTION
Right now, we publish CDK versions before they hit master. We should always overwrite whatever file is in the repository with the current master code every time we merge a modification to version.properties