### PR TITLE
source-oracle,cdk2: add config JSON objects and SPEC operation

### DIFF
--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/ConfigurationJsonObjectSupplier.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/ConfigurationJsonObjectSupplier.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.micronaut.context.annotation.Value
+import jakarta.inject.Singleton
+import java.util.function.Supplier
+
+/**
+ * Supplies a valid [T] configuration POJO instance, based on the `airbyte.connector.config`
+ * Micronaut property values:
+ * - either `airbyte.connector.config.json` if it is set (typically by the CLI)
+ * - or the other, nested `airbyte.connector.config.*` properties (typically in unit tests)
+ *
+ * One may wonder why we need to inject this [Supplier] instead of injecting the POJO directly. The
+ * reason is that injecting the POJO only works if the configuration values are set via the nested
+ * Micronaut properties (i.e. in unit tests). We could make direct injection work the same way as
+ * the [ConfiguredCatalogFactory] or the [InputStateFactory] (via a @Factory) but then we'd lose the
+ * ability to set values via the nested properties. This current design caters to both use cases.
+ * Furthermore, by deferring the parsing and validation of the configuration, we don't need to worry
+ * about exception handling edge cases when implementing the CHECK operation.
+ *
+ * The object is also validated against its [jsonSchema] JSON schema, derived from [javaClass].
+ */
+@Singleton
+class ConfigurationJsonObjectSupplier<T : ConfigurationJsonObjectBase>(
+    private val micronautPropertiesFallback: T,
+    @Value("\${${CONNECTOR_CONFIG_PREFIX}.json}") private val jsonPropertyValue: String? = null
+) : Supplier<T> {
+
+    @Suppress("UNCHECKED_CAST")
+    val javaClass: Class<T> = micronautPropertiesFallback::class.java as Class<T>
+
+    val jsonSchema: JsonNode by lazy { JsonUtils.generator.generateJsonSchema(javaClass) }
+
+    override fun get(): T {
+        val json: String =
+            jsonPropertyValue
+                ?: JsonUtils.jsonNode(javaClass, micronautPropertiesFallback).toString()
+        return JsonUtils.parseOne(javaClass, json)
+    }
+}
+
+/**
+ * Connector configuration POJO supertype.
+ *
+ * This dummy base class is required by Micronaut. Without it, thanks to Java's type erasure, it
+ * thinks that the [ConfigurationJsonObjectSupplier] requires a constructor argument of type [Any].
+ *
+ * Strictly speaking, its subclasses are not really POJOs anymore, but who cares.
+ */
+abstract class ConfigurationJsonObjectBase

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/JsonUtils.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/JsonUtils.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.kjetland.jackson.jsonSchema.JsonSchemaConfig
+import com.kjetland.jackson.jsonSchema.JsonSchemaDraft
+import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator
+import com.networknt.schema.JsonSchema
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SchemaValidatorsConfig
+import com.networknt.schema.SpecVersion
+import io.airbyte.commons.exceptions.ConfigErrorException
+import io.airbyte.commons.jackson.MoreMappers
+
+/**
+ * A grab-bag of JSON utilities because the `Jsons` object doesn't yet support mapping to Kotlin
+ * data classes. Also includes utilities for JSON schemas.
+ */
+object JsonUtils {
+
+    fun <T> jsonNode(klazz: Class<T>, any: T): JsonNode =
+        try {
+            mapper.valueToTree(any)
+        } catch (e: Exception) {
+            throw ConfigErrorException("failed to parse $klazz instance as JsonNode")
+        }
+
+    fun <T> parseOne(klazz: Class<T>, json: String): T {
+        val tree: JsonNode =
+            try {
+                mapper.readTree(json)
+            } catch (e: Exception) {
+                throw ConfigErrorException("malformed json value while parsing for $klazz", e)
+            }
+        return parseList(klazz, tree).firstOrNull()
+            ?: throw ConfigErrorException("missing json value while parsing for $klazz")
+    }
+
+    fun <T> parseList(elementClass: Class<T>, json: String?): List<T> {
+        val tree: JsonNode =
+            try {
+                mapper.readTree(json ?: "[]")
+            } catch (e: Exception) {
+                throw ConfigErrorException(
+                    "malformed json value while parsing for $elementClass",
+                    e
+                )
+            }
+        return parseList(elementClass, tree)
+    }
+
+    fun <T> parseList(elementClass: Class<T>, tree: JsonNode): List<T> {
+        val jsonList: List<JsonNode> = if (tree.isArray) tree.toList() else listOf(tree)
+        val schemaNode: JsonNode = generator.generateJsonSchema(elementClass)
+        val jsonSchema: JsonSchema = jsonSchemaFactory.getSchema(schemaNode, jsonSchemaConfig)
+        for (element in jsonList) {
+            val validationFailures = jsonSchema.validate(element)
+            if (validationFailures.isNotEmpty()) {
+                throw ConfigErrorException(
+                    "$elementClass json schema violation: ${validationFailures.first()}"
+                )
+            }
+        }
+        return jsonList.map { parseUnvalidated(it, elementClass) }
+    }
+
+    fun <T> parseUnvalidated(jsonNode: JsonNode, klazz: Class<T>): T =
+        try {
+            mapper.treeToValue(jsonNode, klazz)
+        } catch (e: Exception) {
+            throw ConfigErrorException("failed to map valid json to $klazz ", e)
+        }
+
+    val generatorConfig: JsonSchemaConfig =
+        JsonSchemaConfig.vanillaJsonSchemaDraft4()
+            .withJsonSchemaDraft(JsonSchemaDraft.DRAFT_07)
+            .withFailOnUnknownProperties(false)
+
+    val generator = JsonSchemaGenerator(MoreMappers.initMapper(), generatorConfig)
+
+    val mapper: ObjectMapper =
+        MoreMappers.initMapper().apply {
+            setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            registerModule(KotlinModule.Builder().build())
+        }
+
+    val jsonSchemaConfig = SchemaValidatorsConfig()
+
+    val jsonSchemaFactory: JsonSchemaFactory =
+        JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7)
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/consumers/OutputConsumer.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/consumers/OutputConsumer.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.consumers
+
+import io.airbyte.commons.json.Jsons
+import io.airbyte.protocol.models.v0.AirbyteCatalog
+import io.airbyte.protocol.models.v0.AirbyteConnectionStatus
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
+import io.airbyte.protocol.models.v0.AirbyteTraceMessage
+import io.airbyte.protocol.models.v0.ConnectorSpecification
+import io.micronaut.context.annotation.DefaultImplementation
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+import java.time.Instant
+import java.util.function.Consumer
+
+/** Emits the [AirbyteMessage] instances produced by the connector. */
+@DefaultImplementation(StdoutOutputConsumer::class)
+interface OutputConsumer : Consumer<AirbyteMessage> {
+
+    val emittedAt: Instant
+
+    fun accept(record: AirbyteRecordMessage) {
+        record.emittedAt = emittedAt.toEpochMilli()
+        accept(AirbyteMessage().withType(AirbyteMessage.Type.RECORD).withRecord(record))
+    }
+
+    fun accept(state: AirbyteStateMessage) {
+        accept(AirbyteMessage().withType(AirbyteMessage.Type.STATE).withState(state))
+    }
+
+    fun accept(spec: ConnectorSpecification) {
+        accept(AirbyteMessage().withType(AirbyteMessage.Type.SPEC).withSpec(spec))
+    }
+
+    fun accept(status: AirbyteConnectionStatus) {
+        accept(
+            AirbyteMessage()
+                .withType(AirbyteMessage.Type.CONNECTION_STATUS)
+                .withConnectionStatus(status)
+        )
+    }
+
+    fun accept(catalog: AirbyteCatalog) {
+        accept(AirbyteMessage().withType(AirbyteMessage.Type.CATALOG).withCatalog(catalog))
+    }
+
+    fun accept(trace: AirbyteTraceMessage) {
+        accept(AirbyteMessage().withType(AirbyteMessage.Type.TRACE).withTrace(trace))
+    }
+}
+
+// Used for integration tests.
+const val CONNECTOR_OUTPUT_FILE = "airbyte.connector.output.file"
+
+/** Default implementation of [OutputConsumer]. */
+@Singleton
+@Secondary
+private class StdoutOutputConsumer : OutputConsumer {
+
+    override val emittedAt: Instant = Instant.now()
+
+    override fun accept(airbyteMessage: AirbyteMessage) {
+        val json: String = Jsons.serialize(airbyteMessage)
+        synchronized(this) { println(json) }
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/operation/SpecOperation.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/operation/SpecOperation.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.operation
+
+import io.airbyte.cdk.command.ConfigurationJsonObjectSupplier
+import io.airbyte.cdk.consumers.OutputConsumer
+import io.airbyte.protocol.models.v0.ConnectorSpecification
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import jakarta.inject.Singleton
+import java.net.URI
+
+@Singleton
+@Requires(property = CONNECTOR_OPERATION, value = "spec")
+class SpecOperation(
+    @Value("\${airbyte.connector.documentationUrl}") val documentationUrl: String,
+    val configJsonObjectSupplier: ConfigurationJsonObjectSupplier<*>,
+    val outputConsumer: OutputConsumer
+) : Operation {
+
+    override fun execute() {
+        outputConsumer.accept(
+            ConnectorSpecification()
+                .withDocumentationUrl(URI.create(documentationUrl))
+                .withConnectionSpecification(configJsonObjectSupplier.jsonSchema)
+        )
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/ssh/SshConnectionOptions.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/ssh/SshConnectionOptions.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.ssh
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
+
+/** These can be passed in the connector configuration as additional parameters. */
+data class SshConnectionOptions(
+    val sessionHeartbeatInterval: Duration,
+    val globalHeartbeatInterval: Duration,
+    val idleTimeout: Duration,
+) {
+    companion object {
+        fun fromAdditionalProperties(map: Map<String, Any>) =
+            SshConnectionOptions(
+                when (val millis = map["session_heartbeat_interval"]) {
+                    is Long -> millis.milliseconds
+                    else -> 1_000.milliseconds
+                },
+                when (val millis = map["global_heartbeat_interval"]) {
+                    is Long -> millis.milliseconds
+                    else -> 2_000.milliseconds
+                },
+                when (val millis = map["idle_timeout"]) {
+                    is Long -> millis.milliseconds
+                    else -> ZERO
+                }
+            )
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/ssh/SshTunnelMethodConfiguration.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/ssh/SshTunnelMethodConfiguration.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.ssh
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonValue
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import io.airbyte.cdk.command.CONNECTOR_CONFIG_PREFIX
+import io.airbyte.commons.exceptions.ConfigErrorException
+import io.micronaut.context.annotation.ConfigurationProperties
+
+/** Union type for SSH tunnel method configuration in connector configurations. */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "tunnel_method")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = SshNoTunnelMethod::class, name = "NO_TUNNEL"),
+    JsonSubTypes.Type(value = SshKeyAuthTunnelMethod::class, name = "SSH_KEY_AUTH"),
+    JsonSubTypes.Type(value = SshPasswordAuthTunnelMethod::class, name = "SSH_PASSWORD_AUTH"),
+)
+@JsonSchemaTitle("SSH Tunnel Method")
+@JsonSchemaDescription(
+    "Whether to initiate an SSH tunnel before connecting to the database, and if so, which kind of authentication to use."
+)
+sealed interface SshTunnelMethodConfiguration
+
+@JsonSchemaTitle("No Tunnel")
+@JsonSchemaDescription("No ssh tunnel needed to connect to database")
+data object SshNoTunnelMethod : SshTunnelMethodConfiguration
+
+@JsonSchemaTitle("SSH Key Authentication")
+@JsonSchemaDescription("Connect through a jump server tunnel host using username and ssh key")
+data class SshKeyAuthTunnelMethod(
+    @get:JsonProperty("tunnel_host", required = true)
+    @param:JsonProperty("tunnel_host", required = true)
+    @JsonSchemaTitle("SSH Tunnel Jump Server Host")
+    @JsonPropertyDescription("Hostname of the jump server host that allows inbound ssh tunnel.")
+    @JsonSchemaInject(json = """{"order":1}""")
+    val host: String,
+    @get:JsonProperty("tunnel_port", required = true)
+    @param:JsonProperty("tunnel_port", required = true)
+    @JsonSchemaTitle("SSH Connection Port")
+    @JsonPropertyDescription("Port on the proxy/jump server that accepts inbound ssh connections.")
+    @JsonSchemaInject(json = """{"order":2,"minimum": 0,"maximum": 65536}""")
+    @JsonSchemaDefault("22")
+    val port: Int,
+    @get:JsonProperty("tunnel_user", required = true)
+    @param:JsonProperty("tunnel_user", required = true)
+    @JsonSchemaTitle("SSH Login Username")
+    @JsonPropertyDescription("OS-level username for logging into the jump server host")
+    @JsonSchemaInject(json = """{"order":3}""")
+    val user: String,
+    @get:JsonProperty("ssh_key", required = true)
+    @param:JsonProperty("ssh_key", required = true)
+    @JsonSchemaTitle("SSH Private Key")
+    @JsonPropertyDescription(
+        "OS-level user account ssh key credentials in RSA PEM format " +
+            "( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )"
+    )
+    @JsonSchemaInject(json = """{"order":4,"multiline":true,"airbyte_secret": true}""")
+    val key: String,
+) : SshTunnelMethodConfiguration
+
+@JsonSchemaTitle("Password Authentication")
+@JsonSchemaDescription(
+    "Connect through a jump server tunnel host using username and password authentication"
+)
+data class SshPasswordAuthTunnelMethod(
+    @get:JsonProperty("tunnel_host", required = true)
+    @param:JsonProperty("tunnel_host", required = true)
+    @JsonSchemaTitle("SSH Tunnel Jump Server Host")
+    @JsonPropertyDescription("Hostname of the jump server host that allows inbound ssh tunnel.")
+    @JsonSchemaInject(json = """{"order":1}""")
+    val host: String,
+    @get:JsonProperty("tunnel_port", required = true)
+    @param:JsonProperty("tunnel_port", required = true)
+    @JsonSchemaTitle("SSH Connection Port")
+    @JsonPropertyDescription("Port on the proxy/jump server that accepts inbound ssh connections.")
+    @JsonSchemaInject(json = """{"order":2,"minimum": 0,"maximum": 65536}""")
+    @JsonSchemaDefault("22")
+    val port: Int,
+    @get:JsonProperty("tunnel_user", required = true)
+    @param:JsonProperty("tunnel_user", required = true)
+    @JsonSchemaTitle("SSH Login Username")
+    @JsonPropertyDescription("OS-level username for logging into the jump server host")
+    @JsonSchemaInject(json = """{"order":3}""")
+    val user: String,
+    @get:JsonProperty("tunnel_user_password", required = true)
+    @param:JsonProperty("tunnel_user_password", required = true)
+    @JsonSchemaTitle("Password")
+    @JsonPropertyDescription("OS-level password for logging into the jump server host")
+    @JsonSchemaInject(json = """{"order":4,"airbyte_secret": true}""")
+    val password: String,
+) : SshTunnelMethodConfiguration
+
+@ConfigurationProperties("$CONNECTOR_CONFIG_PREFIX.tunnel_method")
+class MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject {
+
+    var tunnelMethod: String = "NO_TUNNEL"
+    var tunnelHost: String? = null
+    var tunnelPort: Int = 22
+    var tunnelUser: String? = null
+    var sshKey: String? = null
+    var tunnelUserPassword: String? = null
+
+    @JsonValue
+    fun asSshTunnelMethod(): SshTunnelMethodConfiguration =
+        when (tunnelMethod) {
+            "NO_TUNNEL" -> SshNoTunnelMethod
+            "SSH_KEY_AUTH" ->
+                SshKeyAuthTunnelMethod(tunnelHost!!, tunnelPort, tunnelUser!!, sshKey!!)
+            "SSH_PASSWORD_AUTH" ->
+                SshPasswordAuthTunnelMethod(
+                    tunnelHost!!,
+                    tunnelPort,
+                    tunnelUser!!,
+                    tunnelUserPassword!!
+                )
+            else -> throw ConfigErrorException("invalid value $tunnelMethod")
+        }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/command/ConfigurationJsonObjectSupplierTest.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/command/ConfigurationJsonObjectSupplierTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import io.airbyte.cdk.ssh.SshNoTunnelMethod
+import io.airbyte.cdk.ssh.SshPasswordAuthTunnelMethod
+import io.airbyte.cdk.test.source.TestSourceConfigurationJsonObject
+import io.airbyte.commons.exceptions.ConfigErrorException
+import io.airbyte.commons.json.Jsons
+import io.airbyte.commons.resources.MoreResources
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(rebuildContext = true)
+class ConfigurationJsonObjectSupplierTest {
+
+    @Inject
+    lateinit var supplier: ConfigurationJsonObjectSupplier<TestSourceConfigurationJsonObject>
+
+    @Test
+    fun testSchema() {
+        Assertions.assertEquals(TestSourceConfigurationJsonObject::class.java, supplier.javaClass)
+        val expected: String = MoreResources.readResource("command/expected-schema.json")
+        Assertions.assertEquals(Jsons.deserialize(expected), supplier.jsonSchema)
+    }
+
+    @Test
+    @Property(name = "airbyte.connector.config.host", value = "hello")
+    @Property(name = "airbyte.connector.config.database", value = "testdb")
+    fun testPropertyInjection() {
+        val pojo: TestSourceConfigurationJsonObject = supplier.get()
+        Assertions.assertEquals("hello", pojo.host)
+        Assertions.assertEquals("testdb", pojo.database)
+        Assertions.assertEquals(SshNoTunnelMethod, pojo.getTunnelMethodValue())
+    }
+
+    @Test
+    fun testSchemaViolation() {
+        Assertions.assertThrows(ConfigErrorException::class.java, supplier::get)
+    }
+
+    @Test
+    @Property(
+        name = "airbyte.connector.config.json",
+        value = """{"host":"hello","port":123,"database":"testdb"}"""
+    )
+    fun testGoodJson() {
+        val pojo: TestSourceConfigurationJsonObject = supplier.get()
+        Assertions.assertEquals("hello", pojo.host)
+        Assertions.assertEquals(123, pojo.port)
+        Assertions.assertEquals("testdb", pojo.database)
+        Assertions.assertEquals(SshNoTunnelMethod, pojo.getTunnelMethodValue())
+    }
+
+    @Test
+    @Property(name = "airbyte.connector.config.json", value = """{"foo""")
+    fun testMalformedJson() {
+        Assertions.assertThrows(ConfigErrorException::class.java, supplier::get)
+    }
+
+    @Test
+    @Property(name = "airbyte.connector.config.host", value = "hello")
+    @Property(name = "airbyte.connector.config.database", value = "testdb")
+    @Property(
+        name = "airbyte.connector.config.tunnel_method.tunnel_method",
+        value = "SSH_PASSWORD_AUTH"
+    )
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_host", value = "localhost")
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_port", value = "22")
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_user", value = "sshuser")
+    @Property(
+        name = "airbyte.connector.config.tunnel_method.tunnel_user_password",
+        value = "secret"
+    )
+    fun testPropertySubTypeInjection() {
+        val pojo: TestSourceConfigurationJsonObject = supplier.get()
+        Assertions.assertEquals("hello", pojo.host)
+        Assertions.assertEquals("testdb", pojo.database)
+        val expected = SshPasswordAuthTunnelMethod("localhost", 22, "sshuser", "secret")
+        Assertions.assertEquals(expected, pojo.getTunnelMethodValue())
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSourceConfigurationJsonObject.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSourceConfigurationJsonObject.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.test.source
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonGetter
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaArrayWithUniqueItems
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import io.airbyte.cdk.command.CONNECTOR_CONFIG_PREFIX
+import io.airbyte.cdk.command.ConfigurationJsonObjectBase
+import io.airbyte.cdk.ssh.MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject
+import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
+import io.airbyte.commons.exceptions.ConfigErrorException
+import io.micronaut.context.annotation.ConfigurationBuilder
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+
+/** [ConfigurationJsonObjectBase] implementation for [TestSource]. */
+@JsonSchemaTitle("Test Source Spec")
+@JsonPropertyOrder(
+    value =
+        [
+            "host",
+            "port",
+            "database",
+            "schemas",
+            "tunnel_method",
+            "cursor",
+        ],
+)
+@Singleton
+@Secondary
+@ConfigurationProperties(CONNECTOR_CONFIG_PREFIX)
+class TestSourceConfigurationJsonObject : ConfigurationJsonObjectBase() {
+
+    @JsonProperty("host", required = true)
+    @JsonSchemaTitle("Host")
+    @JsonSchemaInject(json = """{"order":1}""")
+    @JsonSchemaDefault("localhost")
+    @JsonPropertyDescription("Hostname of the database.")
+    var host: String? = "localhost"
+
+    @JsonProperty("port", required = true)
+    @JsonSchemaTitle("Port")
+    @JsonSchemaInject(json = """{"order":2,"minimum": 0,"maximum": 65536}""")
+    @JsonSchemaDefault("9092")
+    @JsonPropertyDescription("Port of the database.")
+    var port: Int? = 9092
+
+    @JsonProperty("database", required = true)
+    @JsonSchemaTitle("Database")
+    @JsonPropertyDescription("Name of the database.")
+    @JsonSchemaInject(json = """{"order":3}""")
+    var database: String? = null
+
+    @JsonProperty("schemas")
+    @JsonSchemaTitle("Schemas")
+    @JsonSchemaArrayWithUniqueItems("schemas")
+    @JsonPropertyDescription("The list of schemas to sync from. Defaults to PUBLIC.")
+    @JsonSchemaInject(json = """{"order":4,"minItems":1,"uniqueItems":true}""")
+    var schemas: List<String> = listOf("PUBLIC")
+
+    @JsonIgnore
+    @ConfigurationBuilder(configurationPrefix = "tunnel_method")
+    val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject()
+
+    @JsonIgnore var tunnelMethodJson: SshTunnelMethodConfiguration? = null
+
+    @JsonSetter("tunnel_method")
+    fun setTunnelMethodValue(value: SshTunnelMethodConfiguration) {
+        tunnelMethodJson = value
+    }
+
+    @JsonGetter("tunnel_method")
+    @JsonSchemaInject(json = """{"order":5}""")
+    fun getTunnelMethodValue(): SshTunnelMethodConfiguration =
+        tunnelMethodJson ?: tunnelMethod.asSshTunnelMethod()
+
+    @JsonIgnore
+    @ConfigurationBuilder(configurationPrefix = "cursor")
+    val cursor = MicronautPropertiesFriendlyCursorConfiguration()
+
+    @JsonIgnore var cursorJson: CursorConfiguration? = null
+
+    @JsonSetter("cursor")
+    fun setCursorMethodValue(value: CursorConfiguration) {
+        cursorJson = value
+    }
+
+    @JsonGetter("cursor")
+    @JsonSchemaInject(json = """{"order":6,"display_type":"radio"}""")
+    fun getCursorConfigurationValue(): CursorConfiguration =
+        cursorJson ?: cursor.asCursorConfiguration()
+
+    @JsonProperty("resumable_preferred")
+    @JsonSchemaDefault("true")
+    @JsonSchemaInject(json = """{"order":7,"display_type":"check"}""")
+    var resumablePreferred: Boolean? = true
+
+    @JsonProperty("timeout")
+    @JsonSchemaDefault("PT0S")
+    @JsonSchemaInject(json = """{"order":8}""")
+    var timeout: String? = "PT0S"
+
+    @JsonIgnore var additionalPropertiesMap = mutableMapOf<String, Any>()
+
+    @JsonAnyGetter
+    fun getAdditionalProperties(): Map<String, Any> {
+        return additionalPropertiesMap
+    }
+
+    @JsonAnySetter
+    fun setAdditionalProperty(name: String, value: Any) {
+        additionalPropertiesMap[name] = value
+    }
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "cursor_method")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = UserDefinedCursor::class, name = "user_defined"),
+    JsonSubTypes.Type(value = CdcCursor::class, name = "cdc"),
+)
+@JsonSchemaTitle("Update Method")
+@JsonSchemaDescription("Configures how data is extracted from the database.")
+sealed interface CursorConfiguration
+
+@JsonSchemaTitle("Scan Changes with User Defined Cursor")
+data object UserDefinedCursor : CursorConfiguration
+
+@JsonSchemaTitle("Read Changes using Change Data Capture (CDC)")
+data object CdcCursor : CursorConfiguration
+
+@ConfigurationProperties("$CONNECTOR_CONFIG_PREFIX.cursor")
+class MicronautPropertiesFriendlyCursorConfiguration {
+
+    var cursorMethod: String = "user_defined"
+
+    fun asCursorConfiguration(): CursorConfiguration =
+        when (cursorMethod) {
+            "user_defined" -> UserDefinedCursor
+            "cdc" -> CdcCursor
+            else -> throw ConfigErrorException("invalid value $cursorMethod")
+        }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSourceSpecTest.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSourceSpecTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.test.source
+
+import com.deblock.jsondiff.DiffGenerator
+import com.deblock.jsondiff.diff.JsonDiff
+import com.deblock.jsondiff.matcher.CompositeJsonMatcher
+import com.deblock.jsondiff.matcher.JsonMatcher
+import com.deblock.jsondiff.matcher.LenientJsonObjectPartialMatcher
+import com.deblock.jsondiff.matcher.StrictJsonArrayPartialMatcher
+import com.deblock.jsondiff.matcher.StrictPrimitivePartialMatcher
+import com.deblock.jsondiff.viewer.OnlyErrorDiffViewer
+import io.airbyte.cdk.consumers.BufferingOutputConsumer
+import io.airbyte.cdk.operation.CONNECTOR_OPERATION
+import io.airbyte.cdk.operation.SpecOperation
+import io.airbyte.commons.json.Jsons
+import io.airbyte.commons.resources.MoreResources
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(environments = ["source"], rebuildContext = true)
+@Property(name = CONNECTOR_OPERATION, value = "spec")
+class TestSourceSpecTest {
+
+    @Inject lateinit var specOperation: SpecOperation
+    @Inject lateinit var outputConsumer: BufferingOutputConsumer
+
+    @Test
+    fun testSpec() {
+        val expected: String = MoreResources.readResource("test/source/expected-spec.json")
+        specOperation.execute()
+        val actual: String = Jsons.serialize(outputConsumer.specs().last())
+
+        val jsonMatcher: JsonMatcher =
+            CompositeJsonMatcher(
+                StrictJsonArrayPartialMatcher(),
+                LenientJsonObjectPartialMatcher(),
+                StrictPrimitivePartialMatcher(),
+            )
+        val diff: JsonDiff = DiffGenerator.diff(expected, actual, jsonMatcher)
+        Assertions.assertEquals("", OnlyErrorDiffViewer.from(diff).toString())
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/expected-schema.json
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/expected-schema.json
@@ -1,0 +1,225 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Test Source Spec",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "host": {
+      "type": "string",
+      "default": "localhost",
+      "description": "Hostname of the database.",
+      "title": "Host",
+      "order": 1
+    },
+    "port": {
+      "type": "integer",
+      "default": 9092,
+      "description": "Port of the database.",
+      "title": "Port",
+      "order": 2,
+      "minimum": 0,
+      "maximum": 65536
+    },
+    "database": {
+      "type": "string",
+      "description": "Name of the database.",
+      "title": "Database",
+      "order": 3
+    },
+    "schemas": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "The list of schemas to sync from. Defaults to PUBLIC.",
+      "title": "Schemas",
+      "order": 4,
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "tunnel_method": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/SshNoTunnelMethod",
+          "title": "No Tunnel"
+        },
+        {
+          "$ref": "#/definitions/SshKeyAuthTunnelMethod",
+          "title": "SSH Key Authentication"
+        },
+        {
+          "$ref": "#/definitions/SshPasswordAuthTunnelMethod",
+          "title": "Password Authentication"
+        }
+      ],
+      "order": 5
+    },
+    "cursor": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/UserDefinedCursor",
+          "title": "Scan Changes with User Defined Cursor"
+        },
+        {
+          "$ref": "#/definitions/CdcCursor",
+          "title": "Read Changes using Change Data Capture (CDC)"
+        }
+      ],
+      "order": 6,
+      "display_type": "radio"
+    },
+    "resumable_preferred": {
+      "type": "boolean",
+      "default": true,
+      "order": 7,
+      "display_type": "check"
+    },
+    "timeout": {
+      "type": "string",
+      "default": "PT0S",
+      "order": 8
+    }
+  },
+  "required": ["host", "port", "database"],
+  "definitions": {
+    "SshNoTunnelMethod": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "No ssh tunnel needed to connect to database",
+      "title": "NO_TUNNEL",
+      "properties": {
+        "tunnel_method": {
+          "type": "string",
+          "enum": ["NO_TUNNEL"],
+          "default": "NO_TUNNEL"
+        }
+      },
+      "required": ["tunnel_method"]
+    },
+    "SshKeyAuthTunnelMethod": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Connect through a jump server tunnel host using username and ssh key",
+      "title": "SSH_KEY_AUTH",
+      "properties": {
+        "tunnel_method": {
+          "type": "string",
+          "enum": ["SSH_KEY_AUTH"],
+          "default": "SSH_KEY_AUTH"
+        },
+        "tunnel_host": {
+          "type": "string",
+          "description": "Hostname of the jump server host that allows inbound ssh tunnel.",
+          "title": "SSH Tunnel Jump Server Host",
+          "order": 1
+        },
+        "tunnel_port": {
+          "type": "integer",
+          "default": 22,
+          "description": "Port on the proxy/jump server that accepts inbound ssh connections.",
+          "title": "SSH Connection Port",
+          "order": 2,
+          "minimum": 0,
+          "maximum": 65536
+        },
+        "tunnel_user": {
+          "type": "string",
+          "description": "OS-level username for logging into the jump server host",
+          "title": "SSH Login Username",
+          "order": 3
+        },
+        "ssh_key": {
+          "type": "string",
+          "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+          "title": "SSH Private Key",
+          "order": 4,
+          "multiline": true,
+          "airbyte_secret": true
+        }
+      },
+      "required": [
+        "tunnel_method",
+        "tunnel_host",
+        "tunnel_port",
+        "tunnel_user",
+        "ssh_key"
+      ]
+    },
+    "SshPasswordAuthTunnelMethod": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Connect through a jump server tunnel host using username and password authentication",
+      "title": "SSH_PASSWORD_AUTH",
+      "properties": {
+        "tunnel_method": {
+          "type": "string",
+          "enum": ["SSH_PASSWORD_AUTH"],
+          "default": "SSH_PASSWORD_AUTH"
+        },
+        "tunnel_host": {
+          "type": "string",
+          "description": "Hostname of the jump server host that allows inbound ssh tunnel.",
+          "title": "SSH Tunnel Jump Server Host",
+          "order": 1
+        },
+        "tunnel_port": {
+          "type": "integer",
+          "default": 22,
+          "description": "Port on the proxy/jump server that accepts inbound ssh connections.",
+          "title": "SSH Connection Port",
+          "order": 2,
+          "minimum": 0,
+          "maximum": 65536
+        },
+        "tunnel_user": {
+          "type": "string",
+          "description": "OS-level username for logging into the jump server host",
+          "title": "SSH Login Username",
+          "order": 3
+        },
+        "tunnel_user_password": {
+          "type": "string",
+          "description": "OS-level password for logging into the jump server host",
+          "title": "Password",
+          "order": 4,
+          "airbyte_secret": true
+        }
+      },
+      "required": [
+        "tunnel_method",
+        "tunnel_host",
+        "tunnel_port",
+        "tunnel_user",
+        "tunnel_user_password"
+      ]
+    },
+    "UserDefinedCursor": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Configures how data is extracted from the database.",
+      "title": "user_defined",
+      "properties": {
+        "cursor_method": {
+          "type": "string",
+          "enum": ["user_defined"],
+          "default": "user_defined"
+        }
+      },
+      "required": ["cursor_method"]
+    },
+    "CdcCursor": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Configures how data is extracted from the database.",
+      "title": "cdc",
+      "properties": {
+        "cursor_method": {
+          "type": "string",
+          "enum": ["cdc"],
+          "default": "cdc"
+        }
+      },
+      "required": ["cursor_method"]
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/test/source/expected-spec.json
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/test/source/expected-spec.json
@@ -1,0 +1,231 @@
+{
+  "documentationUrl": "https://docs.airbyte.com",
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test Source Spec",
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+      "host": {
+        "type": "string",
+        "default": "localhost",
+        "description": "Hostname of the database.",
+        "title": "Host",
+        "order": 1
+      },
+      "port": {
+        "type": "integer",
+        "default": 9092,
+        "description": "Port of the database.",
+        "title": "Port",
+        "order": 2,
+        "minimum": 0,
+        "maximum": 65536
+      },
+      "database": {
+        "type": "string",
+        "description": "Name of the database.",
+        "title": "Database",
+        "order": 3
+      },
+      "schemas": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The list of schemas to sync from. Defaults to PUBLIC.",
+        "title": "Schemas",
+        "order": 4,
+        "minItems": 1,
+        "uniqueItems": true
+      },
+      "tunnel_method": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/SshNoTunnelMethod",
+            "title": "No Tunnel"
+          },
+          {
+            "$ref": "#/definitions/SshKeyAuthTunnelMethod",
+            "title": "SSH Key Authentication"
+          },
+          {
+            "$ref": "#/definitions/SshPasswordAuthTunnelMethod",
+            "title": "Password Authentication"
+          }
+        ],
+        "order": 5
+      },
+      "cursor": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/UserDefinedCursor",
+            "title": "Scan Changes with User Defined Cursor"
+          },
+          {
+            "$ref": "#/definitions/CdcCursor",
+            "title": "Read Changes using Change Data Capture (CDC)"
+          }
+        ],
+        "order": 6,
+        "display_type": "radio"
+      },
+      "resumable_preferred": {
+        "type": "boolean",
+        "default": true,
+        "order": 7,
+        "display_type": "check"
+      },
+      "timeout": {
+        "type": "string",
+        "default": "PT0S",
+        "order": 8
+      }
+    },
+    "required": ["host", "port", "database"],
+    "definitions": {
+      "SshNoTunnelMethod": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "No ssh tunnel needed to connect to database",
+        "title": "NO_TUNNEL",
+        "properties": {
+          "tunnel_method": {
+            "type": "string",
+            "enum": ["NO_TUNNEL"],
+            "default": "NO_TUNNEL"
+          }
+        },
+        "required": ["tunnel_method"]
+      },
+      "SshKeyAuthTunnelMethod": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Connect through a jump server tunnel host using username and ssh key",
+        "title": "SSH_KEY_AUTH",
+        "properties": {
+          "tunnel_method": {
+            "type": "string",
+            "enum": ["SSH_KEY_AUTH"],
+            "default": "SSH_KEY_AUTH"
+          },
+          "tunnel_host": {
+            "type": "string",
+            "description": "Hostname of the jump server host that allows inbound ssh tunnel.",
+            "title": "SSH Tunnel Jump Server Host",
+            "order": 1
+          },
+          "tunnel_port": {
+            "type": "integer",
+            "default": 22,
+            "description": "Port on the proxy/jump server that accepts inbound ssh connections.",
+            "title": "SSH Connection Port",
+            "order": 2,
+            "minimum": 0,
+            "maximum": 65536
+          },
+          "tunnel_user": {
+            "type": "string",
+            "description": "OS-level username for logging into the jump server host",
+            "title": "SSH Login Username",
+            "order": 3
+          },
+          "ssh_key": {
+            "type": "string",
+            "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+            "title": "SSH Private Key",
+            "order": 4,
+            "multiline": true,
+            "airbyte_secret": true
+          }
+        },
+        "required": [
+          "tunnel_method",
+          "tunnel_host",
+          "tunnel_port",
+          "tunnel_user",
+          "ssh_key"
+        ]
+      },
+      "SshPasswordAuthTunnelMethod": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Connect through a jump server tunnel host using username and password authentication",
+        "title": "SSH_PASSWORD_AUTH",
+        "properties": {
+          "tunnel_method": {
+            "type": "string",
+            "enum": ["SSH_PASSWORD_AUTH"],
+            "default": "SSH_PASSWORD_AUTH"
+          },
+          "tunnel_host": {
+            "type": "string",
+            "description": "Hostname of the jump server host that allows inbound ssh tunnel.",
+            "title": "SSH Tunnel Jump Server Host",
+            "order": 1
+          },
+          "tunnel_port": {
+            "type": "integer",
+            "default": 22,
+            "description": "Port on the proxy/jump server that accepts inbound ssh connections.",
+            "title": "SSH Connection Port",
+            "order": 2,
+            "minimum": 0,
+            "maximum": 65536
+          },
+          "tunnel_user": {
+            "type": "string",
+            "description": "OS-level username for logging into the jump server host",
+            "title": "SSH Login Username",
+            "order": 3
+          },
+          "tunnel_user_password": {
+            "type": "string",
+            "description": "OS-level password for logging into the jump server host",
+            "title": "Password",
+            "order": 4,
+            "airbyte_secret": true
+          }
+        },
+        "required": [
+          "tunnel_method",
+          "tunnel_host",
+          "tunnel_port",
+          "tunnel_user",
+          "tunnel_user_password"
+        ]
+      },
+      "UserDefinedCursor": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Configures how data is extracted from the database.",
+        "title": "user_defined",
+        "properties": {
+          "cursor_method": {
+            "type": "string",
+            "enum": ["user_defined"],
+            "default": "user_defined"
+          }
+        },
+        "required": ["cursor_method"]
+      },
+      "CdcCursor": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Configures how data is extracted from the database.",
+        "title": "cdc",
+        "properties": {
+          "cursor_method": {
+            "type": "string",
+            "enum": ["cdc"],
+            "default": "cdc"
+          }
+        },
+        "required": ["cursor_method"]
+      }
+    }
+  },
+  "supportsNormalization": false,
+  "supportsDBT": false,
+  "supported_destination_sync_modes": []
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/testFixtures/kotlin/io/airbyte/cdk/TestClockFactory.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/testFixtures/kotlin/io/airbyte/cdk/TestClockFactory.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import jakarta.inject.Singleton
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+
+const val OFFSET_CLOCK = "offset-clock"
+
+/** Injects more-or-less fake clocks for testing purposes. */
+@Factory
+@Requires(env = [Environment.TEST])
+class TestClockFactory {
+
+    @Singleton
+    @Requires(notEnv = [OFFSET_CLOCK])
+    fun fixed(): Clock = Clock.fixed(fakeNow, ZoneOffset.UTC)
+
+    @Singleton
+    @Requires(env = [OFFSET_CLOCK])
+    fun offset(): Clock = Clock.offset(Clock.systemUTC(), Duration.between(fakeNow, Instant.now()))
+
+    companion object {
+        /** Some convenient timestamp with an easy-to-read ISO8601 representation. */
+        val fakeNow: Instant = Instant.ofEpochSecond(3133641600)
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/testFixtures/kotlin/io/airbyte/cdk/consumers/BufferingOutputConsumer.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/testFixtures/kotlin/io/airbyte/cdk/consumers/BufferingOutputConsumer.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.consumers
+
+import io.airbyte.protocol.models.v0.AirbyteCatalog
+import io.airbyte.protocol.models.v0.AirbyteConnectionStatus
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
+import io.airbyte.protocol.models.v0.AirbyteTraceMessage
+import io.airbyte.protocol.models.v0.ConnectorSpecification
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import jakarta.inject.Singleton
+import java.time.Clock
+import java.time.Instant
+
+/** [OutputConsumer] implementation for unit tests. Collects everything into thread-safe buffers. */
+@Singleton
+@Requires(notEnv = [Environment.CLI])
+@Requires(missingProperty = CONNECTOR_OUTPUT_FILE)
+@Replaces(OutputConsumer::class)
+class BufferingOutputConsumer(clock: Clock) : OutputConsumer {
+
+    override val emittedAt: Instant = Instant.now(clock)
+
+    private val records = mutableListOf<AirbyteRecordMessage>()
+    private val states = mutableListOf<AirbyteStateMessage>()
+    private val specs = mutableListOf<ConnectorSpecification>()
+    private val statuses = mutableListOf<AirbyteConnectionStatus>()
+    private val catalogs = mutableListOf<AirbyteCatalog>()
+    private val traces = mutableListOf<AirbyteTraceMessage>()
+    private val messages = mutableListOf<AirbyteMessage>()
+
+    override fun accept(m: AirbyteMessage) {
+        synchronized(this) {
+            messages.add(m)
+            when (m.type) {
+                AirbyteMessage.Type.RECORD -> records.add(m.record)
+                AirbyteMessage.Type.STATE -> states.add(m.state)
+                AirbyteMessage.Type.SPEC -> specs.add(m.spec)
+                AirbyteMessage.Type.CONNECTION_STATUS -> statuses.add(m.connectionStatus)
+                AirbyteMessage.Type.CATALOG -> catalogs.add(m.catalog)
+                AirbyteMessage.Type.TRACE -> traces.add(m.trace)
+                else -> TODO("${m.type} not supported")
+            }
+        }
+    }
+
+    fun records(): List<AirbyteRecordMessage> =
+        synchronized(this) { listOf(*records.toTypedArray()) }
+
+    fun states(): List<AirbyteStateMessage> = synchronized(this) { listOf(*states.toTypedArray()) }
+
+    fun specs(): List<ConnectorSpecification> = synchronized(this) { listOf(*specs.toTypedArray()) }
+
+    fun statuses(): List<AirbyteConnectionStatus> =
+        synchronized(this) { listOf(*statuses.toTypedArray()) }
+
+    fun catalogs(): List<AirbyteCatalog> = synchronized(this) { listOf(*catalogs.toTypedArray()) }
+
+    fun traces(): List<AirbyteTraceMessage> = synchronized(this) { listOf(*traces.toTypedArray()) }
+
+    fun messages(): List<AirbyteMessage> = synchronized(this) { listOf(*messages.toTypedArray()) }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/main/kotlin/io/airbyte/integrations/source/oracle/OracleSourceConfigurationJsonObject.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/main/kotlin/io/airbyte/integrations/source/oracle/OracleSourceConfigurationJsonObject.kt
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.oracle
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonGetter
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonValue
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaArrayWithUniqueItems
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import io.airbyte.cdk.command.CONNECTOR_CONFIG_PREFIX
+import io.airbyte.cdk.command.ConfigurationJsonObjectBase
+import io.airbyte.cdk.ssh.MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject
+import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
+import io.airbyte.commons.exceptions.ConfigErrorException
+import io.micronaut.context.annotation.ConfigurationBuilder
+import io.micronaut.context.annotation.ConfigurationProperties
+import jakarta.inject.Singleton
+
+/**
+ * The object which is mapped to the Oracle source configuration JSON.
+ *
+ * Use [OracleSourceConfiguration] instead wherever possible. This object also allows injecting
+ * values through Micronaut properties, this is made possible by the classes named
+ * `MicronautPropertiesFriendly.*`.
+ */
+@JsonSchemaTitle("Oracle Source Spec")
+@JsonPropertyOrder(
+    value =
+        [
+            "host",
+            "port",
+            "connection_data",
+            "username",
+            "password",
+            "schemas",
+            "jdbc_url_params",
+            "encryption",
+        ],
+)
+@Singleton
+@ConfigurationProperties(CONNECTOR_CONFIG_PREFIX)
+class OracleSourceConfigurationJsonObject : ConfigurationJsonObjectBase() {
+
+    @JsonProperty("host", required = true)
+    @JsonSchemaTitle("Host")
+    @JsonSchemaInject(json = """{"order":1}""")
+    @JsonPropertyDescription("Hostname of the database.")
+    var host: String? = null
+
+    @JsonProperty("port", required = true)
+    @JsonSchemaTitle("Port")
+    @JsonSchemaInject(json = """{"order":2,"minimum": 0,"maximum": 65536}""")
+    @JsonSchemaDefault("1521")
+    @JsonPropertyDescription(
+        "Port of the database.\n" +
+            "Oracle Corporations recommends the following port numbers:\n" +
+            "1521 - Default listening port for client connections to the listener. \n" +
+            "2484 - Recommended and officially registered listening port for client " +
+            "connections to the listener using TCP/IP with SSL.",
+    )
+    var port: Int? = null
+
+    @JsonIgnore
+    @ConfigurationBuilder(configurationPrefix = "connection_data")
+    val connectionData = MicronautPropertiesFriendlyConnectionData()
+
+    @JsonIgnore var connectionDataJson: ConnectionData? = null
+
+    @JsonSetter("connection_data")
+    fun setConnectionDataValue(value: ConnectionData) {
+        connectionDataJson = value
+    }
+
+    @JsonGetter("connection_data")
+    @JsonSchemaInject(json = """{"order":3}""")
+    fun getConnectionDataValue(): ConnectionData =
+        connectionDataJson ?: connectionData.asConnectionData()
+
+    @JsonProperty("username", required = true)
+    @JsonSchemaTitle("User")
+    @JsonPropertyDescription("The username which is used to access the database.")
+    @JsonSchemaInject(json = """{"order":4}""")
+    var username: String? = null
+
+    @JsonProperty("password")
+    @JsonSchemaTitle("Password")
+    @JsonPropertyDescription("The password associated with the username.")
+    @JsonSchemaInject(json = """{"order":5,"airbyte_secret": true}""")
+    var password: String? = null
+
+    @JsonProperty("schemas")
+    @JsonSchemaTitle("Schemas")
+    @JsonSchemaArrayWithUniqueItems("schemas")
+    @JsonPropertyDescription("The list of schemas to sync from. Defaults to user. Case sensitive.")
+    @JsonSchemaInject(json = """{"order":6,"minItems":1,"uniqueItems":true}""")
+    var schemas: List<String> = listOf()
+
+    @JsonProperty("jdbc_url_params")
+    @JsonSchemaTitle("JDBC URL Params")
+    @JsonPropertyDescription(
+        "Additional properties to pass to the JDBC URL string when connecting to the database " +
+            "formatted as 'key=value' pairs separated by the symbol '&'. " +
+            "(example: key1=value1&key2=value2&key3=value3).",
+    )
+    @JsonSchemaInject(json = """{"order":7}""")
+    var jdbcUrlParams: String? = null
+
+    @JsonIgnore
+    @ConfigurationBuilder(configurationPrefix = "encryption")
+    val encryption = MicronautPropertiesFriendlyEncryption()
+
+    @JsonIgnore var encryptionJson: Encryption? = null
+
+    @JsonSetter("encryption")
+    fun setEncryptionValue(value: Encryption) {
+        encryptionJson = value
+    }
+
+    @JsonGetter("encryption")
+    @JsonSchemaInject(json = """{"order":8}""")
+    fun getEncryptionValue(): Encryption = encryptionJson ?: encryption.asEncryption()
+
+    @JsonIgnore
+    @ConfigurationBuilder(configurationPrefix = "tunnel_method")
+    val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject()
+
+    @JsonIgnore var tunnelMethodJson: SshTunnelMethodConfiguration? = null
+
+    @JsonSetter("tunnel_method")
+    fun setTunnelMethodValue(value: SshTunnelMethodConfiguration) {
+        tunnelMethodJson = value
+    }
+
+    @JsonGetter("tunnel_method")
+    @JsonSchemaInject(json = """{"order":9}""")
+    fun getTunnelMethodValue(): SshTunnelMethodConfiguration =
+        tunnelMethodJson ?: tunnelMethod.asSshTunnelMethod()
+
+    @JsonIgnore
+    @ConfigurationBuilder(configurationPrefix = "cursor")
+    val cursor = MicronautPropertiesFriendlyCursorConfiguration()
+
+    @JsonIgnore var cursorJson: CursorConfiguration? = null
+
+    @JsonSetter("cursor")
+    fun setCursorMethodValue(value: CursorConfiguration) {
+        cursorJson = value
+    }
+
+    @JsonGetter("cursor")
+    @JsonSchemaInject(json = """{"order":10,"display_type":"radio"}""")
+    fun getCursorConfigurationValue(): CursorConfiguration =
+        cursorJson ?: cursor.asCursorConfiguration()
+
+    @JsonIgnore var additionalPropertiesMap = mutableMapOf<String, Any>()
+
+    @JsonAnyGetter
+    fun getAdditionalProperties(): Map<String, Any> {
+        return additionalPropertiesMap
+    }
+
+    @JsonAnySetter
+    fun setAdditionalProperty(name: String, value: Any) {
+        additionalPropertiesMap[name] = value
+    }
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "connection_type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = ServiceName::class, name = "service_name"),
+    JsonSubTypes.Type(value = Sid::class, name = "sid"),
+)
+@JsonSchemaTitle("Connect by")
+@JsonSchemaDescription("Connect data that will be used for DB connection.")
+sealed interface ConnectionData
+
+@JsonSchemaTitle("Service name")
+@JsonSchemaDescription("Use service name.")
+class ServiceName : ConnectionData {
+
+    @JsonProperty("service_name", required = true)
+    @JsonSchemaTitle("Service name")
+    var serviceName: String? = null
+}
+
+@JsonSchemaTitle("System ID (SID)")
+@JsonSchemaDescription("Use Oracle System Identifier.")
+class Sid : ConnectionData {
+
+    @JsonProperty("sid", required = true)
+    @JsonSchemaTitle("System ID (SID)")
+    var sid: String? = null
+}
+
+@ConfigurationProperties("$CONNECTOR_CONFIG_PREFIX.connection_data")
+class MicronautPropertiesFriendlyConnectionData {
+
+    var connectionType: String = "service_name"
+    var serviceName: String? = null
+    var sid: String? = null
+
+    @JsonValue
+    fun asConnectionData(): ConnectionData =
+        when (connectionType) {
+            "service_name" -> ServiceName().also { it.serviceName = serviceName }
+            "sid" -> Sid().also { it.sid = sid }
+            else -> throw ConfigErrorException("invalid value $connectionType")
+        }
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "encryption_method")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = Unencrypted::class, name = "unencrypted"),
+    JsonSubTypes.Type(value = EncryptionAlgorithm::class, name = "client_nne"),
+    JsonSubTypes.Type(value = SslCertificate::class, name = "encrypted_verify_certificate"),
+)
+@JsonSchemaTitle("Encryption")
+@JsonSchemaDescription("The encryption method which is used when communicating with the database.")
+sealed interface Encryption
+
+@JsonSchemaTitle("Unencrypted")
+@JsonSchemaDescription("Data transfer will not be encrypted.")
+data object Unencrypted : Encryption
+
+@JsonSchemaTitle("Native Network Encryption (NNE)")
+@JsonSchemaDescription(
+    "The native network encryption gives you the ability to encrypt database " +
+        "connections, without the configuration overhead of TCP/IP and SSL/TLS and without the need " +
+        "to open and listen on different ports.",
+)
+class EncryptionAlgorithm : Encryption {
+
+    @JsonProperty("encryption_algorithm", required = true)
+    @JsonSchemaTitle("Encryption Algorithm")
+    @JsonPropertyDescription("This parameter defines what encryption algorithm is used.")
+    @JsonSchemaDefault("AES256")
+    @JsonSchemaInject(json = """{"enum":["AES256","RC4_56","3DES168"]}""")
+    var encryptionAlgorithm: String? = null
+}
+
+@JsonSchemaTitle("TLS Encrypted (verify certificate)")
+@JsonSchemaDescription("Verify and use the certificate provided by the server.")
+class SslCertificate : Encryption {
+
+    @JsonProperty("ssl_certificate", required = true)
+    @JsonSchemaTitle("SSL PEM File")
+    @JsonPropertyDescription(
+        "Privacy Enhanced Mail (PEM) files are concatenated certificate " +
+            "containers frequently used in certificate installations.",
+    )
+    @JsonSchemaInject(json = """{"airbyte_secret":true,"multiline":true}""")
+    var sslCertificate: String? = null
+}
+
+@ConfigurationProperties("$CONNECTOR_CONFIG_PREFIX.encryption")
+class MicronautPropertiesFriendlyEncryption {
+
+    var encryptionMethod: String = "unencrypted"
+    var encryptionAlgorithm: String? = null
+    var sslCertificate: String? = null
+
+    @JsonValue
+    fun asEncryption(): Encryption =
+        when (encryptionMethod) {
+            "unencrypted" -> Unencrypted
+            "client_nne" ->
+                EncryptionAlgorithm().also { it.encryptionAlgorithm = encryptionAlgorithm }
+            "encrypted_verify_certificate" ->
+                SslCertificate().also { it.sslCertificate = sslCertificate }
+            else -> throw ConfigErrorException("invalid value $encryptionMethod")
+        }
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "cursor_method")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = UserDefinedCursor::class, name = "user_defined"),
+    JsonSubTypes.Type(value = CdcCursor::class, name = "cdc"),
+)
+@JsonSchemaTitle("Update Method")
+@JsonSchemaDescription("Configures how data is extracted from the database.")
+sealed interface CursorConfiguration
+
+@JsonSchemaTitle("Scan Changes with User Defined Cursor")
+@JsonSchemaDescription(
+    "Incrementally detects new inserts and updates using the " +
+        "<a href=\"https://docs.airbyte.com/understanding-airbyte/connections/incremental-append/" +
+        "#user-defined-cursor\">cursor column</a> chosen when configuring a connection " +
+        "(e.g. created_at, updated_at)."
+)
+data object UserDefinedCursor : CursorConfiguration
+
+@JsonSchemaTitle("Read Changes using Change Data Capture (CDC)")
+@JsonSchemaDescription(
+    "<i>Recommended</i> - " +
+        "Incrementally reads new inserts, updates, and deletes using Oracle's " +
+        "<a href=\"https://docs.airbyte.com/integrations/sources/mssql/#change-data-capture-cdc\">" +
+        "change data capture feature</a>. This must be enabled on your database."
+)
+data object CdcCursor : CursorConfiguration
+
+@ConfigurationProperties("$CONNECTOR_CONFIG_PREFIX.cursor")
+class MicronautPropertiesFriendlyCursorConfiguration {
+
+    var cursorMethod: String = "user_defined"
+
+    fun asCursorConfiguration(): CursorConfiguration =
+        when (cursorMethod) {
+            "user_defined" -> UserDefinedCursor
+            "cdc" -> CdcCursor
+            else -> throw ConfigErrorException("invalid value $cursorMethod")
+        }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/test/kotlin/io/airbyte/integrations/source/oracle/OracleSourceConfigurationJsonObjectTest.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/test/kotlin/io/airbyte/integrations/source/oracle/OracleSourceConfigurationJsonObjectTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.oracle
+
+import io.airbyte.cdk.command.ConfigurationJsonObjectSupplier
+import io.airbyte.cdk.ssh.SshPasswordAuthTunnelMethod
+import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
+import io.airbyte.commons.exceptions.ConfigErrorException
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.env.Environment
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(environments = [Environment.TEST], rebuildContext = true)
+class OracleSourceConfigurationJsonObjectTest {
+
+    @Inject
+    lateinit var supplier: ConfigurationJsonObjectSupplier<OracleSourceConfigurationJsonObject>
+
+    @Test
+    @Property(name = "airbyte.connector.config.host", value = "localhost")
+    @Property(name = "airbyte.connector.config.port", value = "12345")
+    @Property(name = "airbyte.connector.config.username", value = "FOO")
+    @Property(name = "airbyte.connector.config.password", value = "BAR")
+    @Property(name = "airbyte.connector.config.schemas", value = "FOO,SYSTEM")
+    @Property(
+        name = "airbyte.connector.config.connection_data.connection_type",
+        value = "service_name"
+    )
+    @Property(name = "airbyte.connector.config.connection_data.service_name", value = "FREEPDB1")
+    @Property(name = "airbyte.connector.config.encryption.encryption_method", value = "client_nne")
+    @Property(name = "airbyte.connector.config.encryption.encryption_algorithm", value = "3DES168")
+    @Property(
+        name = "airbyte.connector.config.tunnel_method.tunnel_method",
+        value = "SSH_PASSWORD_AUTH"
+    )
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_host", value = "localhost")
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_port", value = "2222")
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_user", value = "sshuser")
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_user_password", value = "***")
+    fun testPropertyInjection() {
+        val pojo: OracleSourceConfigurationJsonObject = supplier.get()
+        Assertions.assertEquals("localhost", pojo.host)
+        Assertions.assertEquals(12345, pojo.port)
+        Assertions.assertEquals("FOO", pojo.username)
+        Assertions.assertEquals("BAR", pojo.password)
+        Assertions.assertEquals(listOf("FOO", "SYSTEM"), pojo.schemas)
+        val connectionData: ConnectionData = pojo.getConnectionDataValue()
+        Assertions.assertTrue(connectionData is ServiceName, connectionData::class.toString())
+        Assertions.assertEquals("FREEPDB1", (connectionData as? ServiceName)?.serviceName)
+        val encryption: Encryption = pojo.getEncryptionValue()
+        Assertions.assertTrue(encryption is EncryptionAlgorithm, encryption::class.toString())
+        Assertions.assertEquals(
+            "3DES168",
+            (encryption as? EncryptionAlgorithm)?.encryptionAlgorithm
+        )
+        val tunnelMethod: SshTunnelMethodConfiguration = pojo.getTunnelMethodValue()
+        Assertions.assertTrue(
+            tunnelMethod is SshPasswordAuthTunnelMethod,
+            tunnelMethod::class.toString()
+        )
+    }
+
+    @Test
+    fun testSchemaViolation() {
+        Assertions.assertThrows(ConfigErrorException::class.java, supplier::get)
+    }
+
+    @Test
+    @Property(name = "airbyte.connector.config.json", value = CONFIG_JSON)
+    fun testJson() {
+        val pojo: OracleSourceConfigurationJsonObject = supplier.get()
+        Assertions.assertEquals("localhost", pojo.host)
+        Assertions.assertEquals(12345, pojo.port)
+        Assertions.assertEquals("FOO", pojo.username)
+        Assertions.assertEquals("BAR", pojo.password)
+        Assertions.assertEquals(listOf("FOO", "SYSTEM"), pojo.schemas)
+        val connectionData: ConnectionData = pojo.getConnectionDataValue()
+        Assertions.assertTrue(connectionData is ServiceName, connectionData::class.toString())
+        Assertions.assertEquals("FREEPDB1", (connectionData as? ServiceName)?.serviceName)
+        val encryption: Encryption = pojo.getEncryptionValue()
+        Assertions.assertTrue(encryption is EncryptionAlgorithm, encryption::class.toString())
+        Assertions.assertEquals(
+            "3DES168",
+            (encryption as? EncryptionAlgorithm)?.encryptionAlgorithm
+        )
+        val tunnelMethod: SshTunnelMethodConfiguration = pojo.getTunnelMethodValue()
+        Assertions.assertTrue(
+            tunnelMethod is SshPasswordAuthTunnelMethod,
+            tunnelMethod::class.toString()
+        )
+    }
+}
+
+const val CONFIG_JSON =
+    """
+{
+  "host": "localhost",
+  "port": 12345,
+  "connection_data": {
+    "connection_type": "service_name",
+    "service_name": "FREEPDB1"
+  },
+  "username": "FOO",
+  "password": "BAR",
+  "schemas": [
+    "FOO",
+    "SYSTEM"
+  ],
+  "encryption": {
+    "encryption_method": "client_nne",
+    "encryption_algorithm": "3DES168"
+  },
+  "tunnel_method": {
+    "tunnel_method": "SSH_PASSWORD_AUTH",
+    "tunnel_host": "localhost",
+    "tunnel_port": 2222,
+    "tunnel_user": "sshuser",
+    "tunnel_user_password": "***"
+  }
+}
+"""

--- a/airbyte-integrations/connectors/source-oracle-v2/src/test/resources/expected-spec.json
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/test/resources/expected-spec.json
@@ -1,0 +1,354 @@
+{
+  "documentationUrl": "https://docs.airbyte.com/integrations/sources/oracle",
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Oracle Source Spec",
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+      "host": {
+        "type": "string",
+        "description": "Hostname of the database.",
+        "title": "Host",
+        "order": 1
+      },
+      "port": {
+        "type": "integer",
+        "default": 1521,
+        "description": "Port of the database.\nOracle Corporations recommends the following port numbers:\n1521 - Default listening port for client connections to the listener. \n2484 - Recommended and officially registered listening port for client connections to the listener using TCP/IP with SSL.",
+        "title": "Port",
+        "order": 2,
+        "minimum": 0,
+        "maximum": 65536
+      },
+      "connection_data": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/ServiceName",
+            "title": "Service name"
+          },
+          {
+            "$ref": "#/definitions/Sid",
+            "title": "System ID (SID)"
+          }
+        ],
+        "order": 3
+      },
+      "username": {
+        "type": "string",
+        "description": "The username which is used to access the database.",
+        "title": "User",
+        "order": 4
+      },
+      "password": {
+        "type": "string",
+        "description": "The password associated with the username.",
+        "title": "Password",
+        "order": 5,
+        "airbyte_secret": true
+      },
+      "schemas": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The list of schemas to sync from. Defaults to user. Case sensitive.",
+        "title": "Schemas",
+        "order": 6,
+        "minItems": 1,
+        "uniqueItems": true
+      },
+      "jdbc_url_params": {
+        "type": "string",
+        "description": "Additional properties to pass to the JDBC URL string when connecting to the database formatted as 'key=value' pairs separated by the symbol '&'. (example: key1=value1&key2=value2&key3=value3).",
+        "title": "JDBC URL Params",
+        "order": 7
+      },
+      "encryption": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/Unencrypted",
+            "title": "Unencrypted"
+          },
+          {
+            "$ref": "#/definitions/EncryptionAlgorithm",
+            "title": "Native Network Encryption (NNE)"
+          },
+          {
+            "$ref": "#/definitions/SslCertificate",
+            "title": "TLS Encrypted (verify certificate)"
+          }
+        ],
+        "order": 8
+      },
+      "tunnel_method": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/SshNoTunnelMethod",
+            "title": "No Tunnel"
+          },
+          {
+            "$ref": "#/definitions/SshKeyAuthTunnelMethod",
+            "title": "SSH Key Authentication"
+          },
+          {
+            "$ref": "#/definitions/SshPasswordAuthTunnelMethod",
+            "title": "Password Authentication"
+          }
+        ],
+        "order": 9
+      },
+      "cursor": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/UserDefinedCursor",
+            "title": "Scan Changes with User Defined Cursor"
+          },
+          {
+            "$ref": "#/definitions/CdcCursor",
+            "title": "Read Changes using Change Data Capture (CDC)"
+          }
+        ],
+        "order": 10,
+        "display_type": "radio"
+      }
+    },
+    "required": ["host", "port", "username"],
+    "definitions": {
+      "ServiceName": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Use service name.",
+        "title": "service_name",
+        "properties": {
+          "connection_type": {
+            "type": "string",
+            "enum": ["service_name"],
+            "default": "service_name"
+          },
+          "service_name": {
+            "type": "string",
+            "title": "Service name"
+          }
+        },
+        "required": ["connection_type", "service_name"]
+      },
+      "Sid": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Use Oracle System Identifier.",
+        "title": "sid",
+        "properties": {
+          "connection_type": {
+            "type": "string",
+            "enum": ["sid"],
+            "default": "sid"
+          },
+          "sid": {
+            "type": "string",
+            "title": "System ID (SID)"
+          }
+        },
+        "required": ["connection_type", "sid"]
+      },
+      "Unencrypted": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Data transfer will not be encrypted.",
+        "title": "unencrypted",
+        "properties": {
+          "encryption_method": {
+            "type": "string",
+            "enum": ["unencrypted"],
+            "default": "unencrypted"
+          }
+        },
+        "required": ["encryption_method"]
+      },
+      "EncryptionAlgorithm": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "The native network encryption gives you the ability to encrypt database connections, without the configuration overhead of TCP/IP and SSL/TLS and without the need to open and listen on different ports.",
+        "title": "client_nne",
+        "properties": {
+          "encryption_method": {
+            "type": "string",
+            "enum": ["client_nne"],
+            "default": "client_nne"
+          },
+          "encryption_algorithm": {
+            "type": "string",
+            "default": "AES256",
+            "description": "This parameter defines what encryption algorithm is used.",
+            "title": "Encryption Algorithm",
+            "enum": ["AES256", "RC4_56", "3DES168"]
+          }
+        },
+        "required": ["encryption_method", "encryption_algorithm"]
+      },
+      "SslCertificate": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Verify and use the certificate provided by the server.",
+        "title": "encrypted_verify_certificate",
+        "properties": {
+          "encryption_method": {
+            "type": "string",
+            "enum": ["encrypted_verify_certificate"],
+            "default": "encrypted_verify_certificate"
+          },
+          "ssl_certificate": {
+            "type": "string",
+            "description": "Privacy Enhanced Mail (PEM) files are concatenated certificate containers frequently used in certificate installations.",
+            "title": "SSL PEM File",
+            "airbyte_secret": true,
+            "multiline": true
+          }
+        },
+        "required": ["encryption_method", "ssl_certificate"]
+      },
+      "SshNoTunnelMethod": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "No ssh tunnel needed to connect to database",
+        "title": "NO_TUNNEL",
+        "properties": {
+          "tunnel_method": {
+            "type": "string",
+            "enum": ["NO_TUNNEL"],
+            "default": "NO_TUNNEL"
+          }
+        },
+        "required": ["tunnel_method"]
+      },
+      "SshKeyAuthTunnelMethod": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Connect through a jump server tunnel host using username and ssh key",
+        "title": "SSH_KEY_AUTH",
+        "properties": {
+          "tunnel_method": {
+            "type": "string",
+            "enum": ["SSH_KEY_AUTH"],
+            "default": "SSH_KEY_AUTH"
+          },
+          "tunnel_host": {
+            "type": "string",
+            "description": "Hostname of the jump server host that allows inbound ssh tunnel.",
+            "title": "SSH Tunnel Jump Server Host",
+            "order": 1
+          },
+          "tunnel_port": {
+            "type": "integer",
+            "default": 22,
+            "description": "Port on the proxy/jump server that accepts inbound ssh connections.",
+            "title": "SSH Connection Port",
+            "order": 2,
+            "minimum": 0,
+            "maximum": 65536
+          },
+          "tunnel_user": {
+            "type": "string",
+            "description": "OS-level username for logging into the jump server host",
+            "title": "SSH Login Username",
+            "order": 3
+          },
+          "ssh_key": {
+            "type": "string",
+            "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+            "title": "SSH Private Key",
+            "order": 4,
+            "multiline": true,
+            "airbyte_secret": true
+          }
+        },
+        "required": [
+          "tunnel_method",
+          "tunnel_host",
+          "tunnel_port",
+          "tunnel_user",
+          "ssh_key"
+        ]
+      },
+      "SshPasswordAuthTunnelMethod": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Connect through a jump server tunnel host using username and password authentication",
+        "title": "SSH_PASSWORD_AUTH",
+        "properties": {
+          "tunnel_method": {
+            "type": "string",
+            "enum": ["SSH_PASSWORD_AUTH"],
+            "default": "SSH_PASSWORD_AUTH"
+          },
+          "tunnel_host": {
+            "type": "string",
+            "description": "Hostname of the jump server host that allows inbound ssh tunnel.",
+            "title": "SSH Tunnel Jump Server Host",
+            "order": 1
+          },
+          "tunnel_port": {
+            "type": "integer",
+            "default": 22,
+            "description": "Port on the proxy/jump server that accepts inbound ssh connections.",
+            "title": "SSH Connection Port",
+            "order": 2,
+            "minimum": 0,
+            "maximum": 65536
+          },
+          "tunnel_user": {
+            "type": "string",
+            "description": "OS-level username for logging into the jump server host",
+            "title": "SSH Login Username",
+            "order": 3
+          },
+          "tunnel_user_password": {
+            "type": "string",
+            "description": "OS-level password for logging into the jump server host",
+            "title": "Password",
+            "order": 4,
+            "airbyte_secret": true
+          }
+        },
+        "required": [
+          "tunnel_method",
+          "tunnel_host",
+          "tunnel_port",
+          "tunnel_user",
+          "tunnel_user_password"
+        ]
+      },
+      "UserDefinedCursor": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Incrementally detects new inserts and updates using the <a href=\"https://docs.airbyte.com/understanding-airbyte/connections/incremental-append/#user-defined-cursor\">cursor column</a> chosen when configuring a connection (e.g. created_at, updated_at).",
+        "title": "user_defined",
+        "properties": {
+          "cursor_method": {
+            "type": "string",
+            "enum": ["user_defined"],
+            "default": "user_defined"
+          }
+        },
+        "required": ["cursor_method"]
+      },
+      "CdcCursor": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "<i>Recommended</i> - Incrementally reads new inserts, updates, and deletes using Oracle's <a href=\"https://docs.airbyte.com/integrations/sources/mssql/#change-data-capture-cdc\">change data capture feature</a>. This must be enabled on your database.",
+        "title": "cdc",
+        "properties": {
+          "cursor_method": {
+            "type": "string",
+            "enum": ["cdc"],
+            "default": "cdc"
+          }
+        },
+        "required": ["cursor_method"]
+      }
+    }
+  },
+  "supportsNormalization": false,
+  "supportsDBT": false,
+  "supported_destination_sync_modes": []
+}


### PR DESCRIPTION
This PR adds support for connector configuration POJOs which map to the `--config` CLI argument value. These class definitions are used to generate the JSON schema for SPEC, which is now also supported (and tested).

This PR defines a configuration for source-oracle-v2 and also for the fake connector used in the CDK tests.
