### PR TITLE
Add a config migration

### DIFF
--- a/airbyte-integrations/connectors/source-okta/main.py
+++ b/airbyte-integrations/connectors/source-okta/main.py
@@ -8,7 +8,6 @@ import sys
 from airbyte_cdk.entrypoint import launch
 from source_okta import SourceOkta
 
-
 if __name__ == "__main__":
     source = SourceOkta()
     launch(source, sys.argv[1:])

--- a/airbyte-integrations/connectors/source-okta/source_okta/config_migration.py
+++ b/airbyte-integrations/connectors/source-okta/source_okta/config_migration.py
@@ -38,10 +38,7 @@ class OktaConfigMigration:
         config["domain"] = config["base_url"].split("https://")[1].split(".")[0]
         if "credentials" not in config:
             if "token" in config:
-                config["credentials"] = {
-                    "auth_type": "api_token",
-                    "api_token": config["token"]
-                }
+                config["credentials"] = {"auth_type": "api_token", "api_token": config["token"]}
             else:
                 raise ValueError(f"Invalid config. got {config}")
         return config

--- a/airbyte-integrations/connectors/source-okta/source_okta/config_migration.py
+++ b/airbyte-integrations/connectors/source-okta/source_okta/config_migration.py
@@ -1,0 +1,88 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+
+import logging
+from typing import Any, List, Mapping
+
+from airbyte_cdk.config_observation import create_connector_config_control_message
+from airbyte_cdk.entrypoint import AirbyteEntrypoint
+from airbyte_cdk.sources import Source
+from airbyte_cdk.sources.message import InMemoryMessageRepository, MessageRepository
+
+logger = logging.getLogger("airbyte")
+
+
+class OktaConfigMigration:
+    """
+    This class stands for migrating the config at runtime,
+    while providing the backward compatibility when falling back to the previous source version.
+    """
+
+    message_repository: MessageRepository = InMemoryMessageRepository()
+    migrate_from_keys_map: dict = {
+        "expand_issue_changelog": "changelog",
+        "render_fields": "renderedFields",
+        "expand_issue_transition": "transitions",
+    }
+    migrate_to_key: str = "issues_stream_expand_with"
+
+    @classmethod
+    def should_migrate(cls, config: Mapping[str, Any]) -> bool:
+        """
+        based on the source spec.
+        Returns:
+            > True, if the transformation is necessary
+            > False, otherwise.
+            > Raises the Exception if the structure could not be migrated.
+        """
+        return "domain" not in config
+
+    @classmethod
+    def modify(cls, config: Mapping[str, Any]) -> Mapping[str, Any]:
+        config["domain"] = config["base_url"].split("https://")[1].split(".")[0]
+        if "credentials" not in config:
+            if "token" in config:
+                config["credentials"] = {
+                    "auth_type": "api_token",
+                    "api_token": config["token"]
+                }
+            else:
+                raise ValueError(f"Invalid config. got {config}")
+        return config
+
+    @classmethod
+    def modify_and_save(cls, config_path: str, source: Source, config: Mapping[str, Any]) -> Mapping[str, Any]:
+        # modify the config
+        migrated_config = cls.modify(config)
+        # save the config
+        source.write_config(migrated_config, config_path)
+        # return modified config
+        return migrated_config
+
+    @classmethod
+    def emit_control_message(cls, migrated_config: Mapping[str, Any]) -> None:
+        # add the Airbyte Control Message to message repo
+        cls.message_repository.emit_message(create_connector_config_control_message(migrated_config))
+        # emit the Airbyte Control Message from message queue to stdout
+        for message in cls.message_repository._message_queue:
+            print(message.json(exclude_unset=True))
+
+    @classmethod
+    def migrate(cls, args: List[str], source: Source) -> None:
+        """
+        This method checks the input args, should the config be migrated,
+        transform if necessary and emit the CONTROL message.
+        """
+        # get config path
+        config_path = AirbyteEntrypoint(source).extract_config(args)
+        # proceed only if `--config` arg is provided
+        if config_path:
+            # read the existing config
+            config = source.read_config(config_path)
+            # migration check
+            if cls.should_migrate(config):
+                cls.emit_control_message(
+                    cls.modify_and_save(config_path, source, config),
+                )

--- a/airbyte-integrations/connectors/source-okta/source_okta/config_migration.py
+++ b/airbyte-integrations/connectors/source-okta/source_okta/config_migration.py
@@ -21,12 +21,6 @@ class OktaConfigMigration:
     """
 
     message_repository: MessageRepository = InMemoryMessageRepository()
-    migrate_from_keys_map: dict = {
-        "expand_issue_changelog": "changelog",
-        "render_fields": "renderedFields",
-        "expand_issue_transition": "transitions",
-    }
-    migrate_to_key: str = "issues_stream_expand_with"
 
     @classmethod
     def should_migrate(cls, config: Mapping[str, Any]) -> bool:

--- a/airbyte-integrations/connectors/source-okta/source_okta/custom_authenticators.py
+++ b/airbyte-integrations/connectors/source-okta/source_okta/custom_authenticators.py
@@ -1,6 +1,6 @@
 from abc import ABC
-from dataclasses import dataclass, InitVar
-from typing import Mapping, Any, Tuple
+from dataclasses import InitVar, dataclass
+from typing import Any, Mapping, Tuple
 
 import requests
 from airbyte_cdk.sources.declarative.auth import DeclarativeOauth2Authenticator
@@ -14,6 +14,7 @@ class CustomBearerAuthenticator(DeclarativeAuthenticator):
     """
     Custom authenticator that uses "SSWS" instead of "Bearer" in the authorization header.
     """
+
     config: Config
     parameters: InitVar[Mapping[str, Any]]
 

--- a/airbyte-integrations/connectors/source-okta/source_okta/run.py
+++ b/airbyte-integrations/connectors/source-okta/source_okta/run.py
@@ -6,8 +6,10 @@
 import sys
 
 from airbyte_cdk.entrypoint import launch
-from .source import SourceOkta
+
 from .config_migration import OktaConfigMigration
+from .source import SourceOkta
+
 
 def run():
     source = SourceOkta()

--- a/airbyte-integrations/connectors/source-okta/source_okta/run.py
+++ b/airbyte-integrations/connectors/source-okta/source_okta/run.py
@@ -7,7 +7,9 @@ import sys
 
 from airbyte_cdk.entrypoint import launch
 from .source import SourceOkta
+from .config_migration import OktaConfigMigration
 
 def run():
     source = SourceOkta()
+    OktaConfigMigration.migrate(sys.argv[1:], source)
     launch(source, sys.argv[1:])


### PR DESCRIPTION
## What
Migrate legacy configs to avoid a breaking change

## How
Most of the code is boiler plate.
1. Add the config migration object
2. Call the migration from the run method

The only methods specific to okta are
1. `should_migrate`, which returns true if `domain` is not in the config since it is a new field
3. `modify`, which does the transformation. This is where the magic happens. 
  - Transform the base_url into the domain
  - Create the credentials object from the `token` field if needed

Context is I think the new config format is an improvement, but it would be nice to avoid introducing a breaking change because it's disruptive to users 