### PR TITLE
check cdk: don't use connector test runenr 

### DIFF
--- a/.github/workflows/python_cdk_tests.yml
+++ b/.github/workflows/python_cdk_tests.yml
@@ -37,7 +37,7 @@ jobs:
     needs:
       - changes
     if: needs.changes.outputs.python_cdk == 'true'
-    runs-on: connector-test-large
+    runs-on: ubuntu-latest
     name: Python CDK Tests
     timeout-minutes: 30
     steps:

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -40,7 +40,7 @@ class AirbyteEntrypoint(object):
     def __init__(self, source: Source):
         init_uncaught_exception_handler(logger)
 
-        # deployment mode is read when instantiating the entrypoint because it is the common path shared by syncs and connector builder test requests
+        # Deployment mode is read when instantiating the entrypoint because it is the common path shared by syncs and connector builder test requests
         if is_cloud_environment():
             _init_internal_request_filter()
 


### PR DESCRIPTION
The CDK tests don't do much fancy now, we don't need a big runner for them. Due to the java cdk changes, there are a million PRs running the `Gradle Check` workflow, which means that CDK test runners are waiting forever. This aims to fix that and clean up some infra costs associated with using unnecessary runner time.