### PR TITLE
airbyte ci test to support --extras

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           # Note: expressions within a filter are OR'ed
           filters: |
+            # This list is duplicated in `pipelines/airbyte_ci/test/__init__.py`
             internal_poetry_packages:
             - airbyte-lib/**
             - airbyte-ci/connectors/pipelines/**

--- a/airbyte-ci/connectors/base_images/pyproject.toml
+++ b/airbyte-ci/connectors/base_images/pyproject.toml
@@ -36,6 +36,6 @@ publish =  "base_images.commands:publish_existing_version"
 test = "pytest tests"
 
 [tool.airbyte_ci]
-extra_poetry_groups = ["dev"]
+optional_poetry_groups = ["dev"]
 poe_tasks = ["test"]
 mount_docker_socket = true

--- a/airbyte-ci/connectors/ci_credentials/pyproject.toml
+++ b/airbyte-ci/connectors/ci_credentials/pyproject.toml
@@ -32,5 +32,5 @@ ci_credentials = "ci_credentials.main:ci_credentials"
 test = "pytest tests"
 
 [tool.airbyte_ci]
-extra_poetry_groups = ["dev"]
+optional_poetry_groups = ["dev"]
 poe_tasks = ["test"]

--- a/airbyte-ci/connectors/common_utils/pyproject.toml
+++ b/airbyte-ci/connectors/common_utils/pyproject.toml
@@ -27,6 +27,6 @@ build-backend = "poetry.core.masonry.api"
 test = "pytest tests"
 
 [tool.airbyte_ci]
-extra_poetry_groups = ["dev"]
+optional_poetry_groups = ["dev"]
 # Disable poe tasks as tests are not passing ATM
 poe_tasks = []

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -38,5 +38,5 @@ allowed-hosts-checks = "connector_ops.allowed_hosts_checks:check_allowed_hosts"
 test = "pytest tests"
 
 [tool.airbyte_ci]
-extra_poetry_groups = ["dev"]
+optional_poetry_groups = ["dev"]
 poe_tasks = ["test"]

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -40,6 +40,6 @@ type_check = "mypy src --disallow-untyped-defs"
 lint = "ruff check src"
 
 [tool.airbyte_ci]
-extra_poetry_groups = ["dev"]
+optional_poetry_groups = ["dev"]
 poe_tasks = ["type_check", "lint", "test"]
 required_environment_variables = ["DOCKER_HUB_USERNAME", "DOCKER_HUB_PASSWORD",]

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -36,7 +36,7 @@ promote-connector-to-latest = "gsutil  -m rsync -r -d gs://$TARGET_BUCKET/metada
 test = "pytest tests"
 
 [tool.airbyte_ci]
-extra_poetry_groups = ["dev"]
+optional_poetry_groups = ["dev"]
 poe_tasks = ["test"]
 
 [build-system]

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -49,5 +49,5 @@ module_name = "orchestrator"
 test = "pytest tests"
 
 [tool.airbyte_ci]
-extra_poetry_groups = ["dev"]
+optional_poetry_groups = ["dev"]
 poe_tasks = ["test"]

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -652,6 +652,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                |
 | ------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| 4.6.3   | [#36527](https://github.com/airbytehq/airbyte/pull/36527)  | Handle extras as well as groups in `airbyte ci test` [poetry packages]                                                     |
 | 4.6.2   | [#36220](https://github.com/airbytehq/airbyte/pull/36220)  | Allow using `migrate-to-base-image` without PULL_REQUEST_NUMBER                                                            |
 | 4.6.1   | [#36319](https://github.com/airbytehq/airbyte/pull/36319)  | Fix `ValueError` related to PR number in migrate-to-poetry                                                                 |
 | 4.6.0   | [#35583](https://github.com/airbytehq/airbyte/pull/35583)  | Implement the `airbyte-ci connectors migrate-to-poetry` command.                                                           |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/models.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/models.py
@@ -11,7 +11,8 @@ class AirbyteCiPackageConfiguration(BaseModel):
     required_environment_variables: Set[str] = Field(
         set(), description="List of unique required environment variables to pass to the container running the poe task"
     )
-    extra_poetry_groups: Set[str] = Field(set(), description="List of unique extra poetry groups to install")
+    poetry_extras: Set[str] = Field(set(), description="List of unique poetry extras to install")
+    optional_poetry_groups: Set[str] = Field(set(), description="List of unique poetry groups to install")
     side_car_docker_engine: bool = Field(
         False, description="Flag indicating the use of a sidecar Docker engine during the poe task executions"
     )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
@@ -191,7 +191,11 @@ def prepare_container_for_poe_tasks(
     container = container.with_workdir(f"/airbyte/{poetry_package_path}")
 
     # Install the poetry package
-    container = container.with_exec(["poetry", "install"] + [f"--with={group}" for group in airbyte_ci_package_config.extra_poetry_groups])
+    container = container.with_exec(
+        ["poetry", "install"]
+        + [f"--with={group}" for group in airbyte_ci_package_config.optional_poetry_groups]
+        + [f"--extras={extra}" for extra in airbyte_ci_package_config.poetry_extras]
+    )
     return container
 
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.6.2"
+version = "4.6.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -62,6 +62,6 @@ type_check = "mypy pipelines --disallow-untyped-defs"
 lint = "ruff check pipelines"
 
 [tool.airbyte_ci]
-extra_poetry_groups = ["dev"]
+optional_poetry_groups = ["dev"]
 poe_tasks = ["type_check", "lint", "test"]
 mount_docker_socket = true

--- a/airbyte-lib/pyproject.toml
+++ b/airbyte-lib/pyproject.toml
@@ -255,7 +255,7 @@ airbyte-lib-validate-source = "airbyte_lib.validate:run"
 test = "pytest tests"
 
 [tool.airbyte_ci]
-extra_poetry_groups = ["dev"]
+optional_poetry_groups = ["dev"]
 poe_tasks = ["test"]
 required_environment_variables = ["GCP_GSM_CREDENTIALS"]
 side_car_docker_engine = true


### PR DESCRIPTION
Our `airbyte-ci test` command supports [groups](https://python-poetry.org/docs/pyproject/#dependencies-and-dependency-groups) but not [extras](https://python-poetry.org/docs/pyproject/#extras). This PR allows configuring extras to install if necessary (like when running the unit tests in the [upstack PR](https://github.com/airbytehq/airbyte/actions/runs/8446603559/job/23135651978?pr=36497)), and renames to better distinguish between the groups. 

We probably don't need to include `dev` as an optional group since it's implicitly installed, but I didn't mess with that here, for one because I wanted to test the rename.

For usage see [upstack PR.](https://github.com/airbytehq/airbyte/pull/36497/files#diff-1734d8b375bd2fc6fd8419f94ca88aad97eefaf2e78fa548c7379b28fca6456dR97-R101)