### PR TITLE
Don't try to run connectors CI tests if only the python CDK changed

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -41,7 +41,7 @@ jobs:
               - '*'
               - 'airbyte-ci/**/*'
               - 'airbyte-integrations/connectors/**/*'
-              - 'airbyte-cdk/**/*'
+              - 'airbyte-cdk/java/**/*'
               - 'buildSrc/**/*'
       # The Connector CI Tests is a status check emitted by airbyte-ci
       # We make it pass once we have determined that there are no changes to the connectors


### PR DESCRIPTION
Save 6 precious minutes every time we change the Python CDK and nothing else :)
