### PR TITLE
Update the abctl Local Deployment documentation to clarify uses and installation methods

### DIFF
--- a/docs/deploying-airbyte/local-deployment.md
+++ b/docs/deploying-airbyte/local-deployment.md
@@ -1,5 +1,12 @@
 # Local Deployment
 
+:::warning
+This tool is in active development. Airbyte strives to provide high quality, reliable software, however there may be
+bugs or usability issues with this command. If you find an issue with the `abctl` command, please report it as a github 
+issue [here](https://github.com/airbytehq/airbyte/issues) with the `area/quickstart` label.
+
+:::
+
 :::info
 These instructions have been tested on MacOS, Windows, Ubuntu and Fedora.
 

--- a/docs/deploying-airbyte/local-deployment.md
+++ b/docs/deploying-airbyte/local-deployment.md
@@ -33,7 +33,7 @@ brew install abctl
 
 :::info
 Mac users may need to use the finder and Open With > Terminal to run the `abctl` command. After the first run
-users should be able to run the command from the terminal.
+users should be able to run the command from the terminal. Airbyte suggests mac users to use `brew` if it is available.
 
 :::
 

--- a/docs/deploying-airbyte/local-deployment.md
+++ b/docs/deploying-airbyte/local-deployment.md
@@ -10,23 +10,42 @@ issue [here](https://github.com/airbytehq/airbyte/issues) with the `area/quickst
 :::info
 These instructions have been tested on MacOS, Windows, Ubuntu and Fedora.
 
+If you are looking for instructions for the `run_ab_platform.sh` script, please refer to the [Docker Compose](/deploying-airbyte/docker-compose) documentation.
+Note that the `abctl` command does not currently allow for customizations via .env files.
 :::
 
 ## Setup & launch Airbyte
+
+:::info
+Mac users can use Brew to install the `abctl` command
+
+```bash
+brew tap airbytehq/tap
+brew install abctl 
+```
+
+:::
 
 - Install `Docker Desktop`  \(see [instructions](https://docs.docker.com/desktop/install/mac-install/)\).
 - After `Docker Desktop` is installed, you must enable `Kubernetes` \(see [instructions](https://docs.docker.com/desktop/kubernetes/)\).
 - Download the latest version of `abctl` from the [releases page](https://github.com/airbytehq/abctl/releases) and run the following command:
 
+:::info
+Mac users may need to use the finder and Open With > Terminal to run the `abctl` command. After the first run
+users should be able to run the command from the terminal.
+
+:::
+
+
 ```bash
-abctl local install
+./abctl local install
 ```
 
 - Your browser should open to the Airbyte Application, if it does not visit [http://localhost](http://localhost)
 - You will be asked for a username and password. By default, that's username `airbyte` and password `password`. You can set these values through command line flags or environment variables. For example, to set the username and password to `foo` and `bar` respectively, you can run the following command:
 
 ```bash
-abctl local install --username foo --password bar
+./abctl local install --username foo --password bar
 
 # Or as Environment Variables
 ABCTL_LOCAL_INSTALL_PASSWORD=foo

--- a/docs/deploying-airbyte/local-deployment.md
+++ b/docs/deploying-airbyte/local-deployment.md
@@ -3,7 +3,7 @@
 :::warning
 This tool is in active development. Airbyte strives to provide high quality, reliable software, however there may be
 bugs or usability issues with this command. If you find an issue with the `abctl` command, please report it as a github 
-issue [here](https://github.com/airbytehq/airbyte/issues) with the tpye of "Issue: 🤷 Others issues requests..." please 
+issue [here](https://github.com/airbytehq/airbyte/issues) with the type of "Issue: 🤷 Others issues requests..." please 
 add the `area/quickstart` label.
 
 :::

--- a/docs/deploying-airbyte/local-deployment.md
+++ b/docs/deploying-airbyte/local-deployment.md
@@ -3,7 +3,8 @@
 :::warning
 This tool is in active development. Airbyte strives to provide high quality, reliable software, however there may be
 bugs or usability issues with this command. If you find an issue with the `abctl` command, please report it as a github 
-issue [here](https://github.com/airbytehq/airbyte/issues) with the `area/quickstart` label.
+issue [here](https://github.com/airbytehq/airbyte/issues) with the tpye of "Issue: 🤷 Others issues requests..." please 
+add the `area/quickstart` label.
 
 :::
 

--- a/docs/deploying-airbyte/local-deployment.md
+++ b/docs/deploying-airbyte/local-deployment.md
@@ -12,6 +12,7 @@ These instructions have been tested on MacOS, Windows, Ubuntu and Fedora.
 
 If you are looking for instructions for the `run_ab_platform.sh` script, please refer to the [Docker Compose](/deploying-airbyte/docker-compose) documentation.
 Note that the `abctl` command does not currently allow for customizations via .env files.
+
 :::
 
 ## Setup & launch Airbyte

--- a/docs/deploying-airbyte/local-deployment.md
+++ b/docs/deploying-airbyte/local-deployment.md
@@ -29,7 +29,7 @@ brew install abctl
 
 - Install `Docker Desktop`  \(see [instructions](https://docs.docker.com/desktop/install/mac-install/)\).
 - After `Docker Desktop` is installed, you must enable `Kubernetes` \(see [instructions](https://docs.docker.com/desktop/kubernetes/)\).
-- Download the latest version of `abctl` from the [releases page](https://github.com/airbytehq/abctl/releases) and run the following command:
+- If you did not use Brew to install `abctl` then download the latest version of `abctl` from the [releases page](https://github.com/airbytehq/abctl/releases) and run the following command:
 
 :::info
 Mac users may need to use the finder and Open With > Terminal to run the `abctl` command. After the first run


### PR DESCRIPTION
## What
A new warning section was added to explain to the user that this software is still in active development. This also links to the existing docker compose solution that provides more options for tweaking the deployment. 

A section on installing abctl from brew was also added, which should easy the installation for many Mac users.

## User Impact
This should make the documentation easier to use the abctl method of running Airbyte.

## Can this PR be safely reverted and rolled back?
[X] YES 💚