### PR TITLE
low-code: Fix cursor pagination instantiation if the stop_condition is a string

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
@@ -42,7 +42,7 @@ class CursorPaginationStrategy(PaginationStrategy):
         if isinstance(self.stop_condition, str):
             self._stop_condition = InterpolatedBoolean(condition=self.stop_condition, parameters=parameters)
         else:
-            self._stop_condition = self.stop_condition
+            self._stop_condition = self.stop_condition # type: ignore # the type has been checked
 
     @property
     def initial_token(self) -> Optional[Any]:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
@@ -42,7 +42,7 @@ class CursorPaginationStrategy(PaginationStrategy):
         if isinstance(self.stop_condition, str):
             self._stop_condition = InterpolatedBoolean(condition=self.stop_condition, parameters=parameters)
         else:
-            self._stop_condition = self.stop_condition # type: ignore # the type has been checked
+            self._stop_condition = self.stop_condition  # type: ignore # the type has been checked
 
     @property
     def initial_token(self) -> Optional[Any]:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
@@ -40,7 +40,7 @@ class CursorPaginationStrategy(PaginationStrategy):
         else:
             self._cursor_value = self.cursor_value
         if isinstance(self.stop_condition, str):
-            self.stop_condition = InterpolatedBoolean(condition=self.stop_condition, parameters=parameters)
+            self._stop_condition = InterpolatedBoolean(condition=self.stop_condition, parameters=parameters)
         else:
             self._stop_condition = self.stop_condition
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_cursor_pagination_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_cursor_pagination_strategy.py
@@ -23,6 +23,7 @@ from airbyte_cdk.sources.declarative.requesters.paginators.strategies.cursor_pag
         ("test_token_not_found", "{{ response.invalid_key }}", None, None, None),
         ("test_static_token_with_stop_condition_false", "token", InterpolatedBoolean("{{False}}", parameters={}), "token", None),
         ("test_static_token_with_stop_condition_true", "token", InterpolatedBoolean("{{True}}", parameters={}), None, None),
+        ("test_static_token_with_string_stop_condition", "token", "{{True}}", None, None),
         (
             "test_token_from_header",
             "{{ headers.next }}",


### PR DESCRIPTION
## What
The `__init__` method should instantiate the `_stop_condition` field instead of `stop_condition`.

Added a test case to cover the branch because this should've been caught by unit tests