### PR TITLE
[danger] print failing redshift SQL statements

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperations.java
@@ -115,7 +115,7 @@ public class RedshiftSqlOperations extends JdbcSqlOperations {
         // > how many records can be inserted at once
         // > TODO(sherif) this should use a smarter, destination-aware partitioning scheme instead of 10k by
         // > default
-        for (final List<PartialAirbyteMessage> batch : Iterables.partition(records, 10_000)) {
+        for (final List<PartialAirbyteMessage> batch : Iterables.partition(records, 10)) {
           LOGGER.info("Prepared batch size: {}, {}, {}", batch.size(), schemaName, tableName);
           final DSLContext create = using(
               connection,

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperations.java
@@ -161,10 +161,12 @@ public class RedshiftSqlOperations extends JdbcSqlOperations {
           LOGGER.info("Executed batch size: {}, {}, {}", batch.size(), schemaName, tableName);
         }
       });
-    } catch (DataAccessException dae) {
-      // Suppressing exception to avoid printing sensitive customer record information.
-      LOGGER.error("Failed to insert records, SQLState class {}", dae.sqlStateClass());
-      throw new RuntimeException("Failed to insert records with DataAccessException");
+// DANGER ZONE: This PR exists only to remove this catch - which exists to hide any SQL logging, which might contain PII.  This branch wants to log failed SQL statements.
+//
+//    } catch (DataAccessException dae) {
+//      // Suppressing exception to avoid printing sensitive customer record information.
+//      LOGGER.error("Failed to insert records, SQLState class {}", dae.sqlStateClass());
+//      throw new RuntimeException("Failed to insert records with DataAccessException");
     } catch (final Exception e) {
       LOGGER.error("Error while inserting records", e);
       throw new RuntimeException(e);


### PR DESCRIPTION
☠️ DO NOT MERGE ☠️

This PR has 2 main changes:
* we'll log SQL statements when things go bad.  That will contain the content of their records
* we'll only try to insert 10 rows at a time.  That will make the sync unbearably slow, but will isolate the problem

Dev images:
* Publishing dev image: https://github.com/airbytehq/airbyte/actions/runs/8608101988 (10K-record batches) - [**airbyte/destination-redshift:2.4.2-dev.37da853c86**](https://hub.docker.com/r/airbyte/destination-redshift/tags)
* Publishing dev image: https://github.com/airbytehq/airbyte/actions/runs/8608120910 (5-record batches) - [**airbyte/destination-redshift:2.4.2-dev.3844147d76**](https://hub.docker.com/r/airbyte/destination-redshift/tags)