### PR TITLE
✨ [source-google-ads] Only use 2 accounts for query validation

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -185,8 +185,9 @@ class SourceGoogleAds(AbstractSource):
 
         customers = self.get_customers(google_api, config)
         logger.info(f"Found {len(customers)} customers: {[customer.id for customer in customers]}")
+        is_not_none = functools.partial(operator.is_not, None)
         # Use only two accounts for validation: one manager account and one non-manager account
-        validate_customers = list(filter(functools.partial(operator.is_not, None), [
+        validate_customers = list(filter(is_not_none, [
             next(filter(lambda c: c.is_manager_account, customers), None),
             next(filter(lambda c: not c.is_manager_account, customers), None),
         ]))

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -48,6 +48,7 @@ from .streams import (
 )
 from .utils import GAQL, logger, traced_exception
 
+DEFAULT_VALIDATION_SAMPLE_SIZE = 10
 
 class SourceGoogleAds(AbstractSource):
     # Skip exceptions on missing streams
@@ -186,7 +187,10 @@ class SourceGoogleAds(AbstractSource):
 
         customers = self.get_customers(google_api, config)
         logger.info(f"Found {len(customers)} customers: {[customer.id for customer in customers]}")
-        validate_customers = random.sample(customers, min(config.get(""), len(customers)))
+        validate_customers = random.sample(customers, min(
+            config.get("validation_sample_size", DEFAULT_VALIDATION_SAMPLE_SIZE),
+            len(customers)
+        ))
         logger.info(f"Using {len(validate_customers)} customers for validation: {[customer.id for customer in validate_customers]}")
         # Check custom query request validity by sending metric request with non-existent time window
         for customer in validate_customers:

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -5,6 +5,7 @@
 
 import logging
 from typing import Any, Iterable, List, Mapping, MutableMapping, Tuple
+import random
 
 from airbyte_cdk.models import FailureType, SyncMode
 from airbyte_cdk.sources import AbstractSource
@@ -185,9 +186,10 @@ class SourceGoogleAds(AbstractSource):
 
         customers = self.get_customers(google_api, config)
         logger.info(f"Found {len(customers)} customers: {[customer.id for customer in customers]}")
-
+        validate_customers = random.sample(customers, min(config.get(""), len(customers)))
+        logger.info(f"Using {len(validate_customers)} customers for validation: {[customer.id for customer in validate_customers]}")
         # Check custom query request validity by sending metric request with non-existent time window
-        for customer in customers:
+        for customer in validate_customers:
             for query in config.get("custom_queries_array", []):
                 table_name = query["table_name"]
                 query = query["query"]

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_errors.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_errors.py
@@ -1,13 +1,11 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
-
-
+import logging
 from contextlib import nullcontext as does_not_raise
 from unittest.mock import Mock
 
 import pytest
-from airbyte_cdk import AirbyteLogger
 from airbyte_cdk.utils import AirbyteTracedException
 from source_google_ads.google_ads import GoogleAds
 from source_google_ads.models import CustomerModel
@@ -59,7 +57,7 @@ def test_expected_errors(mocker, config, exception, error_message):
     )
     source = SourceGoogleAds()
     with pytest.raises(AirbyteTracedException) as exception:
-        status_ok, error = source.check_connection(AirbyteLogger(), config)
+        status_ok, error = source.check_connection(logging.getLogger('airbyte'), config)
     assert exception.value.message == error_message
 
 

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
@@ -4,7 +4,7 @@
 import logging
 import re
 from collections import namedtuple
-from unittest.mock import Mock, call, patch, MagicMock
+from unittest.mock import Mock, call, MagicMock
 
 import pendulum
 import pytest

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
@@ -1,15 +1,13 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
-
-
+import logging
 import re
 from collections import namedtuple
 from unittest.mock import Mock, call, patch, MagicMock
 
 import pendulum
 import pytest
-from airbyte_cdk import AirbyteLogger
 from airbyte_cdk.models import AirbyteStream, ConfiguredAirbyteCatalog, ConfiguredAirbyteStream, DestinationSyncMode, SyncMode
 from pendulum import today
 from source_google_ads.custom_query_stream import IncrementalCustomQuery
@@ -140,7 +138,7 @@ def test_read_missing_stream(config, mock_get_customers):
     )
 
     try:
-        list(source.read(AirbyteLogger(), config=config, catalog=catalog))
+        list(source.read(logging.getLogger('airbyte'), config=config, catalog=catalog))
     except KeyError as error:
         pytest.fail(str(error))
 
@@ -385,7 +383,7 @@ def test_check_connection_should_pass_when_config_valid(mocker):
     source = SourceGoogleAds()
     source.get_customers = lambda *args, **kwargs: [CustomerModel(is_manager_account=False, time_zone="Europe/Berlin", id="123")] * 100
     check_successful, message = source.check_connection(
-        AirbyteLogger(),
+        logging.getLogger('airbyte'),
         {
             "credentials": {
                 "developer_token": "fake_developer_token",

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
@@ -17,8 +17,6 @@ from source_google_ads.source import SourceGoogleAds
 from source_google_ads.streams import AdGroupAdLegacy, chunk_date_range
 from source_google_ads.utils import GAQL
 
-from .common import MockGoogleAdsClient
-
 
 @pytest.fixture
 def mock_get_customers(mocker):

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
@@ -379,7 +379,10 @@ def test_check_connection_should_pass_when_config_valid(mocker):
     mock_google_api_class = Mock(return_value=mock_google_api_client)
     mocker.patch("source_google_ads.source.GoogleAds", mock_google_api_class)
     source = SourceGoogleAds()
-    source.get_customers = lambda *args, **kwargs: [CustomerModel(is_manager_account=False, time_zone="Europe/Berlin", id="123")] * 100
+    source.get_customers = lambda *args, **kwargs: [
+                                                       CustomerModel(is_manager_account=False, time_zone="Europe/Berlin", id="123"),
+                                                       CustomerModel(is_manager_account=True, time_zone="Europe/Berlin", id="123"),
+                                                   ] * 100
     check_successful, message = source.check_connection(
         logging.getLogger('airbyte'),
         {
@@ -416,7 +419,7 @@ def test_check_connection_should_pass_when_config_valid(mocker):
     )
     assert check_successful
     assert message is None
-    assert mock_google_api_client.send_request.call_count == 30
+    assert mock_google_api_client.send_request.call_count == 5
 
 
 def test_end_date_is_not_in_the_future(customers):


### PR DESCRIPTION
Use only two accounts for GAQL query validation, managerial and non-managerial

Resolves #36484