### PR TITLE
jvm connectors: allow integration tests in kotlin

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-java-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-java-connector.gradle
@@ -154,6 +154,9 @@ class AirbyteJavaConnectorPlugin implements Plugin<Project> {
                 java {
                     srcDir 'src/test-integration/java'
                 }
+                kotlin {
+                    srcDir 'src/test-integration/kotlin'
+                }
                 resources {
                     srcDir 'src/test-integration/resources'
                 }
@@ -161,6 +164,9 @@ class AirbyteJavaConnectorPlugin implements Plugin<Project> {
             performanceTestJava {
                 java {
                     srcDir 'src/test-performance/java'
+                }
+                kotlin {
+                    srcDir 'src/test-integration/kotlin'
                 }
                 resources {
                     srcDir 'src/test-performance/resources'


### PR DESCRIPTION
tested locally - was able to run tests on this branch https://github.com/airbytehq/airbyte/pull/36936 using `gw :airbyte-int:conn:dest-mysql:intTestJava --tests io.airbyte.integrations.destination.mysql.typing_deduping.MysqlSqlGeneratorIntegrationTest`