### PR TITLE
convert destination-snowflake to Kotlin CDK

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -173,7 +173,9 @@ corresponds to that version.
 ### Java CDK
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
-|:--------|:-----------| :--------------------------------------------------------- |:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.31.7  | 2024-05-02 | [\#36910](https://github.com/airbytehq/airbyte/pull/36910) | changes for destination-snowflake\                                                                                                                             |
+| 0.31.6  | 2024-05-02 | [\#37746](https://github.com/airbytehq/airbyte/pull/37746) | debuggability improvements.                                                                                                                                    |
 | 0.31.5  | 2024-04-30 | [\#37758](https://github.com/airbytehq/airbyte/pull/37758) | Set debezium max retries to zero                                                                                                                               |
 | 0.31.4  | 2024-04-30 | [\#37754](https://github.com/airbytehq/airbyte/pull/37754) | Add DebeziumEngine notification log                                                                                                                            |
 | 0.31.3  | 2024-04-30 | [\#37726](https://github.com/airbytehq/airbyte/pull/37726) | Remove debezium retries                                                                                                                                        |

--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -174,7 +174,7 @@ corresponds to that version.
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.31.7  | 2024-05-02 | [\#36910](https://github.com/airbytehq/airbyte/pull/36910) | changes for destination-snowflake\                                                                                                                             |
+| 0.31.7  | 2024-05-02 | [\#36910](https://github.com/airbytehq/airbyte/pull/36910) | changes for destination-snowflake                                                                                                                             |
 | 0.31.6  | 2024-05-02 | [\#37746](https://github.com/airbytehq/airbyte/pull/37746) | debuggability improvements.                                                                                                                                    |
 | 0.31.5  | 2024-04-30 | [\#37758](https://github.com/airbytehq/airbyte/pull/37758) | Set debezium max retries to zero                                                                                                                               |
 | 0.31.4  | 2024-04-30 | [\#37754](https://github.com/airbytehq/airbyte/pull/37754) | Add DebeziumEngine notification log                                                                                                                            |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/db/jdbc/JdbcDatabase.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/db/jdbc/JdbcDatabase.kt
@@ -15,6 +15,8 @@ import java.util.function.Consumer
 import java.util.function.Function
 import java.util.stream.Stream
 import java.util.stream.StreamSupport
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /** Database object for interacting with a JDBC connection. */
 abstract class JdbcDatabase(protected val sourceOperations: JdbcCompatibleSourceOperations<*>?) :
@@ -211,6 +213,7 @@ abstract class JdbcDatabase(protected val sourceOperations: JdbcCompatibleSource
     abstract fun <T> executeMetadataQuery(query: Function<DatabaseMetaData?, T>): T
 
     companion object {
+        private val LOGGER: Logger = LoggerFactory.getLogger(JdbcDatabase::class.java)
         /**
          * Map records returned in a result set. It is an "unsafe" stream because the stream must be
          * manually closed. Otherwise, there will be a database connection leak.

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/base/IntegrationRunner.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/base/IntegrationRunner.kt
@@ -370,8 +370,8 @@ internal constructor(
             }
 
         @JvmStatic
-        fun getThreadCreationInfo(thread: Thread): ThreadCreationInfo {
-            return getMethod.invoke(threadCreationInfo, thread) as ThreadCreationInfo
+        fun getThreadCreationInfo(thread: Thread): ThreadCreationInfo? {
+            return getMethod.invoke(threadCreationInfo, thread) as ThreadCreationInfo?
         }
 
         /**

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.31.6
+version=0.31.7

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/JdbcSqlOperations.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/JdbcSqlOperations.kt
@@ -204,7 +204,7 @@ abstract class JdbcSqlOperations : SqlOperations {
         }
     }
 
-    fun dropTableIfExistsQuery(schemaName: String?, tableName: String?): String {
+    open fun dropTableIfExistsQuery(schemaName: String?, tableName: String?): String {
         return String.format("DROP TABLE IF EXISTS %s.%s;\n", schemaName, tableName)
     }
 

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/typing_deduping/JdbcDestinationHandler.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/typing_deduping/JdbcDestinationHandler.kt
@@ -356,7 +356,7 @@ abstract class JdbcDestinationHandler<DestinationState>(
                 existingTable.columns[JavaBaseConstants.COLUMN_NAME_AB_META]!!.type
     }
 
-    private fun existingSchemaMatchesStreamConfig(
+    open protected fun existingSchemaMatchesStreamConfig(
         stream: StreamConfig?,
         existingTable: TableDefinition
     ): Boolean {
@@ -479,9 +479,9 @@ abstract class JdbcDestinationHandler<DestinationState>(
 
     companion object {
         private val LOGGER: Logger = LoggerFactory.getLogger(JdbcDestinationHandler::class.java)
-        private const val DESTINATION_STATE_TABLE_NAME = "_airbyte_destination_state"
-        private const val DESTINATION_STATE_TABLE_COLUMN_NAME = "name"
-        private const val DESTINATION_STATE_TABLE_COLUMN_NAMESPACE = "namespace"
+        protected const val DESTINATION_STATE_TABLE_NAME = "_airbyte_destination_state"
+        protected const val DESTINATION_STATE_TABLE_COLUMN_NAME = "name"
+        protected const val DESTINATION_STATE_TABLE_COLUMN_NAMESPACE = "namespace"
         private const val DESTINATION_STATE_TABLE_COLUMN_STATE = "destination_state"
         private const val DESTINATION_STATE_TABLE_COLUMN_UPDATED_AT = "updated_at"
 
@@ -542,6 +542,7 @@ abstract class JdbcDestinationHandler<DestinationState>(
             return Optional.of(TableDefinition(retrievedColumnDefns))
         }
 
+        @JvmStatic
         fun fromIsNullableIsoString(isNullable: String?): Boolean {
             return "YES".equals(isNullable, ignoreCase = true)
         }

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/typing_deduping/JdbcDestinationHandler.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/typing_deduping/JdbcDestinationHandler.kt
@@ -400,6 +400,29 @@ abstract class JdbcDestinationHandler<DestinationState>(
         return actualColumns == intendedColumns
     }
 
+    protected open fun getDeleteStatesSql(
+        destinationStates: Map<StreamId, DestinationState>
+    ): String {
+        return dslContext
+            .deleteFrom(table(quotedName(rawTableSchemaName, DESTINATION_STATE_TABLE_NAME)))
+            .where(
+                destinationStates.keys
+                    .stream()
+                    .map { streamId: StreamId ->
+                        field(quotedName(DESTINATION_STATE_TABLE_COLUMN_NAME))
+                            .eq(streamId.originalName)
+                            .and(
+                                field(quotedName(DESTINATION_STATE_TABLE_COLUMN_NAMESPACE))
+                                    .eq(streamId.originalNamespace)
+                            )
+                    }
+                    .reduce(DSL.falseCondition()) { obj: Condition, arg2: Condition? ->
+                        obj.or(arg2)
+                    }
+            )
+            .getSQL(ParamType.INLINED)
+    }
+
     @Throws(Exception::class)
     override fun commitDestinationStates(destinationStates: Map<StreamId, DestinationState>) {
         try {
@@ -408,25 +431,7 @@ abstract class JdbcDestinationHandler<DestinationState>(
             }
 
             // Delete all state records where the stream name+namespace match one of our states
-            val deleteStates =
-                dslContext
-                    .deleteFrom(table(quotedName(rawTableSchemaName, DESTINATION_STATE_TABLE_NAME)))
-                    .where(
-                        destinationStates.keys
-                            .stream()
-                            .map { streamId: StreamId ->
-                                field(quotedName(DESTINATION_STATE_TABLE_COLUMN_NAME))
-                                    .eq(streamId.originalName)
-                                    .and(
-                                        field(quotedName(DESTINATION_STATE_TABLE_COLUMN_NAMESPACE))
-                                            .eq(streamId.originalNamespace)
-                                    )
-                            }
-                            .reduce(DSL.falseCondition()) { obj: Condition, arg2: Condition? ->
-                                obj.or(arg2)
-                            }
-                    )
-                    .getSQL(ParamType.INLINED)
+            var deleteStates = getDeleteStatesSql(destinationStates)
 
             // Reinsert all of our states
             var insertStatesStep =
@@ -461,10 +466,15 @@ abstract class JdbcDestinationHandler<DestinationState>(
             }
             val insertStates = insertStatesStep.getSQL(ParamType.INLINED)
 
-            jdbcDatabase.executeWithinTransaction(listOf(deleteStates, insertStates))
+            executeWithinTransaction(listOf(deleteStates, insertStates))
         } catch (e: Exception) {
             LOGGER.warn("Failed to commit destination states", e)
         }
+    }
+
+    @Throws(Exception::class)
+    protected open fun executeWithinTransaction(statements: List<String>) {
+        jdbcDatabase.executeWithinTransaction(statements)
     }
 
     /**

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/standardtest/destination/LocalAirbyteDestination.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/standardtest/destination/LocalAirbyteDestination.kt
@@ -61,7 +61,7 @@ class LocalAirbyteDestination(private val dest: Destination) : AirbyteDestinatio
         return isClosed
     }
 
-    override val exitValue = 0
+    override var exitValue = 0
 
     override fun attemptRead(): Optional<io.airbyte.protocol.models.AirbyteMessage> {
         return Optional.empty()

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/testFixtures/kotlin/io/airbyte/workers/internal/AirbyteDestination.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/testFixtures/kotlin/io/airbyte/workers/internal/AirbyteDestination.kt
@@ -72,7 +72,7 @@ interface AirbyteDestination : CheckedConsumer<AirbyteMessage, Exception>, AutoC
      * @return exit code of the destination process
      * @throws IllegalStateException if the destination process has not exited
      */
-    abstract val exitValue: Int
+    val exitValue: Int
 
     /**
      * Attempts to read an AirbyteMessage from the Destination.

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseDestinationV1V2Migrator.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseDestinationV1V2Migrator.kt
@@ -171,7 +171,7 @@ abstract class BaseDestinationV1V2Migrator<DialectTableDefinition> : Destination
      * @return whether it exists and is in the correct format
      */
     @Throws(Exception::class)
-    protected fun doesValidV1RawTableExist(namespace: String?, tableName: String?): Boolean {
+    protected open fun doesValidV1RawTableExist(namespace: String?, tableName: String?): Boolean {
         val existingV1RawTable = getTableIfExists(namespace, tableName)
         return existingV1RawTable.isPresent &&
             doesV1RawTableMatchExpectedSchema(existingV1RawTable.get())

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseSqlGeneratorIntegrationTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseSqlGeneratorIntegrationTest.kt
@@ -80,7 +80,7 @@ abstract class BaseSqlGeneratorIntegrationTest<DestinationState : MinimumDestina
      * Subclasses should override this method if they need to make changes to the stream ID. For
      * example, you could upcase the final table name here.
      */
-    protected fun buildStreamId(
+    open protected fun buildStreamId(
         namespace: String,
         finalTableName: String,
         rawTableName: String
@@ -149,7 +149,7 @@ abstract class BaseSqlGeneratorIntegrationTest<DestinationState : MinimumDestina
         /** Identical to [BaseTypingDedupingTest.getRawMetadataColumnNames]. */
         get() = HashMap()
 
-    protected val finalMetadataColumnNames: Map<String, String>
+    open protected val finalMetadataColumnNames: Map<String, String>
         /** Identical to [BaseTypingDedupingTest.getFinalMetadataColumnNames]. */
         get() = HashMap()
 
@@ -728,7 +728,7 @@ abstract class BaseSqlGeneratorIntegrationTest<DestinationState : MinimumDestina
      */
     @Test
     @Throws(Exception::class)
-    fun ignoreOldRawRecords() {
+    open fun ignoreOldRawRecords() {
         createRawTable(streamId)
         createFinalTable(incrementalAppendStream, "")
         insertRawTableRecords(
@@ -1519,7 +1519,10 @@ abstract class BaseSqlGeneratorIntegrationTest<DestinationState : MinimumDestina
         executeSoftReset(generator, destinationHandler, incrementalAppendStream)
     }
 
-    protected fun migrationAssertions(v1RawRecords: List<JsonNode>, v2RawRecords: List<JsonNode>) {
+    protected open fun migrationAssertions(
+        v1RawRecords: List<JsonNode>,
+        v2RawRecords: List<JsonNode>
+    ) {
         val v2RecordMap =
             v2RawRecords
                 .stream()
@@ -1570,7 +1573,7 @@ abstract class BaseSqlGeneratorIntegrationTest<DestinationState : MinimumDestina
     }
 
     @Throws(Exception::class)
-    protected fun dumpV1RawTableRecords(streamId: StreamId): List<JsonNode> {
+    open protected fun dumpV1RawTableRecords(streamId: StreamId): List<JsonNode> {
         return dumpRawTableRecords(streamId)
     }
 

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.31.5'
+    cdkVersionRequired = '0.31.7'
     features = ['db-destinations', 's3-destinations', 'typing-deduping']
-    useLocalCdk = true
+    useLocalCdk = false
 }
 
 java {

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.27.7'
+    cdkVersionRequired = '0.31.5'
     features = ['db-destinations', 's3-destinations', 'typing-deduping']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 java {

--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,4 +1,4 @@
 # currently limit the number of parallel threads until further investigation into the issues \
 # where Snowflake will fail to login using config credentials
-testExecutionConcurrency=4
+testExecutionConcurrency=1
 JunitMethodExecutionTimeout=15 m

--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,4 +1,4 @@
 # currently limit the number of parallel threads until further investigation into the issues \
 # where Snowflake will fail to login using config credentials
-testExecutionConcurrency=1
+testExecutionConcurrency=-1
 JunitMethodExecutionTimeout=15 m

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 424892c4-daac-4491-b35d-c6688ba547ba
-  dockerImageTag: 3.7.0
+  dockerImageTag: 3.7.1
   dockerRepository: airbyte/destination-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake
   githubIssueLabel: destination-snowflake

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeDatabase.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeDatabase.java
@@ -197,7 +197,7 @@ public class SnowflakeDatabase {
   }
 
   public static JdbcDatabase getDatabase(final DataSource dataSource) {
-    return new DefaultJdbcDatabase(dataSource);
+    return new DefaultJdbcDatabase(dataSource, new SnowflakeSourceOperations());
   }
 
   private static Runnable getRefreshTokenTask(final HikariDataSource dataSource) {

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeDestinationRunner.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeDestinationRunner.java
@@ -7,12 +7,26 @@ package io.airbyte.integrations.destination.snowflake;
 import static io.airbyte.integrations.destination.snowflake.SnowflakeDestination.SCHEDULED_EXECUTOR_SERVICE;
 
 import io.airbyte.cdk.integrations.base.AirbyteExceptionHandler;
+import io.airbyte.cdk.integrations.base.IntegrationRunner;
 import io.airbyte.cdk.integrations.base.adaptive.AdaptiveDestinationRunner;
+import net.snowflake.client.core.SFSession;
+import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
 
 public class SnowflakeDestinationRunner {
 
   public static void main(final String[] args) throws Exception {
+    IntegrationRunner.addOrphanedThreadFilter((Thread t) -> {
+      for (StackTraceElement stackTraceElement : IntegrationRunner.getThreadCreationInfo(t).getStack()) {
+        String stackClassName = stackTraceElement.getClassName();
+        String stackMethodName = stackTraceElement.getMethodName();
+        if (SFStatement.class.getCanonicalName().equals(stackClassName) && "close".equals(stackMethodName) ||
+            SFSession.class.getCanonicalName().equals(stackClassName) && "callHeartBeatWithQueryTimeout".equals(stackMethodName)) {
+          return false;
+        }
+      }
+      return true;
+    });
     AirbyteExceptionHandler.addThrowableForDeinterpolation(SnowflakeSQLException.class);
     AdaptiveDestinationRunner.baseOnEnv()
         .withOssDestination(() -> new SnowflakeDestination(OssCloudEnvVarConsts.AIRBYTE_OSS))

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestination.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestination.java
@@ -10,6 +10,7 @@ import io.airbyte.cdk.db.jdbc.JdbcDatabase;
 import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.cdk.integrations.base.Destination;
 import io.airbyte.cdk.integrations.base.JavaBaseConstants;
+import io.airbyte.cdk.integrations.base.JavaBaseConstants.DestinationColumns;
 import io.airbyte.cdk.integrations.base.SerializedAirbyteMessageConsumer;
 import io.airbyte.cdk.integrations.base.TypingAndDedupingFlag;
 import io.airbyte.cdk.integrations.destination.NamingConventionTransformer;
@@ -132,7 +133,7 @@ public class SnowflakeInternalStagingDestination extends AbstractJdbcDestination
   }
 
   @Override
-  protected JdbcSqlGenerator getSqlGenerator() {
+  protected JdbcSqlGenerator getSqlGenerator(final JsonNode config) {
     throw new UnsupportedOperationException("Snowflake does not yet use the native JDBC DV2 interface");
   }
 
@@ -209,7 +210,7 @@ public class SnowflakeInternalStagingDestination extends AbstractJdbcDestination
         typerDeduper,
         parsedCatalog,
         defaultNamespace,
-        true)
+        DestinationColumns.V2_WITHOUT_META)
         .setBufferMemoryLimit(Optional.of(getSnowflakeBufferMemoryLimit()))
         .setOptimalBatchSizeBytes(
             // The per stream size limit is following recommendations from:

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSourceOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSourceOperations.java
@@ -8,12 +8,26 @@ import static io.airbyte.cdk.db.jdbc.DateTimeConverter.putJavaSQLDate;
 import static io.airbyte.cdk.db.jdbc.DateTimeConverter.putJavaSQLTime;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.cdk.db.DataTypeUtils;
 import io.airbyte.cdk.db.jdbc.JdbcSourceOperations;
 import io.airbyte.commons.json.Jsons;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 
-public class SnowflakeTestSourceOperations extends JdbcSourceOperations {
+public class SnowflakeSourceOperations extends JdbcSourceOperations {
+
+  private static final DateTimeFormatter SNOWFLAKE_TIMESTAMPTZ_FORMATTER = new DateTimeFormatterBuilder()
+      .parseCaseInsensitive()
+      .append(DateTimeFormatter.ISO_LOCAL_DATE)
+      .appendLiteral(' ')
+      .append(DateTimeFormatter.ISO_LOCAL_TIME)
+      .optionalStart()
+      .appendLiteral(' ')
+      .append(DateTimeFormatter.ofPattern("XX"))
+      .toFormatter();
 
   @Override
   public void copyToJsonField(final ResultSet resultSet, final int colIndex, final ObjectNode json) throws SQLException {
@@ -43,6 +57,14 @@ public class SnowflakeTestSourceOperations extends JdbcSourceOperations {
                          final int index)
       throws SQLException {
     putJavaSQLTime(node, columnName, resultSet, index);
+  }
+
+  @Override
+  protected void putTimestampWithTimezone(final ObjectNode node, final String columnName, final ResultSet resultSet, final int index)
+      throws SQLException {
+    final String timestampAsString = resultSet.getString(index);
+    OffsetDateTime timestampWithOffset = OffsetDateTime.parse(timestampAsString, SNOWFLAKE_TIMESTAMPTZ_FORMATTER);
+    node.put(columnName, timestampWithOffset.format(DataTypeUtils.TIMESTAMPTZ_FORMATTER));
   }
 
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSourceOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSourceOperations.java
@@ -67,4 +67,10 @@ public class SnowflakeSourceOperations extends JdbcSourceOperations {
     node.put(columnName, timestampWithOffset.format(DataTypeUtils.TIMESTAMPTZ_FORMATTER));
   }
 
+  protected void putTimestamp(final ObjectNode node, final String columnName, final ResultSet resultSet, final int index) throws SQLException {
+    // for backward compatibility
+    var instant = resultSet.getTimestamp(index).toInstant();
+    node.put(columnName, DataTypeUtils.toISO8601StringWithMicroseconds(instant));
+  }
+
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlOperations.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.cdk.db.jdbc.JdbcDatabase;
 import io.airbyte.cdk.integrations.base.DestinationConfig;
 import io.airbyte.cdk.integrations.base.JavaBaseConstants;
-import io.airbyte.cdk.integrations.destination.async.partial_messages.PartialAirbyteMessage;
+import io.airbyte.cdk.integrations.destination.async.model.PartialAirbyteMessage;
 import io.airbyte.cdk.integrations.destination.jdbc.JdbcSqlOperations;
 import io.airbyte.cdk.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.cdk.integrations.destination.jdbc.SqlOperationsUtils;
@@ -37,10 +37,10 @@ public class SnowflakeSqlOperations extends JdbcSqlOperations implements SqlOper
   @Override
   public void createSchemaIfNotExists(final JdbcDatabase database, final String schemaName) throws Exception {
     try {
-      if (!schemaSet.contains(schemaName) && !isSchemaExists(database, schemaName)) {
+      if (!getSchemaSet().contains(schemaName) && !isSchemaExists(database, schemaName)) {
         // 1s1t is assuming a lowercase airbyte_internal schema name, so we need to quote it
         database.execute(String.format("CREATE SCHEMA IF NOT EXISTS \"%s\";", schemaName));
-        schemaSet.add(schemaName);
+        getSchemaSet().add(schemaName);
       }
     } catch (final Exception e) {
       throw checkForKnownConfigExceptions(e).orElseThrow(() -> e);

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlStagingOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlStagingOperations.java
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.destination.snowflake;
 
 import io.airbyte.cdk.db.jdbc.JdbcDatabase;
+import io.airbyte.cdk.integrations.base.JavaBaseConstants.DestinationColumns;
 import io.airbyte.cdk.integrations.destination.record_buffer.FileBuffer;
 import io.airbyte.cdk.integrations.destination.s3.csv.CsvSerializedBuffer;
 import io.airbyte.cdk.integrations.destination.s3.csv.StagingDatabaseCsvSheetGenerator;
@@ -18,6 +19,7 @@ public abstract class SnowflakeSqlStagingOperations extends SnowflakeSqlOperatio
   /**
    * This method is used in Check connection method to make sure that user has the Write permission
    */
+  @SuppressWarnings("deprecation")
   protected void attemptWriteToStage(final String outputSchema,
                                      final String stageName,
                                      final JdbcDatabase database)
@@ -25,7 +27,7 @@ public abstract class SnowflakeSqlStagingOperations extends SnowflakeSqlOperatio
 
     final CsvSerializedBuffer csvSerializedBuffer = new CsvSerializedBuffer(
         new FileBuffer(CsvSerializedBuffer.CSV_GZ_SUFFIX),
-        new StagingDatabaseCsvSheetGenerator(true),
+        new StagingDatabaseCsvSheetGenerator(DestinationColumns.V2_WITHOUT_META),
         true);
 
     // create a dummy stream\records that will bed used to test uploading

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeDestinationHandler.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeDestinationHandler.java
@@ -70,8 +70,8 @@ public class SnowflakeDestinationHandler extends JdbcDestinationHandler<Snowflak
     final LinkedHashMap<String, LinkedHashMap<String, TableDefinition>> existingTables = new LinkedHashMap<>();
     final String paramHolder = String.join(",", Collections.nCopies(streamIds.size(), "?"));
     // convert list stream to array
-    final String[] namespaces = streamIds.stream().map(StreamId::finalNamespace).toArray(String[]::new);
-    final String[] names = streamIds.stream().map(StreamId::finalName).toArray(String[]::new);
+    final String[] namespaces = streamIds.stream().map(StreamId::getFinalNamespace).toArray(String[]::new);
+    final String[] names = streamIds.stream().map(StreamId::getFinalName).toArray(String[]::new);
     final String query = """
                          SELECT table_schema, table_name, column_name, data_type, is_nullable
                          FROM information_schema.columns
@@ -103,8 +103,8 @@ public class SnowflakeDestinationHandler extends JdbcDestinationHandler<Snowflak
     final LinkedHashMap<String, LinkedHashMap<String, Integer>> tableRowCounts = new LinkedHashMap<>();
     final String paramHolder = String.join(",", Collections.nCopies(streamIds.size(), "?"));
     // convert list stream to array
-    final String[] namespaces = streamIds.stream().map(StreamId::finalNamespace).toArray(String[]::new);
-    final String[] names = streamIds.stream().map(StreamId::finalName).toArray(String[]::new);
+    final String[] namespaces = streamIds.stream().map(StreamId::getFinalNamespace).toArray(String[]::new);
+    final String[] names = streamIds.stream().map(StreamId::getFinalName).toArray(String[]::new);
     final String query = """
                          SELECT table_schema, table_name, row_count
                          FROM information_schema.tables
@@ -133,8 +133,8 @@ public class SnowflakeDestinationHandler extends JdbcDestinationHandler<Snowflak
     }
     final ResultSet tables = database.getMetaData().getTables(
         databaseName,
-        id.rawNamespace(),
-        id.rawName(),
+        id.getRawNamespace(),
+        id.getRawName(),
         null);
     if (!tables.next()) {
       return new InitialRawTableStatus(false, false, Optional.empty());
@@ -227,25 +227,26 @@ public class SnowflakeDestinationHandler extends JdbcDestinationHandler<Snowflak
   }
 
   private Set<String> getPks(final StreamConfig stream) {
-    return stream.primaryKey() != null ? stream.primaryKey().stream().map(ColumnId::name).collect(Collectors.toSet()) : Collections.emptySet();
+    return stream.getPrimaryKey() != null ? stream.getPrimaryKey().stream().map(ColumnId::getName).collect(Collectors.toSet())
+        : Collections.emptySet();
   }
 
   private boolean isAirbyteRawIdColumnMatch(final TableDefinition existingTable) {
     final String abRawIdColumnName = COLUMN_NAME_AB_RAW_ID.toUpperCase();
     return existingTable.columns().containsKey(abRawIdColumnName) &&
-        toJdbcTypeName(AirbyteProtocolType.STRING).equals(existingTable.columns().get(abRawIdColumnName).type());
+        toJdbcTypeName(AirbyteProtocolType.STRING).equals(existingTable.columns().get(abRawIdColumnName).getType());
   }
 
   private boolean isAirbyteExtractedAtColumnMatch(final TableDefinition existingTable) {
     final String abExtractedAtColumnName = COLUMN_NAME_AB_EXTRACTED_AT.toUpperCase();
     return existingTable.columns().containsKey(abExtractedAtColumnName) &&
-        toJdbcTypeName(AirbyteProtocolType.TIMESTAMP_WITH_TIMEZONE).equals(existingTable.columns().get(abExtractedAtColumnName).type());
+        toJdbcTypeName(AirbyteProtocolType.TIMESTAMP_WITH_TIMEZONE).equals(existingTable.columns().get(abExtractedAtColumnName).getType());
   }
 
   private boolean isAirbyteMetaColumnMatch(TableDefinition existingTable) {
     final String abMetaColumnName = COLUMN_NAME_AB_META.toUpperCase();
     return existingTable.columns().containsKey(abMetaColumnName) &&
-        "VARIANT".equals(existingTable.columns().get(abMetaColumnName).type());
+        "VARIANT".equals(existingTable.columns().get(abMetaColumnName).getType());
   }
 
   protected boolean existingSchemaMatchesStreamConfig(final StreamConfig stream, final TableDefinition existingTable) {
@@ -259,9 +260,9 @@ public class SnowflakeDestinationHandler extends JdbcDestinationHandler<Snowflak
       // Missing AB meta columns from final table, we need them to do proper T+D so trigger soft-reset
       return false;
     }
-    final LinkedHashMap<String, String> intendedColumns = stream.columns().entrySet().stream()
+    final LinkedHashMap<String, String> intendedColumns = stream.getColumns().entrySet().stream()
         .collect(LinkedHashMap::new,
-            (map, column) -> map.put(column.getKey().name(), toJdbcTypeName(column.getValue())),
+            (map, column) -> map.put(column.getKey().getName(), toJdbcTypeName(column.getValue())),
             LinkedHashMap::putAll);
 
     // Filter out Meta columns since they don't exist in stream config.
@@ -269,7 +270,7 @@ public class SnowflakeDestinationHandler extends JdbcDestinationHandler<Snowflak
         .filter(column -> V2_FINAL_TABLE_METADATA_COLUMNS.stream().map(String::toUpperCase)
             .noneMatch(airbyteColumnName -> airbyteColumnName.equals(column.getKey())))
         .collect(LinkedHashMap::new,
-            (map, column) -> map.put(column.getKey(), column.getValue().type()),
+            (map, column) -> map.put(column.getKey(), column.getValue().getType()),
             LinkedHashMap::putAll);
     // soft-resetting https://github.com/airbytehq/airbyte/pull/31082
     @SuppressWarnings("deprecation")
@@ -285,13 +286,13 @@ public class SnowflakeDestinationHandler extends JdbcDestinationHandler<Snowflak
   public List<DestinationInitialStatus<SnowflakeState>> gatherInitialState(List<StreamConfig> streamConfigs) throws Exception {
     final Map<AirbyteStreamNameNamespacePair, SnowflakeState> destinationStates = super.getAllDestinationStates();
 
-    List<StreamId> streamIds = streamConfigs.stream().map(StreamConfig::id).toList();
+    List<StreamId> streamIds = streamConfigs.stream().map(StreamConfig::getId).toList();
     final LinkedHashMap<String, LinkedHashMap<String, TableDefinition>> existingTables = findExistingTables(database, databaseName, streamIds);
     final LinkedHashMap<String, LinkedHashMap<String, Integer>> tableRowCounts = getFinalTableRowCount(streamIds);
     return streamConfigs.stream().map(streamConfig -> {
       try {
-        final String namespace = streamConfig.id().finalNamespace().toUpperCase();
-        final String name = streamConfig.id().finalName().toUpperCase();
+        final String namespace = streamConfig.getId().getFinalNamespace().toUpperCase();
+        final String name = streamConfig.getId().getFinalName().toUpperCase();
         boolean isSchemaMismatch = false;
         boolean isFinalTableEmpty = true;
         boolean isFinalTablePresent = existingTables.containsKey(namespace) && existingTables.get(namespace).containsKey(name);
@@ -301,8 +302,9 @@ public class SnowflakeDestinationHandler extends JdbcDestinationHandler<Snowflak
           isSchemaMismatch = !existingSchemaMatchesStreamConfig(streamConfig, existingTable);
           isFinalTableEmpty = hasRowCount && tableRowCounts.get(namespace).get(name) == 0;
         }
-        final InitialRawTableStatus initialRawTableState = getInitialRawTableState(streamConfig.id(), streamConfig.destinationSyncMode());
-        final SnowflakeState destinationState = destinationStates.getOrDefault(streamConfig.id().asPair(), toDestinationState(Jsons.emptyObject()));
+        final InitialRawTableStatus initialRawTableState = getInitialRawTableState(streamConfig.getId(), streamConfig.getDestinationSyncMode());
+        final SnowflakeState destinationState =
+            destinationStates.getOrDefault(streamConfig.getId().asPair(), toDestinationState(Jsons.emptyObject()));
         return new DestinationInitialStatus<>(
             streamConfig,
             isFinalTablePresent,

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeDestinationHandler.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeDestinationHandler.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.jooq.SQLDialect;
 import org.slf4j.Logger;
@@ -353,6 +354,32 @@ public class SnowflakeDestinationHandler extends JdbcDestinationHandler<Snowflak
       case DATE -> "DATE";
       case UNKNOWN -> "VARIANT";
     };
+  }
+
+  protected String getDeleteStatesSql(Map<StreamId, ? extends SnowflakeState> destinationStates) {
+    // only doing the DELETE where there's rows to delete allows us to avoid taking a lock on the table
+    // when there's nothing to delete
+    // This is particularly relevant in the context of tests, where many instance of the snowflake
+    // destination could be run in parallel
+    String deleteStatesSql = super.getDeleteStatesSql(destinationStates);
+    StringBuilder sql = new StringBuilder();
+    // sql.append("BEGIN\n");
+    sql.append("  IF (EXISTS (").append(deleteStatesSql.replace("delete from", "SELECT 1 FROM ")).append(")) THEN\n");
+    sql.append("    ").append(deleteStatesSql).append(";\n");
+    sql.append("  END IF\n");
+    // sql.append("END;\n");
+    return sql.toString();
+  }
+
+  protected void executeWithinTransaction(List<String> statements) throws SQLException {
+    StringBuilder sb = new StringBuilder();
+    sb.append("BEGIN\n");
+    sb.append("  BEGIN TRANSACTION;\n    ");
+    sb.append(StringUtils.join(statements, ";\n    "));
+    sb.append(";\n  COMMIT;\n");
+    sb.append("END;");
+    LOGGER.info("executing SQL:" + sb);
+    getJdbcDatabase().execute(sb.toString());
   }
 
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV1V2Migrator.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV1V2Migrator.java
@@ -37,7 +37,7 @@ public class SnowflakeV1V2Migrator extends BaseDestinationV1V2Migrator<TableDefi
 
   @SneakyThrows
   @Override
-  protected boolean doesAirbyteInternalNamespaceExist(final StreamConfig streamConfig) throws Exception {
+  public boolean doesAirbyteInternalNamespaceExist(final StreamConfig streamConfig) throws Exception {
     return !database
         .queryJsons(
             """
@@ -46,19 +46,19 @@ public class SnowflakeV1V2Migrator extends BaseDestinationV1V2Migrator<TableDefi
             WHERE schema_name = ?
             AND catalog_name = ?;
             """,
-            streamConfig.id().rawNamespace(),
+            streamConfig.getId().getRawNamespace(),
             databaseName)
         .isEmpty();
   }
 
   @Override
-  protected boolean schemaMatchesExpectation(final TableDefinition existingTable, final Collection<String> columns) {
+  public boolean schemaMatchesExpectation(final TableDefinition existingTable, final Collection<String> columns) {
     return CollectionUtils.containsAllIgnoreCase(existingTable.columns().keySet(), columns);
   }
 
   @SneakyThrows
   @Override
-  protected Optional<TableDefinition> getTableIfExists(final String namespace, final String tableName) throws Exception {
+  public Optional<TableDefinition> getTableIfExists(final String namespace, final String tableName) throws Exception {
     // TODO this looks similar to SnowflakeDestinationHandler#findExistingTables, with a twist;
     // databaseName not upper-cased and rawNamespace and rawTableName as-is (no uppercase).
     // The obvious database.getMetaData().getColumns() solution doesn't work, because JDBC translates
@@ -90,12 +90,12 @@ public class SnowflakeV1V2Migrator extends BaseDestinationV1V2Migrator<TableDefi
   }
 
   @Override
-  protected NamespacedTableName convertToV1RawName(final StreamConfig streamConfig) {
+  public NamespacedTableName convertToV1RawName(final StreamConfig streamConfig) {
     // The implicit upper-casing happens for this in the SqlGenerator
     @SuppressWarnings("deprecation")
-    String tableName = this.namingConventionTransformer.getRawTableName(streamConfig.id().originalName());
+    String tableName = this.namingConventionTransformer.getRawTableName(streamConfig.getId().getOriginalName());
     return new NamespacedTableName(
-        this.namingConventionTransformer.getIdentifier(streamConfig.id().originalNamespace()),
+        this.namingConventionTransformer.getIdentifier(streamConfig.getId().getOriginalNamespace()),
         tableName);
   }
 

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeV2TableMigrator.java
@@ -46,24 +46,24 @@ public class SnowflakeV2TableMigrator implements V2TableMigrator {
   @Override
   public void migrateIfNecessary(final StreamConfig streamConfig) throws Exception {
     final StreamId caseSensitiveStreamId = buildStreamId_caseSensitive(
-        streamConfig.id().originalNamespace(),
-        streamConfig.id().originalName(),
+        streamConfig.getId().getOriginalNamespace(),
+        streamConfig.getId().getOriginalName(),
         rawNamespace);
-    final boolean syncModeRequiresMigration = streamConfig.destinationSyncMode() != DestinationSyncMode.OVERWRITE;
+    final boolean syncModeRequiresMigration = streamConfig.getDestinationSyncMode() != DestinationSyncMode.OVERWRITE;
     final boolean existingTableCaseSensitiveExists = findExistingTable(caseSensitiveStreamId).isPresent();
-    final boolean existingTableUppercaseDoesNotExist = findExistingTable(streamConfig.id()).isEmpty();
+    final boolean existingTableUppercaseDoesNotExist = findExistingTable(streamConfig.getId()).isEmpty();
     LOGGER.info(
         "Checking whether upcasing migration is necessary for {}.{}. Sync mode requires migration: {}; existing case-sensitive table exists: {}; existing uppercased table does not exist: {}",
-        streamConfig.id().originalNamespace(),
-        streamConfig.id().originalName(),
+        streamConfig.getId().getOriginalNamespace(),
+        streamConfig.getId().getOriginalName(),
         syncModeRequiresMigration,
         existingTableCaseSensitiveExists,
         existingTableUppercaseDoesNotExist);
     if (syncModeRequiresMigration && existingTableCaseSensitiveExists && existingTableUppercaseDoesNotExist) {
       LOGGER.info(
           "Executing upcasing migration for {}.{}",
-          streamConfig.id().originalNamespace(),
-          streamConfig.id().originalName());
+          streamConfig.getId().getOriginalNamespace(),
+          streamConfig.getId().getOriginalName());
       TypeAndDedupeTransaction.executeSoftReset(generator, handler, streamConfig);
     }
   }
@@ -94,8 +94,8 @@ public class SnowflakeV2TableMigrator implements V2TableMigrator {
     // VARIANT as VARCHAR
     LinkedHashMap<String, LinkedHashMap<String, TableDefinition>> existingTableMap =
         SnowflakeDestinationHandler.findExistingTables(database, databaseName, List.of(id));
-    if (existingTableMap.containsKey(id.finalNamespace()) && existingTableMap.get(id.finalNamespace()).containsKey(id.finalName())) {
-      return Optional.of(existingTableMap.get(id.finalNamespace()).get(id.finalName()));
+    if (existingTableMap.containsKey(id.getFinalNamespace()) && existingTableMap.get(id.getFinalNamespace()).containsKey(id.getFinalName())) {
+      return Optional.of(existingTableMap.get(id.getFinalNamespace()).get(id.getFinalName()));
     }
     return Optional.empty();
   }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
@@ -123,7 +123,7 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
                                            final JsonNode streamSchema)
       throws Exception {
     final StreamId streamId = new SnowflakeSqlGenerator(0).buildStreamId(namespace, streamName, JavaBaseConstants.DEFAULT_AIRBYTE_INTERNAL_NAMESPACE);
-    return retrieveRecordsFromTable(streamId.rawName(), streamId.rawNamespace())
+    return retrieveRecordsFromTable(streamId.getRawName(), streamId.getRawNamespace())
         .stream()
         .map(r -> r.get(JavaBaseConstants.COLUMN_NAME_DATA))
         .collect(Collectors.toList());
@@ -170,7 +170,7 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
                     JavaBaseConstants.COLUMN_NAME_AB_EXTRACTED_AT));
           }
         },
-        new SnowflakeTestSourceOperations()::rowToJson);
+        new SnowflakeSourceOperations()::rowToJson);
   }
 
   // for each test we create a new schema in the database. run the test in there and then remove it.
@@ -190,8 +190,8 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
 
   @Override
   protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
-    TEST_SCHEMAS.add(config.get("schema").asText());
-    for (final String schema : TEST_SCHEMAS) {
+    getTestSchemas().add(config.get("schema").asText());
+    for (final String schema : getTestSchemas()) {
       // we need to wrap namespaces in quotes, but that means we have to manually upcase them.
       // thanks, v1 destinations!
       // this probably doesn't actually work, because v1 destinations are mangling namespaces and names

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeTestUtils.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeTestUtils.java
@@ -85,7 +85,7 @@ public class SnowflakeTestUtils {
             """
             SELECT ${columns} FROM ${table} ORDER BY ${extracted_at} ASC
             """)),
-        new SnowflakeTestSourceOperations()::rowToJson);
+        new SnowflakeSourceOperations()::rowToJson);
   }
 
   private static String quote(final String name) {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/AbstractSnowflakeTypingDedupingTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/AbstractSnowflakeTypingDedupingTest.java
@@ -29,6 +29,7 @@ import io.airbyte.protocol.models.v0.DestinationSyncMode;
 import io.airbyte.protocol.models.v0.SyncMode;
 import io.airbyte.workers.exception.TestHarnessException;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -46,6 +47,18 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
   private JdbcDatabase database;
   private DataSource dataSource;
 
+  private static volatile boolean cleanedAirbyteInternalTable = false
+  private static void cleanAirbyteInternalTable(JdbcDatabase database) throws SQLException {
+    if (!cleanedAirbyteInternalTable) {
+      synchronized (AbstractSnowflakeTypingDedupingTest.class) {
+        if (!cleanedAirbyteInternalTable) {
+          database.execute("DELETE FROM \"airbyte_internal\".\"_airbyte_destination_state\" WHERE \"updated_at\" < current_date() - 7");
+          cleanedAirbyteInternalTable = true;
+        }
+      }
+    }
+  }
+
   protected abstract String getConfigPath();
 
   @Override
@@ -54,12 +67,13 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
   }
 
   @Override
-  protected JsonNode generateConfig() {
+  protected JsonNode generateConfig() throws SQLException {
     final JsonNode config = Jsons.deserialize(IOs.readFile(Path.of(getConfigPath())));
     ((ObjectNode) config).put("schema", "typing_deduping_default_schema" + getUniqueSuffix());
     databaseName = config.get(JdbcUtils.DATABASE_KEY).asText();
     dataSource = SnowflakeDatabase.createDataSource(config, OssCloudEnvVarConsts.AIRBYTE_OSS);
     database = SnowflakeDatabase.getDatabase(dataSource);
+    cleanAirbyteInternalTable(database);
     return config;
   }
 
@@ -77,7 +91,7 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
   }
 
   @Override
-  protected List<JsonNode> dumpFinalTableRecords(String streamNamespace, final String streamName) throws Exception {
+  public List<JsonNode> dumpFinalTableRecords(String streamNamespace, final String streamName) throws Exception {
     if (streamNamespace == null) {
       streamNamespace = getDefaultSchema();
     }
@@ -99,9 +113,6 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
             // Raw table is still lowercase.
             StreamId.concatenateRawTableName(streamNamespace, streamName),
             streamNamespace.toUpperCase()));
-    database.execute(
-        String.format("DELETE FROM \"airbyte_internal\".\"_airbyte_destination_state\" WHERE \"name\"='%s' AND \"namespace\"='%s'", streamName,
-            streamNamespace));
   }
 
   @Override
@@ -115,7 +126,7 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
   }
 
   @Override
-  protected Map<String, String> getFinalMetadataColumnNames() {
+  public Map<String, String> getFinalMetadataColumnNames() {
     return FINAL_METADATA_COLUMN_NAMES;
   }
 
@@ -138,8 +149,8 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
               .withSyncMode(SyncMode.FULL_REFRESH)
               .withDestinationSyncMode(DestinationSyncMode.APPEND)
               .withStream(new AirbyteStream()
-                  .withNamespace(streamNamespace)
-                  .withName(streamName)
+                  .withNamespace(getStreamNamespace())
+                  .withName(getStreamName())
                   .withJsonSchema(SCHEMA))));
 
       // First sync
@@ -159,7 +170,7 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
       // manually drop the lowercased schema, since we no longer have the code to do it automatically
       // (the raw table is still in lowercase "airbyte_internal"."whatever", so the auto-cleanup code
       // handles it fine)
-      database.execute("DROP SCHEMA IF EXISTS \"" + streamNamespace + "\" CASCADE");
+      database.execute("DROP SCHEMA IF EXISTS \"" + getStreamNamespace() + "\" CASCADE");
     }
   }
 
@@ -171,8 +182,8 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
               .withSyncMode(SyncMode.FULL_REFRESH)
               .withDestinationSyncMode(DestinationSyncMode.OVERWRITE)
               .withStream(new AirbyteStream()
-                  .withNamespace(streamNamespace)
-                  .withName(streamName)
+                  .withNamespace(getStreamNamespace())
+                  .withName(getStreamName())
                   .withJsonSchema(SCHEMA))));
 
       // First sync
@@ -192,7 +203,7 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
       // manually drop the lowercased schema, since we no longer have the code to do it automatically
       // (the raw table is still in lowercase "airbyte_internal"."whatever", so the auto-cleanup code
       // handles it fine)
-      database.execute("DROP SCHEMA IF EXISTS \"" + streamNamespace + "\" CASCADE");
+      database.execute("DROP SCHEMA IF EXISTS \"" + getStreamNamespace() + "\" CASCADE");
     }
   }
 
@@ -204,8 +215,8 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
             .withDestinationSyncMode(DestinationSyncMode.APPEND_DEDUP)
             .withPrimaryKey(List.of(List.of("id1"), List.of("id2")))
             .withStream(new AirbyteStream()
-                .withNamespace(streamNamespace)
-                .withName(streamName)
+                .withNamespace(getStreamNamespace())
+                .withName(getStreamName())
                 .withJsonSchema(SCHEMA))));
 
     // First sync
@@ -218,7 +229,7 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
 
     // Second sync
     runSync(catalog, messages); // does not throw with latest version
-    assertEquals(1, dumpFinalTableRecords(streamNamespace, streamName).toArray().length);
+    assertEquals(1, dumpFinalTableRecords(getStreamNamespace(), getStreamName()).toArray().length);
   }
 
   @Test
@@ -230,8 +241,8 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
             .withPrimaryKey(List.of(List.of("id1"), List.of("id2")))
             .withCursorField(List.of("updated_at"))
             .withStream(new AirbyteStream()
-                .withNamespace(streamNamespace)
-                .withName(streamName)
+                .withNamespace(getStreamNamespace())
+                .withName(getStreamName())
                 .withJsonSchema(SCHEMA))));
 
     // First sync

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/AbstractSnowflakeTypingDedupingTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/AbstractSnowflakeTypingDedupingTest.java
@@ -47,7 +47,8 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
   private JdbcDatabase database;
   private DataSource dataSource;
 
-  private static volatile boolean cleanedAirbyteInternalTable = false
+  private static volatile boolean cleanedAirbyteInternalTable = false;
+
   private static void cleanAirbyteInternalTable(JdbcDatabase database) throws SQLException {
     if (!cleanedAirbyteInternalTable) {
       synchronized (AbstractSnowflakeTypingDedupingTest.class) {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeInternalStagingLowercaseDatabaseTypingDedupingTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeInternalStagingLowercaseDatabaseTypingDedupingTest.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.snowflake.typing_deduping;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.cdk.db.jdbc.JdbcUtils;
+import java.sql.SQLException;
 
 public class SnowflakeInternalStagingLowercaseDatabaseTypingDedupingTest extends AbstractSnowflakeTypingDedupingTest {
 
@@ -21,7 +22,7 @@ public class SnowflakeInternalStagingLowercaseDatabaseTypingDedupingTest extends
    * when checking for an existing final table.
    */
   @Override
-  protected JsonNode generateConfig() {
+  protected JsonNode generateConfig() throws SQLException {
     final JsonNode config = super.generateConfig();
     ((ObjectNode) config).put(JdbcUtils.DATABASE_KEY, config.get(JdbcUtils.DATABASE_KEY).asText().toLowerCase());
     return config;

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlNameTransformerTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlNameTransformerTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.integrations.destination.snowflake;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -20,8 +19,6 @@ class SnowflakeSqlNameTransformerTest {
 
   @Test
   public void testGetIdentifier() {
-    assertNull(INSTANCE.getIdentifier(null));
-    assertNull(INSTANCE.convertStreamName(null));
     RAW_TO_NORMALIZED_IDENTIFIERS.forEach((raw, normalized) -> {
       assertEquals(normalized, INSTANCE.convertStreamName(raw));
       assertEquals(normalized, INSTANCE.getIdentifier(raw));

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlOperationsTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlOperationsTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.verify;
 import io.airbyte.cdk.db.jdbc.JdbcDatabase;
 import io.airbyte.cdk.integrations.base.DestinationConfig;
 import io.airbyte.cdk.integrations.base.JavaBaseConstants;
-import io.airbyte.cdk.integrations.destination.async.partial_messages.PartialAirbyteMessage;
+import io.airbyte.cdk.integrations.destination.async.model.PartialAirbyteMessage;
 import io.airbyte.commons.functional.CheckedConsumer;
 import io.airbyte.commons.json.Jsons;
 import java.sql.SQLException;

--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -276,6 +276,7 @@ desired namespace.
 
 | Version         | Date       | Pull Request                                                 | Subject                                                                                                                                                         |
 |:----------------|:-----------|:-------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.7.1           | 2024-04-30 | [\#36910](https://github.com/airbytehq/airbyte/pull/36910)   | Bump CDK version                                                                                                                                                |
 | 3.7.0           | 2024-04-08 | [\#35754](https://github.com/airbytehq/airbyte/pull/35754)   | Allow configuring `data_retention_time_in_days`; apply to both raw and final tables. *Note*: Existing tables will not be affected; you must manually alter them.|
 | 3.6.6           | 2024-03-26 | [\#36466](https://github.com/airbytehq/airbyte/pull/36466)   | Correctly hhandle instances with `QUOTED_IDENTIFIERS_IGNORE_CASE` enabled globally                                                                              |
 | 3.6.5           | 2024-03-25 | [\#36461](https://github.com/airbytehq/airbyte/pull/36461)   | Internal code change (use published CDK artifact instead of source dependency)                                                                                  |


### PR DESCRIPTION
not only bringing snowflake to the latest CDK but also:
1) Bringing the `SourceOperation` into production code from the test code. There's really no reason those improvements should stay out of production (and they're present in the source-snowflake)
2) adding `putTimestamp` into the `SourceOperation`, so that snowflake doesn't throw an exception at every call, which implies it also creates a new thread
3) make use of the newly added ability to filter orphan thread on shutdown. We filter all the threads created during calls to `SFStatement.close()`
4) don't always take a lock when deleting destinationStates. We now check if there's any states to delete by doing a `SELECT` (and not taking any table lock) before issuing the `DELETE` (the old behavior was causing test contention, and it's a bad idea in general)
5) only execute `airbyte_internal._airbyte_destination_state`