### PR TITLE
Security: Enable GitHub Secret Scanning but ignore sample connector configurations

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,4 @@
+# GitHub Secret Scanning config
+paths-ignore:
+  # Ignore sample configurations in airbyte-integrations.
+  - "airbyte-integrations/connectors/**"


### PR DESCRIPTION
## What

This PR makes a config for [Secret Scanning](https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/about-secret-scanning), but ignores sample connector configurations.

