### PR TITLE
Add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 ## What
 <!--
-* Describe what the change is solving.
-* It helps to add screenshots if it affects the frontend.
+* Describe what the change is solving. Link all GitHub issues related to this change.
 -->
 
 ## How
@@ -9,9 +8,11 @@
 * Describe how code changes achieve the solution.
 -->
 
-## Recommended reading order
+## Review guide
+<!--
 1. `x.py`
 2. `y.py`
+-->
 
 ## User Impact
 <!--
@@ -21,9 +22,7 @@
 
 ## Can this PR be safely reverted and rolled back?
 <!--
-* If you know that your be safely rolled back, check YES.
-* If that is not the case (e.g. a database migration), check NO.
-* If unsure, leave it blank.*
+* If unsure, leave it blank.
 -->
 - [ ] YES 💚
 - [ ] NO ❌

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## What
+<!--
+* Describe what the change is solving.
+* It helps to add screenshots if it affects the frontend.
+-->
+
+## How
+<!--
+* Describe how code changes achieve the solution.
+-->
+
+## Recommended reading order
+1. `x.py`
+2. `y.py`
+
+## User Impact
+<!--
+* What is the end result perceived by the user?
+* If there are negative side effects, please list them. 
+-->
+
+## Can this PR be safely reverted and rolled back?
+<!--
+* If you know that your be safely rolled back, check YES.
+* If that is not the case (e.g. a database migration), check NO.
+* If unsure, leave it blank.*
+-->
+- [ ] YES 💚
+- [ ] NO ❌


### PR DESCRIPTION
## What

[The old template has been removed](https://github.com/airbytehq/airbyte/pull/35921) because it was very exhaustive. However, we feel there were still interesting things that the PR forced the developer to enter. 

## How

Adding back a PR template that is more light weight.

## User Impact

When creating a PR, we expect this template to fill the "description" part of the PR

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