### PR TITLE
Remove the custom implementation of buffered input stream reader

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -144,6 +144,7 @@ Maven and Gradle will automatically reference the correct (pinned) version of th
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.28.21 | 2024-04-02 | [\#36673](https://github.com/airbytehq/airbyte/pull/36673) | Change the destination message parsing to use standard java/kotlin classes. Adds logging to catch empty lines.                                                 |
 | 0.28.20 | 2024-04-01 | [\#36584](https://github.com/airbytehq/airbyte/pull/36584) | Changes to make source-postgres compileable                                                                                                                    |
 | 0.28.19 | 2024-03-29 | [\#36619](https://github.com/airbytehq/airbyte/pull/36619) | Changes to make destination-postgres compileable                                                                                                               |
 | 0.28.19 | 2024-03-29 | [\#36588](https://github.com/airbytehq/airbyte/pull/36588) | Changes to make destination-redshift compileable                                                                                                               |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.28.20
+version=0.28.21

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/base/IntegrationRunnerBackwardsCompatabilityTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/base/IntegrationRunnerBackwardsCompatabilityTest.kt
@@ -9,7 +9,7 @@ import java.util.*
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
-class IntegrationRunnerBackwardsCompatbilityTest {
+class IntegrationRunnerBackwardsCompatabilityTest {
     @Test
     @Throws(Exception::class)
     fun testByteArrayInputStreamVersusScanner() {
@@ -31,11 +31,7 @@ class IntegrationRunnerBackwardsCompatbilityTest {
             val stream1: InputStream =
                 ByteArrayInputStream(testInput.toByteArray(StandardCharsets.UTF_8))
             val consumer2 = MockConsumer()
-            BufferedInputStream(stream1).use { bis ->
-                ByteArrayOutputStream().use { baos ->
-                    IntegrationRunner.consumeWriteStream(consumer2, bis, baos)
-                }
-            }
+            IntegrationRunner.consumeWriteStream(consumer2, stream1)
             val newOutput = consumer2.getOutput()
 
             // get old output


### PR DESCRIPTION
This removes our custom message reader and uses a standard one. It also will log every 1000 empty lines until a max of 10000 is reached and report the number of empty lines at the end.