### PR TITLE
base_images: run connectors as airbyte user, not root

### DIFF
--- a/airbyte-ci/connectors/base_images/base_images/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/bases.py
@@ -98,4 +98,11 @@ class AirbyteConnectorBaseImage(ABC):
         Returns:
             dagger.Container: The container using the base python image.
         """
-        return self.dagger_client.pipeline(self.name_with_tag).container(platform=platform).from_(self.root_image.address)
+        return (
+            self.dagger_client.pipeline(self.name_with_tag)
+            .container(platform=platform)
+            .from_(self.root_image.address)
+            .with_exec(["chmod", "-R", "755", "/airbyte"])
+            .with_exec(["chmod", "-R", "777", "/tmp"])
+            .with_user("airbyte")
+        )

--- a/airbyte-ci/connectors/base_images/base_images/python/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/python/bases.py
@@ -90,7 +90,7 @@ class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
 
         return (
             self.get_base_container(platform)
-            .with_mounted_cache("/root/.cache/pip", pip_cache_volume)
+            .with_mounted_cache("/home/airbyte/.cache/pip", pip_cache_volume)
             # Set the timezone to UTC
             .with_exec(["ln", "-snf", "/usr/share/zoneinfo/Etc/UTC", "/etc/localtime"])
             # Upgrade pip to the expected version


### PR DESCRIPTION
## What

If my pseudocode here actually works, the idea is to run airbyte connectors from airbyte user, instead of root. 

In words of @evantahler:

```
# make a new user
RUN adduser airbyte
# grant access to app dir to the new user
RUN chmod -R 755 /airbyte
# switch to the new user for the rest of the commands
USER airbyte
```

## Questions

- [ ] How should we test this?
- [ ] How do I build an image locally to test that it works? Can we document this into `base_images/README.md` too?
- [ ] Should we _delete_ the root user from those images, to actually get the security benefits? 

/cc @alafanechere and @Hesperide 