### PR TITLE
[airbyte-cdk] add print parameter to flush the print buffer after each invocation

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -235,7 +235,7 @@ def launch(source: Source, args: List[str]) -> None:
     for message in source_entrypoint.run(parsed_args):
         # simply printing is creating issues for concurrent CDK as Python uses different two instructions to print: one for the message and
         # the other for the break line. Adding `\n` to the message ensure that both are printed at the same time
-        print(f"{message}\n", end="")
+        print(f"{message}\n", end="", flush=True)
 
 
 def _init_internal_request_filter() -> None:


### PR DESCRIPTION
Fixes https://github.com/airbytehq/airbyte-internal-issues/issues/7087

## Identifying the fix

For a small number of syncs to `source-salesforce` and `source-stripe` we were seeing a few records not make it to the platform. After validating that both source and platform counts were accurate and there was a legitimate functional mismatch we determined there's an issue with how we use `print()` in the entrypoint.

## What the fix is

There is a Python article related to print buffers: https://realpython.com/python-flush-print-output/#set-the-flush-parameter-if-youve-disabled-newlines

> Note: Remember that changing flush to True when printing output to a terminal only has an effect if you don’t use the default value for end. If you kept the default value for end, which is the newline character, then the data buffer would already flush automatically after each call to print(), even without the explicit flush=True.

In an earlier [PR](https://github.com/airbytehq/airbyte/pull/34578) to fix concurrent CDK printing, we made a small change that replaced the default end value from `\n` to `""`, this had the side effect of disabling automatically flushing the print buffer. Adding back `flush=True`, gets us back to the previous behavior while still retaining the original fix that was made.

This does give me a slight pause because always flushing can have performance implications, but I think our biggest performance bottleneck is still like API request/response and this fix just aligns back to how things were acting before. I wish it were super clear why `print()` at high volume isn't working, but right now we need to fix the dropped records



<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 565847ed1e29294fee4d07bdf1cf46f91ea727f8.  | 
|--------|--------|

### Summary:
This PR fixes an issue with dropped records during syncs by adding `flush=True` to the `print()` function in the `launch()` function in `/airbyte-cdk/python/airbyte_cdk/entrypoint.py`, restoring automatic flushing of the print buffer.

**Key points**:
- Identified an issue with the use of `print()` in the entrypoint causing dropped records during syncs to `source-salesforce` and `source-stripe`.
- Added `flush=True` to the `print()` function in the `launch()` function in `/airbyte-cdk/python/airbyte_cdk/entrypoint.py` to restore automatic flushing of the print buffer.
- The change is expected to fix the issue of dropped records without significantly impacting performance.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
