### PR TITLE
cdk publish: add required token to commit to master and --no-cache for getting just-published version from pypi

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}  # This token is what allows us to commit directly to master
       - name: "Publish Python CDK: bump Poetry package version"
         id: bumpversion
         run: |
@@ -206,10 +206,12 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}  # This token is what allows us to commit directly to master
       - name: Bump CDK dependency of source-declarative-manifest
         run: |
           cd airbyte-integrations/connectors/source-declarative-manifest
-          poetry add airbyte-cdk==${{needs.bump-version.outputs.new_cdk_version}}
+          # --no-cache is used to ensure the latest version is fetched. Let's see if we need to add a wait...
+          poetry add airbyte-cdk==${{needs.bump-version.outputs.new_cdk_version}} --no-cache
       - name: Bump version of source-declarative-manifest
         uses: ./.github/actions/run-airbyte-ci
         with:

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}  # This token is what allows us to commit directly to master
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }} # This token is what allows us to commit directly to master
       - name: "Publish Python CDK: bump Poetry package version"
         id: bumpversion
         run: |
@@ -206,7 +206,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}  # This token is what allows us to commit directly to master
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }} # This token is what allows us to commit directly to master
       - name: Bump CDK dependency of source-declarative-manifest
         run: |
           cd airbyte-integrations/connectors/source-declarative-manifest


### PR DESCRIPTION
Some fixes to the workflow: 
* we need a token when checking out to be able to commit back to master
* Without `--no-cache`, poetry's pypi cache immediately decides it can't find the new version that we just published in the previous step. `--no-cache` forces it to pull the versions again. It's possible that by the time it does this, pypi won't have updated it yet in their apis - if so we'll need to add a timeout too. But we'll try this first. 