### PR TITLE
connector-templates: Unpinning pytest and upgrading to recent base image version

### DIFF
--- a/airbyte-integrations/connector-templates/destination-python/metadata.yaml.hbs
+++ b/airbyte-integrations/connector-templates/destination-python/metadata.yaml.hbs
@@ -11,7 +11,7 @@ data:
     # Please update to the latest version of the connector base image.
     # Please use the full address with sha256 hash to guarantee build reproducibility.
     # https://hub.docker.com/r/airbyte/python-connector-base
-    baseImage: docker.io/airbyte/python-connector-base:1.0.0@sha256:dd17e347fbda94f7c3abff539be298a65af2d7fc27a307d89297df1081a45c27
+    baseImage: docker.io/airbyte/python-connector-base:1.2.0@sha256:c22a9d97464b69d6ef01898edf3f8612dc11614f05a84984451dde195f337db9
   connectorSubtype: database
   connectorType: destination
   definitionId: {{generateDefinitionId}}

--- a/airbyte-integrations/connector-templates/destination-python/setup.py
+++ b/airbyte-integrations/connector-templates/destination-python/setup.py
@@ -9,7 +9,7 @@ MAIN_REQUIREMENTS = [
     "airbyte-cdk",
 ]
 
-TEST_REQUIREMENTS = ["pytest~=6.2"]
+TEST_REQUIREMENTS = ["pytest"]
 
 setup(
     name="destination_{{snakeCase name}}",

--- a/airbyte-integrations/connector-templates/source-low-code/metadata.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-low-code/metadata.yaml.hbs
@@ -15,7 +15,7 @@ data:
     # Please update to the latest version of the connector base image.
     # https://hub.docker.com/r/airbyte/python-connector-base
     # Please use the full address with sha256 hash to guarantee build reproducibility.
-    baseImage: docker.io/airbyte/python-connector-base:1.0.0@sha256:dd17e347fbda94f7c3abff539be298a65af2d7fc27a307d89297df1081a45c27
+    baseImage: docker.io/airbyte/python-connector-base:1.2.0@sha256:c22a9d97464b69d6ef01898edf3f8612dc11614f05a84984451dde195f337db9
   connectorSubtype: api
   connectorType: source
   definitionId: {{generateDefinitionId}}

--- a/airbyte-integrations/connector-templates/source-low-code/pyproject.toml.hbs
+++ b/airbyte-integrations/connector-templates/source-low-code/pyproject.toml.hbs
@@ -22,6 +22,6 @@ airbyte-cdk = "^0"
 source-{{dashCase name}} = "source_{{snakeCase name}}.run:run"
 
 [tool.poetry.group.dev.dependencies]
-requests-mock = "^1.9.3"
-pytest-mock = "^3.6.1"
-pytest = "^6.1"
+requests-mock = "^1.10"
+pytest-mock = "^3.14"
+pytest = "^8.1"

--- a/airbyte-integrations/connector-templates/source-low-code/pyproject.toml.hbs
+++ b/airbyte-integrations/connector-templates/source-low-code/pyproject.toml.hbs
@@ -22,6 +22,6 @@ airbyte-cdk = "^0"
 source-{{dashCase name}} = "source_{{snakeCase name}}.run:run"
 
 [tool.poetry.group.dev.dependencies]
-requests-mock = "^1.10"
-pytest-mock = "^3.14"
-pytest = "^8.1"
+requests-mock = "*"
+pytest-mock = "*"
+pytest = "*"

--- a/airbyte-integrations/connector-templates/source-python/metadata.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-python/metadata.yaml.hbs
@@ -15,7 +15,7 @@ data:
     # Please update to the latest version of the connector base image.
     # https://hub.docker.com/r/airbyte/python-connector-base
     # Please use the full address with sha256 hash to guarantee build reproducibility.
-    baseImage: docker.io/airbyte/python-connector-base:1.0.0@sha256:dd17e347fbda94f7c3abff539be298a65af2d7fc27a307d89297df1081a45c27
+    baseImage: docker.io/airbyte/python-connector-base:1.2.0@sha256:c22a9d97464b69d6ef01898edf3f8612dc11614f05a84984451dde195f337db9
   connectorSubtype: api
   connectorType: source
   definitionId: {{generateDefinitionId}}

--- a/airbyte-integrations/connector-templates/source-python/pyproject.toml.hbs
+++ b/airbyte-integrations/connector-templates/source-python/pyproject.toml.hbs
@@ -22,6 +22,7 @@ airbyte-cdk = "^0"
 source-{{dashCase name}} = "source_{{snakeCase name}}.run:run"
 
 [tool.poetry.group.dev.dependencies]
-requests-mock = "^1.9.3"
-pytest-mock = "^3.6.1"
-pytest = "^6.1"
+requests-mock = "^1.10"
+pytest-mock = "^3.14"
+pytest = "^8.1"
+

--- a/airbyte-integrations/connector-templates/source-python/pyproject.toml.hbs
+++ b/airbyte-integrations/connector-templates/source-python/pyproject.toml.hbs
@@ -22,7 +22,7 @@ airbyte-cdk = "^0"
 source-{{dashCase name}} = "source_{{snakeCase name}}.run:run"
 
 [tool.poetry.group.dev.dependencies]
-requests-mock = "^1.10"
-pytest-mock = "^3.14"
-pytest = "^8.1"
+requests-mock = "*"
+pytest-mock = "*"
+pytest = "*"
 


### PR DESCRIPTION
Based on #36431, but graphite borked my stack, so I'm extracting this.