### PR TITLE
✨ Source Salesforce, Shopify: add maxSecondsBetweenMessages in metadata

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-salesforce
   icon: salesforce.svg
   license: ELv2
+  maxSecondsBetweenMessages: 86400
   name: Salesforce
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -17,6 +17,7 @@ data:
   githubIssueLabel: source-shopify
   icon: shopify.svg
   license: ELv2
+  maxSecondsBetweenMessages: 1
   name: Shopify
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -17,7 +17,7 @@ data:
   githubIssueLabel: source-shopify
   icon: shopify.svg
   license: ELv2
-  maxSecondsBetweenMessages: 1
+  maxSecondsBetweenMessages: 7200
   name: Shopify
   remoteRegistries:
     pypi:


### PR DESCRIPTION
Certified connectors are required to have `maxSecondsBetweenMessages` set in metadata file.
`maxSecondsBetweenMessages` is the longest time frame (in seconds) of API requests limits reset for endpoints used by connector. [Issue](https://app.zenhub.com/workspaces/critical-connectors-659c693d906fcd00178900cf/issues/gh/airbytehq/airbyte-internal-issues/6779)

## What
`maxSecondsBetweenMessages` value for the following connectors was added:

source-salesforce [reference](https://developer.salesforce.com/docs/atlas.en-us.salesforce_app_limits_cheatsheet.meta/salesforce_app_limits_cheatsheet/salesforce_app_limits_platform_api.htm)
source-shopify [reference](https://shopify.dev/docs/api/usage/rate-limits)

## How
Files `metadata.yaml` for connectors mentioned above were updated by adding `maxSecondsBetweenMessages` value.

## 🚨 User Impact 🚨
No breaking changes