### PR TITLE
fix pagination link header docs

### DIFF
--- a/docs/connector-development/config-based/understanding-the-yaml-file/pagination.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/pagination.md
@@ -220,7 +220,7 @@ paginator:
   <...>
   pagination_strategy:
     type: "CursorPagination"
-    cursor_value: "{{ headers['urls']['next'] }}"
+    cursor_value: "{{ headers['link']['next']['url'] }}"
   page_token_option:
     type: "RequestPath"
 ```


### PR DESCRIPTION
the header is parsed by requests into a response.links object with keys such as 'url' and 'rel' this is then attached to the headers dict at `header["link"]` not `headers["urls"]`

https://github.com/airbytehq/airbyte/blob/3b50b0d00c633fc60b8d43c02cf9902cca6ead44/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py#L50-L53