### PR TITLE
Clarify cdk parity test behavior

### DIFF
--- a/airbyte-cdk/python/unit_tests/sources/streams/test_stream_read.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/test_stream_read.py
@@ -170,7 +170,9 @@ def test_full_refresh_read_a_single_slice_with_debug(constructor):
         *records,
     ]
 
-    # Temporary check to only validate the final state message for synchronous sources since it has not been implemented for concurrent yet
+    # Synchronous streams emit a final state message to indicate that the stream has finished reading
+    # Concurrent streams don't emit their own state messages - the concurrent source observes the cursor
+    # and emits the state messages. Therefore, we can only check the value of the cursor's state at the end
     if constructor == _stream:
         expected_records.append(
             AirbyteMessage(
@@ -186,6 +188,10 @@ def test_full_refresh_read_a_single_slice_with_debug(constructor):
         )
 
     actual_records = _read(stream, configured_stream, logger, slice_logger, message_repository, state_manager, internal_config)
+
+    if constructor == _concurrent_stream:
+        assert hasattr(stream._cursor, "state")
+        assert str(stream._cursor.state) == "{'__ab_full_refresh_state_message': True}"
 
     assert actual_records == expected_records
 
@@ -216,7 +222,9 @@ def test_full_refresh_read_a_single_slice(constructor):
 
     expected_records = [*records]
 
-    # Temporary check to only validate the final state message for synchronous sources since it has not been implemented for concurrent yet
+    # Synchronous streams emit a final state message to indicate that the stream has finished reading
+    # Concurrent streams don't emit their own state messages - the concurrent source observes the cursor
+    # and emits the state messages. Therefore, we can only check the value of the cursor's state at the end
     if constructor == _stream:
         expected_records.append(
             AirbyteMessage(
@@ -232,6 +240,10 @@ def test_full_refresh_read_a_single_slice(constructor):
         )
 
     actual_records = _read(stream, configured_stream, logger, slice_logger, message_repository, state_manager, internal_config)
+
+    if constructor == _concurrent_stream:
+        assert hasattr(stream._cursor, "state")
+        assert str(stream._cursor.state) == "{'__ab_full_refresh_state_message': True}"
 
     assert actual_records == expected_records
 
@@ -272,7 +284,7 @@ def test_full_refresh_read_two_slices(constructor):
 
     # Synchronous streams emit a final state message to indicate that the stream has finished reading
     # Concurrent streams don't emit their own state messages - the concurrent source observes the cursor
-    # and emits the state messages. Therefore, we can only check the value of the cursor's state
+    # and emits the state messages. Therefore, we can only check the value of the cursor's state at the end
     if constructor == _stream or constructor == _stream_with_no_cursor_field:
         expected_records.append(
             AirbyteMessage(
@@ -286,11 +298,12 @@ def test_full_refresh_read_two_slices(constructor):
                 ),
             ),
         )
-    elif constructor == _concurrent_stream:
-        assert hasattr(stream._cursor, "state")
-        assert str(stream._cursor.state) == {'__ab_full_refresh_state_message': True}
 
     actual_records = _read(stream, configured_stream, logger, slice_logger, message_repository, state_manager, internal_config)
+
+    if constructor == _concurrent_stream:
+        assert hasattr(stream._cursor, "state")
+        assert str(stream._cursor.state) == "{'__ab_full_refresh_state_message': True}"
 
     for record in expected_records:
         assert record in actual_records


### PR DESCRIPTION
A small change to clarify that the check for "we get a state message from the stream" is not a temporary test behavior, it is permanent for the short term (in the long term, we'd want everything to work as concurrent does) as concurrent streams don't emit state messages, the concurrent source does. 

Changes the test to check the state at the end of the test for concurrent sources, which is about the best we can do right now. 