### PR TITLE
source-oracle,cdk2: add Micronaut CLI entrypoints

### DIFF
--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunnable.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunnable.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import io.airbyte.cdk.operation.Operation
+import io.airbyte.cdk.operation.OperationExecutionException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Value
+import jakarta.inject.Inject
+
+private val log = KotlinLogging.logger {}
+
+/** [AirbyteConnectorRunner] tells Micronaut to use this [Runnable] as the entry point. */
+class AirbyteConnectorRunnable : Runnable {
+
+    @Value("\${micronaut.application.name}") lateinit var connectorName: String
+    @Inject lateinit var operation: Operation
+
+    override fun run() {
+        log.info { "Executing ${operation::class} operation." }
+        try {
+            operation.execute()
+        } catch (e: OperationExecutionException) {
+            log.error(e) { "Failed ${operation::class} operation execution." }
+            throw e
+        } catch (e: Throwable) {
+            log.error(e) { "Failed ${operation::class} operation execution." }
+            throw OperationExecutionException(cause = e)
+        } finally {
+            log.info { "Completed integration: $connectorName." }
+        }
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunner.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunner.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import io.airbyte.cdk.command.ConnectorCommandLinePropertySource
+import io.airbyte.cdk.integrations.base.AirbyteTraceMessageUtility
+import io.airbyte.cdk.integrations.base.JavaBaseConstants
+import io.airbyte.cdk.integrations.util.ApmTraceUtils
+import io.airbyte.cdk.integrations.util.ConnectorExceptionUtil
+import io.micronaut.configuration.picocli.MicronautFactory
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.CommandLinePropertySource
+import io.micronaut.context.env.Environment
+import io.micronaut.core.cli.CommandLine as MicronautCommandLine
+import java.nio.file.Path
+import picocli.CommandLine
+import picocli.CommandLine.Model.ArgGroupSpec
+import picocli.CommandLine.Model.OptionSpec
+import picocli.CommandLine.Model.UsageMessageSpec
+
+/** Source connector entry point. */
+class AirbyteSourceRunner(args: Array<out String>) : AirbyteConnectorRunner("source", args) {
+
+    companion object {
+        @JvmStatic
+        fun run(vararg args: String) {
+            AirbyteSourceRunner(args).run<AirbyteConnectorRunnable>()
+        }
+    }
+}
+
+/** Destination connector entry point. */
+class AirbyteDestinationRunner(args: Array<out String>) :
+    AirbyteConnectorRunner("destination", args) {
+
+    companion object {
+        @JvmStatic
+        fun run(vararg args: String) {
+            AirbyteDestinationRunner(args).run<AirbyteConnectorRunnable>()
+        }
+    }
+}
+
+/**
+ * Replacement for the Micronaut CLI application runner that configures the CLI components and adds
+ * the custom property source used to turn the arguments into configuration properties.
+ */
+sealed class AirbyteConnectorRunner(
+    val connectorType: String,
+    val args: Array<out String>,
+) {
+
+    val envs: Array<String> = arrayOf(Environment.CLI, connectorType)
+
+    inline fun <reified R : Runnable> run() {
+        val picocliCommandLineFactory = PicocliCommandLineFactory(this)
+        val micronautCommandLine: MicronautCommandLine = MicronautCommandLine.parse(*args)
+        val configPropertySource =
+            ConnectorCommandLinePropertySource(
+                micronautCommandLine,
+                picocliCommandLineFactory.commands.options().map { it.longestName() }
+            )
+        val commandLinePropertySource = CommandLinePropertySource(micronautCommandLine)
+        val ctx: ApplicationContext =
+            ApplicationContext.builder(R::class.java, *envs)
+                .propertySources(configPropertySource, commandLinePropertySource)
+                .start()
+        val isTest: Boolean = ctx.environment.activeNames.contains(Environment.TEST)
+        val picocliFactory: CommandLine.IFactory = MicronautFactory(ctx)
+        val picocliCommandLine: CommandLine =
+            picocliCommandLineFactory.build<AirbyteConnectorRunnable>(picocliFactory, isTest)
+        try {
+            picocliCommandLine.execute(*args)
+        } catch (e: Throwable) {
+            // Many of the exceptions thrown are nested inside layers of RuntimeExceptions. An
+            // attempt is made to find the root exception that corresponds to a configuration
+            // error. If that does not exist, we just return the original exception.
+            ApmTraceUtils.addExceptionToTrace(e)
+            val rootThrowable = ConnectorExceptionUtil.getRootConfigError(Exception(e))
+            val displayMessage = ConnectorExceptionUtil.getDisplayMessage(rootThrowable)
+            // If the connector throws a config error, a trace message with the relevant
+            // message should be surfaced.
+            if (ConnectorExceptionUtil.isConfigError(rootThrowable)) {
+                AirbyteTraceMessageUtility.emitConfigErrorTrace(e, displayMessage)
+            }
+        }
+    }
+}
+
+/** Encapsulates all picocli logic. Defines the grammar for the CLI. */
+class PicocliCommandLineFactory(val runner: AirbyteConnectorRunner) {
+
+    inline fun <reified R : Runnable> build(
+        factory: CommandLine.IFactory,
+        isTest: Boolean
+    ): CommandLine {
+        val commandSpec: CommandLine.Model.CommandSpec =
+            CommandLine.Model.CommandSpec.wrapWithoutInspection(R::class.java, factory)
+                .name("airbyte-${runner.connectorType}-connector")
+                .usageMessage(usageMessageSpec)
+                .mixinStandardHelpOptions(true)
+                .addArgGroup(commands)
+                .addOption(config)
+                .addOption(catalog)
+                .addOption(state)
+
+        if (isTest) {
+            commandSpec.addOption(output)
+        }
+        return CommandLine(commandSpec, factory)
+    }
+
+    val usageMessageSpec: UsageMessageSpec =
+        UsageMessageSpec()
+            .header(
+                "@|magenta     ___    _      __          __       |@",
+                "@|magenta    /   |  (_)____/ /_  __  __/ /____   |@",
+                "@|magenta   / /| | / / ___/ __ \\/ / / / __/ _   |@",
+                "@|magenta  / ___ |/ / /  / /_/ / /_/ / /_/  __/  |@",
+                "@|magenta /_/  |_/_/_/  /_.___/\\__, /\\__/\\___/|@",
+                "@|magenta                    /____/              |@"
+            )
+            .description("Executes an Airbyte ${runner.connectorType} connector.")
+
+    fun command(name: String, description: String): OptionSpec =
+        OptionSpec.builder("--$name").description(description).arity("0").build()
+    val spec: OptionSpec = command("spec", "outputs the json configuration specification")
+    val check: OptionSpec = command("check", "checks the config can be used to connect")
+    val discover: OptionSpec =
+        command("discover", "outputs a catalog describing the source's catalog")
+    val read: OptionSpec = command("read", "reads the source and outputs messages to STDOUT")
+    val write: OptionSpec = command("write", "writes messages from STDIN to the integration")
+
+    val commands: ArgGroupSpec =
+        ArgGroupSpec.builder()
+            .multiplicity("1")
+            .exclusive(true)
+            .addArg(spec)
+            .addArg(check)
+            .apply {
+                when (runner) {
+                    is AirbyteSourceRunner -> addArg(discover).addArg(read)
+                    is AirbyteDestinationRunner -> addArg(write)
+                }
+            }
+            .build()
+
+    fun fileOption(name: String, vararg description: String): OptionSpec =
+        OptionSpec.builder("--$name")
+            .description(*description)
+            .type(Path::class.java)
+            .arity("1")
+            .build()
+    val config: OptionSpec =
+        fileOption(
+            JavaBaseConstants.ARGS_CONFIG_KEY,
+            JavaBaseConstants.ARGS_CONFIG_DESC,
+            "Required by the following commands: check, discover, read, write"
+        )
+    val catalog: OptionSpec =
+        fileOption(
+            JavaBaseConstants.ARGS_CATALOG_KEY,
+            JavaBaseConstants.ARGS_CATALOG_DESC,
+            "Required by the following commands: read, write"
+        )
+    val state: OptionSpec =
+        fileOption(
+            JavaBaseConstants.ARGS_STATE_KEY,
+            JavaBaseConstants.ARGS_PATH_DESC,
+            "Required by the following commands: read"
+        )
+    val output: OptionSpec =
+        fileOption(
+            "output",
+            "path to the output file",
+            "When present, the connector writes to this file instead of stdout"
+        )
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/ConnectorCommandLinePropertySource.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/ConnectorCommandLinePropertySource.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import io.airbyte.cdk.integrations.base.JavaBaseConstants
+import io.airbyte.cdk.operation.CONNECTOR_OPERATION
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.env.MapPropertySource
+import io.micronaut.core.cli.CommandLine
+import java.io.File
+import java.nio.file.Path
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Custom Micronaut [MapPropertySource] that reads the command line arguments provided via the
+ * connector CLI and turns them into configuration properties. This allows the arguments to be
+ * injected into code that depends on them via Micronaut.
+ */
+class ConnectorCommandLinePropertySource(commandLine: CommandLine, allLongOptions: List<String>) :
+    MapPropertySource("connector", resolveValues(commandLine, allLongOptions))
+
+const val CONNECTOR_CONFIG_PREFIX: String = "airbyte.connector.config"
+const val CONNECTOR_CATALOG_PREFIX: String = "airbyte.connector.catalog"
+const val CONNECTOR_STATE_PREFIX: String = "airbyte.connector.state"
+const val CONNECTOR_OUTPUT_FILE = "airbyte.connector.output.file"
+
+private fun resolveValues(
+    commandLine: CommandLine,
+    allLongOptions: List<String>
+): Map<String, Any> {
+    val ops: List<String> =
+        allLongOptions.map { it.removePrefix("--") }.filter { commandLine.optionValue(it) != null }
+    if (ops.isEmpty()) {
+        throw IllegalArgumentException("Command line is missing an operation.")
+    }
+    if (ops.size > 1) {
+        throw IllegalArgumentException("Command line has multiple operations: $ops")
+    }
+    val values: MutableMap<String, Any> = mutableMapOf()
+    values[CONNECTOR_OPERATION] = ops.first()
+    commandLine.optionValue("output")?.let { values[CONNECTOR_OUTPUT_FILE] = it }
+    for ((cliOptionKey, prefix) in
+        mapOf(
+            JavaBaseConstants.ARGS_CONFIG_KEY to CONNECTOR_CONFIG_PREFIX,
+            JavaBaseConstants.ARGS_CATALOG_KEY to CONNECTOR_CATALOG_PREFIX,
+            JavaBaseConstants.ARGS_STATE_KEY to CONNECTOR_STATE_PREFIX,
+        )) {
+        val cliOptionValue = commandLine.optionValue(cliOptionKey) as String?
+        if (cliOptionValue.isNullOrBlank()) {
+            continue
+        }
+        val jsonFile: File = Path.of(cliOptionValue).toFile()
+        if (!jsonFile.exists()) {
+            log.warn { "File '$jsonFile' not found for '$cliOptionKey'." }
+            continue
+        }
+        values["$prefix.json"] = jsonFile.readText()
+    }
+    return values
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/operation/Operation.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/operation/Operation.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.operation
+
+const val CONNECTOR_OPERATION: String = "airbyte.connector.operation"
+
+/** Interface that defines a CLI operation. */
+fun interface Operation {
+
+    fun execute()
+}
+
+/** Custom exception that represents a failure to execute an operation. */
+class OperationExecutionException(message: String? = null, cause: Throwable? = null) :
+    Exception(message, cause)

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSource.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSource.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.test.source
+
+import io.airbyte.cdk.AirbyteSourceRunner
+
+/** A fake source database connector, vaguely compatible with the H2 database. */
+class TestSource {
+
+    fun main(args: Array<String>) {
+        AirbyteSourceRunner.run(*args)
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/application.yml
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/application.yml
@@ -1,0 +1,7 @@
+micronaut:
+  application:
+    name: test-connector
+
+airbyte:
+  connector:
+    documentationUrl: "https://docs.airbyte.com"

--- a/airbyte-integrations/connectors/source-oracle-v2/src/main/java/io/airbyte/integrations/source/oracle/OracleSource.java
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/main/java/io/airbyte/integrations/source/oracle/OracleSource.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.oracle;
+
+import io.airbyte.cdk.AirbyteSourceRunner;
+
+public class OracleSource {
+
+  static public void main(String[] args) {
+    AirbyteSourceRunner.run(args);
+  }
+
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/main/resources/application.yml
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+micronaut:
+  application:
+    name: source-oracle-v2
+
+airbyte:
+  connector:
+    documentationUrl: "https://docs.airbyte.com/integrations/sources/oracle"


### PR DESCRIPTION
This PR has the Micronaut connector entrypoint and does basic CLI argument processing by setting Micronaut properties to suitable values.

Most of this was written by @jdpgrailsdev and I didn't invent much. I moved away from the picocli annotations and instead chose to define the CLI grammar using the programmatic API. Ostensibly this is to have separate rules for sources and destinations but really it's to allow for "secret" test-only extra arguments which are going to be rather useful in integration tests.

This PR also adds the barest of skeletons for a fake source connector in the CDK tests.