### PR TITLE
Fix partitioned state saving issue

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/concurrent_source/concurrent_read_processor.py
@@ -100,7 +100,8 @@ class ConcurrentReadProcessor:
         partition = sentinel.partition
 
         try:
-            partition.close()
+            if sentinel.is_successful:
+                partition.close()
         except Exception as exception:
             self._flag_exception(partition.stream_name(), exception)
             yield AirbyteTracedException.from_exception(

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/partition_reader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/partition_reader.py
@@ -13,6 +13,8 @@ class PartitionReader:
     Generates records from a partition and puts them in a queue.
     """
 
+    _IS_SUCCESSFUL = True
+
     def __init__(self, queue: Queue[QueueItem]) -> None:
         """
         :param queue: The queue to put the records in.
@@ -34,7 +36,7 @@ class PartitionReader:
         try:
             for record in partition.read():
                 self._queue.put(record)
-            self._queue.put(PartitionCompleteSentinel(partition))
+            self._queue.put(PartitionCompleteSentinel(partition, self._IS_SUCCESSFUL))
         except Exception as e:
             self._queue.put(StreamThreadException(e, partition.stream_name()))
-            self._queue.put(PartitionCompleteSentinel(partition))
+            self._queue.put(PartitionCompleteSentinel(partition, not self._IS_SUCCESSFUL))

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/partitions/types.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/partitions/types.py
@@ -15,11 +15,12 @@ class PartitionCompleteSentinel:
     Includes a pointer to the partition that was processed.
     """
 
-    def __init__(self, partition: Partition):
+    def __init__(self, partition: Partition, is_successful: bool = True):
         """
         :param partition: The partition that was processed
         """
         self.partition = partition
+        self.is_successful = is_successful
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, PartitionCompleteSentinel):


### PR DESCRIPTION
## What
Currently, we save the state as if the partition sync was always successful. If the partition failed, we should not close the partition

## How
By adding a parameter that mentions if the sync was successful in the `PartitionCompleteSentinel`. 

## User Impact
The slices that are failing will retry on the next sync from now on. As for the other issues, [we have two syncs that failed with system_errors since version 2.5.0](https://airbyte.metabaseapp.com/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InF1ZXJ5Ijp7InNvdXJjZS10YWJsZSI6MzI5MjIsImZpbHRlciI6WyJhbmQiLFsiPSIsWyJmaWVsZCIsNDMyOTY2LG51bGxdLCJTYWxlc2ZvcmNlIl0sWyI9IixbImZpZWxkIiw0MzI5ODMsbnVsbF0sInNvdXJjZSJdLFsiPSIsWyJmaWVsZCIsNDMyOTYyLG51bGxdLHRydWVdLFsiPSIsWyJmaWVsZCIsNDMyOTM2LG51bGxdLCJzeXN0ZW1fZXJyb3IiXV0sIm9yZGVyLWJ5IjpbWyJkZXNjIixbImZpZWxkIiw0MzI5NzgsbnVsbF1dXX0sInR5cGUiOiJxdWVyeSIsImRhdGFiYXNlIjoyfSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319). I'll identify the workspace and communicate with TCS for a reset. I'll also check the config errors but from a quick look at it, all of them did not occur during a sync so we should be good there.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
