### PR TITLE
connectors-qa: introduce run_on_released_connectors flag

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
@@ -51,6 +51,7 @@ TEST_GRADLE_DEPENDENCIES = [
 
 def download_catalog(catalog_url):
     response = requests.get(catalog_url)
+    response.raise_for_status()
     return response.json()
 
 
@@ -554,6 +555,25 @@ class Connector:
     @property
     def is_using_poetry(self) -> bool:
         return Path(self.code_directory / "pyproject.toml").exists()
+
+    @property
+    def is_released(self) -> bool:
+        """Pull the the OSS registry and check if it the current definition ID and docker image tag are in the registry.
+        If there is a match it means the connector is released.
+        We use the OSS registry as the source of truth for released connectors as the cloud registry can be a subset of the OSS registry.
+
+        Returns:
+            bool: True if the connector is released, False otherwise.
+        """
+        metadata = self.metadata
+        registry = download_catalog(OSS_CATALOG_URL)
+        for connector in registry[f"{self.connector_type}s"]:
+            if (
+                connector[f"{self.connector_type}DefinitionId"] == metadata["definitionId"]
+                and connector["dockerImageTag"] == metadata["dockerImageTag"]
+            ):
+                return True
+        return False
 
     def get_secret_manager(self, gsm_credentials: str):
         return SecretsManager(connector_name=self.technical_name, gsm_credentials=gsm_credentials)

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector_ops"
-version = "0.4"
+version = "0.4.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -107,6 +107,9 @@ poe lint
 
 ## Changelog
 
+### 1.1.0
+Introduced the `Check.run_on_released_connectors` flag.
+
 ### 1.0.4
 
 Adds `htmlcov` to list of ignored directories for `CheckConnectorUsesHTTPSOnly` check.

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-qa"
-version = "1.0.4"
+version = "1.1.0"
 description = "A package to run QA checks on Airbyte connectors, generate reports and documentation."
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/packaging.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/packaging.py
@@ -17,6 +17,7 @@ class CheckConnectorUsesPoetry(PackagingCheck):
     name = "Connectors must use Poetry for dependency management"
     description = "Connectors must use [Poetry](https://python-poetry.org/) for dependency management. This is to ensure that all connectors use a dependency management tool which locks dependencies and ensures reproducible installs."
     requires_metadata = False
+    runs_on_released_connectors = False
     applies_to_connector_languages = [
         ConnectorLanguage.PYTHON,
         ConnectorLanguage.LOW_CODE,

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/security.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/security.py
@@ -17,6 +17,7 @@ class CheckConnectorUsesHTTPSOnly(SecurityCheck):
     name = "Connectors must use HTTPS only"
     description = "Connectors must use HTTPS only when making requests to external services."
     requires_metadata = False
+    runs_on_released_connectors = False
 
     ignore_comment = "# ignore-https-check"  # Define the ignore comment pattern
 

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/models.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/models.py
@@ -63,6 +63,7 @@ class CheckResult:
 class Check(ABC):
 
     requires_metadata: bool = True
+    runs_on_released_connectors: bool = True
 
     @property
     @abstractmethod
@@ -135,6 +136,11 @@ class Check(ABC):
         raise NotImplementedError("Subclasses must implement category property/attribute")
 
     def run(self, connector: Connector) -> CheckResult:
+        if not self.runs_on_released_connectors and connector.is_released:
+            return self.skip(
+                connector,
+                "Check does not apply to released connectors",
+            )
         if not connector.metadata and self.requires_metadata:
             return self.fail(
                 connector,

--- a/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_models.py
+++ b/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_models.py
@@ -27,7 +27,7 @@ class TestCheck:
 
     def test_fail_when_language_is_missing(self, mocker):
         # Arrange
-        connector = mocker.MagicMock(language=None)
+        connector = mocker.MagicMock(language=None, is_released=False)
 
         # Act
         results = []
@@ -63,3 +63,17 @@ class TestCheck:
 
         # Assert
         assert all(result.status == CheckStatus.SKIPPED for result in results)
+
+    def test_skip_when_check_does_not_apply_to_released_connectors(self, mocker):
+        # Arrange
+        connector = mocker.MagicMock(is_released=True)
+
+        # Act
+        results = []
+        for check in ENABLED_CHECKS:
+            if not check.runs_on_released_connectors:
+                results.append(check.run(connector))
+
+        # Assert
+        assert all(result.status == CheckStatus.SKIPPED for result in results)
+        assert all(result.message == "Check does not apply to released connectors" for result in results)


### PR DESCRIPTION
We have some check that are not meant to run on nightly builds, for released connectors.
This PR introduce a flag that can be set at the `Check` level to determine if the check should run on a released connector or be skipped.
The released state of the connector is determined by the presence of the current version in metadata in the OSS registry.