### PR TITLE
allow connectors to be written in kotlin

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/dependencies/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/build.gradle
@@ -3,19 +3,6 @@ plugins {
     id "java-library"
 }
 
-java {
-    // TODO: rewrite code to avoid javac wornings in the first place
-    compileJava {
-        options.compilerArgs += "-Xlint:-varargs,-try,-deprecation,-unchecked,-this-escape"
-    }
-    compileTestJava {
-        options.compilerArgs += "-Xlint:-try"
-    }
-    compileTestFixturesJava {
-        options.compilerArgs += "-Xlint:-try"
-    }
-}
-compileKotlin.compilerOptions.allWarningsAsErrors = false
 compileTestFixturesKotlin.compilerOptions.allWarningsAsErrors = false
 compileTestKotlin.compilerOptions.allWarningsAsErrors = false
 

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/features/FeatureFlagHelper.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/features/FeatureFlagHelper.kt
@@ -41,7 +41,7 @@ object FeatureFlagHelper {
                 try {
                     workspaceIds.add(UUID.fromString(id))
                 } catch (e: IllegalArgumentException) {
-                    log.warn("Malformed workspace id for {}: {}", context, id)
+                    log.warn { "${"Malformed workspace id for {}: {}"} $context $id" }
                 }
             }
         }

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/functional/Either.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/functional/Either.kt
@@ -29,14 +29,14 @@ class Either<Error, Result> private constructor(left: Error?, right: Result?) {
         return right != null
     }
 
-    override fun equals(o: Any?): Boolean {
-        if (this === o) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
             return true
         }
-        if (o == null || javaClass != o.javaClass) {
+        if (other == null || javaClass != other.javaClass) {
             return false
         }
-        val either = o as Either<*, *>
+        val either = other as Either<*, *>
         return left == either.left && right == either.right
     }
 
