### PR TITLE
🐛  Source Salesforce: have clear error when stream preparation fails

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b117307c-14b6-41aa-9422-947e34922962
-  dockerImageTag: 2.5.1
+  dockerImageTag: 2.5.2
   dockerRepository: airbyte/source-salesforce
   documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce
   githubIssueLabel: source-salesforce

--- a/airbyte-integrations/connectors/source-salesforce/poetry.lock
+++ b/airbyte-integrations/connectors/source-salesforce/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "airbyte-cdk"
-version = "0.81.3"
+version = "0.81.4"
 description = "A framework for writing Airbyte Connectors."
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "airbyte_cdk-0.81.3-py3-none-any.whl", hash = "sha256:c168acef484120f5b392cbf0c43bb8180d8596a0c87cfe416ac2e8e7fe1ab93a"},
-    {file = "airbyte_cdk-0.81.3.tar.gz", hash = "sha256:e91e7ca66b3f4d5714b44304ff3cb1bb9b703933cf6b38d32e7f06384e9e1108"},
+    {file = "airbyte_cdk-0.81.4-py3-none-any.whl", hash = "sha256:4ed193da4e8be4867e1d8983172d10afb3c3b10f3e10ec618431deec1f2af4cb"},
+    {file = "airbyte_cdk-0.81.4.tar.gz", hash = "sha256:5c63d8c792edf5f24d0ad804b34b3ebcc056ecede6cb4f87ebf9ac07aa987f24"},
 ]
 
 [package.dependencies]

--- a/airbyte-integrations/connectors/source-salesforce/pyproject.toml
+++ b/airbyte-integrations/connectors/source-salesforce/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.5.1"
+version = "2.5.2"
 name = "source-salesforce"
 description = "Source implementation for Salesforce."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
@@ -374,7 +374,13 @@ class Salesforce:
                 ):
                     if err:
                         self.logger.error(f"Loading error of the {stream_name} schema: {err}")
-                        continue
+                        # Without schema information, the source can't determine the type of stream to instantiate and there might be issues
+                        # related to property chunking
+                        raise AirbyteTracedException(
+                            message=f"Schema could not be extracted for stream {stream_name}. Please retry later.",
+                            internal_message=str(err),
+                            failure_type=FailureType.system_error,
+                        )
                     stream_schemas[stream_name] = schema
         return stream_schemas
 

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
@@ -10,7 +10,7 @@ import backoff
 import requests  # type: ignore[import]
 from airbyte_cdk.models import ConfiguredAirbyteCatalog
 from airbyte_cdk.utils import AirbyteTracedException
-from airbyte_protocol.models import FailureType
+from airbyte_protocol.models import FailureType, StreamDescriptor
 from requests import adapters as request_adapters
 from requests.exceptions import HTTPError, RequestException  # type: ignore[import]
 
@@ -380,6 +380,7 @@ class Salesforce:
                             message=f"Schema could not be extracted for stream {stream_name}. Please retry later.",
                             internal_message=str(err),
                             failure_type=FailureType.system_error,
+                            stream_descriptor=StreamDescriptor(name=stream_name),
                         )
                     stream_schemas[stream_name] = schema
         return stream_schemas

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -3,22 +3,17 @@
 import json
 import urllib.parse
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional
 from unittest import TestCase
 
 import freezegun
-from airbyte_cdk.sources.source import TState
-from airbyte_cdk.test.catalog_builder import CatalogBuilder
-from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput, read
 from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
-from airbyte_cdk.test.mock_http.request import ANY_QUERY_PARAMS
-from airbyte_cdk.test.state_builder import StateBuilder
-from airbyte_protocol.models import ConfiguredAirbyteCatalog, SyncMode
+from airbyte_protocol.models import SyncMode
 from config_builder import ConfigBuilder
-from integration.utils import given_stream
+from integration.utils import given_authentication, given_stream, read
 from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
-from source_salesforce import SourceSalesforce
 from source_salesforce.streams import LOOKBACK_SECONDS
+
 
 _A_FIELD_NAME = "a_field"
 _ACCESS_TOKEN = "an_access_token"
@@ -34,37 +29,6 @@ _REFRESH_TOKEN = "a_refresh_token"
 _STREAM_NAME = "a_stream_name"
 
 _BASE_URL = f"{_INSTANCE_URL}/services/data/{_API_VERSION}"
