### PR TITLE
bumping jsonschemafriend to 0.12.4

### DIFF
--- a/airbyte-integrations/connectors/source-e2e-test/build.gradle
+++ b/airbyte-integrations/connectors/source-e2e-test/build.gradle
@@ -15,6 +15,6 @@ application {
 dependencies {
     // random Json object generation from Json schema
     // https://github.com/airbytehq/jsongenerator
-    implementation 'net.jimblackler.jsonschemafriend:core:0.12.1'
+    implementation 'net.jimblackler.jsonschemafriend:core:0.12.4'
     implementation group: 'com.github.airbytehq', name: 'jsongenerator', version: '1.0.2'
 }

--- a/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d53f9084-fa6b-4a5a-976c-5b8392f4ad8a
-  dockerImageTag: 2.2.1
+  dockerImageTag: 2.2.2
   dockerRepository: airbyte/source-e2e-test
   githubIssueLabel: source-e2e-test
   icon: airbyte.svg

--- a/docs/integrations/sources/e2e-test.md
+++ b/docs/integrations/sources/e2e-test.md
@@ -72,6 +72,7 @@ The OSS and Cloud variants have the same version number. The Cloud variant was i
 
 | Version | Date       | Pull request                                                       | Subject                                                                                               |
 |---------|------------| ------------------------------------------------------------------ |-------------------------------------------------------------------------------------------------------|
+| 2.2.2   | 2024-04-25 | [37581](https://github.com/airbytehq/airbyte/pull/37581)           | bump jsonschemafriend to 0.12.4                                                                       |
 | 2.2.1   | 2024-02-13 | [35231](https://github.com/airbytehq/airbyte/pull/35231)           | Adopt JDK 0.20.4.                                                                                     |
 | 2.2.0   | 2023-12-18 | [33485](https://github.com/airbytehq/airbyte/pull/33485)           | Remove LEGACY state                                                                                   |
 | 2.1.5   | 2023-10-04 | [31092](https://github.com/airbytehq/airbyte/pull/31092)           | Bump jsonschemafriend dependency version to fix bug                                                   |


### PR DESCRIPTION
jsonschema seems to have moved from a javascript redirect to a HTTP redirect for their DRAFT_4 URL. Unfortunately, jsonschemafriend doesn't handle HTTP redirect in 0.12.1, which causes our 2e2 source to dump inordinate amounts of logs. This fixes it.
The test GeneratorTest was failing prior to this change and is now passing

I believe [this is the PR](https://github.com/jimblackler/jsonschemafriend/commit/aae56d0738250201e1ff5399db5ab7103d7cd4f3) that fixes the issue (having an offline version of the supported stores, so there's no dependency on the internet at all)