### PR TITLE
connector builder: Set state on stream slices

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -164,6 +164,7 @@ class MessageGrouper:
         current_slice_pages: List[StreamReadPages] = []
         current_page_request: Optional[HttpRequest] = None
         current_page_response: Optional[HttpResponse] = None
+        latest_state_message = Optional = None
 
         while records_count < limit and (message := next(messages, None)):
             json_object = self._parse_json(message.log) if message.type == MessageType.LOG else None
@@ -180,7 +181,7 @@ class MessageGrouper:
                 and message.type == MessageType.LOG
                 and message.log.message.startswith(SliceLogger.SLICE_LOG_PREFIX)
             ):
-                yield StreamReadSlices(pages=current_slice_pages, slice_descriptor=current_slice_descriptor)
+                yield StreamReadSlices(pages=current_slice_pages, slice_descriptor=current_slice_descriptor, state=latest_state_message)
                 current_slice_descriptor = self._parse_slice_description(message.log.message)
                 current_slice_pages = []
                 at_least_one_page_in_group = False
@@ -222,10 +223,12 @@ class MessageGrouper:
                 datetime_format_inferrer.accumulate(message.record)
             elif message.type == MessageType.CONTROL and message.control.type == OrchestratorType.CONNECTOR_CONFIG:
                 yield message.control
+            elif message.type == MessageType.STATE:
+                latest_state_message = message.state
         else:
             if current_page_request or current_page_response or current_page_records:
                 self._close_page(current_page_request, current_page_response, current_slice_pages, current_page_records)
-                yield StreamReadSlices(pages=current_slice_pages, slice_descriptor=current_slice_descriptor)
+                yield StreamReadSlices(pages=current_slice_pages, slice_descriptor=current_slice_descriptor, state=latest_state_message)
 
     @staticmethod
     def _need_to_close_page(at_least_one_page_in_group: bool, message: AirbyteMessage, json_message: Optional[Dict[str, Any]]) -> bool:

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -164,7 +164,7 @@ class MessageGrouper:
         current_slice_pages: List[StreamReadPages] = []
         current_page_request: Optional[HttpRequest] = None
         current_page_response: Optional[HttpResponse] = None
-        latest_state_message = Optional = None
+        latest_state_message: Optional[Dict[str, Any]] = None
 
         while records_count < limit and (message := next(messages, None)):
             json_object = self._parse_json(message.log) if message.type == MessageType.LOG else None

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -6,7 +6,6 @@ import copy
 import dataclasses
 import json
 import logging
-import os
 from unittest import mock
 from unittest.mock import MagicMock, patch
 

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -165,10 +165,10 @@ DUMMY_CATALOG = {
             "stream": {
                 "name": "dummy_stream",
                 "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
-                "supported_sync_modes": ["full_refresh"],
+                "supported_sync_modes": ["full_refresh", "incremental"],
                 "source_defined_cursor": False,
             },
-            "sync_mode": "full_refresh",
+            "sync_mode": "incremental",
             "destination_sync_mode": "overwrite",
         }
     ]
@@ -180,10 +180,10 @@ CONFIGURED_CATALOG = {
             "stream": {
                 "name": _stream_name,
                 "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}},
-                "supported_sync_modes": ["full_refresh"],
+                "supported_sync_modes": ["full_refresh", "incremental"],
                 "source_defined_cursor": False,
             },
-            "sync_mode": "full_refresh",
+            "sync_mode": "incremental",
             "destination_sync_mode": "overwrite",
         }
     ]
@@ -775,109 +775,3 @@ def test_read_source_single_page_single_slice(mock_http_stream):
     streams = source.streams(config)
     for s in streams:
         assert isinstance(s.retriever, SimpleRetrieverTestReadDecorator)
