### PR TITLE
pin zendesk-support 2.3.0 in cloud

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -26,6 +26,7 @@ data:
   registries:
     cloud:
       enabled: true
+      dockerImageTag: 2.3.0  # See https://github.com/airbytehq/oncall/issues/5078
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
* Temporarily pin version 2.3.0, effectively reverting https://github.com/airbytehq/airbyte/pull/36897
* Avoid an issue introduced with the `ticket_metrics` stream - see https://github.com/airbytehq/oncall/issues/5078 for more info

## To Unpin
* This issue looks limited to the `ticket_events` stream. I would recommend releasing a 2.4.1 version which undoes the changes to the `ticket_events` stream while keeping the improvements made to the other streams. When releasing that version, this pin can be removed. We can then tackle figuring out how to introduce the substream functionality for `ticket_events` without running into this issue in a separate follow-up.
