### PR TITLE
disable spotbugs for CDK test and testFixtures submodules

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/core/build.gradle
@@ -50,6 +50,10 @@ compileKotlin {
     }
 }
 
+spotbugsTest.enabled = false
+spotbugsTestFixtures.enabled = false
+
+
 dependencies {
 
     api 'com.datadoghq:dd-trace-api:1.28.0'

--- a/airbyte-cdk/java/airbyte-cdk/datastore-postgres/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/datastore-postgres/build.gradle
@@ -11,6 +11,8 @@ compileKotlin {
     }
 }
 
+spotbugsTest.enabled = false
+
 dependencies {
     implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
     implementation project(':airbyte-cdk:java:airbyte-cdk:core')

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
@@ -12,6 +12,9 @@ compileKotlin.compilerOptions.allWarningsAsErrors = false
 compileTestFixturesKotlin.compilerOptions.allWarningsAsErrors = false
 compileTestKotlin.compilerOptions.allWarningsAsErrors = false
 
+spotbugsTest.enabled = false
+spotbugsTestFixtures.enabled = false
+
 dependencies {
     api 'org.apache.commons:commons-csv:1.10.0'
 

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
@@ -15,6 +15,9 @@ compileKotlin.compilerOptions.allWarningsAsErrors = false
 compileTestFixturesKotlin.compilerOptions.allWarningsAsErrors = false
 compileTestKotlin.compilerOptions.allWarningsAsErrors = false
 
+spotbugsTestFixtures.enabled = false
+spotbugsTest.enabled = false
+
 
 // Convert yaml to java: relationaldb.models
 jsonSchema2Pojo {

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/build.gradle
@@ -25,6 +25,9 @@ compileKotlin.compilerOptions.allWarningsAsErrors = false
 compileTestFixturesKotlin.compilerOptions.allWarningsAsErrors = false
 compileTestKotlin.compilerOptions.allWarningsAsErrors = false
 
+spotbugsTest.enabled = false
+spotbugsTestFixtures.enabled = false
+
 String specFile = "$projectDir/src/main/openapi/config.yaml"
 String serverOutputDir = "$buildDir/generated/api/server"
 String clientOutputDir = "$buildDir/generated/api/client"

--- a/airbyte-cdk/java/airbyte-cdk/gcs-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/gcs-destinations/build.gradle
@@ -20,6 +20,8 @@ compileTestFixturesKotlin {
     }
 }
 
+spotbugsTestFixtures.enabled = false
+
 dependencies {
     implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
     implementation project(':airbyte-cdk:java:airbyte-cdk:core')

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
@@ -32,6 +32,9 @@ compileKotlin {
     }
 }
 
+spotbugsTest.enabled = false
+spotbugsTestFixtures.enabled = false
+
 dependencies {
     implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
     implementation project(':airbyte-cdk:java:airbyte-cdk:core')

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/build.gradle
@@ -26,6 +26,10 @@ compileTestFixturesKotlin {
     }
 }
 
+spotbugsTest.enabled = false
+spotbugsTestFixtures.enabled = false
+
+
 dependencies {
     implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
     implementation project(':airbyte-cdk:java:airbyte-cdk:core')


### PR DESCRIPTION
Some CDK submodules are failing their spotbugs checks. We're disabling those checks so we can publish the CDK