### PR TITLE
🐛Source Mailchimp: fix cursor format for email_activity stream

### DIFF
--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b03a9f3e-22a5-11eb-adc1-0242ac120002
-  dockerImageTag: 2.0.0
+  dockerImageTag: 2.0.1
   dockerRepository: airbyte/source-mailchimp
   documentationUrl: https://docs.airbyte.com/integrations/sources/mailchimp
   githubIssueLabel: source-mailchimp

--- a/airbyte-integrations/connectors/source-mailchimp/pyproject.toml
+++ b/airbyte-integrations/connectors/source-mailchimp/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.0.0"
+version = "2.0.1"
 name = "source-mailchimp"
 description = "Source implementation for Mailchimp."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/manifest.yaml
@@ -331,7 +331,9 @@ definitions:
           field_path: ["{{ parameters.get('data_field') }}"]
     incremental_sync:
       type: DatetimeBasedCursor
-      datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
       cursor_field: "{{ parameters['cursor_field'] }}"
       start_datetime:
         type: MinMaxDatetime

--- a/docs/integrations/sources/mailchimp.md
+++ b/docs/integrations/sources/mailchimp.md
@@ -123,6 +123,7 @@ Now that you have set up the Mailchimp source connector, check out the following
 
 | Version | Date       | Pull Request                                             | Subject                                                                    |
 |---------|------------|----------------------------------------------------------|----------------------------------------------------------------------------|
+| 2.0.1   | 2024-04-19 | [37434](https://github.com/airbytehq/airbyte/pull/37434) | Fix cursor format for the `email_activity` stream                          |
 | 2.0.0   | 2024-04-01 | [35281](https://github.com/airbytehq/airbyte/pull/35281) | Migrate to Low-Code                                                        |
 | 1.2.0   | 2024-03-28 | [36600](https://github.com/airbytehq/airbyte/pull/36600) | Migrate to latest Airbyte-CDK.                                             |
 | 1.1.2   | 2024-02-09 | [35092](https://github.com/airbytehq/airbyte/pull/35092) | Manage dependencies with Poetry.                                           |


### PR DESCRIPTION
## What
Update cursor format for the `email_activity` stream to `%Y-%m-%dT%H:%M:%SZ` in order to avoid 500 errors from the server

## Review guide
1. `manifest.yaml`

## User Impact
No

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
