### PR TITLE
[ISSUE #6829] update salesforce to support partitioned state

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/.coveragerc
+++ b/airbyte-integrations/connectors/source-salesforce/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    source_salesforce/run.py

--- a/airbyte-integrations/connectors/source-salesforce/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/source-salesforce/integration_tests/integration_test.py
@@ -12,6 +12,8 @@ import pendulum
 import pytest
 import requests
 from airbyte_cdk.models import SyncMode
+from airbyte_protocol.models import ConfiguredAirbyteCatalog
+
 from source_salesforce.api import Salesforce
 from source_salesforce.source import SourceSalesforce
 
@@ -19,6 +21,10 @@ HERE = Path(__file__).parent
 
 NOTE_CONTENT = "It's the note for integration test"
 UPDATED_NOTE_CONTENT = "It's the updated note for integration test"
+
+_ANY_CATALOG = ConfiguredAirbyteCatalog.parse_obj({"streams": []})
+_ANY_CONFIG = {}
+_ANY_STATE = {}
 
 
 @pytest.fixture(scope="module")
@@ -41,7 +47,7 @@ def stream_name():
 
 @pytest.fixture(scope="module")
 def stream(input_sandbox_config, stream_name, sf):
-    return SourceSalesforce.generate_streams(input_sandbox_config, {stream_name: None}, sf)[0]
+    return SourceSalesforce(_ANY_CATALOG, _ANY_CONFIG, _ANY_STATE).generate_streams(input_sandbox_config, {stream_name: None}, sf)[0]._legacy_stream
 
 
 def _encode_content(text):

--- a/airbyte-integrations/connectors/source-salesforce/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/source-salesforce/integration_tests/integration_test.py
@@ -13,7 +13,6 @@ import pytest
 import requests
 from airbyte_cdk.models import SyncMode
 from airbyte_protocol.models import ConfiguredAirbyteCatalog
-
 from source_salesforce.api import Salesforce
 from source_salesforce.source import SourceSalesforce
 

--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b117307c-14b6-41aa-9422-947e34922962
-  dockerImageTag: 2.4.5
+  dockerImageTag: 2.5.0
   dockerRepository: airbyte/source-salesforce
   documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce
   githubIssueLabel: source-salesforce

--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b117307c-14b6-41aa-9422-947e34922962
-  dockerImageTag: 2.4.4
+  dockerImageTag: 2.4.5
   dockerRepository: airbyte/source-salesforce
   documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce
   githubIssueLabel: source-salesforce

--- a/airbyte-integrations/connectors/source-salesforce/poetry.lock
+++ b/airbyte-integrations/connectors/source-salesforce/poetry.lock
@@ -2,17 +2,17 @@
 
 [[package]]
 name = "airbyte-cdk"
-version = "0.80.0"
+version = "0.81.1"
 description = "A framework for writing Airbyte Connectors."
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "airbyte_cdk-0.80.0-py3-none-any.whl", hash = "sha256:060e92323a73674fa4e9e2e4a1eb312b9b9d072c9bbe5fa28f54ef21cb4974f3"},
-    {file = "airbyte_cdk-0.80.0.tar.gz", hash = "sha256:1383512a83917fecca5b24cea4c72aa5c561cf96dd464485fbcefda48fe574c5"},
+    {file = "airbyte_cdk-0.81.1-py3-none-any.whl", hash = "sha256:01346dc621859a665ef28e391706b95c9adf2c442e1062862a340f2c3578a23e"},
+    {file = "airbyte_cdk-0.81.1.tar.gz", hash = "sha256:d9731faf241787142b1c1cff054ff11a9f9139de3efd7dc021dcfb8bc37e682e"},
 ]
 
 [package.dependencies]
-airbyte-protocol-models = "0.5.1"
+airbyte-protocol-models = "*"
 backoff = "*"
 cachetools = "*"
 Deprecated = ">=1.2,<1.3"
@@ -38,13 +38,13 @@ vector-db-based = ["cohere (==4.21)", "langchain (==0.0.271)", "openai[embedding
 
 [[package]]
 name = "airbyte-protocol-models"
-version = "0.5.1"
+version = "0.9.0"
 description = "Declares the Airbyte Protocol."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "airbyte_protocol_models-0.5.1-py3-none-any.whl", hash = "sha256:dfe84e130e51ce2ae81a06d5aa36f6c5ce3152b9e36e6f0195fad6c3dab0927e"},
-    {file = "airbyte_protocol_models-0.5.1.tar.gz", hash = "sha256:7c8b16c7c1c7956b1996052e40585a3a93b1e44cb509c4e97c1ee4fe507ea086"},
+    {file = "airbyte_protocol_models-0.9.0-py3-none-any.whl", hash = "sha256:e972e140b5efd1edad5a338bcae8fdee9fc12545caf2c321e0f61b151c163a9b"},
+    {file = "airbyte_protocol_models-0.9.0.tar.gz", hash = "sha256:40b69c33df23fe82d7078e84beb123bd604480e4d73cb277a890fcc92aedc8d2"},
 ]
 
 [package.dependencies]
@@ -326,13 +326,13 @@ files = [
 
 [[package]]
 name = "idna"
-version = "3.6"
+version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"},
-    {file = "idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"},
+    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
+    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
 ]
 
 [[package]]

--- a/airbyte-integrations/connectors/source-salesforce/poetry.lock
+++ b/airbyte-integrations/connectors/source-salesforce/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "airbyte-cdk"
-version = "0.79.2"
+version = "0.80.0"
 description = "A framework for writing Airbyte Connectors."
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "airbyte_cdk-0.79.2-py3-none-any.whl", hash = "sha256:569eaefecf58b0dc9e858f71dab84bbcafaa6f77ba6b0dd7ba4d990780e1e14f"},
-    {file = "airbyte_cdk-0.79.2.tar.gz", hash = "sha256:91fdc734847b6f7b2b9e93bbf9cc66eb8908d3f4318dd82bcbcce7f5c8929dca"},
+    {file = "airbyte_cdk-0.80.0-py3-none-any.whl", hash = "sha256:060e92323a73674fa4e9e2e4a1eb312b9b9d072c9bbe5fa28f54ef21cb4974f3"},
+    {file = "airbyte_cdk-0.80.0.tar.gz", hash = "sha256:1383512a83917fecca5b24cea4c72aa5c561cf96dd464485fbcefda48fe574c5"},
 ]
 
 [package.dependencies]

--- a/airbyte-integrations/connectors/source-salesforce/pyproject.toml
+++ b/airbyte-integrations/connectors/source-salesforce/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.4.5"
+version = "2.5.0"
 name = "source-salesforce"
 description = "Source implementation for Salesforce."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-salesforce/pyproject.toml
+++ b/airbyte-integrations/connectors/source-salesforce/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.4.4"
+version = "2.4.5"
 name = "source-salesforce"
 description = "Source implementation for Salesforce."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/availability_strategy.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/availability_strategy.py
@@ -29,7 +29,7 @@ class SalesforceAvailabilityStrategy(HttpAvailabilityStrategy):
         if error.response.status_code in [codes.FORBIDDEN, codes.BAD_REQUEST]:
             error_data = error.response.json()[0]
             error_code = error_data.get("errorCode", "")
