### PR TITLE
airbyte-ci: fix pull-request-number option for migrate_to_base_image

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_base_image/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_base_image/commands.py
@@ -15,7 +15,7 @@ from pipelines.helpers.utils import fail_if_missing_docker_hub_creds
     cls=DaggerPipelineCommand,
     short_help="Make the selected connectors use our base image: remove dockerfile, update metadata.yaml and update documentation.",
 )
-@click.option("pull-request-number", type=str, required=False, default=None)
+@click.option("--pull-request-number", type=str, required=False, default=None)
 @click.pass_context
 async def migrate_to_base_image(
     ctx: click.Context,


### PR DESCRIPTION
The script was failing with `ValueError: Invalid start character for option (pull-request-number)`

Adding `--` to the option decorator fixes this: