### PR TITLE
Update max rate-limiting metadata

### DIFF
--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -16,7 +16,7 @@ data:
   githubIssueLabel: source-github
   icon: github.svg
   license: MIT
-  maxSecondsBetweenMessages: 5400
+  maxSecondsBetweenMessages: 3600
   name: GitHub
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -16,7 +16,7 @@ data:
   githubIssueLabel: source-sentry
   icon: sentry.svg
   license: MIT
-  maxSecondsBetweenMessages: 64800
+  maxSecondsBetweenMessages: 60
   name: Sentry
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -16,6 +16,10 @@ data:
   githubIssueLabel: source-sentry
   icon: sentry.svg
   license: MIT
+  # Rate limit windows are returned in the response headers of the API requests.
+  # Senty docs (https://docs.sentry.io/api/ratelimits/) state a per-second rate limit, 
+  # but the `x-rate-limit-reset` header has been observed to return a value of up to the next full minute from a request
+  # (e.g. request sent: 12:00:15, `x-rate-limit-reset` header value: 12:01:00).
   maxSecondsBetweenMessages: 60
   name: Sentry
   remoteRegistries:

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: sentry.svg
   license: MIT
   # Rate limit windows are returned in the response headers of the API requests.
-  # Senty docs (https://docs.sentry.io/api/ratelimits/) state a per-second rate limit, 
+  # Senty docs (https://docs.sentry.io/api/ratelimits/) state a per-second rate limit,
   # but the `x-rate-limit-reset` header has been observed to return a value of up to the next full minute from a request
   # (e.g. request sent: 12:00:15, `x-rate-limit-reset` header value: 12:01:00).
   maxSecondsBetweenMessages: 60

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -17,7 +17,7 @@ data:
   githubIssueLabel: source-zendesk-support
   icon: zendesk-support.svg
   license: ELv2
-  maxSecondsBetweenMessages: 10800
+  maxSecondsBetweenMessages: 60
   name: Zendesk Support
   remoteRegistries:
     pypi:


### PR DESCRIPTION
## What

Updating max rate-limit metadata for sources Github, Sentry, Zendesk Support

[Github:](https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api) Per-hour window listed in docs.
[Sentry:](https://docs.sentry.io/api/ratelimits/) Docs do not explicitly list retry windows, and point to checking retry headers to determine these values. All endpoints returned a 1-minute retry window in tests.
[Zendesk Support:](https://developer.zendesk.com/api-reference/introduction/rate-limits/) Per-minute values listed in docs.