@@ -47,7 +47,7 @@ class Either<Error, Result> private constructor(left: Error?, right: Result?) {
     companion object {
         fun <Error, Result> left(error: Error): Either<Error, Result> {
             if (error == null) {
-                LOGGER.warn("Either.left called with a null!")
+                LOGGER.warn { "Either.left called with a null!" }
             }
             return Either(error!!, null)
         }

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/io/IOs.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/io/IOs.kt
@@ -83,7 +83,7 @@ object IOs {
             return emptyList<String>()
         }
 
-        ReversedLinesFileReader(file, Charsets.UTF_8).use { fileReader ->
+        ReversedLinesFileReader.Builder().setFile(file).setCharset(Charsets.UTF_8).get().use { fileReader ->
             val lines: MutableList<String?> = ArrayList()
             var line = fileReader.readLine()
             while (line != null && lines.size < numLines) {

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/io/LineGobbler.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/io/LineGobbler.kt
@@ -27,7 +27,7 @@ internal constructor(
     private val caller: String = GENERIC,
     private val containerLogMdcBuilder: MdcScope.Builder = MdcScope.Companion.DEFAULT_BUILDER
 ) : VoidCallable {
-    private val `is`: BufferedReader? = IOs.newBufferedReader(`is`)
+    private val `is`: BufferedReader = IOs.newBufferedReader(`is`)
 
     internal constructor(
         `is`: InputStream,
@@ -40,9 +40,9 @@ internal constructor(
     override fun voidCall() {
         MDC.setContextMap(mdc)
         try {
-            var line = `is`!!.readLine()
+            var line = `is`.readLine()
             while (line != null) {
-                containerLogMdcBuilder.build().use { mdcScope -> consumer.accept(line) }
+                containerLogMdcBuilder.build().use { consumer.accept(line) }
                 line = `is`.readLine()
             }
         } catch (i: IOException) {

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/JsonPaths.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/JsonPaths.kt
@@ -259,7 +259,7 @@ object JsonPaths {
      * @param replacement
      * - a string value to replace the current value at the jsonPath
      */
-    fun replaceAtString(json: JsonNode, jsonPath: String, replacement: String): JsonNode? {
+    fun replaceAtString(json: JsonNode, jsonPath: String, replacement: String): JsonNode {
         return replaceAtJsonNode(json, jsonPath, Jsons.jsonNode(replacement))
     }
 
@@ -315,7 +315,7 @@ object JsonPaths {
         json: JsonNode,
         jsonPath: String,
         replacementFunction: BiFunction<JsonNode, String, JsonNode>
-    ): JsonNode? {
+    ): JsonNode {
         var clone = Jsons.clone(json)
         assertIsJsonPath(jsonPath)
         val foundPaths = getPaths(clone, jsonPath)

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/JsonSchemas.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/JsonSchemas.kt
@@ -226,9 +226,9 @@ object JsonSchemas {
                             consumer
                         )
                     } else {
-                        log.warn(
+                        log.warn {
                             "The array is missing an items field. The traversal is silently stopped. Current schema: $jsonSchemaNode"
-                        )
+                        }
                     }
                 }
                 OBJECT_TYPE -> {
@@ -247,9 +247,9 @@ object JsonSchemas {
                             traverseJsonSchemaInternal(arrayItem, path, consumer)
                         }
                     } else {
-                        log.warn(
+                        log.warn {
                             "The object is a properties key or a combo keyword. The traversal is silently stopped. Current schema: $jsonSchemaNode"
-                        )
+                        }
                     }
                 }
             }
@@ -331,14 +331,14 @@ object JsonSchemas {
     class FieldNameOrList private constructor(val fieldName: String?) {
         val isList: Boolean = fieldName == null
 
-        override fun equals(o: Any?): Boolean {
-            if (this === o) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) {
                 return true
             }
-            if (o !is FieldNameOrList) {
+            if (other !is FieldNameOrList) {
                 return false
             }
-            val that = o
+            val that = other
             return isList == that.isList && fieldName == that.fieldName
         }
 

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/Jsons.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/Jsons.kt
@@ -221,7 +221,7 @@ object Jsons {
 
     @JvmStatic
     fun <T : Any> clone(o: T): T {
-        return deserialize(serialize(o), o::class.java) as T
+        return deserialize(serialize(o), o::class.java)
     }
 
     fun toBytes(jsonNode: JsonNode): ByteArray {
@@ -262,16 +262,16 @@ object Jsons {
     }
 
     fun navigateTo(node: JsonNode, keys: List<String?>): JsonNode {
-        var node = node
+        var targetNode = node
         for (key in keys) {
-            node = node[key]
+            targetNode = targetNode[key]
         }
-        return node
+        return targetNode
     }
 
     fun replaceNestedValue(json: JsonNode, keys: List<String?>, replacement: JsonNode?) {
         replaceNested(json, keys) { node: ObjectNode, finalKey: String? ->
-            node.put(finalKey, replacement)
+            node.replace(finalKey, replacement)
         }
     }
 
@@ -302,16 +302,16 @@ object Jsons {
     }
 
     fun getOptional(json: JsonNode?, keys: List<String>): Optional<JsonNode> {
-        var json = json
+        var retVal = json
         for (key in keys) {
-            if (json == null) {
+            if (retVal == null) {
                 return Optional.empty()
             }
 
-            json = json[key]
+            retVal = retVal[key]
         }
 
-        return Optional.ofNullable(json)
+        return Optional.ofNullable(retVal)
     }
 
     fun getStringOrNull(json: JsonNode?, vararg keys: String): String? {
@@ -419,11 +419,11 @@ object Jsons {
      * the class name can at least help narrow down the problem, without leaking
      * potentially-sensitive information. </snip...>
      */
-    private fun <T : Any> handleDeserThrowable(t: Throwable): Optional<T> {
+    private fun <T : Any> handleDeserThrowable(throwable: Throwable): Optional<T> {
         // Manually build the stacktrace, excluding the top-level exception object
         // so that we don't accidentally include the exception message.
         // Otherwise we could just do ExceptionUtils.getStackTrace(t).
-        var t: Throwable? = t
+        var t: Throwable? = throwable
         val sb = StringBuilder()
         sb.append(t!!.javaClass)
         for (traceElement in t.stackTrace) {

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/stream/StreamStatusUtils.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/stream/StreamStatusUtils.kt
@@ -62,9 +62,7 @@ object StreamStatusUtils {
         airbyteStream: AutoCloseableIterator<AirbyteMessage>,
         statusEmitter: Optional<Consumer<AirbyteStreamStatusHolder>>
     ) {
-        if (airbyteStream is AirbyteStreamAware) {
-            emitRunningStreamStatus(airbyteStream as AirbyteStreamAware, statusEmitter)
-        }
+        emitRunningStreamStatus(airbyteStream as AirbyteStreamAware, statusEmitter)
     }
 
     /**
@@ -90,7 +88,7 @@ object StreamStatusUtils {
         airbyteStream: Optional<AirbyteStreamNameNamespacePair>,
         statusEmitter: Optional<Consumer<AirbyteStreamStatusHolder>>
     ) {
-        airbyteStream!!.ifPresent { s: AirbyteStreamNameNamespacePair? ->
+        airbyteStream.ifPresent { s: AirbyteStreamNameNamespacePair? ->
             LOGGER.debug("RUNNING -> {}", s)
             emitStreamStatus(
                 s,
@@ -110,9 +108,7 @@ object StreamStatusUtils {
         airbyteStream: AutoCloseableIterator<AirbyteMessage>,
         statusEmitter: Optional<Consumer<AirbyteStreamStatusHolder>>
     ) {
-        if (airbyteStream is AirbyteStreamAware) {
-            emitStartStreamStatus(airbyteStream as AirbyteStreamAware, statusEmitter)
-        }
+        emitStartStreamStatus(airbyteStream as AirbyteStreamAware, statusEmitter)
     }
 
     /**
@@ -138,7 +134,7 @@ object StreamStatusUtils {
         airbyteStream: Optional<AirbyteStreamNameNamespacePair>,
         statusEmitter: Optional<Consumer<AirbyteStreamStatusHolder>>
     ) {
-        airbyteStream!!.ifPresent { s: AirbyteStreamNameNamespacePair? ->
+        airbyteStream.ifPresent { s: AirbyteStreamNameNamespacePair? ->
             LOGGER.debug("STARTING -> {}", s)
             emitStreamStatus(
                 s,
@@ -158,9 +154,7 @@ object StreamStatusUtils {
         airbyteStream: AutoCloseableIterator<AirbyteMessage>,
         statusEmitter: Optional<Consumer<AirbyteStreamStatusHolder>>
     ) {
-        if (airbyteStream is AirbyteStreamAware) {
-            emitCompleteStreamStatus(airbyteStream as AirbyteStreamAware, statusEmitter)
-        }
+        emitCompleteStreamStatus(airbyteStream as AirbyteStreamAware, statusEmitter)
     }
 
     /**
@@ -186,7 +180,7 @@ object StreamStatusUtils {
         airbyteStream: Optional<AirbyteStreamNameNamespacePair>,
         statusEmitter: Optional<Consumer<AirbyteStreamStatusHolder>>
     ) {
-        airbyteStream!!.ifPresent { s: AirbyteStreamNameNamespacePair? ->
+        airbyteStream.ifPresent { s: AirbyteStreamNameNamespacePair? ->
             LOGGER.debug("COMPLETE -> {}", s)
             emitStreamStatus(
                 s,
@@ -206,9 +200,7 @@ object StreamStatusUtils {
         airbyteStream: AutoCloseableIterator<AirbyteMessage>,
         statusEmitter: Optional<Consumer<AirbyteStreamStatusHolder>>
     ) {
-        if (airbyteStream is AirbyteStreamAware) {
             emitIncompleteStreamStatus(airbyteStream as AirbyteStreamAware, statusEmitter)
-        }
     }
 
     /**
@@ -234,7 +226,7 @@ object StreamStatusUtils {
         airbyteStream: Optional<AirbyteStreamNameNamespacePair>,
         statusEmitter: Optional<Consumer<AirbyteStreamStatusHolder>>
     ) {
-        airbyteStream!!.ifPresent { s: AirbyteStreamNameNamespacePair? ->
+        airbyteStream.ifPresent { s: AirbyteStreamNameNamespacePair? ->
             LOGGER.debug("INCOMPLETE -> {}", s)
             emitStreamStatus(
                 s,

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/util/CompositeIterator.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/util/CompositeIterator.kt
@@ -108,7 +108,7 @@ internal constructor(
     private fun emitStartStreamStatus(
         airbyteStream: Optional<AirbyteStreamNameNamespacePair>
     ): Boolean {
-        if (airbyteStream!!.isPresent && !seenIterators.contains(airbyteStream)) {
+        if (airbyteStream.isPresent && !seenIterators.contains(airbyteStream)) {
             seenIterators.add(airbyteStream)
             StreamStatusUtils.emitStartStreamStatus(airbyteStream, airbyteStreamStatusConsumer)
             return true

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/yaml/Yamls.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/yaml/Yamls.kt
@@ -110,7 +110,7 @@ object Yamls {
                 iterator,
                 VoidCallable { parser.close() },
                 null
-            )!!
+            )
         } catch (e: IOException) {
             throw RuntimeException(e)
         }

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/configoss/CatalogDefinitionsConfig.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/configoss/CatalogDefinitionsConfig.kt
@@ -13,7 +13,7 @@ object CatalogDefinitionsConfig {
     val localConnectorCatalogPath: String
         get() {
             val customCatalogPath = EnvConfigs().localCatalogPath
-            if (customCatalogPath!!.isPresent) {
+            if (customCatalogPath.isPresent) {
                 return customCatalogPath.get()
             }
 

--- a/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
@@ -380,7 +380,7 @@ class Connector:
             return ConnectorLanguage.LOW_CODE
         if Path(self.code_directory / "setup.py").is_file() or Path(self.code_directory / "pyproject.toml").is_file():
             return ConnectorLanguage.PYTHON
-        if Path(self.code_directory / "src" / "main" / "java").exists():
+        if Path(self.code_directory / "src" / "main" / "java").exists() or Path(self.code_directory / "src" / "main" / "kotlin").exists():
             return ConnectorLanguage.JAVA
         return None
 


### PR DESCRIPTION
Today, we don't allow java connectors to be written in kotlin. We could add a new language `KOTLIN`, but since all the targets are the same, it seems overkill. So i'm just changing the condition for language=JAVA