### PR TITLE
[ISSUE #6829] adding logs to shutdown hook

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/exception_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/exception_handler.py
@@ -28,11 +28,13 @@ def init_uncaught_exception_handler(logger: logging.Logger) -> None:
             sys.__excepthook__(exception_type, exception_value, traceback_)
             return
 
+        logger.info("Starting shutdown hook...")
         logger.fatal(exception_value, exc_info=exception_value)
 
         # emit an AirbyteTraceMessage for any exception that gets to this spot
         traced_exc = assemble_uncaught_exception(exception_type, exception_value)
 
         traced_exc.emit_message()
+        logger.info("Shutdown hook completed successfully. Source should exit with a failing exit code...")
 
     sys.excepthook = hook_fn

--- a/airbyte-cdk/python/unit_tests/test_exception_handler.py
+++ b/airbyte-cdk/python/unit_tests/test_exception_handler.py
@@ -60,7 +60,7 @@ def test_uncaught_exception_handler():
     stdout_lines = err.value.output.decode("utf-8").strip().split("\n")
     assert len(stdout_lines) == 4
 
-    log_output, trace_output = stdout_lines
+    entry_log, log_output, trace_output, exit_log = stdout_lines
 
     out_log_message = AirbyteMessage.parse_obj(json.loads(log_output))
     assert out_log_message == expected_log_message, "Log message should be emitted in expected form"

--- a/airbyte-cdk/python/unit_tests/test_exception_handler.py
+++ b/airbyte-cdk/python/unit_tests/test_exception_handler.py
@@ -58,7 +58,7 @@ def test_uncaught_exception_handler():
     assert not err.value.stderr, "nothing on the stderr"
 
     stdout_lines = err.value.output.decode("utf-8").strip().split("\n")
-    assert len(stdout_lines) == 2
+    assert len(stdout_lines) == 4
 
     log_output, trace_output = stdout_lines
 


### PR DESCRIPTION
## What

Trying to have more logs to investigate issue https://github.com/airbytehq/airbyte-internal-issues/issues/6829. After investigating with the client on https://github.com/airbytehq/oncall/issues/4679, we could see in Datadog that the pod was still up even though all the logs that would lead to an exit code 1 were there.

## How

Based on https://docs.python.org/3/library/sys.html#sys.excepthook, the excepthook should be the last thing being executed before the python program gets killed. We see the `logger.fatal` but want to make sure that we go all the way through the excepthook so we added log at the end of the method as well.