### PR TITLE
✨ Fix empty internal_message empty when ExceptionWithDisplayMessage raised

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/exceptions.py
@@ -14,5 +14,5 @@ class ExceptionWithDisplayMessage(Exception):
         super().__init__(**kwargs)
         self.display_message = display_message
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f'ExceptionWithDisplayMessage: "{self.display_message}"'

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/exceptions.py
@@ -13,3 +13,6 @@ class ExceptionWithDisplayMessage(Exception):
     def __init__(self, display_message: str, **kwargs: Any):
         super().__init__(**kwargs)
         self.display_message = display_message
+
+    def __str__(self):
+        return f"ExceptionWithDisplayMessage: \"{self.display_message}\""

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/exceptions.py
@@ -15,4 +15,4 @@ class ExceptionWithDisplayMessage(Exception):
         self.display_message = display_message
 
     def __str__(self):
-        return f"ExceptionWithDisplayMessage: \"{self.display_message}\""
+        return f'ExceptionWithDisplayMessage: "{self.display_message}"'

--- a/airbyte-cdk/python/unit_tests/test_exception_handler.py
+++ b/airbyte-cdk/python/unit_tests/test_exception_handler.py
@@ -10,6 +10,7 @@ import sys
 import pytest
 from airbyte_cdk.exception_handler import assemble_uncaught_exception
 from airbyte_cdk.models import AirbyteErrorTraceMessage, AirbyteLogMessage, AirbyteMessage, AirbyteTraceMessage
+from airbyte_cdk.sources.streams.concurrent.exceptions import ExceptionWithDisplayMessage
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 
 
@@ -23,6 +24,13 @@ def test_given_exception_not_traced_exception_when_assemble_uncaught_exception_t
     exception = ValueError("any error")
     assembled_exception = assemble_uncaught_exception(type(exception), exception)
     assert isinstance(assembled_exception, AirbyteTracedException)
+
+
+def test_given_exception_with_display_message_when_assemble_uncaught_exception_then_internal_message_contains_display_message():
+    display_message = "some display message"
+    exception = ExceptionWithDisplayMessage(display_message)
+    assembled_exception = assemble_uncaught_exception(type(exception), exception)
+    assert display_message in assembled_exception.internal_message
 
 
 def test_uncaught_exception_handler():


### PR DESCRIPTION
Some exceptions raised are logged with an `internal_message` field empty in the concurrent CDK. This makes it hard to categorize and solve problems. [issue 6830](https://app.zenhub.com/workspaces/critical-connectors-659c693d906fcd00178900cf/issues/gh/airbytehq/airbyte-internal-issues/6830)

## What
Fixed empty `internal_message` fields when an `ExceptionWithDisplayMessage` is raised.

## How
* A `__str__()` implementation was added to `ExceptionWithDisplayMessage` to avoid empty `internal_message` fields
* Added relevant unit test

## 🚨 User Impact 🚨
No breaking changes