### PR TITLE
:bug: File based CDK: do not raise RecordParseError if an OSError was raised before

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/avro_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/avro_parser.py
@@ -146,8 +146,8 @@ class AvroParser(FileTypeParser):
             raise ValueError(f"Expected ParquetFormat, got {avro_format}")
 
         line_no = 0
-        try:
-            with stream_reader.open_file(file, self.file_read_mode, self.ENCODING, logger) as fp:
+        with stream_reader.open_file(file, self.file_read_mode, self.ENCODING, logger) as fp:
+            try:
                 avro_reader = fastavro.reader(fp)
                 schema = avro_reader.writer_schema
                 schema_field_name_to_type = {field["name"]: field["type"] for field in schema["fields"]}
@@ -157,8 +157,8 @@ class AvroParser(FileTypeParser):
                         record_field: self._to_output_value(avro_format, schema_field_name_to_type[record_field], record[record_field])
                         for record_field, record_value in schema_field_name_to_type.items()
                     }
-        except Exception as exc:
-            raise RecordParseError(FileBasedSourceError.ERROR_PARSING_RECORD, filename=file.uri, lineno=line_no) from exc
+            except Exception as exc:
+                raise RecordParseError(FileBasedSourceError.ERROR_PARSING_RECORD, filename=file.uri, lineno=line_no) from exc
 
     @property
     def file_read_mode(self) -> FileReadMode:

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
@@ -66,8 +66,8 @@ class ParquetParser(FileTypeParser):
             raise ConfigValidationError(FileBasedSourceError.CONFIG_VALIDATION_ERROR)
 
         line_no = 0
-        try:
-            with stream_reader.open_file(file, self.file_read_mode, self.ENCODING, logger) as fp:
+        with stream_reader.open_file(file, self.file_read_mode, self.ENCODING, logger) as fp:
+            try:
                 reader = pq.ParquetFile(fp)
                 partition_columns = {x.split("=")[0]: x.split("=")[1] for x in self._extract_partitions(file.uri)}
                 for row_group in range(reader.num_row_groups):
@@ -81,10 +81,10 @@ class ParquetParser(FileTypeParser):
                             },
                             **partition_columns,
                         }
-        except Exception as exc:
-            raise RecordParseError(
-                FileBasedSourceError.ERROR_PARSING_RECORD, filename=file.uri, lineno=f"{row_group=}, {line_no=}"
-            ) from exc
+            except Exception as exc:
+                raise RecordParseError(
+                    FileBasedSourceError.ERROR_PARSING_RECORD, filename=file.uri, lineno=f"{row_group=}, {line_no=}"
+                ) from exc
 
     @staticmethod
     def _extract_partitions(filepath: str) -> List[str]:

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py
@@ -9,6 +9,8 @@ import pytest
 from airbyte_cdk.sources.file_based.config.avro_format import AvroFormat
 from airbyte_cdk.sources.file_based.file_types import AvroParser
 
+from unittest.mock import MagicMock
+
 _default_avro_format = AvroFormat()
 _double_as_string_avro_format = AvroFormat(double_as_string=True)
 _uuid_value = uuid.uuid4()
@@ -241,3 +243,14 @@ def test_convert_primitive_avro_type_to_json(avro_format, avro_type, expected_js
 def test_to_output_value(avro_format, record_type, record_value, expected_value):
     parser = AvroParser()
     assert parser._to_output_value(avro_format, record_type, record_value) == expected_value
+
+
+def test_given_os_error_raise_os_error():
+    fake_file = MagicMock()
+    logger = MagicMock()
+    config = MagicMock()
+    config.format = _default_avro_format
+    stream_reader = MagicMock(open_file=MagicMock(side_effect=OSError("File does not exist")))
+
+    with pytest.raises(OSError):
+        list(AvroParser().parse_records(config, fake_file, stream_reader, logger, MagicMock()))

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_avro_parser.py
@@ -4,12 +4,11 @@
 
 import datetime
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 from airbyte_cdk.sources.file_based.config.avro_format import AvroFormat
 from airbyte_cdk.sources.file_based.file_types import AvroParser
-
-from unittest.mock import MagicMock
 
 _default_avro_format = AvroFormat()
 _double_as_string_avro_format = AvroFormat(double_as_string=True)

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_csv_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_csv_parser.py
@@ -327,6 +327,12 @@ class CsvReaderTest(unittest.TestCase):
         with pytest.raises(RecordParseError):
             list(self._read_data())
 
+    def test_given_os_error_then_raise_os_error(self) -> None:
+        self._stream_reader.open_file.side_effect = OSError("File does not exist")
+
+        with pytest.raises(OSError):
+            list(self._read_data())
+
     def test_given_skip_rows_after_header_when_read_data_then_do_not_parse_skipped_rows(self) -> None:
         self._config_format.skip_rows_after_header = 1
         self._stream_reader.open_file.return_value = (

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_jsonl_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_jsonl_parser.py
@@ -156,3 +156,12 @@ def test_given_unparsable_json_when_parse_records_then_raise_error(stream_reader
     with pytest.raises(RecordParseError):
         list(JsonlParser().parse_records(Mock(), Mock(), stream_reader, logger, None))
     assert logger.warning.call_count == 0
+
+
+def test_given_os_error_then_raise_os_error(stream_reader: MagicMock) -> None:
+    stream_reader.open_file.side_effect = OSError("File does not exist")
+    logger = Mock()
+
+    with pytest.raises(OSError):
+        list(JsonlParser().parse_records(Mock(), Mock(), stream_reader, logger, None))
+    assert logger.warning.call_count == 0

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_parquet_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_parquet_parser.py
@@ -18,6 +18,8 @@ from airbyte_cdk.sources.file_based.file_types import ParquetParser
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from pyarrow import Scalar
 
+from unittest.mock import MagicMock
+
 _default_parquet_format = ParquetFormat()
 _decimal_as_float_parquet_format = ParquetFormat(decimal_as_float=True)
 
@@ -272,3 +274,14 @@ def test_wrong_file_format(file_format: Union[CsvFormat, JsonlFormat]) -> None:
     logger = Mock()
     with pytest.raises(ValueError):
         asyncio.get_event_loop().run_until_complete(parser.infer_schema(config, file, stream_reader, logger))
+
+
+def test_given_os_error_raise_os_error():
+    fake_file = MagicMock()
+    logger = MagicMock()
+    config = MagicMock()
+    config.format = _default_parquet_format
+    stream_reader = MagicMock(open_file=MagicMock(side_effect=OSError("File does not exist")))
+
+    with pytest.raises(OSError):
+        list(ParquetParser().parse_records(config, fake_file, stream_reader, logger, MagicMock()))

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_parquet_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_parquet_parser.py
@@ -6,7 +6,7 @@ import asyncio
 import datetime
 import math
 from typing import Any, Mapping, Union
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pyarrow as pa
 import pytest
@@ -17,8 +17,6 @@ from airbyte_cdk.sources.file_based.config.parquet_format import ParquetFormat
 from airbyte_cdk.sources.file_based.file_types import ParquetParser
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from pyarrow import Scalar
-
-from unittest.mock import MagicMock
 
 _default_parquet_format = ParquetFormat()
 _decimal_as_float_parquet_format = ParquetFormat(decimal_as_float=True)


### PR DESCRIPTION
## What
This is one of two PRs to address https://github.com/airbytehq/oncall/issues/4805

## How
In this PR we make sure that when faced an OSError, we do not substitute it with a RecordParseError as it is now done in .parquet and .avro parsers