-
-
-def _catalog(sync_mode: SyncMode) -> ConfiguredAirbyteCatalog:
-    return CatalogBuilder().with_stream(_STREAM_NAME, sync_mode).build()
-
-
-def _source(catalog: ConfiguredAirbyteCatalog, config: Dict[str, Any], state: Optional[TState]) -> SourceSalesforce:
-    return SourceSalesforce(catalog, config, state)
-
-
-def _read(
-    sync_mode: SyncMode,
-    config_builder: Optional[ConfigBuilder] = None,
-    state_builder: Optional[StateBuilder] = None,
-    expecting_exception: bool = False
-) -> EntrypointOutput:
-    catalog = _catalog(sync_mode)
-    config = config_builder.build() if config_builder else ConfigBuilder().build()
-    state = state_builder.build() if state_builder else StateBuilder().build()
-    return read(_source(catalog, config, state), config, catalog, state, expecting_exception)
-
-
-def _given_authentication(http_mocker: HttpMocker, client_id: str, client_secret: str, refresh_token: str) -> None:
-    http_mocker.post(
-        HttpRequest(
-            "https://login.salesforce.com/services/oauth2/token",
-            query_params=ANY_QUERY_PARAMS,
-            body=f"grant_type=refresh_token&client_id={client_id}&client_secret={client_secret}&refresh_token={refresh_token}"
-        ),
-        HttpResponse(json.dumps({"access_token": _ACCESS_TOKEN, "instance_url": _INSTANCE_URL})),
-    )
 
 
 def _create_field(name: str, _type: Optional[str] = None) -> Dict[str, Any]:
@@ -93,7 +57,7 @@ class FullRefreshTest(TestCase):
 
     @HttpMocker()
     def test_when_read_then_create_job_and_extract_records_from_result(self, http_mocker: HttpMocker) -> None:
