### PR TITLE
Source Monday: roll back cloud to 2.0.4

### DIFF
--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -41,7 +41,7 @@ data:
       packageName: airbyte-source-monday
   registries:
     cloud:
-      dockerImageTag: 2.0.4  # pinned until https://airbyte.pagerduty.com/incidents/Q1C9A1VU1A3NLH is resolved
+      dockerImageTag: 2.0.4 # pinned until https://airbyte.pagerduty.com/incidents/Q1C9A1VU1A3NLH is resolved
       enabled: true
     oss:
       enabled: true

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -41,6 +41,7 @@ data:
       packageName: airbyte-source-monday
   registries:
     cloud:
+      dockerImageTag: 2.0.4  # pinned until https://airbyte.pagerduty.com/incidents/Q1C9A1VU1A3NLH is resolved
       enabled: true
     oss:
       enabled: true


### PR DESCRIPTION
Roll back version in cloud due to an [incident](https://airbyte.pagerduty.com/incidents/Q1C9A1VU1A3NLH) related to the [latest release](https://github.com/airbytehq/airbyte/pull/36746).