### PR TITLE
Set maxSecondsBetweenMessages value for certified connectors Phase 3

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -17,7 +17,7 @@ data:
   githubIssueLabel: source-airtable
   icon: airtable.svg
   license: MIT
-  maxSecondsBetweenMessages: 2592000
+  maxSecondsBetweenMessages: 5400
   name: Airtable
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -19,6 +19,7 @@ data:
   githubIssueLabel: source-amazon-ads
   icon: amazonads.svg
   license: MIT
+  maxSecondsBetweenMessages: 5400
   name: Amazon Ads
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -17,7 +17,7 @@ data:
   githubIssueLabel: source-amplitude
   icon: amplitude.svg
   license: MIT
-  maxSecondsBetweenMessages: 2592000
+  maxSecondsBetweenMessages: 86400
   name: Amplitude
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-chargebee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-chargebee
   icon: chargebee.svg
   license: MIT
+  maxSecondsBetweenMessages: 300
   name: Chargebee
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-file
   icon: file.svg
   license: MIT
+  maxSecondsBetweenMessages: 5400
   name: File (CSV, JSON, Excel, Feather, Parquet)
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-freshdesk
   icon: freshdesk.svg
   license: MIT
+  maxSecondsBetweenMessages: 60
   name: Freshdesk
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-gitlab
   icon: gitlab.svg
   license: MIT
+  maxSecondsBetweenMessages: 60
   name: Gitlab
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-greenhouse
   icon: greenhouse.svg
   license: MIT
+  maxSecondsBetweenMessages: 10
   name: Greenhouse
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-harvest
   icon: harvest.svg
   license: MIT
+  maxSecondsBetweenMessages: 15
   name: Harvest
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-iterable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-iterable/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-iterable
   icon: iterable.svg
   license: MIT
+  maxSecondsBetweenMessages: 60
   name: Iterable
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -16,7 +16,7 @@ data:
   githubIssueLabel: source-jira
   icon: jira.svg
   license: MIT
-  maxSecondsBetweenMessages: 21600
+  maxSecondsBetweenMessages: 5400
   name: Jira
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -17,6 +17,7 @@ data:
   githubIssueLabel: source-mailchimp
   icon: mailchimp.svg
   license: MIT
+  maxSecondsBetweenMessages: 120
   name: Mailchimp
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -33,6 +33,7 @@ data:
   githubIssueLabel: source-monday
   icon: monday.svg
   license: MIT
+  maxSecondsBetweenMessages: 60
   name: Monday
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-notion
   icon: notion.svg
   license: MIT
+  maxSecondsBetweenMessages: 1
   name: Notion
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -17,6 +17,7 @@ data:
   githubIssueLabel: source-paypal-transaction
   icon: paypal.svg
   license: MIT
+  maxSecondsBetweenMessages: 5400
   name: Paypal Transaction
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-pinterest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pinterest/metadata.yaml
@@ -12,6 +12,7 @@ data:
   githubIssueLabel: source-pinterest
   icon: pinterest.svg
   license: MIT
+  maxSecondsBetweenMessages: 86400
   name: Pinterest
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-recharge/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recharge/metadata.yaml
@@ -12,6 +12,7 @@ data:
   githubIssueLabel: source-recharge
   icon: recharge.svg
   license: MIT
+  maxSecondsBetweenMessages: 1
   name: Recharge
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-sendgrid
   icon: sendgrid.svg
   license: MIT
+  maxSecondsBetweenMessages: 5400
   name: Sendgrid
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-slack
   icon: slack.svg
   license: MIT
+  maxSecondsBetweenMessages: 60
   name: Slack
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -13,6 +13,7 @@ data:
   githubIssueLabel: source-snapchat-marketing
   icon: snapchat.svg
   license: MIT
+  maxSecondsBetweenMessages: 1
   name: Snapchat Marketing
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-surveymonkey/metadata.yaml
+++ b/airbyte-integrations/connectors/source-surveymonkey/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-surveymonkey
   icon: surveymonkey.svg
   license: MIT
+  maxSecondsBetweenMessages: 86400
   name: SurveyMonkey
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -19,6 +19,7 @@ data:
   githubIssueLabel: source-twilio
   icon: twilio.svg
   license: MIT
+  maxSecondsBetweenMessages: 5400
   name: Twilio
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -16,6 +16,7 @@ data:
   githubIssueLabel: source-typeform
   icon: typeform.svg
   license: MIT
+  maxSecondsBetweenMessages: 1
   name: Typeform
   remoteRegistries:
     pypi:


### PR DESCRIPTION
For certified connectors is requirement to have `maxSecondsBetweenMessages` set in metadata file.
`maxSecondsBetweenMessages` is the longest time frame (in seconds) of API requests limits reset for endpoints used by connector.

## What
`maxSecondsBetweenMessages` value for the following connectors was added:

