### PR TITLE
follow up to #36294: allow migrate sub stream state with custom partition router

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
@@ -57,7 +57,6 @@ class LegacyToPerPartitionStateMigration(StateMigration):
 
         return parent_key
 
-
     def should_migrate(self, stream_state: Mapping[str, Any]) -> bool:
         if _is_already_migrated(stream_state):
             return False

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
@@ -5,6 +5,7 @@ from typing import Any, Mapping
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.migrations.state_migration import StateMigration
 from airbyte_cdk.sources.declarative.models import DatetimeBasedCursor, SubstreamPartitionRouter
+from airbyte_cdk.sources.declarative.models.declarative_component_schema import ParentStreamConfig
 
 
 def _is_already_migrated(stream_state: Mapping[str, Any]) -> bool:
@@ -40,9 +41,22 @@ class LegacyToPerPartitionStateMigration(StateMigration):
         self._config = config
         self._parameters = parameters
         self._partition_key_field = InterpolatedString.create(
-            self._partition_router.parent_stream_configs[0].parent_key, parameters=self._parameters
+            self._get_parent_key(self._partition_router), parameters=self._parameters
         ).eval(self._config)
         self._cursor_field = InterpolatedString.create(self._cursor.cursor_field, parameters=self._parameters).eval(self._config)
+
+    def _get_parent_key(self, partition_router: SubstreamPartitionRouter) -> str:
+        parent_stream_config = partition_router.parent_stream_configs[0]
+
+        # Retrieve the parent key with a condition, as properties are returned as a dictionary for custom components.
+        parent_key = (
+            parent_stream_config.parent_key
+            if isinstance(parent_stream_config, ParentStreamConfig)
+            else parent_stream_config.get("parent_key")
+        )
+
+        return parent_key
+
 
     def should_migrate(self, stream_state: Mapping[str, Any]) -> bool:
         if _is_already_migrated(stream_state):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -316,10 +316,10 @@ class ModelToComponentFactory:
         )
 
     def create_legacy_to_per_partition_state_migration(
-            self,
-            model: LegacyToPerPartitionStateMigrationModel,
-            config: Mapping[str, Any],
-            declarative_stream: DeclarativeStreamModel,
+        self,
+        model: LegacyToPerPartitionStateMigrationModel,
+        config: Mapping[str, Any],
+        declarative_stream: DeclarativeStreamModel,
     ) -> LegacyToPerPartitionStateMigration:
         retriever = declarative_stream.retriever
         partition_router = retriever.partition_router
@@ -333,9 +333,7 @@ class ModelToComponentFactory:
                 f"LegacyToPerPartitionStateMigrations can only be applied on a SimpleRetriever with a Substream partition router. Got {type(partition_router)}"
             )
         if not hasattr(partition_router, "parent_stream_configs"):
-            raise ValueError(
-                "LegacyToPerPartitionStateMigrations can only be applied with a parent stream configuration."
-            )
+            raise ValueError("LegacyToPerPartitionStateMigrations can only be applied with a parent stream configuration.")
 
         return LegacyToPerPartitionStateMigration(declarative_stream.retriever.partition_router, declarative_stream.incremental_sync, config, declarative_stream.parameters)  # type: ignore # The retriever type was already checked
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -325,7 +325,7 @@ class ModelToComponentFactory:
             raise ValueError(
                 f"LegacyToPerPartitionStateMigrations can only be applied on a DeclarativeStream with a SimpleRetriever. Got {type(declarative_stream.retriever)}"
             )
-        if not isinstance(declarative_stream.retriever.partition_router, SubstreamPartitionRouterModel):
+        if not isinstance(declarative_stream.retriever.partition_router, (SubstreamPartitionRouterModel, CustomPartitionRouterModel)):
             raise ValueError(
                 f"LegacyToPerPartitionStateMigrations can only be applied on a SimpleRetriever with a Substream partition router. Got {type(declarative_stream.retriever.partition_router)}"
             )

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -328,9 +328,10 @@ class ModelToComponentFactory:
 
         partition_router = declarative_stream.retriever.partition_router
         router_class = partition_router[0].get("class_name") if partition_router else None
+        is_parent_stream_config = True if partition_router.parent_stream_configs else False
 
         is_default_substream_partition_router = isinstance(partition_router, SubstreamPartitionRouterModel)