-        _given_authentication(http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN)
+        given_authentication(http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN, _INSTANCE_URL)
         given_stream(http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         http_mocker.post(
             HttpRequest(f"{_BASE_URL}/jobs/query", body=json.dumps({"operation": "queryAll", "query": "SELECT a_field FROM a_stream_name", "contentType": "CSV", "columnDelimiter": "COMMA", "lineEnding": "LF"})),
@@ -108,6 +72,6 @@ class FullRefreshTest(TestCase):
             HttpResponse(f"{_A_FIELD_NAME}\nfield_value"),
         )
 
-        output = _read(SyncMode.full_refresh, self._config)
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
 
         assert len(output.records) == 1

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -10,14 +10,12 @@ import freezegun
 from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
 from airbyte_protocol.models import SyncMode
 from config_builder import ConfigBuilder
-from integration.utils import given_authentication, given_stream, read
+from integration.utils import create_base_url, given_authentication, given_stream, read
 from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
 from source_salesforce.streams import LOOKBACK_SECONDS
 
-
 _A_FIELD_NAME = "a_field"
 _ACCESS_TOKEN = "an_access_token"
-_API_VERSION = "v57.0"
 _CLIENT_ID = "a_client_id"
 _CLIENT_SECRET = "a_client_secret"
 _CURSOR_FIELD = "SystemModstamp"
@@ -28,7 +26,7 @@ _NOW = datetime.now(timezone.utc)
 _REFRESH_TOKEN = "a_refresh_token"
 _STREAM_NAME = "a_stream_name"
 
-_BASE_URL = f"{_INSTANCE_URL}/services/data/{_API_VERSION}"
+_BASE_URL = create_base_url(_INSTANCE_URL)
 
 
 def _create_field(name: str, _type: Optional[str] = None) -> Dict[str, Any]:

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_rest_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_rest_stream.py
@@ -3,26 +3,21 @@
 import json
 import urllib.parse
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional
 from unittest import TestCase
 
 import freezegun
-from airbyte_cdk.sources.source import TState
-from airbyte_cdk.test.catalog_builder import CatalogBuilder
-from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput, read
 from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
-from airbyte_cdk.test.mock_http.request import ANY_QUERY_PARAMS
+
 from airbyte_cdk.test.state_builder import StateBuilder
-from airbyte_protocol.models import ConfiguredAirbyteCatalog, SyncMode
+from airbyte_protocol.models import SyncMode
 from config_builder import ConfigBuilder
-from integration.utils import given_stream
+from integration.utils import given_authentication, given_stream, read
 from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
-from source_salesforce import SourceSalesforce
 from source_salesforce.api import UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS
 from source_salesforce.streams import LOOKBACK_SECONDS
 
 _A_FIELD_NAME = "a_field"
-_ACCESS_TOKEN = "an_access_token"
 _API_VERSION = "v57.0"
 _CLIENT_ID = "a_client_id"
 _CLIENT_SECRET = "a_client_secret"
@@ -33,37 +28,6 @@ _LOOKBACK_WINDOW = timedelta(seconds=LOOKBACK_SECONDS)
 _NOW = datetime.now(timezone.utc)
 _REFRESH_TOKEN = "a_refresh_token"
 _STREAM_NAME = UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS[0]
-
-
-def _catalog(sync_mode: SyncMode) -> ConfiguredAirbyteCatalog:
-    return CatalogBuilder().with_stream(_STREAM_NAME, sync_mode).build()
-
-
-def _source(catalog: ConfiguredAirbyteCatalog, config: Dict[str, Any], state: Optional[TState]) -> SourceSalesforce:
-    return SourceSalesforce(catalog, config, state)
-
-
-def _read(
-    sync_mode: SyncMode,
-    config_builder: Optional[ConfigBuilder] = None,
-    state_builder: Optional[StateBuilder] = None,
-    expecting_exception: bool = False
-) -> EntrypointOutput:
-    catalog = _catalog(sync_mode)
-    config = config_builder.build() if config_builder else ConfigBuilder().build()
-    state = state_builder.build() if state_builder else StateBuilder().build()
-    return read(_source(catalog, config, state), config, catalog, state, expecting_exception)
-
-
-def _given_authentication(http_mocker: HttpMocker, client_id: str, client_secret: str, refresh_token: str) -> None:
-    http_mocker.post(
-        HttpRequest(
-            "https://login.salesforce.com/services/oauth2/token",
-            query_params=ANY_QUERY_PARAMS,
-            body=f"grant_type=refresh_token&client_id={client_id}&client_secret={client_secret}&refresh_token={refresh_token}"
-        ),
-        HttpResponse(json.dumps({"access_token": _ACCESS_TOKEN, "instance_url": _INSTANCE_URL})),
-    )
 
 
 def _create_field(name: str, _type: Optional[str] = None) -> Dict[str, Any]:
@@ -92,7 +56,7 @@ class FullRefreshTest(TestCase):
 
     @HttpMocker()
     def test_given_error_on_fetch_chunk_when_read_then_retry(self, http_mocker: HttpMocker) -> None:
-        _given_authentication(http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN)
+        given_authentication(http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN, _INSTANCE_URL)
         given_stream(http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         http_mocker.get(
             HttpRequest(f"{_INSTANCE_URL}/services/data/{_API_VERSION}/queryAll?q=SELECT+{_A_FIELD_NAME}+FROM+{_STREAM_NAME}+"),
@@ -102,7 +66,7 @@ class FullRefreshTest(TestCase):
             ]
         )
 
-        output = _read(SyncMode.full_refresh, self._config)
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
 
         assert len(output.records) == 1
 
@@ -115,7 +79,7 @@ class IncrementalTest(TestCase):
         self._http_mocker = HttpMocker()
         self._http_mocker.__enter__()
 
-        _given_authentication(self._http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN)
+        given_authentication(self._http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN, _INSTANCE_URL)
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME).field(_CURSOR_FIELD, "datetime"))
 
     def tearDown(self) -> None:
@@ -132,7 +96,7 @@ class IncrementalTest(TestCase):
             HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
         )
 
-        _read(SyncMode.incremental, self._config, StateBuilder().with_stream_state(_STREAM_NAME, {}))
+        read(_STREAM_NAME, SyncMode.incremental, self._config, StateBuilder().with_stream_state(_STREAM_NAME, {}))
 
         # then HTTP requests are performed
 
@@ -145,7 +109,7 @@ class IncrementalTest(TestCase):
             HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
         )
 
-        output = _read(SyncMode.incremental, self._config, StateBuilder().with_stream_state(_STREAM_NAME, {_CURSOR_FIELD: cursor_value.isoformat(timespec="milliseconds")}))
+        output = read(_STREAM_NAME, SyncMode.incremental, self._config, StateBuilder().with_stream_state(_STREAM_NAME, {_CURSOR_FIELD: cursor_value.isoformat(timespec="milliseconds")}))
 
         assert output.most_recent_state.stream_state.dict() == {"state_type": "date-range", "slices": [{"start": _to_partitioned_datetime(start), "end": _to_partitioned_datetime(_NOW)}]}
 
