### PR TITLE
re-enable rabbitmq on OSS

### DIFF
--- a/airbyte-integrations/connectors/destination-rabbitmq/Dockerfile
+++ b/airbyte-integrations/connectors/destination-rabbitmq/Dockerfile
@@ -34,5 +34,5 @@ COPY destination_rabbitmq ./destination_rabbitmq
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/destination-rabbitmq

--- a/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
@@ -10,9 +10,9 @@ data:
   name: RabbitMQ
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide RabbitMQ Destination https://github.com/airbytehq/airbyte/issues/16315
     oss:
-      enabled: false
+      enabled: true
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/rabbitmq
   tags:

--- a/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: e06ad785-ad6f-4647-b2e8-3027a5c59454
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   dockerRepository: airbyte/destination-rabbitmq
   githubIssueLabel: destination-rabbitmq
   icon: pulsar.svg

--- a/docs/integrations/destinations/rabbitmq.md
+++ b/docs/integrations/destinations/rabbitmq.md
@@ -45,6 +45,7 @@ To use the RabbitMQ destination, you'll need:
 
 | Version | Date             | Pull Request                                              | Subject                                         |
 | :------ | :--------------- | :-------------------------------------------------------- | :---------------------------------------------- |
+| 0.1.3   | 2024-04-02       | [#36749](https://github.com/airbytehq/airbyte/pull/36749) | Un-archive connector (again)                    |
 | 0.1.2   | 2024-03-05       | [#35838](https://github.com/airbytehq/airbyte/pull/35838) | Un-archive connector                            |
 | 0.1.1   | 2022-09-09       | [16528](https://github.com/airbytehq/airbyte/pull/16528)  | Marked password field in spec as airbyte_secret |
 | 0.1.0   | October 29, 2021 | [\#7560](https://github.com/airbytehq/airbyte/pull/7560)  | Initial release                                 |


### PR DESCRIPTION
destination-rabbitmq was mistakenly removed from the OSS registry as part of the archival process