### PR TITLE
gradle: push down lombok deps, add ksp support, disable some FB rules

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/core/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     api 'org.jooq:jooq:3.16.23'
     api 'org.apache.commons:commons-csv:1.10.0'
 
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
 
     implementation 'commons-cli:commons-cli:1.4'
@@ -74,6 +77,9 @@ dependencies {
 
     testFixturesApi 'org.testcontainers:testcontainers:1.19.0'
     testFixturesApi 'org.testcontainers:jdbc:1.19.0'
+
+    testCompileOnly 'org.projectlombok:lombok:1.18.30'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
 
     testImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
     testImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-db-sources'))

--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/build.gradle
@@ -2,11 +2,15 @@ compileTestFixturesKotlin.compilerOptions.allWarningsAsErrors = false
 compileTestKotlin.compilerOptions.allWarningsAsErrors = false
 
 dependencies {
+
     api 'org.apache.commons:commons-csv:1.10.0'
 
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
     compileOnly project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-typing-deduping')
+
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
     implementation 'io.aesy:datasize:1.0.0'
 

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     api 'org.apache.parquet:parquet-avro:1.13.1'
     runtimeOnly 'com.hadoop.gplcompression:hadoop-lzo:0.4.20'
 
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+
     testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
     testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies'))
     testFixturesApi project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/build.gradle
@@ -16,10 +16,14 @@ dependencies {
 
     implementation 'commons-codec:commons-codec:1.16.0'
 
+    testCompileOnly 'org.projectlombok:lombok:1.18.30'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
+
     testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
     testFixturesImplementation testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies'))
     testFixturesImplementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core')
     testFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
     testFixturesImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'
+
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'
 }

--- a/airbyte-integrations/connectors-performance/destination-harness/build.gradle
+++ b/airbyte-integrations/connectors-performance/destination-harness/build.gradle
@@ -8,6 +8,9 @@ application {
 }
 
 dependencies {
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30' // Lombok must be added BEFORE Micronaut
+
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
 
     implementation 'io.fabric8:kubernetes-client:5.12.2'

--- a/airbyte-integrations/connectors-performance/source-harness/build.gradle
+++ b/airbyte-integrations/connectors-performance/source-harness/build.gradle
@@ -8,6 +8,9 @@ application {
 }
 
 dependencies {
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30' // Lombok must be added BEFORE Micronaut
+
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-dependencies')
 
     implementation 'io.fabric8:kubernetes-client:5.12.2'

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'base'
     id 'com.github.spotbugs' version '6.0.7' apply false
     id 'org.jetbrains.kotlin.jvm' version '1.9.23' apply false
+    id 'com.google.devtools.ksp' version '1.9.23-1.0.19' apply false
 }
 
 allprojects {
@@ -16,6 +17,7 @@ allprojects {
     apply plugin: 'java-test-fixtures'
     apply plugin: 'com.github.spotbugs'
     apply plugin: 'org.jetbrains.kotlin.jvm'
+    apply plugin: 'com.google.devtools.ksp'
     apply plugin: 'idea'
 
 

--- a/spotbugs-exclude-filter-file.xml
+++ b/spotbugs-exclude-filter-file.xml
@@ -19,4 +19,14 @@
     <Class name="io.airbyte.cdk.integrations.debezium.internals.AirbyteFileOffsetBackingStore" />
     <Bug code="SECOBDES" />
   </Match>
+  <!-- Suppress warnings triggered because Spotbugs doesn't understand Kotlin. -->
+  <Match>
+    <Source name="~.*/kotlin/.*" />
+    <Bug pattern="NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER" />
+  </Match>
+  <!-- Suppress warnings triggered because Spotbugs doesn't understand dependency injection. -->
+  <Match>
+    <Source name="~.*/airbyte-integrations/connectors/source-oracle-v2/.*" />
+    <Bug pattern="NP_NONNULL_RETURN_VIOLATION" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Micronaut doesn't play well with lombok so a prereq is to remove the blanket lombok dependency added in the root `build.gradle`.

Micronaut when used with Kotlin requires KSP (or something similar) for its annotation processor(s?) to be able to generate the code it needs. Micronaut does a fair bit of work at compile-time, which distinguishes it from other DI frameworks like Spring etc.

edit: Micronaut also requires some FindBugs rules disabled.