### PR TITLE
fix wrong partition key definition after legacy state migration

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
@@ -49,13 +49,13 @@ class LegacyToPerPartitionStateMigration(StateMigration):
         parent_stream_config = partition_router.parent_stream_configs[0]
 
         # Retrieve the parent key with a condition, as properties are returned as a dictionary for custom components.
-        parent_key = (
-            parent_stream_config.parent_key
+        partition_field = (
+            parent_stream_config.partition_field
             if isinstance(parent_stream_config, ParentStreamConfig)
             else parent_stream_config.get("parent_key")
         )
 
-        return parent_key
+        return partition_field
 
     def should_migrate(self, stream_state: Mapping[str, Any]) -> bool:
         if _is_already_migrated(stream_state):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/migrations/legacy_to_per_partition_state_migration.py
@@ -41,18 +41,18 @@ class LegacyToPerPartitionStateMigration(StateMigration):
         self._config = config
         self._parameters = parameters
         self._partition_key_field = InterpolatedString.create(
-            self._get_parent_key(self._partition_router), parameters=self._parameters
+            self._get_partition_field(self._partition_router), parameters=self._parameters
         ).eval(self._config)
         self._cursor_field = InterpolatedString.create(self._cursor.cursor_field, parameters=self._parameters).eval(self._config)
 
-    def _get_parent_key(self, partition_router: SubstreamPartitionRouter) -> str:
+    def _get_partition_field(self, partition_router: SubstreamPartitionRouter) -> str:
         parent_stream_config = partition_router.parent_stream_configs[0]
 
-        # Retrieve the parent key with a condition, as properties are returned as a dictionary for custom components.
+        # Retrieve the partition field with a condition, as properties are returned as a dictionary for custom components.
         partition_field = (
             parent_stream_config.partition_field
             if isinstance(parent_stream_config, ParentStreamConfig)
-            else parent_stream_config.get("parent_key")
+            else parent_stream_config.get("partition_field")
         )
 
         return partition_field

--- a/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/migrations/test_legacy_to_per_partition_migration.py
@@ -38,11 +38,11 @@ def test_migrate_a_valid_legacy_state_to_per_partition():
     expected_state = {
         "states": [
             {
-                "partition": {"id": "13506132"},
+                "partition": {"parent_id": "13506132"},
                 "cursor": {"last_changed": "2022-12-27T08:34:39+00:00"}
             },
             {
-                "partition": {"id": "14351124"},
+                "partition": {"parent_id": "14351124"},
                 "cursor": {"last_changed": "2022-12-27T08:35:39+00:00"}
             },
         ]


### PR DESCRIPTION
## What

In the original [PR](https://github.com/airbytehq/airbyte/pull/36294), it was defined that after migration, the state format would be a partition dictionary with a parent key. However, in the `PerPartitionCursor` class, we filter cursor values by partition key, potentially causing us to lose ignore state if it's formatted after migration.

## How 

I've updated the LegacyToPerPartitionStateMigration class by replacing `_get_parent_key` with `_get_partition_field`.