-            if error_code != "REQUEST_LIMIT_EXCEEDED" or error_code == "INVALID_TYPE_FOR_OPERATION":
+            if error_code != "REQUEST_LIMIT_EXCEEDED":
                 return False, f"Cannot receive data for stream '{stream.name}', error message: '{error_data.get('message')}'"
             return True, None
         raise error

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
@@ -247,7 +247,7 @@ class SourceSalesforce(ConcurrentSourceAdapter):
         """
         cursor_field_key = stream.cursor_field or ""
         if not isinstance(cursor_field_key, str):
-            raise AssertionError(f"A string cursor field key is required, but got {cursor_field_key}.")
+            raise AssertionError(f"Nested cursor field are not supported hence type str is expected but got {cursor_field_key}.")
         cursor_field = CursorField(cursor_field_key)
         legacy_state = state_manager.get_stream_state(stream.name, stream.namespace)
         return ConcurrentCursor(

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
@@ -216,6 +216,8 @@ class SourceSalesforce(ConcurrentSourceAdapter):
         stream_slicer_cursor = self._create_stream_slicer_cursor(config, state_manager, stream)
         if hasattr(stream, "set_cursor"):
             stream.set_cursor(stream_slicer_cursor)
+        elif hasattr(stream, "parent") and hasattr(stream.parent, "set_cursor"):
+            stream.parent.set_cursor(stream_slicer_cursor)
 
         if self._get_sync_mode_from_catalog(stream) == SyncMode.full_refresh:
             cursor = FinalStateCursor(

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
@@ -3,9 +3,10 @@
 #
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any, Iterator, List, Mapping, MutableMapping, Optional, Tuple, Union
 
+import isodate
 import pendulum
 import requests
 from airbyte_cdk import AirbyteLogger
@@ -29,6 +30,7 @@ from requests import codes, exceptions  # type: ignore[import]
 
 from .api import PARENT_SALESFORCE_OBJECTS, UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS, UNSUPPORTED_FILTERING_STREAMS, Salesforce
 from .streams import (
+    LOOKBACK_SECONDS,
     BulkIncrementalSalesforceStream,
     BulkSalesforceStream,
     BulkSalesforceSubStream,
@@ -172,9 +174,8 @@ class SourceSalesforce(ConcurrentSourceAdapter):
 
         return stream_class, stream_kwargs
 
-    @classmethod
     def generate_streams(
-        cls,
+        self,
         config: Mapping[str, Any],
         stream_objects: Mapping[str, Any],
         sf_object: Salesforce,
@@ -184,29 +185,47 @@ class SourceSalesforce(ConcurrentSourceAdapter):
         schemas = sf_object.generate_schemas(stream_objects)
         default_args = [sf_object, authenticator, config]
         streams = []
+        state_manager = ConnectorStateManager(stream_instance_map={s.name: s for s in streams}, state=self.state)
         for stream_name, sobject_options in stream_objects.items():
             json_schema = schemas.get(stream_name, {})
 
-            stream_class, kwargs = cls.prepare_stream(stream_name, json_schema, sobject_options, *default_args)
+            stream_class, kwargs = self.prepare_stream(stream_name, json_schema, sobject_options, *default_args)
 
             parent_name = PARENT_SALESFORCE_OBJECTS.get(stream_name, {}).get("parent_name")
             if parent_name:
                 # get minimal schema required for getting proper class name full_refresh/incremental, rest/bulk
                 parent_schema = PARENT_SALESFORCE_OBJECTS.get(stream_name, {}).get("schema_minimal")
-                parent_class, parent_kwargs = cls.prepare_stream(parent_name, parent_schema, sobject_options, *default_args)
+                parent_class, parent_kwargs = self.prepare_stream(parent_name, parent_schema, sobject_options, *default_args)
                 kwargs["parent"] = parent_class(**parent_kwargs)
 
             stream = stream_class(**kwargs)
 
-            api_type = cls._get_api_type(stream_name, json_schema, config.get("force_use_bulk_api", False))
+            api_type = self._get_api_type(stream_name, json_schema, config.get("force_use_bulk_api", False))
             if api_type == "rest" and not stream.primary_key and stream.too_many_properties:
                 logger.warning(
                     f"Can not instantiate stream {stream_name}. It is not supported by the BULK API and can not be "
                     "implemented via REST because the number of its properties exceeds the limit and it lacks a primary key."
                 )
                 continue
-            streams.append(stream)
+
+            streams.append(self._wrap_for_concurrency(config, stream, state_manager))
+        streams.append(self._wrap_for_concurrency(config, Describe(sf_api=sf_object, catalog=self.catalog), state_manager))
         return streams
+
+    def _wrap_for_concurrency(self, config, stream, state_manager):
+        stream_slicer_cursor = self._create_stream_slicer_cursor(config, state_manager, stream)
+        if hasattr(stream, "set_cursor"):
+            stream.set_cursor(stream_slicer_cursor)
+
+        if self._get_sync_mode_from_catalog(stream) == SyncMode.full_refresh:
+            cursor = FinalStateCursor(
+                stream_name=stream.name, stream_namespace=stream.namespace, message_repository=self.message_repository
+            )
+            state = None
+        else:
+            cursor = stream_slicer_cursor
+            state = cursor.state
+        return StreamFacade.create_from_stream(stream, self, logger, state, cursor)
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         if not config.get("start_date"):
@@ -214,39 +233,33 @@ class SourceSalesforce(ConcurrentSourceAdapter):
         sf = self._get_sf_object(config)
         stream_objects = sf.get_validated_streams(config=config, catalog=self.catalog)
         streams = self.generate_streams(config, stream_objects, sf)
-        streams.append(Describe(sf_api=sf, catalog=self.catalog))
-        state_manager = ConnectorStateManager(stream_instance_map={s.name: s for s in streams}, state=self.state)
+        return streams
 
-        configured_streams = []
-
-        for stream in streams:
-            sync_mode = self._get_sync_mode_from_catalog(stream)
-            if sync_mode == SyncMode.full_refresh:
-                cursor = FinalStateCursor(
-                    stream_name=stream.name, stream_namespace=stream.namespace, message_repository=self.message_repository
-                )
-                state = None
-            else:
-                cursor_field_key = stream.cursor_field or ""
-                if not isinstance(cursor_field_key, str):
-                    raise AssertionError(f"A string cursor field key is required, but got {cursor_field_key}.")
-                cursor_field = CursorField(cursor_field_key)
-                legacy_state = state_manager.get_stream_state(stream.name, stream.namespace)
-                cursor = ConcurrentCursor(
-                    stream.name,
-                    stream.namespace,
-                    legacy_state,
-                    self.message_repository,
-                    state_manager,
-                    stream.state_converter,
-                    cursor_field,
-                    self._get_slice_boundary_fields(stream, state_manager),
-                    config["start_date"],
-                )
-                state = cursor.state
-
-            configured_streams.append(StreamFacade.create_from_stream(stream, self, logger, state, cursor))
-        return configured_streams
+    def _create_stream_slicer_cursor(
+        self, config: Mapping[str, Any], state_manager: ConnectorStateManager, stream: Stream
+    ) -> ConcurrentCursor:
+        """
+        We have moved the generation of stream slices to the concurrent CDK cursor
+        """
+        cursor_field_key = stream.cursor_field or ""
+        if not isinstance(cursor_field_key, str):
+            raise AssertionError(f"A string cursor field key is required, but got {cursor_field_key}.")
+        cursor_field = CursorField(cursor_field_key)
+        legacy_state = state_manager.get_stream_state(stream.name, stream.namespace)
+        return ConcurrentCursor(
+            stream.name,
+            stream.namespace,
+            legacy_state,
+            self.message_repository,
+            state_manager,
+            stream.state_converter,
+            cursor_field,
+            self._get_slice_boundary_fields(stream, state_manager),
+            datetime.fromtimestamp(pendulum.parse(config["start_date"]).timestamp(), timezone.utc),
+            stream.state_converter.get_end_provider(),
+            timedelta(seconds=LOOKBACK_SECONDS),
+            isodate.parse_duration(config["stream_slice_step"]) if "stream_slice_step" in config else timedelta(days=30),
+        )
 
     def _get_slice_boundary_fields(self, stream: Stream, state_manager: ConnectorStateManager) -> Optional[Tuple[str, str]]:
         return ("start_date", "end_date")

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
@@ -250,11 +250,11 @@ class SourceSalesforce(ConcurrentSourceAdapter):
         if not isinstance(cursor_field_key, str):
             raise AssertionError(f"Nested cursor field are not supported hence type str is expected but got {cursor_field_key}.")
         cursor_field = CursorField(cursor_field_key)
-        legacy_state = state_manager.get_stream_state(stream.name, stream.namespace)
+        stream_state = state_manager.get_stream_state(stream.name, stream.namespace)
         return ConcurrentCursor(
             stream.name,
             stream.namespace,
-            legacy_state,
+            stream_state,
             self.message_repository,
             state_manager,
             stream.state_converter,

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
@@ -218,8 +218,9 @@ class SourceSalesforce(ConcurrentSourceAdapter):
             stream_slicer_cursor = self._create_stream_slicer_cursor(config, state_manager, stream)
             if hasattr(stream, "set_cursor"):
                 stream.set_cursor(stream_slicer_cursor)
-            elif hasattr(stream, "parent") and hasattr(stream.parent, "set_cursor"):
-                stream.parent.set_cursor(stream_slicer_cursor)
+        if hasattr(stream, "parent") and hasattr(stream.parent, "set_cursor"):
+            stream_slicer_cursor = self._create_stream_slicer_cursor(config, state_manager, stream)
+            stream.parent.set_cursor(stream_slicer_cursor)
 
         if not stream_slicer_cursor or self._get_sync_mode_from_catalog(stream) == SyncMode.full_refresh:
             cursor = FinalStateCursor(

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/api_test.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/api_test.py
@@ -26,7 +26,9 @@ from airbyte_cdk.models import (
 )
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.concurrent.adapters import StreamFacade
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
 from airbyte_cdk.test.entrypoint_wrapper import read
+from airbyte_cdk.test.state_builder import StateBuilder
 from airbyte_cdk.utils import AirbyteTracedException
 from conftest import encoding_symbols_parameters, generate_stream
 from requests.exceptions import ChunkedEncodingError, HTTPError
@@ -402,131 +404,6 @@ def configure_request_params_mock(stream_1, stream_2):
 
     stream_2.request_params = Mock()
     stream_2.request_params.return_value = {"q": "query"}
-
-
-def test_rate_limit_bulk(stream_config, stream_api, bulk_catalog, state):
-    """
-    Connector should stop the sync if one stream reached rate limit
-    stream_1, stream_2, stream_3, ...
-    While reading `stream_1` if 403 (Rate Limit) is received, it should finish that stream with success and stop the sync process.
-    Next streams should not be executed.
-    """
-    stream_config.update({"start_date": "2021-10-01"})
-    stream_1: BulkIncrementalSalesforceStream = generate_stream("Account", stream_config, stream_api)
-    stream_2: BulkIncrementalSalesforceStream = generate_stream("Asset", stream_config, stream_api)
-    streams = [stream_1, stream_2]
-    configure_request_params_mock(stream_1, stream_2)
-
-    stream_1.page_size = 6
-    stream_1.state_checkpoint_interval = 5
-
-    source = SourceSalesforce(_ANY_CATALOG, _ANY_CONFIG, _ANY_STATE)
-    source.streams = Mock()
-    source.streams.return_value = streams
-
-    json_response = [{"errorCode": "REQUEST_LIMIT_EXCEEDED", "message": "TotalRequests Limit exceeded."}]
-    with requests_mock.Mocker() as m:
-        for stream in streams:
-            creation_responses = []
-            for page in [1, 2]:
-                job_id = f"fake_job_{page}_{stream.name}"
-                creation_responses.append({"json": {"id": job_id}})
-
-                m.register_uri("GET", stream.path() + f"/{job_id}", json={"state": "JobComplete"})
-
-                resp = ["Field1,LastModifiedDate,Id"] + [f"test,2021-10-0{i},{i}" for i in range(1, 7)]  # 6 records per page
-
-                if page == 1:
-                    # Read the first page successfully
-                    m.register_uri("GET", stream.path() + f"/{job_id}/results", text="\n".join(resp))
-                else:
-                    # Requesting for results when reading second page should fail with 403 (Rate Limit error)
-                    m.register_uri("GET", stream.path() + f"/{job_id}/results", status_code=403, json=json_response)
-
-                m.register_uri("DELETE", stream.path() + f"/{job_id}")
-
-            m.register_uri("POST", stream.path(), creation_responses)
-        result = read(source=source, config=stream_config, catalog=bulk_catalog, state=state)
-        assert stream_1.request_params.called
-        assert (
-            not stream_2.request_params.called
-        ), "The second stream should not be executed, because the first stream finished with Rate Limit."
-
-        records = result.records
-        assert len(records) == 6  # stream page size: 6
-
-        state_record = result.state_messages[0]
-        assert state_record.state.stream.stream_descriptor == StreamDescriptor(name="Account")
-        assert state_record.state.stream.stream_state == AirbyteStateBlob(LastModifiedDate="2021-10-05T00:00:00+00:00")
-
-
-def test_rate_limit_rest(stream_config, stream_api, rest_catalog, state):
-    """
-    Connector should stop the sync if one stream reached rate limit
-    stream_1, stream_2, stream_3, ...
-    While reading `stream_1` if 403 (Rate Limit) is received, it should finish that stream with success and stop the sync process.
-    Next streams should not be executed.
-    """
-    stream_config.update({"start_date": "2021-11-01"})
-
-    stream_1: IncrementalRestSalesforceStream = generate_stream("KnowledgeArticle", stream_config, stream_api)
-    stream_2: IncrementalRestSalesforceStream = generate_stream("AcceptedEventRelation", stream_config, stream_api)
-
-    stream_1.state_checkpoint_interval = 3
-    streams = [stream_1, stream_2]
-    configure_request_params_mock(stream_1, stream_2)
-
-    source = SourceSalesforce(_ANY_CATALOG, _ANY_CONFIG, _ANY_STATE)
-    source.streams = Mock()
-    source.streams.return_value = streams
-
-    next_page_url = "/services/data/v57.0/query/012345"
-    response_1 = {
-        "done": False,
-        "totalSize": 10,
-        "nextRecordsUrl": next_page_url,
-        "records": [
-            {
-                "ID": 1,
-                "LastModifiedDate": "2021-11-15",
-            },
-            {
-                "ID": 2,
-                "LastModifiedDate": "2021-11-16",
-            },
-            {
-                "ID": 3,
-                "LastModifiedDate": "2021-11-17",  # check point interval
-            },
-            {
-                "ID": 4,
-                "LastModifiedDate": "2021-11-18",
-            },
-            {
-                "ID": 5,
-                "LastModifiedDate": "2021-11-19",
-            },
-        ],
-    }
-    response_2 = [{"errorCode": "REQUEST_LIMIT_EXCEEDED", "message": "TotalRequests Limit exceeded."}]
-
-    with requests_mock.Mocker() as m:
-        m.register_uri("GET", stream_1.path(), json=response_1, status_code=200)
-        m.register_uri("GET", next_page_url, json=response_2, status_code=403)
-
-        result = read(source=source, config=stream_config, catalog=rest_catalog, state=state)
-
-        assert stream_1.request_params.called
-        assert (
-            not stream_2.request_params.called
-        ), "The second stream should not be executed, because the first stream finished with Rate Limit."
-
-        records = result.records
-        assert len(records) == 5
-
-        state_record = result.state_messages[0]
-        assert state_record.state.stream.stream_descriptor == StreamDescriptor(name="KnowledgeArticle")
-        assert state_record.state.stream.stream_state == AirbyteStateBlob(LastModifiedDate="2021-11-17T00:00:00+00:00")
 
 
 def test_pagination_rest(stream_config, stream_api):
@@ -949,15 +826,15 @@ def test_bulk_stream_error_on_wait_for_job(requests_mock, stream_config, stream_
 @freezegun.freeze_time("2023-01-01")
 @pytest.mark.parametrize(
     "lookback, stream_slice_step, expected_len_stream_slices, expect_error",
-    [(None, "P30D", 0, True), (0, "P30D", 158, False), (10, "P1D", 4732, False), (10, "PT12H", 9463, False), (-1, "P30D", 0, True)],
-    ids=["lookback-is-none", "lookback-is-0-step-30D", "lookback-is-valid-step-1D", "lookback-is-valid-step-12H", "lookback-is-negative"],
+    [(0, "P30D", 158, False), (10, "P1D", 4732, False), (10, "PT12H", 9463, False)],
+    ids=["lookback-is-0-step-30D", "lookback-is-valid-step-1D", "lookback-is-valid-step-12H"],
 )
 def test_bulk_stream_slices(
     stream_config_date_format, stream_api, lookback, expect_error, stream_slice_step: str, expected_len_stream_slices: int
 ):
     stream_config_date_format["stream_slice_step"] = stream_slice_step
-    stream: BulkIncrementalSalesforceStream = generate_stream("FakeBulkStream", stream_config_date_format, stream_api)
-    with patch("source_salesforce.streams.LOOKBACK_SECONDS", lookback):
+    with patch("source_salesforce.source.LOOKBACK_SECONDS", lookback):
+        stream: BulkIncrementalSalesforceStream = generate_stream("FakeBulkStream", stream_config_date_format, stream_api)
         if expect_error:
             with pytest.raises(AssertionError):
                 list(stream.stream_slices(sync_mode=SyncMode.full_refresh))
@@ -984,11 +861,15 @@ def test_bulk_stream_slices(
 def test_bulk_stream_request_params_states(stream_config_date_format, stream_api, bulk_catalog, requests_mock):
     """Check that request params ignore records cursor and use start date from slice ONLY"""
     stream_config_date_format.update({"start_date": "2023-01-01"})
-    stream: BulkIncrementalSalesforceStream = generate_stream("Account", stream_config_date_format, stream_api)
+    state = StateBuilder().with_stream_state("Account", {"LastModifiedDate": "2023-01-01T10:10:10.000Z"}).build()
+    with patch("source_salesforce.source.LOOKBACK_SECONDS", 0):
 
-    source = SourceSalesforce(_ANY_CATALOG, _ANY_CONFIG, _ANY_STATE)
-    source.streams = Mock()
-    source.streams.return_value = [stream]
+        source = SourceSalesforce(CatalogBuilder().with_stream("Account", SyncMode.full_refresh).build(), _ANY_CONFIG, _ANY_STATE)
+        source.streams = Mock()
+        source.streams.return_value = [generate_stream("Account", stream_config_date_format, stream_api, state=state, legacy=False)]
+
+        # using legacy state to configure HTTP requests
+        stream: BulkIncrementalSalesforceStream = generate_stream("Account", stream_config_date_format, stream_api, state=state, legacy=True)
 
     job_id_1 = "fake_job_1"
     requests_mock.register_uri("GET", stream.path() + f"/{job_id_1}", [{"json": {"state": "JobComplete"}}])
@@ -1014,30 +895,29 @@ def test_bulk_stream_request_params_states(stream_config_date_format, stream_api
     requests_mock.register_uri("PATCH", stream.path() + f"/{job_id_3}")
 
     logger = logging.getLogger("airbyte")
-    state = {"Account": {"LastModifiedDate": "2023-01-01T10:10:10.000Z"}}
     bulk_catalog.streams.pop(1)
-    with patch("source_salesforce.streams.LOOKBACK_SECONDS", 0):
-        result = [i for i in source.read(logger=logger, config=stream_config_date_format, catalog=bulk_catalog, state=state)]
 
-    actual_state_values = [item.state.stream.stream_state.dict().get(stream.cursor_field) for item in result if item.type == Type.STATE]
-    # assert request params
-    assert (
+    result = [i for i in source.read(logger=logger, config=stream_config_date_format, catalog=bulk_catalog, state=state)]
+
+    # assert request params: has requests might not be performed in a specific order because of concurrent CDK, we match on any request
+    all_requests = {request.text for request in queries_history.request_history}
+    assert any([
         "LastModifiedDate >= 2023-01-01T10:10:10.000+00:00 AND LastModifiedDate < 2023-01-31T10:10:10.000+00:00"
-        in queries_history.request_history[0].text
-    )
-    assert (
+        in request for request in all_requests
+    ])
+    assert any([
         "LastModifiedDate >= 2023-01-31T10:10:10.000+00:00 AND LastModifiedDate < 2023-03-02T10:10:10.000+00:00"
-        in queries_history.request_history[1].text
-    )
-    assert (
+        in request for request in all_requests
+    ])
+    assert any([
         "LastModifiedDate >= 2023-03-02T10:10:10.000+00:00 AND LastModifiedDate < 2023-04-01T00:00:00.000+00:00"
-        in queries_history.request_history[2].text
-    )
+        in request for request in all_requests
+    ])
 
-    # assert states
-    # if connector meets record with cursor `2023-04-01` out of current slice range 2023-01-31 <> 2023-03-02, we ignore all other values and set state to slice end_date
-    expected_state_values = ["2023-01-15T00:00:00+00:00", "2023-03-02T10:10:10+00:00", "2023-04-01T00:00:00+00:00"]
-    assert actual_state_values == expected_state_values
+    # as the execution is concurrent, we can only assert the last state message here
+    last_actual_state = [item.state.stream.stream_state.dict() for item in result if item.type == Type.STATE][-1]
+    last_expected_state = {"slices": [{"start": "2023-01-01T10:10:10.000Z", "end": "2023-04-01T00:00:00.000Z"}]}
+    assert last_actual_state == last_expected_state
 
 
 def test_request_params_incremental(stream_config_date_format, stream_api):
@@ -1052,39 +932,3 @@ def test_request_params_substream(stream_config_date_format, stream_api):
     params = stream.request_params(stream_state={}, stream_slice={"parents": [{"Id": 1}, {"Id": 2}]})
 
     assert params == {"q": "SELECT LastModifiedDate, Id FROM ContentDocumentLink WHERE ContentDocumentId IN ('1','2')"}
-
-
-@freezegun.freeze_time("2023-03-20")
-def test_stream_slices_for_substream(stream_config, stream_api, requests_mock):
-    """Test BulkSalesforceSubStream for ContentDocumentLink (+ parent ContentDocument)
-
-    ContentDocument return 1 record for each slice request.
-    Given start/end date leads to 3 date slice for ContentDocument, thus 3 total records
-
-    ContentDocumentLink
-    It means that ContentDocumentLink should have 2 slices, with 2 and 1 records in each
-    """
-    stream_config["start_date"] = "2023-01-01"
-    stream: BulkSalesforceSubStream = generate_stream("ContentDocumentLink", stream_config, stream_api)
-    stream.SLICE_BATCH_SIZE = 2  # each ContentDocumentLink should contain 2 records from parent ContentDocument stream
-
-    job_id = "fake_job"
-    requests_mock.register_uri("POST", stream.path(), json={"id": job_id})
-    requests_mock.register_uri("GET", stream.path() + f"/{job_id}", json={"state": "JobComplete"})
-    requests_mock.register_uri(
-        "GET",
-        stream.path() + f"/{job_id}/results",
-        [{"text": "Field1,LastModifiedDate,ID\ntest,2021-11-16,123", "headers": {"Sforce-Locator": "null"}}],
-    )
-    requests_mock.register_uri("DELETE", stream.path() + f"/{job_id}")
-
-    stream_slices = list(stream.stream_slices(sync_mode=SyncMode.full_refresh))
-    assert stream_slices == [
-        {
-            "parents": [
-                {"Field1": "test", "ID": "123", "LastModifiedDate": "2021-11-16"},
-                {"Field1": "test", "ID": "123", "LastModifiedDate": "2021-11-16"},
-            ]
-        },
-        {"parents": [{"Field1": "test", "ID": "123", "LastModifiedDate": "2021-11-16"}]},
-    ]

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/conftest.py
@@ -1,18 +1,22 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
-
 import json
 import pathlib
-from typing import List
+from typing import Any, List, Mapping
 from unittest.mock import Mock
 
 import pytest
 from airbyte_cdk.models import ConfiguredAirbyteCatalog
 from airbyte_cdk.test.state_builder import StateBuilder
 from airbyte_protocol.models import AirbyteStateMessage
+from config_builder import ConfigBuilder
 from source_salesforce.api import Salesforce
 from source_salesforce.source import SourceSalesforce
+
+_ANY_CATALOG = ConfiguredAirbyteCatalog.parse_obj({"streams": []})
+_ANY_CONFIG = ConfigBuilder().build()
+_ANY_STATE = StateBuilder().build()
 
 
 @pytest.fixture(autouse=True)
@@ -48,32 +52,22 @@ def state() -> List[AirbyteStateMessage]:
 @pytest.fixture(scope="module")
 def stream_config():
     """Generates streams settings for BULK logic"""
-    return {
-        "client_id": "fake_client_id",
-        "client_secret": "fake_client_secret",
-        "refresh_token": "fake_refresh_token",
-        "start_date": "2010-01-18T21:18:20Z",
-        "is_sandbox": False,
-        "wait_timeout": 15,
-    }
+    return ConfigBuilder().build()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def stream_config_date_format():
     """Generates streams settings with `start_date` in format YYYY-MM-DD"""
-    return {
-        "client_id": "fake_client_id",
-        "client_secret": "fake_client_secret",
-        "refresh_token": "fake_refresh_token",
-        "start_date": "2010-01-18",
-        "is_sandbox": False,
-        "wait_timeout": 15,
-    }
+    config = ConfigBuilder().build()
+    config["start_date"] = "2010-01-18"
+    return config
 
 
 @pytest.fixture(scope="module")
 def stream_config_without_start_date():
     """Generates streams settings for REST logic without start_date"""
+    config = ConfigBuilder().build()
+    config.pop("start_date")
     return {
         "client_id": "fake_client_id",
         "client_secret": "fake_client_secret",
@@ -83,7 +77,7 @@ def stream_config_without_start_date():
     }
 
 
-def _stream_api(stream_config, describe_response_data=None):
+def mock_stream_api(stream_config: Mapping[str, Any], describe_response_data=None):
     sf_object = Salesforce(**stream_config)
     sf_object.login = Mock()
     sf_object.access_token = Mock()
@@ -98,37 +92,45 @@ def _stream_api(stream_config, describe_response_data=None):
 
 @pytest.fixture(scope="module")
 def stream_api(stream_config):
-    return _stream_api(stream_config)
+    return mock_stream_api(stream_config)
 
 
 @pytest.fixture(scope="module")
 def stream_api_v2(stream_config):
     describe_response_data = {"fields": [{"name": "LastModifiedDate", "type": "string"}, {"name": "BillingAddress", "type": "address"}]}
-    return _stream_api(stream_config, describe_response_data=describe_response_data)
+    return mock_stream_api(stream_config, describe_response_data=describe_response_data)
 
 
 @pytest.fixture(scope="module")
 def stream_api_pk(stream_config):
     describe_response_data = {"fields": [{"name": "LastModifiedDate", "type": "string"}, {"name": "Id", "type": "string"}]}
-    return _stream_api(stream_config, describe_response_data=describe_response_data)
+    return mock_stream_api(stream_config, describe_response_data=describe_response_data)
 
 
 @pytest.fixture(scope="module")
 def stream_api_v2_too_many_properties(stream_config):
     describe_response_data = {"fields": [{"name": f"Property{str(i)}", "type": "string"} for i in range(Salesforce.REQUEST_SIZE_LIMITS)]}
     describe_response_data["fields"].extend([{"name": "BillingAddress", "type": "address"}])
-    return _stream_api(stream_config, describe_response_data=describe_response_data)
+    return mock_stream_api(stream_config, describe_response_data=describe_response_data)
 
 
 @pytest.fixture(scope="module")
 def stream_api_v2_pk_too_many_properties(stream_config):
     describe_response_data = {"fields": [{"name": f"Property{str(i)}", "type": "string"} for i in range(Salesforce.REQUEST_SIZE_LIMITS)]}
     describe_response_data["fields"].extend([{"name": "BillingAddress", "type": "address"}, {"name": "Id", "type": "string"}])
-    return _stream_api(stream_config, describe_response_data=describe_response_data)
+    return mock_stream_api(stream_config, describe_response_data=describe_response_data)
 
 
-def generate_stream(stream_name, stream_config, stream_api):
-    return SourceSalesforce.generate_streams(stream_config, {stream_name: None}, stream_api)[0]
+def generate_stream(stream_name, stream_config, stream_api, state=None, legacy=True):
+    if state is None:
+        state = _ANY_STATE
+
+    stream = SourceSalesforce(_ANY_CATALOG, _ANY_CONFIG, state).generate_streams(stream_config, {stream_name: None}, stream_api)[0]
+    if legacy and hasattr(stream, "_legacy_stream"):
+        # Many tests are going through `generate_streams` to test things that are part of the legacy interface. To smooth the transition,
+        # we will access the legacy stream through the StreamFacade private field
+        return stream._legacy_stream
+    return stream
 
 
 def encoding_symbols_parameters():

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+import json
+import urllib.parse
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple, Union
+from unittest import TestCase
+
+import freezegun
+from airbyte_cdk.sources.source import TState
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput, read
+from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
+from airbyte_cdk.test.mock_http.request import ANY_QUERY_PARAMS
+from airbyte_cdk.test.state_builder import StateBuilder
+from airbyte_protocol.models import ConfiguredAirbyteCatalog, SyncMode
+from config_builder import ConfigBuilder
+from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
+from integration.utils import given_stream
+from source_salesforce import SourceSalesforce
+from source_salesforce.streams import LOOKBACK_SECONDS
+
+_A_FIELD_NAME = "a_field"
+_ACCESS_TOKEN = "an_access_token"
+_API_VERSION = "v57.0"
+_CLIENT_ID = "a_client_id"
+_CLIENT_SECRET = "a_client_secret"
+_CURSOR_FIELD = "SystemModstamp"
+_INSTANCE_URL = "https://instance.salesforce.com"
+_JOB_ID = "a-job-id"
+_LOOKBACK_WINDOW = timedelta(seconds=LOOKBACK_SECONDS)
+_NOW = datetime.now(timezone.utc)
+_REFRESH_TOKEN = "a_refresh_token"
+_STREAM_NAME = "a_stream_name"
+
+_BASE_URL = f"{_INSTANCE_URL}/services/data/{_API_VERSION}"
+
+
+def _catalog(sync_mode: SyncMode) -> ConfiguredAirbyteCatalog:
+    return CatalogBuilder().with_stream(_STREAM_NAME, sync_mode).build()
+
+
+def _source(catalog: ConfiguredAirbyteCatalog, config: Dict[str, Any], state: Optional[TState]) -> SourceSalesforce:
+    return SourceSalesforce(catalog, config, state)
+
+
+def _read(
+    sync_mode: SyncMode,
+    config_builder: Optional[ConfigBuilder] = None,
+    state_builder: Optional[StateBuilder] = None,
+    expecting_exception: bool = False
+) -> EntrypointOutput:
+    catalog = _catalog(sync_mode)
+    config = config_builder.build() if config_builder else ConfigBuilder().build()
+    state = state_builder.build() if state_builder else StateBuilder().build()
+    return read(_source(catalog, config, state), config, catalog, state, expecting_exception)
+
+
+def _given_authentication(http_mocker: HttpMocker, client_id: str, client_secret: str, refresh_token: str) -> None:
+    http_mocker.post(
+        HttpRequest(
+            "https://login.salesforce.com/services/oauth2/token",
+            query_params=ANY_QUERY_PARAMS,
+            body=f"grant_type=refresh_token&client_id={client_id}&client_secret={client_secret}&refresh_token={refresh_token}"
+        ),
+        HttpResponse(json.dumps({"access_token": _ACCESS_TOKEN, "instance_url": _INSTANCE_URL})),
+    )
+
+
+def _create_field(name: str, _type: Optional[str] = None) -> Dict[str, Any]:
+    return {"name": name, "type": _type if _type else "string"}
+
+
+def _to_url(to_convert: datetime) -> str:
+    to_format = to_convert.isoformat(timespec="milliseconds")
+    return urllib.parse.quote_plus(to_format)
+
+
+def _to_partitioned_datetime(to_convert: datetime) -> str:
+    return to_convert.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _calculate_start_time(start_time: datetime) -> datetime:
+    # the start is granular to the second hence why we have `0` in terms of milliseconds
+    return start_time.replace(microsecond=0)
+
+
+@freezegun.freeze_time(_NOW.isoformat())
+class FullRefreshTest(TestCase):
+
+    def setUp(self) -> None:
+        self._config = ConfigBuilder().client_id(_CLIENT_ID).client_secret(_CLIENT_SECRET).refresh_token(_REFRESH_TOKEN)
+
+    @HttpMocker()
+    def test_when_read_then_create_job_and_extract_records_from_result(self, http_mocker: HttpMocker) -> None:
+        _given_authentication(http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN)
+        given_stream(http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        http_mocker.post(
+            HttpRequest(f"{_BASE_URL}/jobs/query", body=json.dumps({"operation": "queryAll", "query": "SELECT a_field FROM a_stream_name", "contentType": "CSV", "columnDelimiter": "COMMA", "lineEnding": "LF"})),
+            HttpResponse(json.dumps({"id": _JOB_ID})),
+        )
+        http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            HttpResponse(json.dumps({"state": "JobComplete"})),
+        )
+        http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}/results"),
+            HttpResponse(f"{_A_FIELD_NAME}\nfield_value"),
+        )
+
+        output = _read(SyncMode.full_refresh, self._config)
+
+        assert len(output.records) == 1

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -15,8 +15,8 @@ from airbyte_cdk.test.mock_http.request import ANY_QUERY_PARAMS
 from airbyte_cdk.test.state_builder import StateBuilder
 from airbyte_protocol.models import ConfiguredAirbyteCatalog, SyncMode
 from config_builder import ConfigBuilder
-from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
 from integration.utils import given_stream
+from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
 from source_salesforce import SourceSalesforce
 from source_salesforce.streams import LOOKBACK_SECONDS
 

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_rest_salesforce_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_rest_salesforce_stream.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
 import json
-from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+import urllib.parse
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple, Union
 from unittest import TestCase
 
 import freezegun
@@ -16,13 +17,16 @@ from airbyte_protocol.models import ConfiguredAirbyteCatalog, SyncMode
 from config_builder import ConfigBuilder
 from source_salesforce import SourceSalesforce
 from source_salesforce.api import UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS
+from source_salesforce.streams import LOOKBACK_SECONDS
 
 _A_FIELD_NAME = "a_field"
 _ACCESS_TOKEN = "an_access_token"
 _API_VERSION = "v57.0"
 _CLIENT_ID = "a_client_id"
 _CLIENT_SECRET = "a_client_secret"
+_CURSOR_FIELD = "SystemModstamp"
 _INSTANCE_URL = "https://instance.salesforce.com"
+_LOOKBACK_WINDOW = timedelta(seconds=LOOKBACK_SECONDS)
 _NOW = datetime.now(timezone.utc)
 _REFRESH_TOKEN = "a_refresh_token"
 _STREAM_NAME = UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS[0]
@@ -39,11 +43,12 @@ def _source(catalog: ConfiguredAirbyteCatalog, config: Dict[str, Any], state: Op
 def _read(
     sync_mode: SyncMode,
     config_builder: Optional[ConfigBuilder] = None,
+    state_builder: Optional[StateBuilder] = None,
     expecting_exception: bool = False
 ) -> EntrypointOutput:
     catalog = _catalog(sync_mode)
     config = config_builder.build() if config_builder else ConfigBuilder().build()
-    state = StateBuilder().build()
+    state = state_builder.build() if state_builder else StateBuilder().build()
     return read(_source(catalog, config, state), config, catalog, state, expecting_exception)
 
 
@@ -58,15 +63,33 @@ def _given_authentication(http_mocker: HttpMocker, client_id: str, client_secret
     )
 
 
-def _given_stream(http_mocker: HttpMocker, stream_name: str, field_name: str) -> None:
+def _given_stream(http_mocker: HttpMocker, stream_name: str, fields: List[Dict[str, Any]]) -> None:
     http_mocker.get(
         HttpRequest(f"{_INSTANCE_URL}/services/data/{_API_VERSION}/sobjects"),
         HttpResponse(json.dumps({"sobjects": [{"name": stream_name, "queryable": True}]})),
     )
     http_mocker.get(
         HttpRequest(f"{_INSTANCE_URL}/services/data/{_API_VERSION}/sobjects/AcceptedEventRelation/describe"),
-        HttpResponse(json.dumps({"fields": [{"name": field_name, "type": "string"}]})),
+        HttpResponse(json.dumps({"fields": fields})),
     )
+
+
+def _create_field(name: str, _type: Optional[str] = None) -> Dict[str, Any]:
+    return {"name": name, "type": _type if _type else "string"}
+
+
+def _to_url(to_convert: datetime) -> str:
+    to_format = to_convert.isoformat(timespec="milliseconds")
+    return urllib.parse.quote_plus(to_format)
+
+
+def _to_partitioned_datetime(to_convert: datetime) -> str:
+    return to_convert.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _calculate_start_time(start_time: datetime) -> datetime:
+    # the start is granular to the second hence why we have `0` in terms of milliseconds
+    return start_time.replace(microsecond=0)
 
 
 @freezegun.freeze_time(_NOW.isoformat())
@@ -78,7 +101,7 @@ class FullRefreshTest(TestCase):
     @HttpMocker()
     def test_given_error_on_fetch_chunk_when_read_then_retry(self, http_mocker: HttpMocker) -> None:
         _given_authentication(http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN)
-        _given_stream(http_mocker, _STREAM_NAME, _A_FIELD_NAME)
+        _given_stream(http_mocker, _STREAM_NAME, [_create_field(_A_FIELD_NAME)])
         http_mocker.get(
             HttpRequest(f"{_INSTANCE_URL}/services/data/{_API_VERSION}/queryAll?q=SELECT+{_A_FIELD_NAME}+FROM+{_STREAM_NAME}+"),
             [
@@ -90,3 +113,76 @@ class FullRefreshTest(TestCase):
         output = _read(SyncMode.full_refresh, self._config)
 
         assert len(output.records) == 1
+
+
+@freezegun.freeze_time(_NOW.isoformat())
+class IncrementalTest(TestCase):
+    def setUp(self) -> None:
+        self._config = ConfigBuilder().client_id(_CLIENT_ID).client_secret(_CLIENT_SECRET).refresh_token(_REFRESH_TOKEN)
+
+        self._http_mocker = HttpMocker()
+        self._http_mocker.__enter__()
+
+        _given_authentication(self._http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN)
+        _given_stream(self._http_mocker, _STREAM_NAME, [_create_field(_A_FIELD_NAME), _create_field(_CURSOR_FIELD, "datetime")])
+
+    def tearDown(self) -> None:
+        self._http_mocker.__exit__(None, None, None)
+
+    def test_given_no_state_when_read_then_start_sync_from_start(self) -> None:
+        start = _calculate_start_time(_NOW - timedelta(days=5))
+        # as the start comes from the config, we can't use the same format as `_to_url`
+        start_format_url = urllib.parse.quote_plus(start.strftime('%Y-%m-%dT%H:%M:%SZ'))
+        self._config.stream_slice_step("P30D").start_date(start)
+
+        self._http_mocker.get(
+            HttpRequest(f"{_INSTANCE_URL}/services/data/{_API_VERSION}/queryAll?q=SELECT+{_A_FIELD_NAME},{_CURSOR_FIELD}+FROM+{_STREAM_NAME}+WHERE+SystemModstamp+%3E%3D+{start_format_url}+AND+SystemModstamp+%3C+{_to_url(_NOW)}"),
+            HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
+        )
+
+        _read(SyncMode.incremental, self._config, StateBuilder().with_stream_state(_STREAM_NAME, {}))
+
+        # then HTTP requests are performed
+
+    def test_given_sequential_state_when_read_then_migrate_to_partitioned_state(self) -> None:
+        cursor_value = _NOW - timedelta(days=5)
+        start = _calculate_start_time(_NOW - timedelta(days=10))
+        self._config.stream_slice_step("P30D").start_date(start)
+        self._http_mocker.get(
+            HttpRequest(f"{_INSTANCE_URL}/services/data/{_API_VERSION}/queryAll?q=SELECT+{_A_FIELD_NAME},{_CURSOR_FIELD}+FROM+{_STREAM_NAME}+WHERE+SystemModstamp+%3E%3D+{_to_url(cursor_value - _LOOKBACK_WINDOW)}+AND+SystemModstamp+%3C+{_to_url(_NOW)}"),
+            HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
+        )
+
+        output = _read(SyncMode.incremental, self._config, StateBuilder().with_stream_state(_STREAM_NAME, {_CURSOR_FIELD: cursor_value.isoformat(timespec="milliseconds")}))
+
+        assert output.most_recent_state.stream_state.dict() == {"state_type": "date-range", "slices": [{"start": _to_partitioned_datetime(start), "end": _to_partitioned_datetime(_NOW)}]}
+
+    def test_given_partitioned_state_when_read_then_sync_missing_partitions_and_update_state(self) -> None:
+        missing_chunk = (_NOW - timedelta(days=5), _NOW - timedelta(days=3))
+        most_recent_state_value = _NOW - timedelta(days=1)
+        start = _calculate_start_time(_NOW - timedelta(days=10))
+        state = StateBuilder().with_stream_state(
+            _STREAM_NAME,
+            {
+                "state_type": "date-range",
+                "slices": [
+                    {"start": start.strftime("%Y-%m-%dT%H:%M:%S.000") + "Z", "end": _to_partitioned_datetime(missing_chunk[0])},
+                    {"start": _to_partitioned_datetime(missing_chunk[1]), "end": _to_partitioned_datetime(most_recent_state_value)},
+                ]
+            }
+        )
+        self._config.stream_slice_step("P30D").start_date(start)
+
+        self._http_mocker.get(
+            HttpRequest(f"{_INSTANCE_URL}/services/data/{_API_VERSION}/queryAll?q=SELECT+{_A_FIELD_NAME},{_CURSOR_FIELD}+FROM+{_STREAM_NAME}+WHERE+SystemModstamp+%3E%3D+{_to_url(missing_chunk[0])}+AND+SystemModstamp+%3C+{_to_url(missing_chunk[1])}"),
+            HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_INSTANCE_URL}/services/data/{_API_VERSION}/queryAll?q=SELECT+{_A_FIELD_NAME},{_CURSOR_FIELD}+FROM+{_STREAM_NAME}+WHERE+SystemModstamp+%3E%3D+{_to_url(most_recent_state_value - _LOOKBACK_WINDOW)}+AND+SystemModstamp+%3C+{_to_url(_NOW)}"),
+            HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
+        )
+
+        output = _read(SyncMode.incremental, self._config, state)
+
+        # the start is granular to the second hence why we have `000` in terms of milliseconds
+        assert output.most_recent_state.stream_state.dict() == {"state_type": "date-range", "slices": [{"start": _to_partitioned_datetime(start), "end": _to_partitioned_datetime(_NOW)}]}

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_rest_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_rest_stream.py
@@ -15,8 +15,8 @@ from airbyte_cdk.test.mock_http.request import ANY_QUERY_PARAMS
 from airbyte_cdk.test.state_builder import StateBuilder
 from airbyte_protocol.models import ConfiguredAirbyteCatalog, SyncMode
 from config_builder import ConfigBuilder
-from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
 from integration.utils import given_stream
+from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
 from source_salesforce import SourceSalesforce
 from source_salesforce.api import UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS
 from source_salesforce.streams import LOOKBACK_SECONDS

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/utils.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
 import json
 
 from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/utils.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/utils.py
@@ -1,0 +1,15 @@
+import json
+
+from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
+from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
+
+
+def given_stream(http_mocker: HttpMocker, base_url: str, stream_name: str, schema_builder: SalesforceDescribeResponseBuilder) -> None:
+    http_mocker.get(
+        HttpRequest(f"{base_url}/sobjects"),
+        HttpResponse(json.dumps({"sobjects": [{"name": stream_name, "queryable": True}]})),
+    )
+    http_mocker.get(
+        HttpRequest(f"{base_url}/sobjects/{stream_name}/describe"),
+        schema_builder.build(),
+    )

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/salesforce_describe_response_builder.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/salesforce_describe_response_builder.py
@@ -1,0 +1,16 @@
+import json
+from typing import Optional
+
+from airbyte_cdk.test.mock_http import HttpResponse
+
+
+class SalesforceDescribeResponseBuilder:
+    def __init__(self) -> None:
+        self._fields = []
+
+    def field(self, name: str, _type: Optional[str] = None) -> "SalesforceDescribeResponseBuilder":
+        self._fields.append({"name": name, "type": _type if _type else "string"})
+        return self
+
+    def build(self) -> HttpResponse:
+        return HttpResponse(json.dumps({"fields": self._fields}))

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/salesforce_describe_response_builder.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/salesforce_describe_response_builder.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
 import json
 from typing import Optional
 

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/test_availability_strategy.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/test_availability_strategy.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from unittest import TestCase
+from unittest.mock import Mock
+
+import pytest
+from airbyte_cdk.sources.streams import Stream
+from requests import HTTPError, Response
+from source_salesforce.availability_strategy import SalesforceAvailabilityStrategy
+
+_NO_SOURCE = None
+
+
+class SalesforceAvailabilityStrategyTest(TestCase):
+    def setUp(self) -> None:
+        self._stream = Mock(spec=Stream)
+        self._logger = Mock()
+        self._error = HTTPError(response=Mock(spec=Response))
+
+    def test_given_status_code_is_not_forbidden_or_bad_request_when_handle_http_error_then_raise_error(self) -> None:
+        availability_strategy = SalesforceAvailabilityStrategy()
+        self._error.response.status_code = 401
+
+        with pytest.raises(HTTPError):
+            availability_strategy.handle_http_error(self._stream, self._logger, _NO_SOURCE, self._error)
+
+    def test_given_status_code_is_forbidden_when_handle_http_error_then_is_not_available_with_reason(self) -> None:
+        availability_strategy = SalesforceAvailabilityStrategy()
+        self._error.response.status_code = 403
+        self._error.response.json.return_value = [{}]
+
+        is_available, reason = availability_strategy.handle_http_error(self._stream, self._logger, _NO_SOURCE, self._error)
+
+        assert not is_available
+        assert reason
+
+    def test_given_status_code_is_bad_request_when_handle_http_error_then_is_not_available_with_reason(self) -> None:
+        availability_strategy = SalesforceAvailabilityStrategy()
+        self._error.response.status_code = 400
+        self._error.response.json.return_value = [{}]
+
+        is_available, reason = availability_strategy.handle_http_error(self._stream, self._logger, _NO_SOURCE, self._error)
+
+        assert not is_available
+        assert reason
+
+    def test_given_rate_limited_when_handle_http_error_then_is_available(self) -> None:
+        availability_strategy = SalesforceAvailabilityStrategy()
+        self._error.response.status_code = 400
+        self._error.response.json.return_value = [{"errorCode": "REQUEST_LIMIT_EXCEEDED"}]
+
+        is_available, reason = availability_strategy.handle_http_error(self._stream, self._logger, _NO_SOURCE, self._error)
+
+        assert is_available
+        assert reason is None

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/test_slice_generation.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/test_slice_generation.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from datetime import datetime, timedelta, timezone
+from unittest import TestCase
+
+import freezegun
+from airbyte_protocol.models import SyncMode
+from config_builder import ConfigBuilder
+from conftest import generate_stream, mock_stream_api
+
+_NOW = datetime.fromisoformat("2020-01-01T00:00:00+00:00")
+
+
+@freezegun.freeze_time(time_to_freeze=_NOW)
+class IncrementalSliceGenerationTest(TestCase):
+    def test_given_start_within_slice_range_when_stream_slices_then_return_one_slice_considering_10_minutes_lookback(self) -> None:
+        config = ConfigBuilder().start_date(_NOW - timedelta(days=15)).stream_slice_step("P30D").build()
+        stream = generate_stream("Account", config, mock_stream_api(config))
+
+        slices = list(stream.stream_slices(sync_mode=SyncMode.full_refresh))
+
+        assert slices == [{"start_date": "2019-12-16T23:50:00.000+00:00", "end_date": "2020-01-01T00:00:00.000+00:00"}]
+
+    def test_given_slice_range_smaller_than_now_minus_start_date_when_stream_slices_then_return_many_slices(self) -> None:
+        config = ConfigBuilder().start_date(_NOW - timedelta(days=40)).stream_slice_step("P30D").build()
+        stream = generate_stream("Account", config, mock_stream_api(config))
+
+        slices = list(stream.stream_slices(sync_mode=SyncMode.full_refresh))
+
+        assert slices == [
+            {"start_date": "2019-11-21T23:50:00.000+00:00", "end_date": "2019-12-21T23:50:00.000+00:00"},
+            {"start_date": "2019-12-21T23:50:00.000+00:00", "end_date": "2020-01-01T00:00:00.000+00:00"}
+        ]

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/test_slice_generation.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/test_slice_generation.py
@@ -19,7 +19,7 @@ class IncrementalSliceGenerationTest(TestCase):
 
         slices = list(stream.stream_slices(sync_mode=SyncMode.full_refresh))
 
-        assert slices == [{"start_date": "2019-12-16T23:50:00.000+00:00", "end_date": "2020-01-01T00:00:00.000+00:00"}]
+        assert slices == [{"start_date": "2019-12-17T00:00:00.000+00:00", "end_date": "2020-01-01T00:00:00.000+00:00"}]
 
     def test_given_slice_range_smaller_than_now_minus_start_date_when_stream_slices_then_return_many_slices(self) -> None:
         config = ConfigBuilder().start_date(_NOW - timedelta(days=40)).stream_slice_step("P30D").build()
@@ -28,6 +28,6 @@ class IncrementalSliceGenerationTest(TestCase):
         slices = list(stream.stream_slices(sync_mode=SyncMode.full_refresh))
 
         assert slices == [
-            {"start_date": "2019-11-21T23:50:00.000+00:00", "end_date": "2019-12-21T23:50:00.000+00:00"},
-            {"start_date": "2019-12-21T23:50:00.000+00:00", "end_date": "2020-01-01T00:00:00.000+00:00"}
+            {"start_date": "2019-11-22T00:00:00.000+00:00", "end_date": "2019-12-22T00:00:00.000+00:00"},
+            {"start_date": "2019-12-22T00:00:00.000+00:00", "end_date": "2020-01-01T00:00:00.000+00:00"}
         ]

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -193,7 +193,7 @@ Now that you have set up the Salesforce source connector, check out the followin
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| 2.4.5   | 2024-04-10 | [36942](https://github.com/airbytehq/airbyte/pull/36942) | Move Salesforce to partitioned state in order to avoid stuck syncs                                                                   |
+| 2.5.0   | 2024-04-11 | [36942](https://github.com/airbytehq/airbyte/pull/36942) | Move Salesforce to partitioned state in order to avoid stuck syncs                                                                   |
 | 2.4.4   | 2024-04-08 | [36901](https://github.com/airbytehq/airbyte/pull/36901) | Upgrade CDK for empty internal_message empty when ExceptionWithDisplayMessage raised                                                 |
 | 2.4.3   | 2024-04-08 | [36885](https://github.com/airbytehq/airbyte/pull/36885) | Add missing retry on REST API                                                                                                        |
 | 2.4.2   | 2024-04-05 | [36862](https://github.com/airbytehq/airbyte/pull/36862) | Upgrade CDK for updated error messaging regarding missing streams                                                                    |

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -193,6 +193,7 @@ Now that you have set up the Salesforce source connector, check out the followin
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 2.4.5   | 2024-04-10 | [36942](https://github.com/airbytehq/airbyte/pull/36942) | Move Salesforce to partitioned state in order to avoid stuck syncs                                                                   |
 | 2.4.4   | 2024-04-08 | [36901](https://github.com/airbytehq/airbyte/pull/36901) | Upgrade CDK for empty internal_message empty when ExceptionWithDisplayMessage raised                                                 |
 | 2.4.3   | 2024-04-08 | [36885](https://github.com/airbytehq/airbyte/pull/36885) | Add missing retry on REST API                                                                                                        |
 | 2.4.2   | 2024-04-05 | [36862](https://github.com/airbytehq/airbyte/pull/36862) | Upgrade CDK for updated error messaging regarding missing streams                                                                    |


### PR DESCRIPTION
## What
Addressing https://github.com/airbytehq/airbyte-internal-issues/issues/6829 to avoid stuck syncs.

Basically, syncs would get stuck when there was an error in a thread because we would try to shutdown the threads and threads that were already active would continue to sync without anything to consume the queue. To avoid that, we will run all the threads without breaking the main thread and save the state as a partitioned one so we only have to retry the slices that failed.

## How
* Update how we instantiate the ConcurrentCursor (`__init__` have breaking changes)
* Passing the cursor to the stream so that stream generation relies on the cursor and not the old `stream_slices` implementation

## Manual Testing
Compared output for:
* Accounts
* AcceptedEventRelation (UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS)
* ContentDocumentLink (PARENT_SALESFORCE_OBJECTS): this helped me understand an issue that we had in production (see [this](https://github.com/airbytehq/airbyte-internal-issues/issues/6888))


## 🚨 User Impact 🚨
This is a breaking change as the state format will change. It does not need opt-in mechanism because the new version of the connector can understand the previous state format. However we *can't* revert this change as the old version doesn't understand the state of the new version.

This should allow threads to continue sync records even though one failed.