### PR TITLE
Move AI-partner connectors to certified

### DIFF
--- a/airbyte-integrations/connectors/destination-astra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-astra/metadata.yaml
@@ -1,4 +1,7 @@
 data:
+  ab_internal:
+    ql: 300
+    sl: 300
   allowedHosts:
     hosts:
       - "*.apps.astra.datastax.com"
@@ -22,8 +25,8 @@ data:
   license: MIT
   name: Astra DB
   releaseDate: 2024-01-10
-  releaseStage: alpha
-  supportLevel: community
+  releaseStage: generally_available
+  supportLevel: certified
   documentationUrl: https://docs.airbyte.com/integrations/destinations/astra
   tags:
     - language:python

--- a/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
@@ -15,7 +15,7 @@ data:
       enabled: true
     oss:
       enabled: true
-  releaseStage: alpha
+  releaseStage: generally_available
   releases:
     breakingChanges:
       0.3.0:
@@ -36,7 +36,7 @@ data:
     - language:python
     - cdk:python
   ab_internal:
-    sl: 100
+    sl: 300
     ql: 100
-  supportLevel: community
+  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-milvus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-milvus/metadata.yaml
@@ -29,13 +29,13 @@ data:
   license: MIT
   name: Milvus
   releaseDate: 2023-08-15
-  releaseStage: alpha
+  releaseStage: generally_available
   documentationUrl: https://docs.airbyte.com/integrations/destinations/milvus
   tags:
     - language:python
     - cdk:python
   ab_internal:
-    sl: 200
+    sl: 300
     ql: 300
   supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   ab_internal:
     ql: 300
-    sl: 200
+    sl: 300
   allowedHosts:
     hosts:
       - "*.${indexing.pinecone_environment}.pinecone.io"
@@ -30,7 +30,7 @@ data:
     oss:
       enabled: true
   releaseDate: 2023-08-15
-  releaseStage: beta
+  releaseStage: generally_available
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
@@ -29,13 +29,13 @@ data:
   license: MIT
   name: Qdrant
   releaseDate: 2023-09-22
-  releaseStage: alpha
+  releaseStage: generally_available
   documentationUrl: https://docs.airbyte.com/integrations/destinations/qdrant
   tags:
     - language:python
     - cdk:python
   ab_internal:
-    sl: 100
-    ql: 100
-  supportLevel: community
+    sl: 300
+    ql: 300
+  supportLevel: certified
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-vectara/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-vectara/metadata.yaml
@@ -24,8 +24,8 @@ data:
       enabled: false # TODO: enable once the CLI is working
       packageName: airbyte-destination-vectara
   releaseDate: 2023-12-16
-  releaseStage: alpha
-  supportLevel: community
+  releaseStage: generally_available
+  supportLevel: certified
   documentationUrl: https://docs.airbyte.com/integrations/destinations/vectara
   tags:
     - language:python

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   ab_internal:
     ql: 300
-    sl: 200
+    sl: 300
   allowedHosts:
     hosts:
       - ${indexing.host}
@@ -25,7 +25,7 @@ data:
       enabled: true
     oss:
       enabled: true
-  releaseStage: alpha
+  releaseStage: generally_available
   releases:
     breakingChanges:
       0.2.0:


### PR DESCRIPTION
Bumps strategic AI-partner connectors to certified:

1. Astra DB
2. DuckDB
3. Milvus
4. Pinecone
5. QDrant
6. Vectara
7. Weaviate
