### PR TITLE
Regression tests: make --connection-id optional

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -237,6 +237,9 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.15.0
+Allow test runs without a connection ID.
+
 ### 0.14.2
 Fix KeyError when target & control streams differ.
 

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.14.2"
+version = "0.15.0"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/regression_tests/report.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/regression_tests/report.py
@@ -146,11 +146,17 @@ class Report:
             len(self.connection_objects.configured_catalog.streams) if self.connection_objects.configured_catalog else 0
         )
         catalog_stream_count = len(self.connection_objects.catalog.streams) if self.connection_objects.catalog else 0
-        return {
+        metrics = {
             "Available in catalog": str(catalog_stream_count),
             "In use (in configured catalog)": str(configured_catalog_stream_count),
-            "Coverage": f"{(configured_catalog_stream_count / catalog_stream_count) * 100:.2f}%",
+            "Coverage": "0%",  # We do not fetch a catalog when no connection ID is passed in
         }
+        if catalog_stream_count:
+            metrics["Coverage"] = (
+                f"{(configured_catalog_stream_count / catalog_stream_count) * 100:.2f}%",
+            )
+
+        return metrics
 
     def get_record_count_per_stream(
         self,

--- a/airbyte-ci/connectors/live-tests/src/live_tests/regression_tests/templates/report.html.j2
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/regression_tests/templates/report.html.j2
@@ -219,8 +219,8 @@
                     <li><b><a href="{{connection_url}}" target="_blank">Connection</a></b></li>
                     <li>Tester: <span class="monospace">{{ user }}</span></li>
                     <li>Test date: <span class="monospace">{{ test_date }}</span></li>
-                    <li>Workspace ID: <span class="monospace">{{ workspace_id }}</span></li>
-                    <li>Connection ID: <span class="monospace">{{ connection_id }}</span></li>
+                    <li>Workspace ID: <span class="monospace">{{ workspace_id if connection_id else "Not available - connection ID not provided" }}</span></li>
+                    <li>Connection ID: <span class="monospace">{{ connection_id | default("Not provided", true) }}</span></li>
                     <li>Connector image: <span class="monospace">{{ connector_image }}</span></li>
                     <li>Control version: <span class="monospace">{{ control_version }}</span></li>
                     <li>Target version: <span class="monospace">{{ target_version }}</span></li>


### PR DESCRIPTION
Allow users to run regression tests without passing in a --connection-id.

This will allow us to test with internal credentials without having to create a Cloud connection.

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/6889.
Replaces https://github.com/airbytehq/airbyte-platform-internal/pull/12073.