### PR TITLE
Destination CDK: Simplify AsyncStreamConsumer constructors

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -144,6 +144,7 @@ Maven and Gradle will automatically reference the correct (pinned) version of th
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.30.3  | 2024-04-12 | [\#37106](https://github.com/airbytehq/airbyte/pull/37106) | Destinations: Simplify constructors in `AsyncStreamConsumer`                                                                                                   |
 | 0.30.2  | 2024-04-12 | [\#36926](https://github.com/airbytehq/airbyte/pull/36926) | Destinations: Remove `JdbcSqlOperations#formatData`; misc changes for java interop                                                                             |
 | 0.30.1  | 2024-04-11 | [\#36919](https://github.com/airbytehq/airbyte/pull/36919) | Fix regression in sources conversion of null values                                                                                                            |
 | 0.30.0  | 2024-04-11 | [\#36974](https://github.com/airbytehq/airbyte/pull/36974) | Destinations: Pass config to jdbc sqlgenerator; allow cascade drop                                                                                             |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.30.2
+version=0.30.3

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumerTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumerTest.kt
@@ -7,8 +7,7 @@ package io.airbyte.cdk.integrations.destination.async
 import com.fasterxml.jackson.databind.JsonNode
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.integrations.destination.async.buffers.BufferManager
-import io.airbyte.cdk.integrations.destination.async.deser.DeserializationUtil
-import io.airbyte.cdk.integrations.destination.async.deser.IdentityDataTransformer
+import io.airbyte.cdk.integrations.destination.async.deser.AirbyteMessageDeserializer
 import io.airbyte.cdk.integrations.destination.async.deser.StreamAwareDataTransformer
 import io.airbyte.cdk.integrations.destination.async.function.DestinationFlushFunction
 import io.airbyte.cdk.integrations.destination.async.model.PartialAirbyteMessage
@@ -125,7 +124,7 @@ class AsyncStreamConsumerTest {
     private lateinit var outputRecordCollector: Consumer<AirbyteMessage>
     private lateinit var flushFailure: FlushFailure
     private lateinit var streamAwareDataTransformer: StreamAwareDataTransformer
-    private lateinit var deserializationUtil: DeserializationUtil
+    private lateinit var airbyteMessageDeserializer: AirbyteMessageDeserializer
 
     @BeforeEach
     @Suppress("UNCHECKED_CAST")
@@ -139,20 +138,18 @@ class AsyncStreamConsumerTest {
         flushFunction = Mockito.mock(DestinationFlushFunction::class.java)
         outputRecordCollector = Mockito.mock(Consumer::class.java) as Consumer<AirbyteMessage>
         flushFailure = Mockito.mock(FlushFailure::class.java)
-        deserializationUtil = DeserializationUtil()
-        streamAwareDataTransformer = IdentityDataTransformer()
+        airbyteMessageDeserializer = AirbyteMessageDeserializer()
         consumer =
             AsyncStreamConsumer(
                 outputRecordCollector = outputRecordCollector,
                 onStart = onStart,
                 onClose = onClose,
-                flusher = flushFunction,
+                onFlush = flushFunction,
                 catalog = CATALOG,
                 bufferManager = BufferManager(),
                 flushFailure = flushFailure,
                 defaultNamespace = Optional.of("default_ns"),
-                dataTransformer = streamAwareDataTransformer,
-                deserializationUtil = deserializationUtil,
+                airbyteMessageDeserializer = airbyteMessageDeserializer,
                 workerPool = Executors.newFixedThreadPool(5),
             )
 
@@ -330,9 +327,8 @@ class AsyncStreamConsumerTest {
         val serializedAirbyteMessage = Jsons.serialize(airbyteMessage)
         val airbyteRecordString = Jsons.serialize(PAYLOAD)
         val partial =
-            deserializationUtil.deserializeAirbyteMessage(
+            airbyteMessageDeserializer.deserializeAirbyteMessage(
                 serializedAirbyteMessage,
-                streamAwareDataTransformer,
             )
         assertEquals(airbyteRecordString, partial.serialized)
     }
@@ -357,9 +353,8 @@ class AsyncStreamConsumerTest {
         val serializedAirbyteMessage = Jsons.serialize(airbyteMessage)
         val airbyteRecordString = Jsons.serialize(payload)
         val partial =
-            deserializationUtil.deserializeAirbyteMessage(
+            airbyteMessageDeserializer.deserializeAirbyteMessage(
                 serializedAirbyteMessage,
-                streamAwareDataTransformer,
             )
         assertEquals(airbyteRecordString, partial.serialized)
     }
@@ -378,9 +373,8 @@ class AsyncStreamConsumerTest {
                 )
         val serializedAirbyteMessage = Jsons.serialize(airbyteMessage)
         val partial =
-            deserializationUtil.deserializeAirbyteMessage(
+            airbyteMessageDeserializer.deserializeAirbyteMessage(
                 serializedAirbyteMessage,
-                streamAwareDataTransformer,
             )
         assertEquals(emptyMap.toString(), partial.serialized)
     }
@@ -393,9 +387,8 @@ class AsyncStreamConsumerTest {
         assertThrows(
             RuntimeException::class.java,
         ) {
-            deserializationUtil.deserializeAirbyteMessage(
+            airbyteMessageDeserializer.deserializeAirbyteMessage(
                 serializedAirbyteMessage,
-                streamAwareDataTransformer,
             )
         }
     }
@@ -404,9 +397,8 @@ class AsyncStreamConsumerTest {
     internal fun deserializeAirbyteMessageWithAirbyteState() {
         val serializedAirbyteMessage = Jsons.serialize(STATE_MESSAGE1)
         val partial =
-            deserializationUtil.deserializeAirbyteMessage(
+            airbyteMessageDeserializer.deserializeAirbyteMessage(
                 serializedAirbyteMessage,
-                streamAwareDataTransformer,
             )
         assertEquals(serializedAirbyteMessage, partial.serialized)
     }
@@ -430,9 +422,8 @@ class AsyncStreamConsumerTest {
         assertThrows(
             RuntimeException::class.java,
         ) {
-            deserializationUtil.deserializeAirbyteMessage(
+            airbyteMessageDeserializer.deserializeAirbyteMessage(
                 serializedAirbyteMessage,
-                streamAwareDataTransformer,
             )
         }
     }

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/JdbcBufferedConsumerFactory.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/JdbcBufferedConsumerFactory.kt
@@ -15,7 +15,7 @@ import io.airbyte.cdk.integrations.destination.NamingConventionTransformer
 import io.airbyte.cdk.integrations.destination.StreamSyncSummary
 import io.airbyte.cdk.integrations.destination.async.AsyncStreamConsumer
 import io.airbyte.cdk.integrations.destination.async.buffers.BufferManager
-import io.airbyte.cdk.integrations.destination.async.deser.DeserializationUtil
+import io.airbyte.cdk.integrations.destination.async.deser.AirbyteMessageDeserializer
 import io.airbyte.cdk.integrations.destination.async.deser.IdentityDataTransformer
 import io.airbyte.cdk.integrations.destination.async.deser.StreamAwareDataTransformer
 import io.airbyte.cdk.integrations.destination.async.model.PartialAirbyteMessage
@@ -78,11 +78,10 @@ object JdbcBufferedConsumerFactory {
             ),
             catalog,
             BufferManager((Runtime.getRuntime().maxMemory() * 0.2).toLong()),
-            FlushFailure(),
             Optional.ofNullable(defaultNamespace),
+            FlushFailure(),
             Executors.newFixedThreadPool(2),
-            dataTransformer,
-            DeserializationUtil()
+            AirbyteMessageDeserializer(dataTransformer)
         )
     }
 

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/staging/AsyncFlush.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/staging/AsyncFlush.kt
@@ -25,7 +25,7 @@ import org.apache.commons.io.FileUtils
 private val logger = KotlinLogging.logger {}
 
 internal class AsyncFlush(
-    streamDescToWriteConfig: Map<StreamDescriptor, WriteConfig>,
+    private val streamDescToWriteConfig: Map<StreamDescriptor, WriteConfig>,
     private val stagingOperations: StagingOperations?,
     private val database: JdbcDatabase?,
     private val catalog: ConfiguredAirbyteCatalog?,
@@ -41,8 +41,6 @@ internal class AsyncFlush(
     override val optimalBatchSizeBytes: Long,
     private val useDestinationsV2Columns: Boolean
 ) : DestinationFlushFunction {
-    private val streamDescToWriteConfig: Map<StreamDescriptor, WriteConfig> =
-        streamDescToWriteConfig
 
     @Throws(Exception::class)
     override fun flush(decs: StreamDescriptor, stream: Stream<PartialAirbyteMessage>) {


### PR DESCRIPTION
### TL;DR

This pull request removes complex constructors and unifies into single constructor in `AsyncStreamConsumer` and related classes.

### What changed?

- Renamed `DeserializationUtil` to `AirbyteMessageDeserializer`
- Simplified Injection of `Transformer` & `Deserializer`
- Removed combinatorics constructors in `AsyncStreamConsumer`
- Updated references in `StagingConsumerFactory` & `JdbcBufferedConsumerFactory`


