### PR TITLE
Adds jenv's .java-version to project .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ out
 **/gmon.out
 static_checker_reports/
 
+# jenv version mgmt artifacts
+.java-version
+
 # Logs
 acceptance_tests_logs/
 airbyte_ci_logs/


### PR DESCRIPTION
Fixes https://github.com/airbytehq/airbyte-internal-issues/issues/7034

Problem

For parts of the repository that require jenv to control the Java version, a corresponding .java-version file artifact is required to co-exist in the target directory for the following command:

    `jenv local <version #>`

This file should only be explicitly added to the repository.

This relates to the initial steps defined in this document: [developing-locally](https://docs.airbyte.com/contributing-to-airbyte/resources/developing-locally)

Solution

- Adds a rule to the project-level .gitignore file to ignore all .java-version files

Note

No additional steps required.