### PR TITLE
remove testing attribute from telemetry

### DIFF
--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -149,7 +149,6 @@ TelemetrySend()
     "state":"$state",
     "os":"$OSTYPE",
     "script_version":"$VERSION",
-    "testing":"true",
     "error":"$err"
   },
   "timestamp":"$now",


### PR DESCRIPTION
see title

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit ef3c4b0a7b5384380f5afa5987b5b044aa09dd3b.  | 
|--------|--------|

### Summary:
This PR removes the `testing` attribute from the telemetry data sent by the `run-ab-platform.sh` script.

**Key points**:
- Removed `testing` attribute from `TelemetrySend` function in `run-ab-platform.sh`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