@@ -174,7 +138,7 @@ class IncrementalTest(TestCase):
             HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
         )
 
-        output = _read(SyncMode.incremental, self._config, state)
+        output = read(_STREAM_NAME, SyncMode.incremental, self._config, state)
 
         # the start is granular to the second hence why we have `000` in terms of milliseconds
         assert output.most_recent_state.stream_state.dict() == {"state_type": "date-range", "slices": [{"start": _to_partitioned_datetime(start), "end": _to_partitioned_datetime(_NOW)}]}

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_source.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_source.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+import json
+from unittest import TestCase
+
+import pytest
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
+from airbyte_cdk.test.state_builder import StateBuilder
+from airbyte_cdk.utils.traced_exception import AirbyteTracedException
+from airbyte_protocol.models import FailureType, SyncMode
+from config_builder import ConfigBuilder
+from integration.utils import create_base_url, given_authentication, given_stream
+from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
+from source_salesforce import SourceSalesforce
+
+_CLIENT_ID = "a_client_id"
+_CLIENT_SECRET = "a_client_secret"
+_FIELD_NAME = "a_field_name"
+_INSTANCE_URL = "https://instance.salesforce.com"
+_REFRESH_TOKEN = "a_refresh_token"
+_STREAM_NAME = "StreamName"
+
+_BASE_URL = create_base_url(_INSTANCE_URL)
+
+
+class StreamGenerationTest(TestCase):
+
+    def setUp(self) -> None:
+        self._config = ConfigBuilder().client_id(_CLIENT_ID).client_secret(_CLIENT_SECRET).refresh_token(_REFRESH_TOKEN).build()
+        self._source = SourceSalesforce(
+            CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build(),
+            self._config,
+            StateBuilder().build()
+        )
+
+        self._http_mocker = HttpMocker()
+        self._http_mocker.__enter__()
+
+    def tearDown(self) -> None:
+        self._http_mocker.__exit__(None, None, None)
+
+    def test_given_transient_error_fetching_schema_when_streams_then_retry(self) -> None:
+        given_authentication(self._http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN, _INSTANCE_URL)
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/sobjects"),
+            HttpResponse(json.dumps({"sobjects": [{"name": _STREAM_NAME, "queryable": True}]})),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/sobjects/{_STREAM_NAME}/describe"),
+            [
+                HttpResponse("", status_code=406),
+                SalesforceDescribeResponseBuilder().field("a_field_name").build()
+            ]
+        )
+
+        streams = self._source.streams(self._config)
+
+        assert len(streams) == 2  # _STREAM_NAME and Describe which is always added
+        assert _FIELD_NAME in next(filter(lambda stream: stream.name == _STREAM_NAME, streams)).get_json_schema()["properties"]
+
+    def test_given_errors_fetching_schema_when_streams_then_raise_exception(self) -> None:
+        given_authentication(self._http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN, _INSTANCE_URL)
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/sobjects"),
+            HttpResponse(json.dumps({"sobjects": [{"name": _STREAM_NAME, "queryable": True}]})),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/sobjects/{_STREAM_NAME}/describe"),
+            HttpResponse("", status_code=406),
+        )
+
+        with pytest.raises(AirbyteTracedException) as exception:
+            self._source.streams(self._config)
+
+        assert exception.value.failure_type == FailureType.system_error

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/utils.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/utils.py
@@ -1,9 +1,52 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
 import json
+from typing import Any, Dict, Optional
 
+
+from airbyte_cdk.sources.source import TState
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput, read as entrypoint_read
 from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
+from airbyte_cdk.test.mock_http.request import ANY_QUERY_PARAMS
+from airbyte_cdk.test.state_builder import StateBuilder
+from airbyte_protocol.models import SyncMode, ConfiguredAirbyteCatalog
+
+from config_builder import ConfigBuilder
 from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