- source-notion: `maxSecondsBetweenMessages: 1`. Longest time frame of limits reset is [1 second](https://developers.notion.com/reference/request-limits)
- source-pinterest: `maxSecondsBetweenMessages: 86400`. Longest time frame of limits reset is [1 day or 86400 seconds](https://developers.pinterest.com/docs/reference/ratelimits/)
- source-recharge: `maxSecondsBetweenMessages: 1`. Longest time frame of limits reset is [1 second](https://docs.rechargepayments.com/docs/api-rate-limits)
- source-slack: `maxSecondsBetweenMessages: 60`. Longest time frame of limits reset is [1 minute or 60 seconds](https://api.slack.com/apis/rate-limits)
- source-snapchat-marketing: `maxSecondsBetweenMessages: 1`. Longest time frame of limits reset is [1 second](https://marketingapi.snapchat.com/docs/#rate-limits)
- source-freshdesk: `maxSecondsBetweenMessages: 60`. Longest time frame of limits reset is [1 minute or 60 seconds](https://developers.freshdesk.com/api/#ratelimit)
- source-greenhouse: `maxSecondsBetweenMessages: 10`. Longest time frame of limits reset is [10 seconds](https://developers.greenhouse.io/harvest.html#rate-limiting)
- source-harvest: `maxSecondsBetweenMessages: 15`. Longest time frame of limits reset is [15 seconds](https://help.getharvest.com/api-v2/introduction/overview/general/#rate-limiting)
- source-iterable: `maxSecondsBetweenMessages: 60`. Longest time frame of limits reset is [1 minute or 60 seconds](https://api.iterable.com/api/docs#campaigns_abort_campaign)
- source-surveymonkey: `maxSecondsBetweenMessages: 86400`. Longest time frame of limits reset is [1 day or 86400 seconds](https://api.surveymonkey.com/v3/docs#request-and-response-limits)
- source-airtable: `maxSecondsBetweenMessages: 5400`. Longest time frame of limits reset based on billing plan is [1 month](https://airtable.com/pricing?_gl=1*1xemogu*_ga*MTM1ODU3NzE4MS4xNzA3NDczNDcw*_ga_VJY8J9RFZM*MTcxMTM3NjU0NC4zLjEuMTcxMTM3NjgxNy42MC4wLjA.). Set value to 90 minutes (5400 seconds) as 1 month is to long time to keep connection.
- source-amplitude: `maxSecondsBetweenMessages: 86400`. Longest time frame of limits reset for Behavioral Cohorts API that is used by connector is [1 month](https://airtable.com/pricing?_gl=1*1xemogu*_ga*MTM1ODU3NzE4MS4xNzA3NDczNDcw*_ga_VJY8J9RFZM*MTcxMTM3NjU0NC4zLjEuMTcxMTM3NjgxNy42MC4wLjA.). Set value to 1 day (86400 seconds) as 1 month is to long time to keep connection and there is no info regarding limits reset time for Export jobs.
- source-gitlab: `maxSecondsBetweenMessages: 60`. Longest time frame of limits reset is [1 minute or 60 seconds](https://docs.gitlab.com/ee/user/gitlab_com/index.html#gitlabcom-specific-rate-limits)
- source-chargebee: `maxSecondsBetweenMessages: 300`. Longest time frame of limits reset is [5 minutes or 300 seconds](https://apidocs.chargebee.com/docs/api/error-handling#api_rate_limits)
- source-mailchimp: `maxSecondsBetweenMessages: 120`. Longest time frame of limits reset is [2 minutes or 120 seconds](https://mailchimp.com/developer/marketing/docs/fundamentals/#api-limits)
- source-monday: `maxSecondsBetweenMessages: 60`. Longest time frame of limits reset is [1 minute or 60 seconds](https://developer.monday.com/api-reference/docs/rate-limits)
- source-file: `maxSecondsBetweenMessages: 5400`. As it's hard to define some value, platform default value is set: 90 minutes or 5400 seconds.
- source-jira: `maxSecondsBetweenMessages: 5400`. As there is no requests rate limits time reset specified platform default value is set: 90 minutes or 5400 seconds - [link](https://developer.atlassian.com/cloud/jira/platform/rate-limiting/)
- source-amazon-ads: `maxSecondsBetweenMessages: 5400`. As there is no requests rate limits time reset specified platform default value is set: 90 minutes or 5400 seconds
- source-twilio: `maxSecondsBetweenMessages: 5400`. As there is no requests rate limits time reset specified, platform default value is set: 90 minutes or 5400 seconds - [link](https://help.twilio.com/articles/360044308153-Twilihttps://www.typeform.com/developers/get-started/#rate-limitso-API-response-Error-429-Too-Many-Requests)
- source-sendgrid: `maxSecondsBetweenMessages: 5400`. As there is no requests rate limits time reset specified, platform default value is set: 90 minutes or 5400 seconds - [link](https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/rate-limits)
- source-paypal-transcation: `maxSecondsBetweenMessages: 5400`. As there is no requests rate limits time reset specified, platform default value is set: 90 minutes or 5400 seconds - [link](https://developer.paypal.com/api/rest/reference/rate-limiting/)
- source-typeform: `maxSecondsBetweenMessages: 1`. Longest time frame of limits reset is [1 second](https://www.typeform.com/developers/get-started/#rate-limits)



## How
Files `metadata.yaml` for connectors mentioned above were updated by adding `maxSecondsBetweenMessages` value.

## 🚨 User Impact 🚨
No breaking changes