### PR TITLE
Source Quick Books: hide in cloud

### DIFF
--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -21,7 +21,7 @@ data:
       packageName: airbyte-source-quickbooks
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
Connector have hidden in cloud as its cannot be configured - https://airbyte-globallogic.slack.com/archives/C02U9R3AF37/p1712858803196519?thread_ts=1706114304.283499&cid=C02U9R3AF37

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 97bf384141494771b44b1097b6f8b6dd6082a841.  | 
|--------|--------|

### Summary:
This PR disables the QuickBooks connector in the cloud by modifying the `enabled` field in the `metadata.yaml` file of the `source-quickbooks` connector.

**Key points**:
- Disabled QuickBooks connector in the cloud
- Change made in `metadata.yaml` file of `source-quickbooks` connector
- `enabled` field under `cloud` in `registries` changed from `true` to `false`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