+from source_salesforce import SourceSalesforce
+
+
+def _catalog(stream_name: str, sync_mode: SyncMode) -> ConfiguredAirbyteCatalog:
+    return CatalogBuilder().with_stream(stream_name, sync_mode).build()
+
+
+def _source(catalog: ConfiguredAirbyteCatalog, config: Dict[str, Any], state: Optional[TState]) -> SourceSalesforce:
+    return SourceSalesforce(catalog, config, state)
+
+
+def read(
+    stream_name: str,
+    sync_mode: SyncMode,
+    config_builder: Optional[ConfigBuilder] = None,
+    state_builder: Optional[StateBuilder] = None,
+    expecting_exception: bool = False
+) -> EntrypointOutput:
+    catalog = _catalog(stream_name, sync_mode)
+    config = config_builder.build() if config_builder else ConfigBuilder().build()
+    state = state_builder.build() if state_builder else StateBuilder().build()
+    return entrypoint_read(_source(catalog, config, state), config, catalog, state, expecting_exception)
+
+
+def given_authentication(http_mocker: HttpMocker, client_id: str, client_secret: str, refresh_token: str, instance_url: str) -> None:
+    http_mocker.post(
+        HttpRequest(
+            "https://login.salesforce.com/services/oauth2/token",
+            query_params=ANY_QUERY_PARAMS,
+            body=f"grant_type=refresh_token&client_id={client_id}&client_secret={client_secret}&refresh_token={refresh_token}"
+        ),
+        HttpResponse(json.dumps({"access_token": "any_access_token", "instance_url": instance_url})),
+    )
 
 
 def given_stream(http_mocker: HttpMocker, base_url: str, stream_name: str, schema_builder: SalesforceDescribeResponseBuilder) -> None:

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/utils.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/utils.py
@@ -3,18 +3,19 @@
 import json
 from typing import Any, Dict, Optional
 
-
 from airbyte_cdk.sources.source import TState
 from airbyte_cdk.test.catalog_builder import CatalogBuilder
-from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput, read as entrypoint_read
+from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput
+from airbyte_cdk.test.entrypoint_wrapper import read as entrypoint_read
 from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
 from airbyte_cdk.test.mock_http.request import ANY_QUERY_PARAMS
 from airbyte_cdk.test.state_builder import StateBuilder
-from airbyte_protocol.models import SyncMode, ConfiguredAirbyteCatalog
-
+from airbyte_protocol.models import ConfiguredAirbyteCatalog, SyncMode
 from config_builder import ConfigBuilder
 from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
 from source_salesforce import SourceSalesforce
+
+_API_VERSION = "v57.0"
 
 
 def _catalog(stream_name: str, sync_mode: SyncMode) -> ConfiguredAirbyteCatalog:
@@ -23,6 +24,10 @@ def _catalog(stream_name: str, sync_mode: SyncMode) -> ConfiguredAirbyteCatalog:
 
 def _source(catalog: ConfiguredAirbyteCatalog, config: Dict[str, Any], state: Optional[TState]) -> SourceSalesforce:
     return SourceSalesforce(catalog, config, state)
+
+
+def create_base_url(instance_url: str) -> str:
+    return f"{instance_url}/services/data/{_API_VERSION}"
 
 
 def read(

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -193,7 +193,8 @@ Now that you have set up the Salesforce source connector, check out the followin
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| 2.5.1   | 2024-04-11 | [37001](https://github.com/airbytehq/airbyte/pull/37001)     | Update airbyte-cdk to flush print buffer for every message                                                                           |
+| 2.5.2   | 2024-04-15 | [37105](https://github.com/airbytehq/airbyte/pull/37105) | Raise error when schema generation fails                                                                                             |
+| 2.5.1   | 2024-04-11 | [37001](https://github.com/airbytehq/airbyte/pull/37001) | Update airbyte-cdk to flush print buffer for every message                                                                           |
 | 2.5.0   | 2024-04-11 | [36942](https://github.com/airbytehq/airbyte/pull/36942) | Move Salesforce to partitioned state in order to avoid stuck syncs                                                                   |
 | 2.4.4   | 2024-04-08 | [36901](https://github.com/airbytehq/airbyte/pull/36901) | Upgrade CDK for empty internal_message empty when ExceptionWithDisplayMessage raised                                                 |
 | 2.4.3   | 2024-04-08 | [36885](https://github.com/airbytehq/airbyte/pull/36885) | Add missing retry on REST API                                                                                                        |


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/6888 where a stream instantiation problem would cause cursor issue.

## How
The version 2.4.1 already added retries on this call so we don't expect to see the problem anymore. However, if it occurs, we want the error to be clear. Hence, a traced exception has been added.

## Proposed reading order
* Commit da619cfb9cb4a787994f83ee660256d303c9e072 that does add some clean up/remove code duplication
* Error was added: airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
* Tests to validate the new behavior: airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_source.py

## 🚨 User Impact 🚨 

None as we don't expect the error to come up anymore but if it does, we will have a better error message than before.