-        is_custom_substream_partition_router = router_class == SubstreamPartitionRouterModel and isinstance(
+        is_custom_substream_partition_router = is_parent_stream_config and router_class == SubstreamPartitionRouterModel and isinstance(
             partition_router, CustomPartitionRouterModel
         )
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
@@ -241,3 +241,33 @@ def _migrator_with_multiple_parent_streams():
     config = {}
     parameters = {}
     return LegacyToPerPartitionStateMigration(partition_router, cursor, config, parameters)
+
+
+def _migrator_with_custom_partition_router():
+    partition_router = CustomPartitionRouter(
+        type="CustomPartitionRouter",
+        class_name="a_class_namer",
+        parent_stream_configs=[
+            ParentStreamConfig(
+                type="ParentStreamConfig",
+                parent_key="id",
+                partition_field="parent_id",
+                stream=DeclarativeStream(
+                    type="DeclarativeStream",
+                    retriever=CustomRetriever(
+                        type="CustomRetriever",
+                        class_name="a_class_name"
+                    )
+                )
+            )
+        ]
+    )
+    cursor = DatetimeBasedCursor(
+        type="DatetimeBasedCursor",
+        cursor_field="{{ parameters['cursor_field'] }}",
+        datetime_format="%Y-%m-%dT%H:%M:%S.%fZ",
+        start_datetime="1970-01-01T00:00:00.0Z",
+    )
+    config = {}
+    parameters = {}
+    return LegacyToPerPartitionStateMigration(partition_router, cursor, config, parameters)

--- a/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
@@ -4,6 +4,7 @@
 import pytest
 from airbyte_cdk.sources.declarative.migrations.legacy_to_per_partition_state_migration import LegacyToPerPartitionStateMigration
 from airbyte_cdk.sources.declarative.models import (
+    CustomPartitionRouter,
     CustomRetriever,
     DatetimeBasedCursor,
     DeclarativeStream,

--- a/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
@@ -251,6 +251,7 @@ def _migrator_with_multiple_parent_streams():
     parameters = {}
     return LegacyToPerPartitionStateMigration(partition_router, cursor, config, parameters)
 
+
 @pytest.mark.parametrize(
     "retriever_type, partition_router_class, is_parent_stream_config, expected_exception, expected_error_message",
     [
@@ -269,7 +270,7 @@ def test_create_legacy_to_per_partition_state_migration(
 ):
     partition_router = partition_router_class(type="CustomPartitionRouter", class_name="a_class_namer") if partition_router_class else None
 
-    stream =  MagicMock()
+    stream = MagicMock()
     stream.retriever = MagicMock(spec=retriever_type)
     stream.retriever.partition_router = partition_router
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
@@ -2,23 +2,17 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-import pytest
 from unittest.mock import MagicMock
-from airbyte_cdk.sources.declarative.parsers.model_to_component_factory import ModelToComponentFactory
+
+import pytest
 from airbyte_cdk.sources.declarative.migrations.legacy_to_per_partition_state_migration import LegacyToPerPartitionStateMigration
-from airbyte_cdk.sources.declarative.models import (
-    CustomPartitionRouter,
-    CustomRetriever,
-    DatetimeBasedCursor,
-    DeclarativeStream,
-    ParentStreamConfig,
-    SimpleRetriever,
-    SubstreamPartitionRouter,
-)
+from airbyte_cdk.sources.declarative.models import CustomPartitionRouter, CustomRetriever, DatetimeBasedCursor, DeclarativeStream
 from airbyte_cdk.sources.declarative.models import LegacyToPerPartitionStateMigration as LegacyToPerPartitionStateMigrationModel
-from airbyte_cdk.sources.declarative.yaml_declarative_source import YamlDeclarativeSource
-from airbyte_cdk.sources.declarative.parsers.manifest_reference_resolver import ManifestReferenceResolver
+from airbyte_cdk.sources.declarative.models import ParentStreamConfig, SimpleRetriever, SubstreamPartitionRouter
 from airbyte_cdk.sources.declarative.parsers.manifest_component_transformer import ManifestComponentTransformer
+from airbyte_cdk.sources.declarative.parsers.manifest_reference_resolver import ManifestReferenceResolver
+from airbyte_cdk.sources.declarative.parsers.model_to_component_factory import ModelToComponentFactory
+from airbyte_cdk.sources.declarative.yaml_declarative_source import YamlDeclarativeSource
 
 factory = ModelToComponentFactory()
 resolver = ManifestReferenceResolver()

--- a/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
@@ -15,8 +15,12 @@ from airbyte_cdk.sources.declarative.parsers.model_to_component_factory import M
 from airbyte_cdk.sources.declarative.yaml_declarative_source import YamlDeclarativeSource
 
 factory = ModelToComponentFactory()
+
 resolver = ManifestReferenceResolver()
+
 transformer = ManifestComponentTransformer()
+
+
 def test_migrate_a_valid_legacy_state_to_per_partition():
     input_state = {
         "13506132": {


### PR DESCRIPTION
## What

The implementation proposed in [this PR](https://github.com/airbytehq/airbyte/pull/36294) allows migrating sub-stream state only if the stream uses `SubstreamPartitionRouter` as the partition router. However, for some streams that use `CustomPartitionRouter` instead of the default, it would also be beneficial to have a solution for migration (e.g. Source Survey Monkey - `survey_responses` stream).

## How

- Update type validation in `create_legacy_to_per_partition_state_migration`.
- Add conditional retrieval for `parent_key` in the initialization logic of `LegacyToPerPartitionStateMigration`.