-
-
-@pytest.mark.parametrize(
-    "deployment_mode, url_base, expected_error",
-    [
-        pytest.param("CLOUD", "https://airbyte.com/api/v1/characters", None, id="test_cloud_read_with_public_endpoint"),
-        pytest.param("CLOUD", "https://10.0.27.27", "AirbyteTracedException", id="test_cloud_read_with_private_endpoint"),
-        pytest.param("CLOUD", "https://localhost:80/api/v1/cast", "AirbyteTracedException", id="test_cloud_read_with_localhost"),
-        pytest.param("CLOUD", "http://unsecured.protocol/api/v1", "InvalidSchema", id="test_cloud_read_with_unsecured_endpoint"),
-        pytest.param("CLOUD", "https://domainwithoutextension", "Invalid URL", id="test_cloud_read_with_invalid_url_endpoint"),
-        pytest.param("OSS", "https://airbyte.com/api/v1/", None, id="test_oss_read_with_public_endpoint"),
-        pytest.param("OSS", "https://10.0.27.27/api/v1/", None, id="test_oss_read_with_private_endpoint"),
-    ],
-)
-@patch.object(requests.Session, "send", _mocked_send)
-def test_handle_read_external_requests(deployment_mode, url_base, expected_error):
-    """
-    This test acts like an integration test for the connector builder when it receives Test Read requests.
-
-    The scenario being tested is whether requests should be denied if they are done on an unsecure channel or are made to internal
-    endpoints when running on Cloud or OSS deployments
-    """
-
-    limits = TestReadLimits(max_records=100, max_pages_per_slice=1, max_slices=1)
-
-    catalog = ConfiguredAirbyteCatalog(
-        streams=[
-            ConfiguredAirbyteStream(
-                stream=AirbyteStream(name=_stream_name, json_schema={}, supported_sync_modes=[SyncMode.full_refresh]),
-                sync_mode=SyncMode.full_refresh,
-                destination_sync_mode=DestinationSyncMode.append,
-            )
-        ]
-    )
-
-    test_manifest = MANIFEST
-    test_manifest["streams"][0]["$parameters"]["url_base"] = url_base
-    config = {"__injected_declarative_manifest": test_manifest}
-
-    source = create_source(config, limits)
-
-    with mock.patch.dict(os.environ, {"DEPLOYMENT_MODE": deployment_mode}, clear=False):
-        output_data = read_stream(source, config, catalog, limits).record.data
-        if expected_error:
-            assert len(output_data["logs"]) > 0, "Expected at least one log message with the expected error"
-            error_message = output_data["logs"][0]
-            assert error_message["level"] == "ERROR"
-            assert expected_error in error_message["message"]
-        else:
-            page_records = output_data["slices"][0]["pages"][0]
-            assert len(page_records) == len(MOCK_RESPONSE["result"])
-
-
-@pytest.mark.parametrize(
-    "deployment_mode, token_url, expected_error",
-    [
-        pytest.param("CLOUD", "https://airbyte.com/tokens/bearer", None, id="test_cloud_read_with_public_endpoint"),
-        pytest.param("CLOUD", "https://10.0.27.27/tokens/bearer", "AirbyteTracedException", id="test_cloud_read_with_private_endpoint"),
-        pytest.param("CLOUD", "http://unsecured.protocol/tokens/bearer", "InvalidSchema", id="test_cloud_read_with_unsecured_endpoint"),
-        pytest.param("CLOUD", "https://domainwithoutextension", "Invalid URL", id="test_cloud_read_with_invalid_url_endpoint"),
-        pytest.param("OSS", "https://airbyte.com/tokens/bearer", None, id="test_oss_read_with_public_endpoint"),
-        pytest.param("OSS", "https://10.0.27.27/tokens/bearer", None, id="test_oss_read_with_private_endpoint"),
-    ],
-)
-@patch.object(requests.Session, "send", _mocked_send)
-def test_handle_read_external_oauth_request(deployment_mode, token_url, expected_error):
-    """
-    This test acts like an integration test for the connector builder when it receives Test Read requests.
-
-    The scenario being tested is whether requests should be denied if they are done on an unsecure channel or are made to internal
-    endpoints when running on Cloud or OSS deployments
-    """
-
-    limits = TestReadLimits(max_records=100, max_pages_per_slice=1, max_slices=1)
-
-    catalog = ConfiguredAirbyteCatalog(
-        streams=[
-            ConfiguredAirbyteStream(
-                stream=AirbyteStream(name=_stream_name, json_schema={}, supported_sync_modes=[SyncMode.full_refresh]),
-                sync_mode=SyncMode.full_refresh,
-                destination_sync_mode=DestinationSyncMode.append,
-            )
-        ]
-    )
-
-    oauth_authenticator_config: dict[str, str] = {
-        "type": "OAuthAuthenticator",
-        "token_refresh_endpoint": token_url,
-        "client_id": "greta",
-        "client_secret": "teo",
-        "refresh_token": "john",
-    }
-
-    test_manifest = MANIFEST
-    test_manifest["definitions"]["retriever"]["requester"]["authenticator"] = oauth_authenticator_config
-    config = {"__injected_declarative_manifest": test_manifest}
-
-    source = create_source(config, limits)
-
-    with mock.patch.dict(os.environ, {"DEPLOYMENT_MODE": deployment_mode}, clear=False):
-        output_data = read_stream(source, config, catalog, limits).record.data
-        if expected_error:
-            assert len(output_data["logs"]) > 0, "Expected at least one log message with the expected error"
-            error_message = output_data["logs"][0]
-            assert error_message["level"] == "ERROR"
-            assert expected_error in error_message["message"]

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -15,7 +15,6 @@ from airbyte_cdk.models import (
     AirbyteLogMessage,
     AirbyteMessage,
     AirbyteRecordMessage,
-    AirbyteStateBlob,
     AirbyteStateMessage,
     AirbyteStreamState,
     Level,
@@ -704,6 +703,7 @@ def response_log_message(response: Mapping[str, Any]) -> AirbyteMessage:
 
 def record_message(stream: str, data: Mapping[str, Any]) -> AirbyteMessage:
     return AirbyteMessage(type=MessageType.RECORD, record=AirbyteRecordMessage(stream=stream, data=data, emitted_at=1234))
+
 
 def state_message(stream: str, data: Mapping[str, Any]) -> AirbyteMessage:
     return AirbyteMessage(type=MessageType.STATE, state=AirbyteStateMessage(stream=AirbyteStreamState(

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -15,8 +15,12 @@ from airbyte_cdk.models import (
     AirbyteLogMessage,
     AirbyteMessage,
     AirbyteRecordMessage,
+    AirbyteStateBlob,
+    AirbyteStateMessage,
+    AirbyteStreamState,
     Level,
     OrchestratorType,
+    StreamDescriptor,
 )
 from airbyte_cdk.models import Type as MessageType
 from unit_tests.connector_builder.utils import create_configured_catalog
@@ -470,6 +474,7 @@ def test_get_grouped_messages_with_many_slices(mock_entrypoint_read: Mock) -> No
                 request_response_log_message(request, response, url),
                 record_message("hashiras", {"name": "Obanai Iguro"}),
                 request_response_log_message(request, response, url),
+                state_message("hashiras", {"a_timestamp": 123}),
             ]
         ),
     )
@@ -486,12 +491,15 @@ def test_get_grouped_messages_with_many_slices(mock_entrypoint_read: Mock) -> No
     assert stream_read.slices[0].slice_descriptor == {"descriptor": "first_slice"}
     assert len(stream_read.slices[0].pages) == 1
     assert len(stream_read.slices[0].pages[0].records) == 1
+    assert stream_read.slices[0].state is None
 
     assert stream_read.slices[1].slice_descriptor == {"descriptor": "second_slice"}
     assert len(stream_read.slices[1].pages) == 3
     assert len(stream_read.slices[1].pages[0].records) == 2
     assert len(stream_read.slices[1].pages[1].records) == 1
     assert len(stream_read.slices[1].pages[2].records) == 0
+
+    assert stream_read.slices[1].state.stream.stream_state == {"a_timestamp": 123}
 
 
 @patch("airbyte_cdk.connector_builder.message_grouper.AirbyteEntrypoint.read")
@@ -696,6 +704,12 @@ def response_log_message(response: Mapping[str, Any]) -> AirbyteMessage:
 
 def record_message(stream: str, data: Mapping[str, Any]) -> AirbyteMessage:
     return AirbyteMessage(type=MessageType.RECORD, record=AirbyteRecordMessage(stream=stream, data=data, emitted_at=1234))
+
+def state_message(stream: str, data: Mapping[str, Any]) -> AirbyteMessage:
+    return AirbyteMessage(type=MessageType.STATE, state=AirbyteStateMessage(stream=AirbyteStreamState(
+        stream_descriptor=StreamDescriptor(name=stream),
+        stream_state=data
+    )))
 
 
 def slice_message(slice_descriptor: str = '{"key": "value"}') -> AirbyteMessage:


### PR DESCRIPTION
## What
Update the builder's message grouper to set the state on the output stream slices.

The BE server does not need to be updated, but we'll need to update the webapp to display them.

Solves a part of https://github.com/airbytehq/airbyte-internal-issues/issues/1561

## How
- Keep track of the latest state message emitted by the source
- Set the latest state on the stream slice before yielding it

Example response from the server:
![Screenshot 2024-04-15 at 10 24 53 AM](https://github.com/airbytehq/airbyte/assets/1451943/e30fab35-8685-4995-821e-1b91aef11c62)
