### PR TITLE
move connector version increment check to its own airbyte-ci command

### DIFF
--- a/.github/workflows/connectors_version_increment.yml
+++ b/.github/workflows/connectors_version_increment.yml
@@ -1,0 +1,69 @@
+name: Connectors Version Increment Check
+
+concurrency:
+  # This is the name of the concurrency group. It is used to prevent concurrent runs of the same workflow.
+  #
+  # - github.head_ref is only defined on PR runs, it makes sure that the concurrency group is unique for pull requests
+  #  ensuring that only one run per pull request is active at a time.
+  #
+  # - github.run_id is defined on all runs, it makes sure that the concurrency group is unique for workflow dispatches.
+  # This allows us to run multiple workflow dispatches in parallel.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      connectors: ${{ steps.changes.outputs.connectors }}
+    permissions:
+      statuses: write
+    steps:
+      - name: Checkout Airbyte
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v3
+      - id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          # Note: expressions within a filter are OR'ed
+          filters: |
+            connectors:
+              - 'airbyte-integrations/connectors/**/*'
+
+  connectors_ci:
+    needs: changes
+    if: needs.changes.outputs.connectors == 'true'
+    name: Connectors Version Increment
+    runs-on: connector-test-large
+    timeout-minutes: 10
+    steps:
+      - name: Check PAT rate limits
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+      - name: Fetch last commit id from remote branch [PULL REQUESTS]
+        if: github.event_name == 'pull_request'
+        id: fetch_last_commit_id_pr
+        run: echo "commit_id=$(git ls-remote --heads origin ${{ github.head_ref }} | cut -f 1)" >> $GITHUB_OUTPUT
+      - name: Test connectors [PULL REQUESTS]
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/run-airbyte-ci
+        with:
+          context: "pull_request"
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_2 }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          git_branch: ${{ github.head_ref }}
+          git_revision: ${{ steps.fetch_last_commit_id_pr.outputs.commit_id }}
+          github_token: ${{ env.PAT }}
+          s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          subcommand: "connectors --modified  check_version_increment"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/check_version_increment/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/check_version_increment/commands.py
@@ -1,0 +1,55 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+
+import asyncclick as click
+from pipelines.airbyte_ci.connectors.check_version_increment.pipeline import VersionIncrementCheck
+from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
+from pipelines.airbyte_ci.connectors.context import ConnectorContext
+from pipelines.cli.click_decorators import click_ignore_unused_kwargs, click_merge_args_into_context_obj
+from pipelines.cli.dagger_pipeline_command import DaggerPipelineCommand
+from pipelines.helpers.execution.run_steps import StepToRun, run_steps
+from pipelines.models.contexts.pipeline_context import PipelineContext
+from pipelines.models.reports import Report
+
+
+@click.command(cls=DaggerPipelineCommand, short_help="Check that a connector has a version increment")
+@click_merge_args_into_context_obj
+@click.pass_context
+@click_ignore_unused_kwargs
+async def check_version_increment(
+    ctx: click.Context,
+) -> bool:
+    if not ctx.obj["selected_connectors_with_modified_files"]:
+        return True
+    results = list()
+    pipeline_context = PipelineContext(
+        pipeline_name="Checking connector version increments",
+        is_local=ctx.obj["is_local"],
+        git_branch=ctx.obj["git_branch"],
+        git_revision=ctx.obj["git_revision"],
+        report_output_prefix=ctx.obj["report_output_prefix"],
+    )
+
+    for connector in ctx.obj["selected_connectors_with_modified_files"]:
+        connector_context = ConnectorContext(
+            pipeline_name=f"Checking version increment for connector {connector.technical_name}",
+            connector=connector,
+            is_local=ctx.obj["is_local"],
+            git_branch=ctx.obj["git_branch"],
+            git_revision=ctx.obj["git_revision"],
+            report_output_prefix=ctx.obj["report_output_prefix"],
+        )
+        result_dict = await run_steps(
+            runnables=[
+                StepToRun(id=CONNECTOR_TEST_STEP_ID.VERSION_INC_CHECK, step=VersionIncrementCheck(connector_context)),
+            ],
+            options=connector_context.run_step_options,
+        )
+        results += list(result_dict.values())
+
+    report = Report(pipeline_context, steps_results=results, name="Version Increment Check Results")
+    pipeline_context.report = report
+
+    return report.success

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/check_version_increment/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/check_version_increment/pipeline.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+
+from abc import ABC, abstractmethod
+from functools import cached_property
+from typing import ClassVar, Optional
+
+import anyio
+import requests  # type: ignore
+import semver
+import yaml  # type: ignore
+from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
+from pipelines.airbyte_ci.connectors.context import ConnectorContext
+from pipelines.airbyte_ci.connectors.reports import ConnectorReport
+from pipelines.consts import CIContext
+from pipelines.helpers.execution.run_steps import STEP_TREE, StepToRun, run_steps
+from pipelines.helpers.utils import METADATA_FILE_NAME
+from pipelines.models.steps import Step, StepResult, StepStatus
+
+
+class VersionCheck(Step, ABC):
+    """A step to validate the connector version was bumped if files were modified"""
+
+    context: ConnectorContext
+    GITHUB_URL_PREFIX_FOR_CONNECTORS = "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations/connectors"
+    failure_message: ClassVar
+
+    @property
+    def should_run(self) -> bool:
+        return True
+
+    @property
+    def github_master_metadata_url(self) -> str:
+        return f"{self.GITHUB_URL_PREFIX_FOR_CONNECTORS}/{self.context.connector.technical_name}/{METADATA_FILE_NAME}"
+
+    @cached_property
+    def master_metadata(self) -> Optional[dict]:
+        response = requests.get(self.github_master_metadata_url)
+
+        # New connectors will not have a metadata file in master
+        if not response.ok:
+            return None
+        return yaml.safe_load(response.text)
+
+    @property
+    def master_connector_version(self) -> semver.Version:
+        metadata = self.master_metadata
+        if not metadata:
+            return semver.Version.parse("0.0.0")
+
+        return semver.Version.parse(str(metadata["data"]["dockerImageTag"]))
+
+    @property
+    def current_connector_version(self) -> semver.Version:
+        return semver.Version.parse(str(self.context.metadata["dockerImageTag"]))
+
+    @property
+    def success_result(self) -> StepResult:
+        return StepResult(step=self, status=StepStatus.SUCCESS)
+
+    @property
+    def failure_result(self) -> StepResult:
+        return StepResult(step=self, status=StepStatus.FAILURE, stderr=self.failure_message)
+
+    @abstractmethod
+    def validate(self) -> StepResult:
+        raise NotImplementedError()
+
+    async def _run(self) -> StepResult:
+        if not self.should_run:
+            return StepResult(step=self, status=StepStatus.SKIPPED, stdout="No modified files required a version bump.")
+        if self.context.ci_context == CIContext.MASTER:
+            return StepResult(step=self, status=StepStatus.SKIPPED, stdout="Version check are not running in master context.")
+        try:
+            return self.validate()
+        except (requests.HTTPError, ValueError, TypeError) as e:
+            return StepResult(step=self, status=StepStatus.FAILURE, stderr=str(e))
+
+
+class VersionIncrementCheck(VersionCheck):
+    context: ConnectorContext
+    title = "Connector version increment check"
+
+    BYPASS_CHECK_FOR = [
+        METADATA_FILE_NAME,
+        "acceptance-test-config.yml",
+        "README.md",
+        "bootstrap.md",
+        ".dockerignore",
+        "unit_tests",
+        "integration_tests",
+        "src/test",
+        "src/test-integration",
+        "src/test-performance",
+        "build.gradle",
+    ]
+
+    @property
+    def failure_message(self) -> str:
+        return f"The dockerImageTag in {METADATA_FILE_NAME} was not incremented. The files you modified should lead to a version bump. Master version is {self.master_connector_version}, current version is {self.current_connector_version}"
+
+    @property
+    def should_run(self) -> bool:
+        for filename in self.context.modified_files:
+            relative_path = str(filename).replace(str(self.context.connector.code_directory) + "/", "")
+            if not any([relative_path.startswith(to_bypass) for to_bypass in self.BYPASS_CHECK_FOR]):
+                return True
+        return False
+
+    def validate(self) -> StepResult:
+        if not self.current_connector_version > self.master_connector_version:
+            return self.failure_result
+        return self.success_result
+
+
+async def run_check_version_increment_pipeline(context: ConnectorContext, semaphore: anyio.Semaphore) -> ConnectorReport:
+    """
+    Compute the steps to run for a connector test pipeline.
+    """
+    all_steps_to_run: STEP_TREE = [
+        [
+            StepToRun(id=CONNECTOR_TEST_STEP_ID.VERSION_INC_CHECK, step=VersionIncrementCheck(context)),
+        ]
+    ]
+
+    async with semaphore:
+        async with context:
+            result_dict = await run_steps(
+                runnables=all_steps_to_run,
+                options=context.run_step_options,
+            )
+
+            results = list(result_dict.values())
+            report = ConnectorReport(context, steps_results=results, name="Version Increment Check Results")
+            context.report = report
+
+        return report

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
@@ -155,6 +155,7 @@ def should_use_remote_secrets(use_remote_secrets: Optional[bool]) -> bool:
         "upgrade_base_image": "pipelines.airbyte_ci.connectors.upgrade_base_image.commands.upgrade_base_image",
         "upgrade_cdk": "pipelines.airbyte_ci.connectors.upgrade_cdk.commands.upgrade_cdk",
         "up_to_date": "pipelines.airbyte_ci.connectors.up_to_date.commands.up_to_date",
