### PR TITLE
🐛 Source Facebook Marketing: apply configured statuses to ads insight streams

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
-  dockerImageTag: 2.1.5
+  dockerImageTag: 2.1.6
   dockerRepository: airbyte/source-facebook-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-marketing
   githubIssueLabel: source-facebook-marketing

--- a/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.1.5"
+version = "2.1.6"
 name = "source-facebook-marketing"
 description = "Source implementation for Facebook Marketing."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -141,6 +141,7 @@ class SourceFacebookMarketing(AbstractSource):
             end_date=config.end_date,
             insights_lookback_window=config.insights_lookback_window,
             insights_job_timeout=config.insights_job_timeout,
+            filter_statuses=config.ad_statuses
         )
         streams = [
             AdAccount(api=api, account_ids=config.account_ids),
@@ -307,6 +308,12 @@ class SourceFacebookMarketing(AbstractSource):
                 insights_lookback_window=insight.insights_lookback_window or config.insights_lookback_window,
                 insights_job_timeout=insight.insights_job_timeout or config.insights_job_timeout,
                 level=insight.level,
+                filter_statuses=(
+                    config.ad_statuses if insight.level == "ad"
+                    else config.adset_statuses if insight.level == "adset"
+                    else config.campaign_statuses if insight.level == "campaign"
+                    else []
+                )
             )
             streams.append(stream)
         return streams

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
@@ -50,6 +50,8 @@ class AdsInsights(FBMarketingIncrementalStream):
     action_attribution_windows = ALL_ACTION_ATTRIBUTION_WINDOWS
     time_increment = 1
 
+    status_field = "effective_status"
+
     def __init__(
         self,
         name: str = None,
@@ -82,6 +84,7 @@ class AdsInsights(FBMarketingIncrementalStream):
         self._insights_lookback_window = insights_lookback_window
         self._insights_job_timeout = insights_job_timeout
         self.level = level
+        self.entity_prefix = level
 
         # state
         self._cursor_values: Optional[Mapping[str, pendulum.Date]] = None  # latest period that was read for each account
@@ -340,6 +343,7 @@ class AdsInsights(FBMarketingIncrementalStream):
             "time_increment": self.time_increment,
             "action_attribution_windows": self.action_attribution_windows,
         }
+        req_params.update(self._filter_all_statuses())
         return req_params
 
     def _state_filter(self, stream_state: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_base_insight_streams.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_base_insight_streams.py
@@ -91,6 +91,23 @@ class TestBaseInsightsStream:
             "test2",
         ]
 
+    def test_init_statuses(self, api, some_config):
+        stream = AdsInsights(
+            api=api,
+            account_ids=some_config["account_ids"],
+            start_date=datetime(2010, 1, 1),
+            end_date=datetime(2011, 1, 1),
+            insights_lookback_window=28,
+            fields=["account_id", "account_currency"],
+            filter_statuses=["ACTIVE", "ARCHIVED"]
+        )
+
+        assert stream.request_params()["filtering"] == [
+            {'field': 'ad.effective_status',
+             'operator': 'IN',
+             'value': ['ACTIVE', 'ARCHIVED']}
+        ]
+
     def test_read_records_all(self, mocker, api, some_config):
         """1. yield all from mock
         2. if read slice 2, 3 state not changed

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_source.py
@@ -161,6 +161,23 @@ class TestSourceFacebookMarketing:
         config = ConnectorConfig.parse_obj(config)
         assert fb_marketing.get_custom_insights_streams(api, config)
 
+    def test_get_custom_insights_streams_status_filter(self, api, config, fb_marketing):
+        config["custom_insights"] = [
+            {
+                "name": "test",
+                "fields": ["account_id"],
+                "breakdowns": ["ad_format_asset"],
+                "action_breakdowns": ["action_device"],
+                "level": "ad"
+            },
+        ]
+        config["ad_statuses"] = ["ACTIVE", "ARCHIVED"]
+        config["adset_statuses"] = ["ACTIVE", "DELETED"]
+        config = ConnectorConfig.parse_obj(config)
+        streams = fb_marketing.get_custom_insights_streams(api, config)
+        assert len(streams) == 1
+        assert streams[0]._filter_statuses == ["ACTIVE", "ARCHIVED"]
+
     def test_get_custom_insights_action_breakdowns_allow_empty(self, api, config, fb_marketing):
         config["custom_insights"] = [
             {


### PR DESCRIPTION
## What
* Fixes https://github.com/airbytehq/airbyte/issues/36998. 
* When running a sync for Ad Insights, if the first attempt at the jobs never fails, all data is returned properly. But if a job fails twice and needs to be split into smaller jobs, deleted/archived ads are not synced. Only if we apply status filters will all statuses be synced.

## How
* Pass status filters from config to Ads Insights streams. Add status filter to request params. 

## Review guide
<!--
-->

## User Impact
<!--
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
