### PR TITLE
[connector-template] macro to use current year for new connectors

### DIFF
--- a/airbyte-integrations/connector-templates/destination-python/destination_{{snakeCase name}}/__init__.py.hbs
+++ b/airbyte-integrations/connector-templates/destination-python/destination_{{snakeCase name}}/__init__.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/destination-python/destination_{{snakeCase name}}/destination.py.hbs
+++ b/airbyte-integrations/connector-templates/destination-python/destination_{{snakeCase name}}/destination.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/destination-python/integration_tests/integration_test.py.hbs
+++ b/airbyte-integrations/connector-templates/destination-python/integration_tests/integration_test.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/destination-python/main.py.hbs
+++ b/airbyte-integrations/connector-templates/destination-python/main.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/destination-python/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/destination-python/setup.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/destination-python/unit_tests/unit_test.py
+++ b/airbyte-integrations/connector-templates/destination-python/unit_tests/unit_test.py
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-#
-
-
-def test_example_method():
-    assert True

--- a/airbyte-integrations/connector-templates/destination-python/unit_tests/unit_test.py.hbs
+++ b/airbyte-integrations/connector-templates/destination-python/unit_tests/unit_test.py.hbs
@@ -1,0 +1,7 @@
+#
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
+#
+
+
+def test_example_method():
+    assert True

--- a/airbyte-integrations/connector-templates/generator/plopfile.js
+++ b/airbyte-integrations/connector-templates/generator/plopfile.js
@@ -51,6 +51,10 @@ module.exports = function (plop) {
     return capitalCase.capitalCase(name);
   });
 
+  plop.setHelper("currentYear", function () {
+    return new Date().getFullYear();
+  });
+
   plop.setHelper("generateDefinitionId", function () {
     // if the env var CI is set then return a fixed FAKE uuid  so that the tests are deterministic
     if (process.env.CI) {

--- a/airbyte-integrations/connector-templates/source-low-code/__init__.py
+++ b/airbyte-integrations/connector-templates/source-low-code/__init__.py
@@ -1,3 +1,0 @@
-#
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-#

--- a/airbyte-integrations/connector-templates/source-low-code/__init__.py.hbs
+++ b/airbyte-integrations/connector-templates/source-low-code/__init__.py.hbs
@@ -1,0 +1,3 @@
+#
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-integrations/connector-templates/source-low-code/integration_tests/__init__.py
+++ b/airbyte-integrations/connector-templates/source-low-code/integration_tests/__init__.py
@@ -1,3 +1,0 @@
-#
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-#

--- a/airbyte-integrations/connector-templates/source-low-code/integration_tests/__init__.py.hbs
+++ b/airbyte-integrations/connector-templates/source-low-code/integration_tests/__init__.py.hbs
@@ -1,0 +1,3 @@
+#
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-integrations/connector-templates/source-low-code/integration_tests/acceptance.py
+++ b/airbyte-integrations/connector-templates/source-low-code/integration_tests/acceptance.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/source-low-code/main.py.hbs
+++ b/airbyte-integrations/connector-templates/source-low-code/main.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/source-low-code/source_{{snakeCase name}}/__init__.py.hbs
+++ b/airbyte-integrations/connector-templates/source-low-code/source_{{snakeCase name}}/__init__.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/source-low-code/source_{{snakeCase name}}/run.py.hbs
+++ b/airbyte-integrations/connector-templates/source-low-code/source_{{snakeCase name}}/run.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/source-low-code/source_{{snakeCase name}}/source.py.hbs
+++ b/airbyte-integrations/connector-templates/source-low-code/source_{{snakeCase name}}/source.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 from airbyte_cdk.sources.declarative.yaml_declarative_source import YamlDeclarativeSource

--- a/airbyte-integrations/connector-templates/source-python/integration_tests/__init__.py
+++ b/airbyte-integrations/connector-templates/source-python/integration_tests/__init__.py
@@ -1,3 +1,0 @@
-#
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-#

--- a/airbyte-integrations/connector-templates/source-python/integration_tests/__init__.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/integration_tests/__init__.py.hbs
@@ -1,0 +1,3 @@
+#
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-integrations/connector-templates/source-python/integration_tests/acceptance.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/integration_tests/acceptance.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/source-python/main.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/main.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 from source_{{snakeCase name}}.run import run

--- a/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/__init__.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/__init__.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/run.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/run.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/source.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/source.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 
@@ -10,7 +10,7 @@ import requests
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
-from airbyte_cdk.sources.streams.http.auth import TokenAuthenticator
+from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
 
 """
 TODO: Most comments in this class are instructive and should be deleted after the source is implemented.

--- a/airbyte-integrations/connector-templates/source-python/unit_tests/__init__.py
+++ b/airbyte-integrations/connector-templates/source-python/unit_tests/__init__.py
@@ -1,3 +1,0 @@
-#
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-#

--- a/airbyte-integrations/connector-templates/source-python/unit_tests/__init__.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/unit_tests/__init__.py.hbs
@@ -1,0 +1,3 @@
+#
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-integrations/connector-templates/source-python/unit_tests/test_incremental_streams.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/unit_tests/test_incremental_streams.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connector-templates/source-python/unit_tests/test_source.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/unit_tests/test_source.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 from unittest.mock import MagicMock

--- a/airbyte-integrations/connector-templates/source-python/unit_tests/test_streams.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/unit_tests/test_streams.py.hbs
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+# Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
 from http import HTTPStatus


### PR DESCRIPTION
## What
Improvements for connector-templates introduce 2 changes:
1) added `currentYear` helper. Instead of fixed `Copyright (c) 2023 Airbyte, Inc., all rights reserved.`, currentYear will be used in template `Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.`
2) replaced [deprecated TokenAuthenticator](https://github.com/airbytehq/airbyte/blob/f3a3b98922b1743e0a05d3cea2834f3afe67395f/airbyte-cdk/python/airbyte_cdk/sources/streams/http/auth/token.py#L15-L16) with newer version
```patch
-from airbyte_cdk.sources.streams.http.auth import TokenAuthenticator
+from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
```

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide

1. `airbyte-integrations/connector-templates/generator/plopfile.js`
2. `airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/source.py.hbs`

## User Impact

Templates are used by developers creating [their own connectors](https://docs.airbyte.com/connector-development/tutorials/custom-python-connector/environment-setup)

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
