### PR TITLE
CDK: fix misaligned version numbers

### DIFF
--- a/airbyte-cdk/python/.bumpversion.cfg
+++ b/airbyte-cdk/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.78.7
+current_version = 0.78.8
 commit = False
 
 [bumpversion:file:Dockerfile]

--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.78.8
-Update error messaging/type for missing streams
+Update error messaging/type for missing streams. Note: version mismatch, please use 0.78.9 instead
 
 ## 0.78.6
 low-code: add backward compatibility for old close slice behavior 

--- a/airbyte-cdk/python/Dockerfile
+++ b/airbyte-cdk/python/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache upgrade \
     && apk --no-cache add tzdata build-base
 
 # install airbyte-cdk
-RUN pip install --prefix=/install airbyte-cdk==0.78.7
+RUN pip install --prefix=/install airbyte-cdk==0.78.8
 
 # build a clean environment
 FROM base
@@ -32,5 +32,5 @@ ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
 # needs to be the same as CDK
-LABEL io.airbyte.version=0.78.7
+LABEL io.airbyte.version=0.78.8
 LABEL io.airbyte.name=airbyte/source-declarative-manifest


### PR DESCRIPTION
## What

While updating the CDK, I goofed and manually bumped the CDK version in 'pyproject.toml', leading to a [mismatch in versions](https://github.com/airbytehq/airbyte/commit/848ecad5799d590b36577aede76d9acfd7508f2f) after running the publich Github workflow. This PR bumps all versions to `0.78.8` so we can run the workflow again and publish the latest version as `0.78.9`.