### PR TITLE
add quickstart issue template; fix typos in other templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-issue-docker.yaml
+++ b/.github/ISSUE_TEMPLATE/2-issue-docker.yaml
@@ -39,7 +39,7 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Revelant information
+      label: Relevant information
       description: Please give any additional information you have and steps to reproduce the problem.
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/3-issue-helm.yaml
+++ b/.github/ISSUE_TEMPLATE/3-issue-helm.yaml
@@ -39,7 +39,7 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Revelant information
+      label: Relevant information
       description: Please give any additional information you have and steps to reproduce the problem.
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/4-issue-abctl.yaml
+++ b/.github/ISSUE_TEMPLATE/4-issue-abctl.yaml
@@ -38,12 +38,12 @@ body:
       label: Abctl Version
       value: |
         <details>
-        
+
         ```console
         $ abctl version
         # paste output here
         ```
-        
+
         </details>
     validations:
       required: true
@@ -53,12 +53,12 @@ body:
       label: Docker Version
       value: |
         <details>
-        
+
         ```console
         $ docker version
         # paste output here
         ```
-        
+
         </details>
     validations:
       required: true
@@ -68,21 +68,21 @@ body:
       label: OS Version
       value: |
         <details>
-        
+
         ```console
         # On Linux:
         $ cat /etc/os-release
         # paste output here
-        
+
         # On Mac:
         $ uname -a
         # paste output here
-        
+
         # On Windows:
         C:\> wmic os get Caption, Version, BuildNumber, OSArchitecture
         # paste output here
         ```
-        
+
         </details>
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/4-issue-abctl.yaml
+++ b/.github/ISSUE_TEMPLATE/4-issue-abctl.yaml
@@ -19,7 +19,6 @@ body:
         Thanks for taking the time to fill out this bug report...
         Make sure to update this issue with a concise title and provide all information you have to 
         help us debug the problem together. Issues not following the template will be closed.
-
   - type: textarea
     id: problem
     attributes:
@@ -27,14 +26,12 @@ body:
       description: Please give any additional information you have and steps to reproduce the problem.
     validations:
       required: true
-
   - type: textarea
     id: expected
     attributes:
       label: What did you expect to happen?
     validations:
       required: true
-
   - type: textarea
     id: abctlVersion
     attributes:
@@ -50,7 +47,6 @@ body:
         </details>
     validations:
       required: true
-
   - type: textarea
     id: dockerVersion
     attributes:
@@ -66,7 +62,6 @@ body:
         </details>
     validations:
       required: true
-
   - type: textarea
     id: osVersion
     attributes:

--- a/.github/ISSUE_TEMPLATE/4-issue-abctl.yaml
+++ b/.github/ISSUE_TEMPLATE/4-issue-abctl.yaml
@@ -1,6 +1,6 @@
-name: 🐛 [abctl] Report an issue with the abctl quickstart tool
+name: 🐛 [abctl] Report an issue with the abctl tool
 description: Use this template when you experience an issue with the abctl tool
-labels: [type/bug, area/quickstart, needs-triage]
+labels: [type/bug, area/abctl, needs-triage]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4-issue-quickstart.yaml
+++ b/.github/ISSUE_TEMPLATE/4-issue-quickstart.yaml
@@ -1,0 +1,93 @@
+name: 🐛 [abctl] Report an issue with the abctl quickstart tool
+description: Use this template when you experience an issue with the abctl tool
+labels: [type/bug, area/quickstart, needs-triage]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        <p align="center">
+          <a target="_blank" href="https://airbyte.com">
+            <image>
+              <source srcset="https://raw.githubusercontent.com/airbytehq/airbyte/master/.github/octavia-issue-template.svg">
+              <img alt="octavia-welcome" src="https://raw.githubusercontent.com/airbytehq/airbyte/master/.github/octavia-issue-template.svg" width="auto" height="120">
+            </image>
+          </a>
+        </p>
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report...
+        Make sure to update this issue with a concise title and provide all information you have to 
+        help us debug the problem together. Issues not following the template will be closed.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Please give any additional information you have and steps to reproduce the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: abctlVersion
+    attributes:
+      label: Abctl Version
+      value: |
+        <details>
+        
+        ```console
+        $ abctl version
+        # paste output here
+        ```
+        
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
+    id: dockerVersion
+    attributes:
+      label: Docker Version
+      value: |
+        <details>
+        
+        ```console
+        $ docker version
+        # paste output here
+        ```
+        
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
+    id: osVersion
+    attributes:
+      label: OS Version
+      value: |
+        <details>
+        
+        ```console
+        # On Linux:
+        $ cat /etc/os-release
+        # paste output here
+        
+        # On Mac:
+        $ uname -a
+        # paste output here
+        
+        # On Windows:
+        C:\> wmic os get Caption, Version, BuildNumber, OSArchitecture
+        # paste output here
+        ```
+        
+        </details>
+    validations:
+      required: true


### PR DESCRIPTION
## What
- add `abctl` issue template
- rename `2-issue-helm` to `3-issue-helm`
    - we had two files prefixed with `2`, I'm assuming a prior copy paste error
- fix typo in `2-issue-docker` and `3-issue-helm`; `Revelant` -> `Relevant`

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
