### PR TITLE
Destination Snowflake: Tear down destination state after tests

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/AbstractSnowflakeTypingDedupingTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/typing_deduping/AbstractSnowflakeTypingDedupingTest.java
@@ -99,6 +99,9 @@ public abstract class AbstractSnowflakeTypingDedupingTest extends BaseTypingDedu
             // Raw table is still lowercase.
             StreamId.concatenateRawTableName(streamNamespace, streamName),
             streamNamespace.toUpperCase()));
+    database.execute(
+        String.format("DELETE FROM \"airbyte_internal\".\"_airbyte_destination_state\" WHERE \"name\"='%s' AND \"namespace\"='%s'", streamName,
+            streamNamespace));
   }
 
   @Override


### PR DESCRIPTION
Nightly builds were failing for a while. We forgot to cleanup `airbyte_internal`.`_airbyte_destination_state` as part of teardown and that table becomes ever growing in our test workspace. 