+        "check_version_increment": "pipelines.airbyte_ci.connectors.check_version_increment.commands.check_version_increment",
     },
 )
 @click.option(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/pipeline.py
@@ -9,11 +9,12 @@ from typing import TYPE_CHECKING
 
 import anyio
 from connector_ops.utils import ConnectorLanguage  # type: ignore
+from pipelines.airbyte_ci.connectors.check_version_increment.pipeline import VersionIncrementCheck
 from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.airbyte_ci.connectors.reports import ConnectorReport
 from pipelines.airbyte_ci.connectors.test.steps import java_connectors, python_connectors
-from pipelines.airbyte_ci.connectors.test.steps.common import QaChecks, VersionIncrementCheck
+from pipelines.airbyte_ci.connectors.test.steps.common import QaChecks
 from pipelines.helpers.execution.run_steps import StepToRun, run_steps
 
 if TYPE_CHECKING:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -7,120 +7,20 @@
 import datetime
 import os
 import time
-from abc import ABC, abstractmethod
-from functools import cached_property
 from pathlib import Path
 from textwrap import dedent
-from typing import ClassVar, List, Optional
+from typing import List, Optional
 
-import requests  # type: ignore
-import semver
-import yaml  # type: ignore
 from dagger import Container, Directory
 from pipelines import hacks
 from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.airbyte_ci.steps.docker import SimpleDockerStep
-from pipelines.consts import INTERNAL_TOOL_PATHS, CIContext
+from pipelines.consts import INTERNAL_TOOL_PATHS
 from pipelines.dagger.actions import secrets
 from pipelines.dagger.actions.python.poetry import with_poetry
 from pipelines.helpers.utils import METADATA_FILE_NAME, get_exec_result
 from pipelines.models.steps import STEP_PARAMS, MountPath, Step, StepResult, StepStatus
-
-
-class VersionCheck(Step, ABC):
-    """A step to validate the connector version was bumped if files were modified"""
-
-    context: ConnectorContext
-    GITHUB_URL_PREFIX_FOR_CONNECTORS = "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations/connectors"
-    failure_message: ClassVar
-
-    @property
-    def should_run(self) -> bool:
-        return True
-
-    @property
-    def github_master_metadata_url(self) -> str:
-        return f"{self.GITHUB_URL_PREFIX_FOR_CONNECTORS}/{self.context.connector.technical_name}/{METADATA_FILE_NAME}"
-
-    @cached_property
-    def master_metadata(self) -> Optional[dict]:
-        response = requests.get(self.github_master_metadata_url)
-
-        # New connectors will not have a metadata file in master
-        if not response.ok:
-            return None
-        return yaml.safe_load(response.text)
-
-    @property
-    def master_connector_version(self) -> semver.Version:
-        metadata = self.master_metadata
-        if not metadata:
-            return semver.Version.parse("0.0.0")
-
-        return semver.Version.parse(str(metadata["data"]["dockerImageTag"]))
-
-    @property
-    def current_connector_version(self) -> semver.Version:
-        return semver.Version.parse(str(self.context.metadata["dockerImageTag"]))
-
-    @property
-    def success_result(self) -> StepResult:
-        return StepResult(step=self, status=StepStatus.SUCCESS)
-
-    @property
-    def failure_result(self) -> StepResult:
-        return StepResult(step=self, status=StepStatus.FAILURE, stderr=self.failure_message)
-
-    @abstractmethod
-    def validate(self) -> StepResult:
-        raise NotImplementedError()
-
-    async def _run(self) -> StepResult:
-        if not self.should_run:
-            return StepResult(step=self, status=StepStatus.SKIPPED, stdout="No modified files required a version bump.")
-        if self.context.ci_context == CIContext.MASTER:
-            return StepResult(step=self, status=StepStatus.SKIPPED, stdout="Version check are not running in master context.")
-        try:
-            return self.validate()
-        except (requests.HTTPError, ValueError, TypeError) as e:
-            return StepResult(step=self, status=StepStatus.FAILURE, stderr=str(e))
-
-
-class VersionIncrementCheck(VersionCheck):
-    context: ConnectorContext
-    title = "Connector version increment check"
-
-    BYPASS_CHECK_FOR = [
-        METADATA_FILE_NAME,
-        "acceptance-test-config.yml",
-        "README.md",
-        "bootstrap.md",
-        ".dockerignore",
-        "unit_tests",
-        "integration_tests",
-        "src/test",
-        "src/test-integration",
-        "src/test-performance",
-        "build.gradle",
-    ]
-
-    @property
-    def failure_message(self) -> str:
-        return f"The dockerImageTag in {METADATA_FILE_NAME} was not incremented. The files you modified should lead to a version bump. Master version is {self.master_connector_version}, current version is {self.current_connector_version}"
-
-    @property
-    def should_run(self) -> bool:
-        for filename in self.context.modified_files:
-            relative_path = str(filename).replace(str(self.context.connector.code_directory) + "/", "")
-            if not any([relative_path.startswith(to_bypass) for to_bypass in self.BYPASS_CHECK_FOR]):
-                return True
-        return False
-
-    def validate(self) -> StepResult:
-        if not self.current_connector_version > self.master_connector_version:
-            return self.failure_result
-        return self.success_result
 
 
 class QaChecks(SimpleDockerStep):


### PR DESCRIPTION
We want to be able to run connector version bump checks independently of connector tests (for example on PR description updates), so this is simply moving the existing logic to a new file and plopping a workflow on top of it.