### PR TITLE
Small fixes to python cdk publishing

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -208,10 +208,15 @@ jobs:
           ref: ${{ github.event.inputs.gitref }}
           token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }} # This token is what allows us to commit directly to master
       - name: Bump CDK dependency of source-declarative-manifest
+        timeout-minutes: 10
         run: |
           cd airbyte-integrations/connectors/source-declarative-manifest
-          # --no-cache is used to ensure the latest version is fetched. Let's see if we need to add a wait...
-          poetry add airbyte-cdk==${{needs.bump-version.outputs.new_cdk_version}} --no-cache
+          while true; do
+            # --no-cache to force looking for the new version
+            poetry add airbyte-cdk==${{needs.bump-version.outputs.new_cdk_version}} --no-cache && break
+            # Loop to wait for the new version to be available to poetry
+            sleep 10
+          done
       - name: Bump version of source-declarative-manifest
         uses: ./.github/actions/run-airbyte-ci
         with:

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -246,7 +246,7 @@ jobs:
           channel-id: C04J1M66D8B
           payload: |
             {
-                "text": ":warning: A new version of Python CDK has been released but Connector Builder hasn't been automatically updated",
+                "text": ":warning: A new version of Python CDK has been released but `source-declarative-manifest` and Connector Builder haven't been automatically updated",
                 "blocks": [
                     {
                         "type": "section",
@@ -259,7 +259,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": ":warning: Could not automatically create a PR for Connector Builder>\n"
+                            "text": ":warning: Could not bump version of `source-declarative-manifest`.>\n"
                         }
                     },
                     {

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -111,7 +111,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           file_pattern: airbyte-cdk/python/pyproject.toml airbyte-cdk/python/CHANGELOG.md
-          commit_message: 🤖 ${{ github.event.inputs.release-type }} bump Python CDK to version $NEW_VERSION
+          commit_message: 🤖 ${{ github.event.inputs.release-type }} bump Python CDK to version ${{ steps.bumpversion.outputs.NEW_VERSION }}
           commit_user_name: Octavia Squidington III
           commit_user_email: octavia-squidington-iii@users.noreply.github.com
       - name: Post failure to Slack channel dev-connectors-extensibility
@@ -229,7 +229,7 @@ jobs:
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           # There is no pull request number as we do this manually, so will just reference when we started doing it manually for now
-          subcommand: "connectors --concurrency=1 --execute-timeout=3600 --name=source-declarative-manifest bump_version ${{ github.event.inputs.release-type }} '36501' 'Bump CDK version to ${{ steps.bumpversion.outputs.NEW_VERSION }}'"
+          subcommand: "connectors --concurrency=1 --execute-timeout=3600 --name=source-declarative-manifest bump_version ${{ github.event.inputs.release-type }} '36501' 'Bump CDK version to ${{needs.bump-version.outputs.new_cdk_version}}'"
           python_registry_token: ${{ secrets.PYPI_TOKEN }}
       - name: Commit and Push Changes
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -211,12 +211,15 @@ jobs:
         timeout-minutes: 10
         run: |
           cd airbyte-integrations/connectors/source-declarative-manifest
+          echo "Attempting to pull the newly published version of airbyte-cdk."
           while true; do
             # --no-cache to force looking for the new version
             poetry add airbyte-cdk==${{needs.bump-version.outputs.new_cdk_version}} --no-cache && break
             # Loop to wait for the new version to be available to poetry
+            echo "Couldn't add new dependency. This is normal if the dependency could not (yet) be found. Retrying in 10 seconds..."
             sleep 10
           done
+          echo "Successfully updated the CDK dependency of source-declarative-manifest to ${{needs.bump-version.outputs.new_cdk_version}}"
       - name: Bump version of source-declarative-manifest
         uses: ./.github/actions/run-airbyte-ci
         with:

--- a/docs/integrations/sources/low-code.md
+++ b/docs/integrations/sources/low-code.md
@@ -9,9 +9,9 @@ The changelog below is automatically updated by the `bump_version` command as pa
 
 | Version | Date       | Pull Request                                             | Subject                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------|
-| 0.81.0 | 2024-04-09 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to  |
-| 0.80.0 | 2024-04-09 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to |
-| 0.79.2 | 2024-04-09 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to |
-| 0.79.1 | 2024-04-05 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to |
-| 0.79.0 | 2024-04-05 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 0.79.0 |
+| 0.81.0 | 2024-04-09 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 0.81.0                                           |
+| 0.80.0 | 2024-04-09 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 0.80.0                                           |
+| 0.79.2 | 2024-04-09 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 0.79.2                                           |
+| 0.79.1 | 2024-04-05 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 0.79.1                                           |
+| 0.79.0 | 2024-04-05 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 0.79.0                                           |
 | 0.78.9 | 2024-04-04 | [36834](https://github.com/airbytehq/airbyte/pull/36834) | Update CDK dependency to version 0.78.9 (before new publishing flow) |


### PR DESCRIPTION
* Use correct version reference in commit message
* Use correct version reference in changelog message
  * Backfill changelog messages
* Add loop with timeout to keep trying to get the newly published CDK version until it is available 
* Update error messaging when `source-declarative-manifest` cannot be published