### PR TITLE
🐛 Source Salesforce: Break Python application with status 1 on exception

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b117307c-14b6-41aa-9422-947e34922962
-  dockerImageTag: 2.5.4
+  dockerImageTag: 2.5.5
   dockerRepository: airbyte/source-salesforce
   documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce
   githubIssueLabel: source-salesforce

--- a/airbyte-integrations/connectors/source-salesforce/poetry.lock
+++ b/airbyte-integrations/connectors/source-salesforce/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "airbyte-cdk"
-version = "0.81.7"
+version = "0.81.8"
 description = "A framework for writing Airbyte Connectors."
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "airbyte_cdk-0.81.7-py3-none-any.whl", hash = "sha256:539f3fc0c3a500240183c61bcd3aa016d54b88ce8f8b41cebae1441af2b5f579"},
-    {file = "airbyte_cdk-0.81.7.tar.gz", hash = "sha256:aa35b9da836dcb1d803cb0b4f1595e9d820f860fef4df908c89a4249d3e7e441"},
+    {file = "airbyte_cdk-0.81.8-py3-none-any.whl", hash = "sha256:1f826715e99b190b0581f0ce5192bd7e5eae69133e77a242a339a4227df02642"},
+    {file = "airbyte_cdk-0.81.8.tar.gz", hash = "sha256:8854a899c9a4fabd2143b86befece8fd62130ffd74049b8c6fb8ac67c7c1da54"},
 ]
 
 [package.dependencies]

--- a/airbyte-integrations/connectors/source-salesforce/pyproject.toml
+++ b/airbyte-integrations/connectors/source-salesforce/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.5.4"
+version = "2.5.5"
 name = "source-salesforce"
 description = "Source implementation for Salesforce."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -193,6 +193,7 @@ Now that you have set up the Salesforce source connector, check out the followin
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 2.5.5   | 2024-04-18 | [37392](https://github.com/airbytehq/airbyte/pull/37419) | Ensure python return code != 0 in case of error                                                                                     |
 | 2.5.4   | 2024-04-18 | [37392](https://github.com/airbytehq/airbyte/pull/37392) | Update CDK version to have partitioned state fix                                                                                     |
 | 2.5.3   | 2024-04-17 | [37376](https://github.com/airbytehq/airbyte/pull/37376) | Improve rate limit error message during check command                                                                                |
 | 2.5.2   | 2024-04-15 | [37105](https://github.com/airbytehq/airbyte/pull/37105) | Raise error when schema generation fails                                                                                             |


### PR DESCRIPTION
## What
To fail an attempt, the return code from the source should be != 0. Since the change to support partitioned state, this is not the case for Concurrent CDK. This change ensure that if there was an exception, we return status code 1.

## How
Update CDK version following https://github.com/airbytehq/airbyte/pull/37390

The rest is updating the tests based on this new exception that is thrown

## User Impact
Error will be reported properly as it needs error code != 0 to be reported

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
