### PR TITLE
Add expand parameter and schema for Price.Tiers

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/prices.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/prices.json
@@ -71,29 +71,29 @@
     "tax_behavior": {
       "type": ["null", "string"]
     },
-    "tiers" : {
-      "type" : ["null", "array"],
-      "items" : {
-        "properties" : {
-          "flat_amount" : {
-            "type" : ["null", "integer"]
+    "tiers": {
+      "type": ["null", "array"],
+      "items": {
+        "properties": {
+          "flat_amount": {
+            "type": ["null", "integer"]
           },
-          "flat_amount_decimal" : {
-            "type" : ["null", "string"]
+          "flat_amount_decimal": {
+            "type": ["null", "string"]
           },
-          "unit_amount" : {
-            "type" : ["null","integer"]
+          "unit_amount": {
+            "type": ["null", "integer"]
           },
-          "unit_amount_decimal" : {
-            "type" : ["null","string"]
+          "unit_amount_decimal": {
+            "type": ["null", "string"]
           },
-          "up_to" : {
-            "type" : ["null", "string"]
+          "up_to": {
+            "type": ["null", "string"]
           }
         }
       }
     },
-    "tiers_mode" : {
+    "tiers_mode": {
       "type": ["null", "string"]
     },
     "transform_quantity": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/prices.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/prices.json
@@ -71,7 +71,29 @@
     "tax_behavior": {
       "type": ["null", "string"]
     },
-    "tiers_mode": {
+    "tiers" : {
+      "type" : ["null", "array"],
+      "items" : {
+        "properties" : {
+          "flat_amount" : {
+            "type" : ["null", "integer"]
+          },
+          "flat_amount_decimal" : {
+            "type" : ["null", "string"]
+          },
+          "unit_amount" : {
+            "type" : ["null","integer"]
+          },
+          "unit_amount_decimal" : {
+            "type" : ["null","string"]
+          },
+          "up_to" : {
+            "type" : ["null", "string"]
+          }
+        }
+      }
+    },
+    "tiers_mode" : {
       "type": ["null", "string"]
     },
     "transform_quantity": {

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -393,7 +393,13 @@ class SourceStripe(ConcurrentSourceAdapter):
                 event_types=["plan.created", "plan.updated", "plan.deleted"],
                 **args,
             ),
-            IncrementalStripeStream(name="prices", path="prices", event_types=["price.created", "price.updated", "price.deleted"], expand_items=["data.tiers"], **args),
+            IncrementalStripeStream(
+                name="prices",
+                path="prices",
+                event_types=["price.created", "price.updated", "price.deleted"],
+                expand_items=["data.tiers"],
+                **args,
+            ),
             IncrementalStripeStream(
                 name="products", path="products", event_types=["product.created", "product.updated", "product.deleted"], **args
             ),

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -393,7 +393,7 @@ class SourceStripe(ConcurrentSourceAdapter):
                 event_types=["plan.created", "plan.updated", "plan.deleted"],
                 **args,
             ),
-            IncrementalStripeStream(name="prices", path="prices", event_types=["price.created", "price.updated", "price.deleted"], **args),
+            IncrementalStripeStream(name="prices", path="prices", event_types=["price.created", "price.updated", "price.deleted"], expand_items=["data.tiers"], **args),
             IncrementalStripeStream(
                 name="products", path="products", event_types=["product.created", "product.updated", "product.deleted"], **args
             ),


### PR DESCRIPTION
## What

Enabled reading the Prices.Tiers object for the Stripe source connector. Issue #30362 

## How

* Added the Price.Tiers object to prices.json schema.
* Added expand query parameter to Prices API call.

##  🚨 User Impact  🚨
* No braking changes