### PR TITLE
java-cdk: re-export airbyte-api dependency

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -144,6 +144,7 @@ Maven and Gradle will automatically reference the correct (pinned) version of th
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.29.0  | 2024-04-02 | [\#36759](https://github.com/airbytehq/airbyte/pull/36759) | Build artifact publication changes and fixes.                                                                                                                  |
 | 0.28.21 | 2024-04-02 | [\#36673](https://github.com/airbytehq/airbyte/pull/36673) | Change the destination message parsing to use standard java/kotlin classes. Adds logging to catch empty lines.                                                 |
 | 0.28.20 | 2024-04-01 | [\#36584](https://github.com/airbytehq/airbyte/pull/36584) | Changes to make source-postgres compileable                                                                                                                    |
 | 0.28.19 | 2024-03-29 | [\#36619](https://github.com/airbytehq/airbyte/pull/36619) | Changes to make destination-postgres compileable                                                                                                               |

--- a/airbyte-cdk/java/airbyte-cdk/azure-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/azure-destinations/build.gradle
@@ -5,10 +5,10 @@ compileKotlin {
 }
 
 dependencies {
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:core')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
 
     implementation 'com.azure:azure-storage-blob:12.12.0'
 
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
 }

--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -33,12 +33,6 @@ allprojects {
         }
     }
 
-    project.configurations {
-        testImplementation.extendsFrom implementation
-        testFixturesImplementation.extendsFrom implementation
-        testFixturesRuntimeOnly.extendsFrom runtimeOnly
-    }
-
     // This is necessary because the mockit.kotlin any() generates a bunch of bad casts
     spotbugsTest.omitVisitors = ['FindBadCast2']
 }

--- a/airbyte-cdk/java/airbyte-cdk/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/build.gradle
@@ -10,24 +10,12 @@ allprojects {
 
     group 'io.airbyte.cdk'
 
-    def artifactBaseName = 'airbyte-cdk-' + project.name
-    // E.g. airbyte-cdk-core, airbyte-cdk-db-sources, airbyte-cdk-db-destinations, etc.
-
     project.version = cdkVersion
 
     publishing {
         publications {
-            main(MavenPublication) {
-                groupId = 'io.airbyte.cdk'
-                artifactId = artifactBaseName
-                version = project.version
+            cdk(MavenPublication) {
                 from components.java
-            }
-            testFixtures(MavenPublication) {
-                groupId = 'io.airbyte.cdk'
-                artifactId = artifactBaseName + '-test-fixtures'
-                version = project.version
-                artifact project.tasks.testFixturesJar
             }
         }
         // This repository is only defined and used in the context of an artifact publishing

--- a/airbyte-cdk/java/airbyte-cdk/core/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/core/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     api 'org.jooq:jooq:3.16.23'
     api 'org.apache.commons:commons-csv:1.10.0'
 
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
 
     implementation 'commons-cli:commons-cli:1.4'
     implementation 'io.aesy:datasize:1.0.0'
@@ -79,9 +79,9 @@ dependencies {
     testFixturesApi 'org.testcontainers:testcontainers:1.19.0'
     testFixturesApi 'org.testcontainers:jdbc:1.19.0'
 
-    testImplementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    testImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:db-sources'))
-    testImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:datastore-postgres'))
+    testImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    testImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-db-sources'))
+    testImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-datastore-postgres'))
 
     testImplementation 'mysql:mysql-connector-java:8.0.33'
     testImplementation 'org.postgresql:postgresql:42.6.0'

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.28.21
+version=0.29.0

--- a/airbyte-cdk/java/airbyte-cdk/datastore-bigquery/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/datastore-bigquery/build.gradle
@@ -20,10 +20,10 @@ compileKotlin {
 }
 
 dependencies {
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:core')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
 
     api 'com.google.cloud:google-cloud-bigquery:2.37.0'
 
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
 }

--- a/airbyte-cdk/java/airbyte-cdk/datastore-mongo/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/datastore-mongo/build.gradle
@@ -27,12 +27,12 @@ compileKotlin {
 }
 
 dependencies {
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:core')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
 
     api 'org.mongodb:mongodb-driver-sync:4.10.2'
 
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
 
     testFixturesApi 'org.testcontainers:mongodb:1.19.0'
 }

--- a/airbyte-cdk/java/airbyte-cdk/datastore-postgres/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/datastore-postgres/build.gradle
@@ -14,12 +14,12 @@ compileKotlin {
 spotbugsTest.enabled = false
 
 dependencies {
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:core')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
 
     api 'org.postgresql:postgresql:42.6.0'
 
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
 
     testFixturesApi 'org.testcontainers:postgresql:1.19.0'
 }

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
@@ -18,22 +18,22 @@ spotbugsTestFixtures.enabled = false
 dependencies {
     api 'org.apache.commons:commons-csv:1.10.0'
 
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:core')
-    compileOnly project(':airbyte-cdk:java:airbyte-cdk:typing-deduping')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
+    compileOnly project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-typing-deduping')
 
     implementation 'io.aesy:datasize:1.0.0'
 
     testFixturesCompileOnly libs.lombok
     testFixturesAnnotationProcessor libs.lombok
-    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:dependencies'))
-    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:core')
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
-    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:typing-deduping')
-    testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:typing-deduping'))
+    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies'))
+    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
+    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-typing-deduping')
+    testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-typing-deduping'))
 
-    testImplementation project(':airbyte-cdk:java:airbyte-cdk:typing-deduping')
+    testImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-typing-deduping')
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'
 
 }

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
     testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:typing-deduping')
     testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:typing-deduping'))
-    testFixturesImplementation 'org.jetbrains.kotlin:kotlin-test'
 
     testImplementation project(':airbyte-cdk:java:airbyte-cdk:typing-deduping')
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
@@ -52,12 +52,10 @@ dependencies {
     testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:core')
     testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
 
-    testFixturesImplementation ('io.airbyte:airbyte-api:0.55.2') { transitive = false }
     testFixturesImplementation 'net.sourceforge.argparse4j:argparse4j:0.9.0'
     testFixturesImplementation 'io.swagger:swagger-annotations:1.6.13'
     testFixturesImplementation 'org.hamcrest:hamcrest-all:1.3'
     testFixturesImplementation 'org.junit.platform:junit-platform-launcher:1.10.1'
-    testFixturesImplementation 'org.jetbrains.kotlin:kotlin-test'
 
     testImplementation project(':airbyte-cdk:java:airbyte-cdk:datastore-postgres')
     testImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:datastore-postgres'))

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/build.gradle
@@ -40,25 +40,25 @@ tasks.register('generate').configure {
 
 dependencies {
 
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:core')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
 
     implementation 'io.debezium:debezium-api:2.4.0.Final'
     implementation 'io.debezium:debezium-embedded:2.4.0.Final'
     implementation 'org.codehaus.plexus:plexus-utils:4.0.0'
 
-    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:dependencies'))
-    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:core')
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
+    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies'))
+    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
 
     testFixturesImplementation 'net.sourceforge.argparse4j:argparse4j:0.9.0'
     testFixturesImplementation 'io.swagger:swagger-annotations:1.6.13'
     testFixturesImplementation 'org.hamcrest:hamcrest-all:1.3'
     testFixturesImplementation 'org.junit.platform:junit-platform-launcher:1.10.1'
 
-    testImplementation project(':airbyte-cdk:java:airbyte-cdk:datastore-postgres')
-    testImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:datastore-postgres'))
+    testImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-datastore-postgres')
+    testImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-datastore-postgres'))
 
     testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.0.1'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/build.gradle
@@ -56,7 +56,9 @@ dependencies {
 
     testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
 
-    testFixturesImplementation ('io.airbyte:airbyte-api:0.55.2') { transitive = false }
+    testFixturesApi ('io.airbyte:airbyte-api:0.55.2') { transitive = false }
+    testFixturesApi 'org.jetbrains.kotlin:kotlin-test'
+
     testFixturesImplementation 'io.swagger:swagger-annotations:1.6.2'
     testFixturesImplementation 'org.apache.ant:ant:1.10.11'
 

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'me.andrz.jackson:jackson-json-reference-core:0.3.2' // needed so that we can follow $ref when parsing json
     implementation 'org.openapitools:jackson-databind-nullable:0.2.1'
 
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
 
     testFixturesApi ('io.airbyte:airbyte-api:0.55.2') { transitive = false }
     testFixturesApi 'org.jetbrains.kotlin:kotlin-test'

--- a/airbyte-cdk/java/airbyte-cdk/gcs-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/gcs-destinations/build.gradle
@@ -23,13 +23,13 @@ compileTestFixturesKotlin {
 spotbugsTestFixtures.enabled = false
 
 dependencies {
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:core')
-    api project(':airbyte-cdk:java:airbyte-cdk:s3-destinations')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
+    api project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-s3-destinations')
 
     api 'com.google.cloud:google-cloud-storage:2.32.1'
 
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
-    testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:s3-destinations')
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:s3-destinations'))
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
+    testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-s3-destinations')
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-s3-destinations'))
 }

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
@@ -36,10 +36,10 @@ spotbugsTest.enabled = false
 spotbugsTestFixtures.enabled = false
 
 dependencies {
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:core')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:typing-deduping')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:db-destinations')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-typing-deduping')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-db-destinations')
 
     // Re-export dependencies for gcs-destinations.
     api 'com.amazonaws:aws-java-sdk-s3:1.12.647'
@@ -54,14 +54,14 @@ dependencies {
     api 'org.apache.parquet:parquet-avro:1.13.1'
     runtimeOnly 'com.hadoop.gplcompression:hadoop-lzo:0.4.20'
 
-    testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:dependencies'))
-    testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:core')
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
-    testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:typing-deduping')
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:typing-deduping'))
-    testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:db-destinations')
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:db-destinations'))
+    testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies'))
+    testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
+    testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-typing-deduping')
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-typing-deduping'))
+    testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-db-destinations')
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-db-destinations'))
 
     testImplementation 'org.mockito:mockito-inline:5.2.0'
 }

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/build.gradle
@@ -31,14 +31,14 @@ spotbugsTestFixtures.enabled = false
 
 
 dependencies {
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    implementation project(':airbyte-cdk:java:airbyte-cdk:core')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
 
     implementation 'commons-codec:commons-codec:1.16.0'
 
-    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
-    testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:dependencies'))
-    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:core')
-    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:core'))
+    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
+    testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies'))
+    testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
+    testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'
 }

--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -4,17 +4,17 @@ plugins {
 }
 
 dependencies {
-    testFixtures(project(':airbyte-cdk:java:airbyte-cdk:dependencies'))
+    testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies'))
 }
 
 // we need to access the sshtunneling script from airbyte-workers for ssh support
 def copySshScript = tasks.register('copySshScript', Copy) {
-    from "${project(':airbyte-cdk:java:airbyte-cdk:dependencies').buildDir}/resources/testFixtures"
+    from "${project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies').buildDir}/resources/testFixtures"
     into "${buildDir}"
     include "sshtunneling.sh"
 }
 copySshScript.configure {
-    dependsOn project(':airbyte-cdk:java:airbyte-cdk:dependencies').tasks.named('processTestFixturesResources')
+    dependsOn project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies').tasks.named('processTestFixturesResources')
 }
 
 // make sure the copy task above worked (if it fails, it fails silently annoyingly)

--- a/airbyte-integrations/connectors-performance/destination-harness/build.gradle
+++ b/airbyte-integrations/connectors-performance/destination-harness/build.gradle
@@ -8,7 +8,7 @@ application {
 }
 
 dependencies {
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
 
     implementation 'io.fabric8:kubernetes-client:5.12.2'
     implementation 'org.apache.commons:commons-lang3:3.11'

--- a/airbyte-integrations/connectors-performance/source-harness/build.gradle
+++ b/airbyte-integrations/connectors-performance/source-harness/build.gradle
@@ -8,7 +8,7 @@ application {
 }
 
 dependencies {
-    implementation project(':airbyte-cdk:java:airbyte-cdk:dependencies')
+    implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
 
     implementation 'io.fabric8:kubernetes-client:5.12.2'
     implementation 'org.apache.commons:commons-lang3:3.11'

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -14,7 +14,7 @@ java {
 airbyteJavaConnector {
     cdkVersionRequired = '0.29.0'
     features = ['db-sources', 'datastore-postgres']
-    useLocalCdk = true
+    useLocalCdk = false
 }
 
 application {

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -14,7 +14,7 @@ java {
 airbyteJavaConnector {
     cdkVersionRequired = '0.28.20'
     features = ['db-sources', 'datastore-postgres']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 application {

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -12,7 +12,7 @@ java {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.28.20'
+    cdkVersionRequired = '0.29.0'
     features = ['db-sources', 'datastore-postgres']
     useLocalCdk = true
 }

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -27,8 +27,6 @@ dependencies {
     implementation 'io.debezium:debezium-embedded:2.4.0.Final'
     implementation 'io.debezium:debezium-connector-postgres:2.4.0.Final'
 
-    testFixturesImplementation ('io.airbyte:airbyte-api:0.55.2') { transitive = false }
-    testFixturesImplementation ('org.jetbrains.kotlin:kotlin-test')
     testFixturesApi 'org.testcontainers:postgresql:1.19.0'
 
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.3.22
+  dockerImageTag: 3.3.23
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ allprojects {
     // Common java configurations
 
     java {
+        withSourcesJar()
+        withJavadocJar()
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
         compileJava {
@@ -62,6 +64,10 @@ allprojects {
             //rawtypes and unchecked are necessary for mockito
             options.compilerArgs += ["-Werror", "-Xlint:all,-serial,-processing,-rawtypes,-unchecked"]
         }
+    }
+
+    tasks.named('sourcesJar').configure {
+        dependsOn tasks.matching { it.name == 'generate' }
     }
 
     compileKotlin {

--- a/buildSrc/src/main/groovy/airbyte-java-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-java-connector.gradle
@@ -46,7 +46,7 @@ class AirbyteJavaConnectorExtension {
     ]
 
     void addCdkDependencies() {
-        def projectName = { ":airbyte-cdk:java:airbyte-cdk:${it}" }
+        def projectName = { ":airbyte-cdk:java:airbyte-cdk:airbyte-cdk-${it}" }
         def jarName = { "io.airbyte.cdk:airbyte-cdk-${it}:${cdkVersionRequired}" }
         project.processIntegrationTestJavaResources {
             // The metadata.yaml file is required by DestinationAcceptanceTest.

--- a/buildSrc/src/main/groovy/airbyte-java-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-java-connector.gradle
@@ -55,10 +55,20 @@ class AirbyteJavaConnectorExtension {
                 duplicatesStrategy DuplicatesStrategy.EXCLUDE
             }
         }
+        if (!cdkVersionRequired.matches("^[0-9]+\\.[0-9]+\\.[0-9]+")) {
+            throw new IllegalArgumentException("cdkVersionRequired should be a well-formed 3-part version number")
+        }
+        final int minor = Integer.parseInt(cdkVersionRequired.split('\\.')[1])
+
         project.dependencies {
-            def dep = { useLocalCdk ? project.project(projectName(it)) : jarName(it) }
-            def testFixturesDep = { useLocalCdk ? testFixtures(project.project(projectName(it))) : "${jarName(it)}:test-fixtures" }
-            if (useLocalCdk || !cdkVersionRequired.matches("^0\\.[0-9]\\..*|^0\\.1[0-8]\\..*")) {
+            def dep = useLocalCdk
+                    ? { project.project(projectName(it)) }
+                    : { jarName(it) }
+            def testFixturesDep = (useLocalCdk || minor >= 29)
+                    ? { testFixtures(dep(it)) }
+                    : { "${jarName(it)}:test-fixtures" } // handle pre-v0.29 publications
+
+            if (useLocalCdk || minor >= 19) {
                 // v0.19+ module structure
                 compileOnly "org.projectlombok:lombok:1.18.30"
                 annotationProcessor "org.projectlombok:lombok:1.18.30"     // Lombok must be added BEFORE Micronaut

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -292,18 +292,19 @@ According to Postgres [documentation](https://www.postgresql.org/docs/14/datatyp
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                    |
 |---------|------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.3.22  | 2024-04-01 | [36739](https://github.com/airbytehq/airbyte/pull/36739) | Fix useLocalCdk flag.                                                                                                                                                      |
-| 3.3.21  | 2024-03-25 | [36584](https://github.com/airbytehq/airbyte/pull/36584) | Adopt Kotlin CDK.                                                                                                                                                          |
-| 3.3.20  | 2024-03-25 | [36432](https://github.com/airbytehq/airbyte/pull/36432) | Failure to serialize values from Postgres DB shouldn't fail sync.                                                                                                          |
-| 3.3.19  | 2024-03-12 | [36333](https://github.com/airbytehq/airbyte/pull/36333) | Use newest CDK - deprecate dbz iterator                                                                                                                                    |
-| 3.3.18  | 2024-03-12 | [35599](https://github.com/airbytehq/airbyte/pull/35599) | Use newest CDK                                                                                                                                                             |
-| 3.3.17  | 2024-03-12 | [35939](https://github.com/airbytehq/airbyte/pull/35939) | Use lsn_commit value instead of lsn_proc for CDC checkpointing logic.                                                                                                      |
-| 3.3.16  | 2024-03-11 | [35904](https://github.com/airbytehq/airbyte/pull/35904) | Adopt Java CDK 0.23.1- debezium retries.                                                                                                                                   |
-| 3.3.15  | 2024-02-29 | [34724](https://github.com/airbytehq/airbyte/pull/34724) | Add record count in state message.                                                                                                                                         |
-| 3.3.14  | 2024-03-06 | [35842](https://github.com/airbytehq/airbyte/pull/35842) | Add logging to understand cases with a large number of records with the same LSN.                                                                                          |
-| 3.3.12  | 2024-02-22 | [35569](https://github.com/airbytehq/airbyte/pull/35569) | Fix logging bug.                                                                                                                                                           |
-| 3.3.13  | 2024-02-27 | [35675](https://github.com/airbytehq/airbyte/pull/35675) | Fix invalid cdc error message.                                                                                                                                             |
-| 3.3.11  | 2024-02-20 | [35304](https://github.com/airbytehq/airbyte/pull/35304) | Add config to throw an error on invalid CDC position and enable it by default.                                                                                             |
+| 3.3.23 | 2024-04-02 | [36759](https://github.com/airbytehq/airbyte/pull/36759) | Track latest CDK |
+| 3.3.22 | 2024-04-01 | [36739](https://github.com/airbytehq/airbyte/pull/36739) | Fix useLocalCdk flag. |
+| 3.3.21 | 2024-03-25 | [36584](https://github.com/airbytehq/airbyte/pull/36584) | Adopt Kotlin CDK. |
+| 3.3.20 | 2024-03-25 | [36432](https://github.com/airbytehq/airbyte/pull/36432) | Failure to serialize values from Postgres DB shouldn't fail sync. |
+| 3.3.19 | 2024-03-12 | [36333](https://github.com/airbytehq/airbyte/pull/36333) | Use newest CDK - deprecate dbz iterator |
+| 3.3.18 | 2024-03-12 | [35599](https://github.com/airbytehq/airbyte/pull/35599) | Use newest CDK |
+| 3.3.17 | 2024-03-12 | [35939](https://github.com/airbytehq/airbyte/pull/35939) | Use lsn_commit value instead of lsn_proc for CDC checkpointing logic. |
+| 3.3.16 | 2024-03-11 | [35904](https://github.com/airbytehq/airbyte/pull/35904) | Adopt Java CDK 0.23.1- debezium retries. |
+| 3.3.15 | 2024-02-29 | [34724](https://github.com/airbytehq/airbyte/pull/34724) | Add record count in state message. |
+| 3.3.14 | 2024-03-06 | [35842](https://github.com/airbytehq/airbyte/pull/35842) | Add logging to understand cases with a large number of records with the same LSN. |
+| 3.3.13 | 2024-02-27 | [35675](https://github.com/airbytehq/airbyte/pull/35675) | Fix invalid cdc error message. |
+| 3.3.12 | 2024-02-22 | [35569](https://github.com/airbytehq/airbyte/pull/35569) | Fix logging bug. |
+| 3.3.11 | 2024-02-20 | [35304](https://github.com/airbytehq/airbyte/pull/35304) | Add config to throw an error on invalid CDC position and enable it by default. |
 | 3.3.10  | 2024-02-13 | [35036](https://github.com/airbytehq/airbyte/pull/34751) | Emit analytics message for invalid CDC cursor.                                                                                                                             |
 | 3.3.9   | 2024-02-13 | [35224](https://github.com/airbytehq/airbyte/pull/35224) | Adopt CDK 0.20.4                                                                                                                                                           |
 | 3.3.8   | 2024-02-08 | [34751](https://github.com/airbytehq/airbyte/pull/34751) | Adopt CDK 0.19.0                                                                                                                                                           |

--- a/settings.gradle
+++ b/settings.gradle
@@ -149,7 +149,9 @@ def cdkPath = rootDir.toPath().resolve('airbyte-cdk/java/airbyte-cdk')
 cdkPath.eachDir { dir ->
     def buildFiles = file(dir).list { file, name -> name == "build.gradle" }
     if (buildFiles.length == 1) {
-        include ":airbyte-cdk:java:airbyte-cdk:${dir.getFileName()}"
+        def path = ":airbyte-cdk:java:airbyte-cdk:${dir.getFileName()}"
+        include path
+        project(path).name = "airbyte-cdk-${dir.getFileName()}"
     }
 }
 


### PR DESCRIPTION
This PR fixes some things which were wrong in how we published and referenced CDK artifacts. These became apparent when dealing with test fixtures which re-export their dependencies on the runtime classpath. This was quite painful to debug because of how there's more than one way to skin a cat in gradle! But only one of these is secretly the good way! Fun!