### PR TITLE
Concurrent CDK: add logging on exception

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
@@ -137,6 +137,7 @@ class ConcurrentReadProcessor:
         2. Raise the exception
         """
         self._exceptions_per_stream_name.setdefault(exception.stream_name, []).append(exception.exception)
+        self._logger.exception(f"Exception while syncing stream {exception.stream_name}", exc_info=exception.exception)
         yield AirbyteTracedException.from_exception(exception).as_airbyte_message(
             stream_descriptor=StreamDescriptor(name=exception.stream_name)
         )


### PR DESCRIPTION
Right now, it is a bit hard to debug during mock server tests because trace messages are not printed to the console. We can still check `entrypoint.trace_messages` but it is less obvious so I would prefer logging.