### PR TITLE
fix publish-java-cdk workflow on push-to-master

### DIFF
--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -49,7 +49,7 @@ env:
   # Use the provided GITREF or default to the branch triggering the workflow.
   GITREF: ${{ github.event.inputs.gitref || github.ref }}
   FORCE: "${{ github.event_name == 'push' || github.event.inputs.force == null && 'false' ||  github.event.inputs.force }}"
-  DRY_RUN: "${{ github.event.inputs.dry-run == null && 'true' || github.event.inputs.dry-run }}"
+  DRY_RUN: "${{ github.event_name == 'push' && 'false' || github.event.inputs.dry-run == null && 'true' || github.event.inputs.dry-run }}"
   CDK_VERSION_FILE_PATH: "./airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties"
   S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
   S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
@@ -77,6 +77,9 @@ jobs:
         id: read-target-java-cdk-version
         run: |
           cdk_version=$(cat $CDK_VERSION_FILE_PATH | tr -d '\n')
+          echo "CDK_VERSION=$CDK_VERSION"
+          echo "FORCE=$FORCE"
+          echo "DRY_RUN=$DRY_RUN"
           if [[ -z "$cdk_version" ]]; then
             echo "Failed to retrieve CDK version from $CDK_VERSION_FILE_PATH"
             exit 1


### PR DESCRIPTION
the publish-java-cdk on push-to-master wasn't working because the value of dry-run was set to true. 
I'm also adding some debugging info so we know what the values of DRY_RUN and FORCE are

This was tested on my fork of the airbyte repo