### PR TITLE
Fix (source-facebook-marketing): [Do not merge] Update schema to use integer type for account id fields

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ad_account.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ad_account.json
@@ -69,7 +69,7 @@
       "type": ["null", "number"]
     },
     "end_advertiser": {
-      "type": ["null", "number"]
+      "type": ["null", "integer"]
     },
     "end_advertiser_name": {
       "type": ["null", "string"]
@@ -118,10 +118,10 @@
       }
     },
     "fb_entity": {
-      "type": ["null", "number"]
+      "type": ["null", "integer"]
     },
     "funding_source": {
-      "type": ["null", "number"]
+      "type": ["null", "integer"]
     },
     "funding_source_details": {
       "type": ["null", "object"],
@@ -186,7 +186,7 @@
       "type": ["null", "boolean"]
     },
     "owner": {
-      "type": ["null", "number"]
+      "type": ["null", "integer"]
     },
     "partner": {
       "type": ["null", "number"]

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -7,43 +7,50 @@ from typing import Any, List, Mapping, Optional, Tuple, Type
 
 import facebook_business
 import pendulum
-from airbyte_cdk.models import AdvancedAuth, AuthFlowType, ConnectorSpecification, DestinationSyncMode, FailureType, OAuthConfigSpecification
+from airbyte_cdk.models import (
+    AdvancedAuth,
+    AuthFlowType,
+    ConnectorSpecification,
+    DestinationSyncMode,
+    FailureType,
+    OAuthConfigSpecification,
+)
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.utils import AirbyteTracedException
 from source_facebook_marketing.api import API
 from source_facebook_marketing.spec import ConnectorConfig
 from source_facebook_marketing.streams import (
-        Activities,
-        AdAccount,
-        AdCreatives,
-        Ads,
-        AdSets,
-        AdsInsights,
-        AdsInsightsActionCarouselCard,
-        AdsInsightsActionConversionDevice,
-        AdsInsightsActionProductID,
-        AdsInsightsActionReaction,
-        AdsInsightsActionType,
-        AdsInsightsActionVideoSound,
-        AdsInsightsActionVideoType,
-        AdsInsightsAgeAndGender,
-        AdsInsightsCountry,
-        AdsInsightsDeliveryDevice,
-        AdsInsightsDeliveryPlatform,
-        AdsInsightsDeliveryPlatformAndDevicePlatform,
-        AdsInsightsDemographicsAge,
-        AdsInsightsDemographicsCountry,
-        AdsInsightsDemographicsDMARegion,
-        AdsInsightsDemographicsGender,
-        AdsInsightsDma,
-        AdsInsightsPlatformAndDevice,
-        AdsInsightsRegion,
-        Campaigns,
-        CustomAudiences,
-        CustomConversions,
-        Images,
-        Videos,
+    Activities,
+    AdAccount,
+    AdCreatives,
+    Ads,
+    AdSets,
+    AdsInsights,
+    AdsInsightsActionCarouselCard,
+    AdsInsightsActionConversionDevice,
+    AdsInsightsActionProductID,
+    AdsInsightsActionReaction,
+    AdsInsightsActionType,
+    AdsInsightsActionVideoSound,
+    AdsInsightsActionVideoType,
+    AdsInsightsAgeAndGender,
+    AdsInsightsCountry,
+    AdsInsightsDeliveryDevice,
+    AdsInsightsDeliveryPlatform,
+    AdsInsightsDeliveryPlatformAndDevicePlatform,
+    AdsInsightsDemographicsAge,
+    AdsInsightsDemographicsCountry,
+    AdsInsightsDemographicsDMARegion,
+    AdsInsightsDemographicsGender,
+    AdsInsightsDma,
+    AdsInsightsPlatformAndDevice,
+    AdsInsightsRegion,
+    Campaigns,
+    CustomAudiences,
+    CustomConversions,
+    Images,
+    Videos,
 )
 
 from .utils import validate_end_date, validate_start_date

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -7,50 +7,43 @@ from typing import Any, List, Mapping, Optional, Tuple, Type
 
 import facebook_business
 import pendulum
-from airbyte_cdk.models import (
-    AdvancedAuth,
-    AuthFlowType,
-    ConnectorSpecification,
-    DestinationSyncMode,
-    FailureType,
-    OAuthConfigSpecification,
-)
+from airbyte_cdk.models import AdvancedAuth, AuthFlowType, ConnectorSpecification, DestinationSyncMode, FailureType, OAuthConfigSpecification
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.utils import AirbyteTracedException
 from source_facebook_marketing.api import API
 from source_facebook_marketing.spec import ConnectorConfig
 from source_facebook_marketing.streams import (
-    Activities,
-    AdAccount,
-    AdCreatives,
-    Ads,
-    AdSets,
-    AdsInsights,
-    AdsInsightsActionCarouselCard,
-    AdsInsightsActionConversionDevice,
-    AdsInsightsActionProductID,
-    AdsInsightsActionReaction,
-    AdsInsightsActionType,
-    AdsInsightsActionVideoSound,
-    AdsInsightsActionVideoType,
-    AdsInsightsAgeAndGender,
-    AdsInsightsCountry,
-    AdsInsightsDeliveryDevice,
-    AdsInsightsDeliveryPlatform,
-    AdsInsightsDeliveryPlatformAndDevicePlatform,
-    AdsInsightsDemographicsAge,
-    AdsInsightsDemographicsCountry,
-    AdsInsightsDemographicsDMARegion,
-    AdsInsightsDemographicsGender,
-    AdsInsightsDma,
-    AdsInsightsPlatformAndDevice,
-    AdsInsightsRegion,
-    Campaigns,
-    CustomAudiences,
-    CustomConversions,
-    Images,
-    Videos,
+        Activities,
+        AdAccount,
+        AdCreatives,
+        Ads,
+        AdSets,
+        AdsInsights,
+        AdsInsightsActionCarouselCard,
+        AdsInsightsActionConversionDevice,
+        AdsInsightsActionProductID,
+        AdsInsightsActionReaction,
+        AdsInsightsActionType,
+        AdsInsightsActionVideoSound,
+        AdsInsightsActionVideoType,
+        AdsInsightsAgeAndGender,
+        AdsInsightsCountry,
+        AdsInsightsDeliveryDevice,
+        AdsInsightsDeliveryPlatform,
+        AdsInsightsDeliveryPlatformAndDevicePlatform,
+        AdsInsightsDemographicsAge,
+        AdsInsightsDemographicsCountry,
+        AdsInsightsDemographicsDMARegion,
+        AdsInsightsDemographicsGender,
+        AdsInsightsDma,
+        AdsInsightsPlatformAndDevice,
+        AdsInsightsRegion,
+        Campaigns,
+        CustomAudiences,
+        CustomConversions,
+        Images,
+        Videos,
 )
 
 from .utils import validate_end_date, validate_start_date


### PR DESCRIPTION
This probably needs some discussion before it could be merged. 

I'm not sure if this would entail a breaking change for existing users.

These are very long integer IDs (~15 digits) and the integer type is a more correct definition, I believe. 