### PR TITLE
Destination postgres: detect column name collision

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/AbstractJdbcDestination.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/AbstractJdbcDestination.kt
@@ -256,6 +256,7 @@ abstract class AbstractJdbcDestination<DestinationState : MinimumDestinationStat
                 .map { override: String -> CatalogParser(sqlGenerator, override) }
                 .orElse(CatalogParser(sqlGenerator))
                 .parseCatalog(catalog!!)
+        verifyCatalog(parsedCatalog)
         val databaseName = getDatabaseName(config)
         val migrator = JdbcV1V2Migrator(namingResolver, database, databaseName)
         val v2TableMigrator = NoopV2TableMigrator()
@@ -302,6 +303,15 @@ abstract class AbstractJdbcDestination<DestinationState : MinimumDestinationStat
             getDataTransformer(parsedCatalog, defaultNamespace)
         )
     }
+
+    /**
+     * Subclasses can override this method to check that the catalog is valid for the destination.
+     * This is kind of hacky, in that ideally a destination should be able to inject logic into the
+     * CatalogParser to _make_ a valid catalog... but that's not how we live for now.
+     *
+     * Also ideally, we'd return something interesting instead of just throwing exceptions, but alas
+     */
+    open fun verifyCatalog(parsedCatalog: ParsedCatalog) {}
 
     companion object {
         private val LOGGER: Logger = LoggerFactory.getLogger(AbstractJdbcDestination::class.java)

--- a/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
@@ -171,13 +171,13 @@ public class PostgresDestination extends AbstractJdbcDestination<PostgresState> 
   public void verifyCatalog(@NotNull ParsedCatalog parsedCatalog) {
     super.verifyCatalog(parsedCatalog);
 
-    // Check for collisions between column names, after applying the 64-character truncation
+    // Check for collisions between column names, after applying the 63-character truncation
     List<String> streamErrorMessages = new ArrayList<>();
     for (StreamConfig stream : parsedCatalog.getStreams()) {
       Set<String> truncatedColumnNames = new HashSet<>();
       Set<String> collidingColumnNames = new HashSet<>();
       for (ColumnId column : stream.getColumns().keySet()) {
-        String truncatedColumnName = column.getName().substring(0, Math.min(column.getName().length(), 64));
+        String truncatedColumnName = column.getName().substring(0, Math.min(column.getName().length(), 63));
         if (truncatedColumnNames.contains(truncatedColumnName)) {
           collidingColumnNames.add(truncatedColumnName);
         }
@@ -191,7 +191,7 @@ public class PostgresDestination extends AbstractJdbcDestination<PostgresState> 
     }
     if (!streamErrorMessages.isEmpty()) {
       throw new ConfigErrorException(
-          "Postgres truncates column names to 64 characters, which may result in multiple source fields having the same column name in your destination. Remove columns within each stream to prevent these collisions.\n"
+          "Postgres truncates column names to 63 characters, which may result in multiple source fields having the same column name in your destination. Remove columns within each stream to prevent these collisions.\n"
               + String.join("\n", streamErrorMessages));
     }
   }


### PR DESCRIPTION
based on https://github.com/airbytehq/airbyte/pull/36620. see also https://github.com/airbytehq/airbyte/pull/36805 for "maybe handle these collisions intelligently".

throw a more informative error when we detect collisions between truncated column names.