### PR TITLE
source-python-http-tutorial: ensure inline schemas, updated cdk, poetry (where possible)

### DIFF
--- a/airbyte-integrations/connectors/source-python-http-tutorial/source_python_http_tutorial/schemas/customers.json
+++ b/airbyte-integrations/connectors/source-python-http-tutorial/source_python_http_tutorial/schemas/customers.json
@@ -3,12 +3,15 @@
   "type": "object",
   "properties": {
     "id": {
+      "description": "The unique identifier for the customer.",
       "type": ["null", "string"]
     },
     "name": {
+      "description": "The full name of the customer.",
       "type": ["null", "string"]
     },
     "signup_date": {
+      "description": "The date and time when the customer signed up.",
       "type": ["null", "string"],
       "format": "date-time"
     }

--- a/airbyte-integrations/connectors/source-python-http-tutorial/source_python_http_tutorial/schemas/employees.json
+++ b/airbyte-integrations/connectors/source-python-http-tutorial/source_python_http_tutorial/schemas/employees.json
@@ -3,15 +3,19 @@
   "type": "object",
   "properties": {
     "id": {
+      "description": "Unique identifier for the employee.",
       "type": ["null", "string"]
     },
     "name": {
+      "description": "Name of the employee.",
       "type": ["null", "string"]
     },
     "years_of_service": {
+      "description": "Number of years the employee has been in service.",
       "type": ["null", "integer"]
     },
     "start_date": {
+      "description": "Date when the employee started their employment.",
       "type": ["null", "string"],
       "format": "date-time"
     }

--- a/airbyte-integrations/connectors/source-python-http-tutorial/source_python_http_tutorial/schemas/exchange_rates.json
+++ b/airbyte-integrations/connectors/source-python-http-tutorial/source_python_http_tutorial/schemas/exchange_rates.json
@@ -3,119 +3,157 @@
   "type": "object",
   "properties": {
     "access_key": {
+      "description": "Access key required to access the exchange rates data.",
       "type": "string"
     },
     "base": {
+      "description": "Base currency for the exchange rates.",
       "type": "string"
     },
     "rates": {
+      "description": "Object containing exchange rates for various currencies",
       "type": "object",
       "properties": {
         "GBP": {
+          "description": "British Pound exchange rate.",
           "type": "number"
         },
         "HKD": {
+          "description": "Hong Kong Dollar exchange rate.",
           "type": "number"
         },
         "IDR": {
+          "description": "Indonesian Rupiah exchange rate.",
           "type": "number"
         },
         "PHP": {
+          "description": "Philippine Peso exchange rate.",
           "type": "number"
         },
         "LVL": {
+          "description": "Latvian Lats exchange rate.",
           "type": "number"
         },
         "INR": {
+          "description": "Indian Rupee exchange rate.",
           "type": "number"
         },
         "CHF": {
+          "description": "Swiss Franc exchange rate.",
           "type": "number"
         },
         "MXN": {
+          "description": "Mexican Peso exchange rate.",
           "type": "number"
         },
         "SGD": {
+          "description": "Singapore Dollar exchange rate.",
           "type": "number"
         },
         "CZK": {
+          "description": "Czech Koruna exchange rate.",
           "type": "number"
         },
         "THB": {
+          "description": "Thai Baht exchange rate.",
           "type": "number"
         },
         "BGN": {
+          "description": "Bulgarian Lev exchange rate.",
           "type": "number"
         },
         "EUR": {
+          "description": "Euro exchange rate.",
           "type": "number"
         },
         "MYR": {
+          "description": "Malaysian Ringgit exchange rate.",
           "type": "number"
         },
         "NOK": {
+          "description": "Norwegian Krone exchange rate.",
           "type": "number"
         },
         "CNY": {
+          "description": "Chinese Yuan exchange rate.",
           "type": "number"
         },
         "HRK": {
+          "description": "Croatian Kuna exchange rate.",
           "type": "number"
         },
         "PLN": {
+          "description": "Polish Zloty exchange rate.",
           "type": "number"
         },
         "LTL": {
+          "description": "Lithuanian Litas exchange rate.",
           "type": "number"
         },
         "TRY": {
+          "description": "Turkish Lira exchange rate.",
           "type": "number"
         },
         "ZAR": {
+          "description": "South African Rand exchange rate.",
           "type": "number"
         },
         "CAD": {
+          "description": "Canadian Dollar exchange rate.",
           "type": "number"
         },
         "BRL": {
+          "description": "Brazilian Real exchange rate.",
           "type": "number"
         },
         "RON": {
+          "description": "Romanian Leu exchange rate.",
           "type": "number"
         },
         "DKK": {
+          "description": "Danish Krone exchange rate.",
           "type": "number"
         },
         "NZD": {
+          "description": "New Zealand Dollar exchange rate.",
           "type": "number"
         },
         "EEK": {
+          "description": "Estonian Kroon exchange rate.",
           "type": "number"
         },
         "JPY": {
+          "description": "Japanese Yen exchange rate.",
           "type": "number"
         },
         "RUB": {
+          "description": "Russian Ruble exchange rate.",
           "type": "number"
         },
         "KRW": {
+          "description": "South Korean Won exchange rate.",
           "type": "number"
         },
         "USD": {
+          "description": "US Dollar exchange rate.",
           "type": "number"
         },
         "AUD": {
+          "description": "Australian Dollar exchange rate.",
           "type": "number"
         },
         "HUF": {
+          "description": "Hungarian Forint exchange rate.",
           "type": "number"
         },
         "SEK": {
+          "description": "Swedish Krona exchange rate.",
           "type": "number"
         }
       }
     },
     "date": {
+      "description": "Date for which the exchange rates are applicable.",
       "type": "string"
     }
   }


### PR DESCRIPTION
This was created from a set of automated scripts. In each case, not every update was needed for every connector, but overall here is what happened:

 * `auto-schema update -s all description`: added descriptions to json and inline schemas
 * `connector-code migrate_to_yaml -c all --type source`: migrates json schemas to connectors with a manifest
 * `airbyte-ci connectors --name=<all modified connectors from above> migrate_to_base_image`: makes sure that each is using a base docker image and updates docs
 * `airbyte-ci connectors --name=<all modified connectors from above> migrate-to-poetry`: moves connectors not already using poetry to do so and updates documentation
 * `airbyte-ci connectors --name=<all modified connectors from above> up_to_date`: updated the CDK to newer (0.80.0) version

The version number and changelogs were also bumped using the `connector-code pulls` command.