### PR TITLE
connector-builder: return full url-encoded URL instead of separating parameters

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -300,15 +300,12 @@ class MessageGrouper:
 
     @staticmethod
     def _create_request_from_log_message(json_http_message: Dict[str, Any]) -> HttpRequest:
-        url = urlparse(json_http_message.get("url", {}).get("full", ""))
-        full_path = f"{url.scheme}://{url.hostname}{url.path}" if url else ""
+        url = json_http_message.get("url", {}).get("full", "")
         request = json_http_message.get("http", {}).get("request", {})
-        parameters = parse_qs(url.query) or None
         return HttpRequest(
-            url=full_path,
+            url=url,
             http_method=request.get("method", ""),
             headers=request.get("headers"),
-            parameters=parameters,
             body=request.get("body", {}).get("content", ""),
         )
 

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -7,7 +7,6 @@ import logging
 from copy import deepcopy
 from json import JSONDecodeError
 from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Union
-from urllib.parse import parse_qs, urlparse
 
 from airbyte_cdk.connector_builder.models import (
     AuxiliaryRequest,

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
@@ -16,7 +16,6 @@ class HttpResponse:
 @dataclass
 class HttpRequest:
     url: str
-    parameters: Optional[Dict[str, Any]]
     headers: Optional[Dict[str, Any]]
     http_method: str
     body: Optional[str] = None

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -106,8 +106,7 @@ def test_get_grouped_messages(mock_entrypoint_read: Mock) -> None:
     expected_pages = [
         StreamReadPages(
             request=HttpRequest(
-                url="https://demonslayers.com/api/v1/hashiras",
-                parameters={"era": ["taisho"]},
+                url="https://demonslayers.com/api/v1/hashiras?era=taisho",
                 headers={"Content-Type": "application/json"},
                 body='{"custom": "field"}',
                 http_method="GET",
@@ -117,8 +116,7 @@ def test_get_grouped_messages(mock_entrypoint_read: Mock) -> None:
         ),
         StreamReadPages(
             request=HttpRequest(
-                url="https://demonslayers.com/api/v1/hashiras",
-                parameters={"era": ["taisho"]},
+                url="https://demonslayers.com/api/v1/hashiras?era=taisho",
                 headers={"Content-Type": "application/json"},
                 body='{"custom": "field"}',
                 http_method="GET",
@@ -166,8 +164,7 @@ def test_get_grouped_messages_with_logs(mock_entrypoint_read: Mock) -> None:
     expected_pages = [
         StreamReadPages(
             request=HttpRequest(
-                url="https://demonslayers.com/api/v1/hashiras",
-                parameters={"era": ["taisho"]},
+                url="https://demonslayers.com/api/v1/hashiras?era=taisho",
                 headers={"Content-Type": "application/json"},
                 body='{"custom": "field"}',
                 http_method="GET",
@@ -177,8 +174,7 @@ def test_get_grouped_messages_with_logs(mock_entrypoint_read: Mock) -> None:
         ),
         StreamReadPages(
             request=HttpRequest(
-                url="https://demonslayers.com/api/v1/hashiras",
-                parameters={"era": ["taisho"]},
+                url="https://demonslayers.com/api/v1/hashiras?era=taisho",
                 headers={"Content-Type": "application/json"},
                 body='{"custom": "field"}',
                 http_method="GET",
@@ -351,8 +347,7 @@ def test_get_grouped_messages_no_records(mock_entrypoint_read: Mock) -> None:
     expected_pages = [
         StreamReadPages(
             request=HttpRequest(
-                url="https://demonslayers.com/api/v1/hashiras",
-                parameters={"era": ["taisho"]},
+                url="https://demonslayers.com/api/v1/hashiras?era=taisho",
                 headers={"Content-Type": "application/json"},
                 body='{"custom": "field"}',
                 http_method="GET",
@@ -362,8 +357,7 @@ def test_get_grouped_messages_no_records(mock_entrypoint_read: Mock) -> None:
         ),
         StreamReadPages(
             request=HttpRequest(
-                url="https://demonslayers.com/api/v1/hashiras",
-                parameters={"era": ["taisho"]},
+                url="https://demonslayers.com/api/v1/hashiras?era=taisho",
                 headers={"Content-Type": "application/json"},
                 body='{"custom": "field"}',
                 http_method="GET",


### PR DESCRIPTION
Return the full URL with request param encoded instead of separating them in a separate field.

This is the first PR for https://github.com/airbytehq/airbyte-internal-issues/issues/2437

There will be a follow up PR in the platform