### PR TITLE
[Python CDK] Bump python version in pypi manifest to 3.10

### DIFF
--- a/airbyte-cdk/python/pyproject.toml
+++ b/airbyte-cdk/python/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.10",
 ]
 keywords = ["airbyte", "connector-development-kit", "cdk"]
 


### PR DESCRIPTION
## What

_Minor minor_ change — we target 3.10, made pypi manifest consistent.