### PR TITLE
Set maxSecondsBetweenMessages value for certified connectors Phase 2

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -17,6 +17,7 @@ data:
   githubIssueLabel: source-airtable
   icon: airtable.svg
   license: MIT
+  maxSecondsBetweenMessages: 2592000
   name: Airtable
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -17,6 +17,7 @@ data:
   githubIssueLabel: source-amplitude
   icon: amplitude.svg
   license: MIT
+  maxSecondsBetweenMessages: 2592000
   name: Amplitude
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -22,6 +22,7 @@ data:
   githubIssueLabel: source-bing-ads
   icon: bingads.svg
   license: MIT
+  maxSecondsBetweenMessages: 60
   name: Bing Ads
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-facebook-marketing
   icon: facebook.svg
   license: ELv2
+  maxSecondsBetweenMessages: 3600
   name: Facebook Marketing
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -17,6 +17,7 @@ data:
   githubIssueLabel: source-google-ads
   icon: google-adwords.svg
   license: Elv2
+  maxSecondsBetweenMessages: 86400
   name: Google Ads
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -19,6 +19,7 @@ data:
   githubIssueLabel: source-google-analytics-v4
   icon: google-analytics.svg
   license: Elv2
+  maxSecondsBetweenMessages: 86400
   name: Google Analytics (Universal Analytics)
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -12,6 +12,7 @@ data:
   githubIssueLabel: source-instagram
   icon: instagram.svg
   license: MIT
+  maxSecondsBetweenMessages: 86400
   name: Instagram
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-intercom
   icon: intercom.svg
   license: MIT
+  maxSecondsBetweenMessages: 60
   name: Intercom
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -13,6 +13,7 @@ data:
   githubIssueLabel: source-klaviyo
   icon: klaviyo.svg
   license: MIT
+  maxSecondsBetweenMessages: 60
   name: Klaviyo
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-marketo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-marketo/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-marketo
   icon: marketo.svg
   license: ELv2
+  maxSecondsBetweenMessages: 86400
   name: Marketo
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -17,6 +17,7 @@ data:
   githubIssueLabel: source-mixpanel
   icon: mixpanel.svg
   license: MIT
+  maxSecondsBetweenMessages: 3600
   name: Mixpanel
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-s3
   icon: s3.svg
   license: ELv2
+  maxSecondsBetweenMessages: 1
   name: S3
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-stripe
   icon: stripe.svg
   license: ELv2
+  maxSecondsBetweenMessages: 1
   name: Stripe
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -17,6 +17,7 @@ data:
   githubIssueLabel: source-tiktok-marketing
   icon: tiktok.svg
   license: MIT
+  maxSecondsBetweenMessages: 86400
   name: TikTok Marketing
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
@@ -17,6 +17,7 @@ data:
   icon: zendesk-chat.svg
   license: MIT
   name: Zendesk Chat
+  maxSecondsBetweenMessages: 60
   remoteRegistries:
     pypi:
       enabled: true

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -17,6 +17,7 @@ data:
   githubIssueLabel: source-zendesk-talk
   icon: zendesk-talk.svg
   license: MIT
+  maxSecondsBetweenMessages: 300
   name: Zendesk Talk
   remoteRegistries:
     pypi:


### PR DESCRIPTION
For certified connectors is requirement to have `maxSecondsBetweenMessages` set in metadata file.
`maxSecondsBetweenMessages` is the longest time frame (in seconds) of API requests limits reset for endpoints used by connector.

## What
`maxSecondsBetweenMessages` value for the following connectors was added:

- source-facebook-marketing: `maxSecondsBetweenMessages: 3600`. Longest time frame of limits reset is [1 hour or 3600 seconds](https://developers.facebook.com/docs/marketing-apis/rate-limiting)
- source-instagram: `maxSecondsBetweenMessages: 86400`. Longest time frame of limits reset is [1 day or 86400 seconds](https://developers.facebook.com/docs/graph-api/overview/rate-limiting/#instagram-graph-api)
- source-google-ads: `maxSecondsBetweenMessages: 86400`. Longest time frame of limits reset is [1 day or 86400 seconds](https://developers.google.com/google-ads/api/docs/best-practices/quotas)
- source-intercom: `maxSecondsBetweenMessages: 60`. Longest time frame of limits reset is [1 minute or 60 seconds](https://developers.intercom.com/docs/references/rest-api/errors/rate-limiting/#what-is-the-default-amount-of-requests)
- source-s3: `maxSecondsBetweenMessages: 1`. Longest time frame of limits reset is [1 second](https://docs.aws.amazon.com/athena/latest/ug/performance-tuning-s3-throttling.html)
- source-stripe: `maxSecondsBetweenMessages: 1`. Longest time frame of limits reset is [1 second](https://docs.stripe.com/rate-limits)
- source-tiktok-marketing: `maxSecondsBetweenMessages: 86400`. Longest time frame of limits reset is [1 day or 86400 seconds](https://business-api.tiktok.com/portal/docs?id=1740029171730433)
- source-zendesk-chat: `maxSecondsBetweenMessages: 60`. Longest time frame of limits reset is [1 minute or 60 seconds](https://developer.zendesk.com/api-reference/live-chat/introduction/)
- source-zendesk-talk: `maxSecondsBetweenMessages: 300`. Longest time frame of limits reset is [5 minutes or 300 seconds](https://developer.zendesk.com/api-reference/voice/talk-api/introduction/#rate-limits)
- source-airtable: `maxSecondsBetweenMessages: 2592000`. Longest time frame of limits reset is [1 month or 2592000 seconds](https://airtable.com/pricing?_gl=1*1xemogu*_ga*MTM1ODU3NzE4MS4xNzA3NDczNDcw*_ga_VJY8J9RFZM*MTcxMTM3NjU0NC4zLjEuMTcxMTM3NjgxNy42MC4wLjA.)
- source-amplitude: `maxSecondsBetweenMessages: 2592000`. Longest time frame of limits reset is [1 month or 2592000 seconds](https://www.docs.developers.amplitude.com/analytics/apis/behavioral-cohorts-api/#authorization)
- source-bing-ads: `maxSecondsBetweenMessages: 60`. Longest time frame of limits reset is [1 minute or 60 seconds](https://learn.microsoft.com/en-us/advertising/guides/services-protocol?view=bingads-13#throttling)
- source-google-analytics-v4: `maxSecondsBetweenMessages: 86400`. Longest time frame of limits reset is [1 day or 86400 seconds](https://developers.google.com/analytics/devguides/reporting/data/v1/quotas)
- source-klaviyo: `maxSecondsBetweenMessages: 60`. Longest time frame of limits reset is [1 minute or 60 seconds](https://developers.klaviyo.com/en/docs/rate_limits_and_error_handling)
- source-marketo: `maxSecondsBetweenMessages: 86400`. Longest time frame of limits reset is [1 day or 86400 seconds](https://developers.marketo.com/rest-api/marketo-integration-best-practices/)
- source-mixpanel: `maxSecondsBetweenMessages: 3600`. Longest time frame of limits reset is [1 hour or 3600 seconds](https://developer.mixpanel.com/reference/rate-limits)


## How
Files `metadata.yaml` for connectors mentioned above were updated by adding `maxSecondsBetweenMessages` value.

## 🚨 User Impact 🚨
No breaking changes