### PR TITLE
source-oracle,cdk2: add Configuration interfaces and factories

### DIFF
--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/Configuration.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/Configuration.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import io.airbyte.cdk.ssh.SshConnectionOptions
+import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
+import java.time.Duration
+
+/**
+ * Interface that defines a typed connector configuration.
+ *
+ * Prefer this or its implementations over the corresponding configuration POJOs; i.e.
+ * [ConfigurationJsonObjectBase] subclasses.
+ */
+sealed interface Configuration {
+
+    val realHost: String
+    val realPort: Int
+    val sshTunnel: SshTunnelMethodConfiguration
+    val sshConnectionOptions: SshConnectionOptions
+
+    val workerConcurrency: Int
+    val workUnitSoftTimeout: Duration
+}
+
+/** Subtype of [Configuration] for sources. */
+interface SourceConfiguration : Configuration {
+
+    /** Does READ generate states of type GLOBAL? */
+    val global: Boolean
+
+    /** Are resumable backfills preferred to non-resumable backfills? */
+    val resumablePreferred: Boolean
+
+    /**
+     * JDBC URL format string with placeholders for the host and port. These are dynamically
+     * assigned by SSH tunnel port forwarding, if applicable.
+     */
+    val jdbcUrlFmt: String
+
+    /** Properties map (with username, password, etc.) passed along to the JDBC driver. */
+    val jdbcProperties: Map<String, String>
+
+    /** Ordered set of schemas for the connector to consider. */
+    val schemas: Set<String>
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/ConfigurationFactory.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/ConfigurationFactory.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import io.airbyte.commons.exceptions.ConfigErrorException
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Singleton
+
+/**
+ * Each connector contains an implementation of this interface in a stateless class which maps the
+ * configuration JSON object to a typed [Configuration] implementation which is more directly useful
+ * to the rest of the connector.
+ */
+interface ConfigurationFactory<I : ConfigurationJsonObjectBase, O : Configuration> {
+
+    fun makeWithoutExceptionHandling(pojo: I): O
+
+    /** Wraps [makeWithoutExceptionHandling] exceptions in [ConfigErrorException]. */
+    fun make(pojo: I): O =
+        try {
+            makeWithoutExceptionHandling(pojo)
+        } catch (e: Exception) {
+            // Wrap NPEs (mostly) in ConfigErrorException.
+            throw ConfigErrorException("Failed to build ConnectorConfiguration.", e)
+        }
+
+    /**
+     * Micronaut factory which glues [ConfigurationJsonObjectSupplier] and [ConfigurationFactory]
+     * together to produce a [Configuration] singleton.
+     */
+    @Factory
+    private class MicronautFactory {
+
+        @Singleton
+        fun <I : ConfigurationJsonObjectBase> sourceConfig(
+            pojoSupplier: ConfigurationJsonObjectSupplier<I>,
+            factory: ConfigurationFactory<I, out SourceConfiguration>
+        ): SourceConfiguration = factory.make(pojoSupplier.get())
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSourceConfiguration.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSourceConfiguration.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.test.source
+
+import io.airbyte.cdk.command.ConfigurationFactory
+import io.airbyte.cdk.command.SourceConfiguration
+import io.airbyte.cdk.ssh.SshConnectionOptions
+import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Secondary
+import io.micronaut.context.env.Environment
+import jakarta.inject.Singleton
+import java.time.Duration
+
+/** [SourceConfiguration] implementation for [TestSource]. */
+data class TestSourceConfiguration(
+    override val realHost: String,
+    override val realPort: Int,
+    override val sshTunnel: SshTunnelMethodConfiguration,
+    override val sshConnectionOptions: SshConnectionOptions,
+    override val jdbcUrlFmt: String,
+    override val schemas: Set<String>,
+    val cursor: CursorConfiguration,
+    override val resumablePreferred: Boolean,
+    override val workerConcurrency: Int,
+    override val workUnitSoftTimeout: Duration,
+) : SourceConfiguration {
+
+    override val global: Boolean = cursor is CdcCursor
+    override val jdbcProperties: Map<String, String> = mapOf()
+}
+
+/** [ConfigurationFactory] implementation for [TestSource]. */
+@Singleton
+@Requires(env = [Environment.TEST])
+@Secondary
+class TestSourceConfigurationFactory :
+    ConfigurationFactory<TestSourceConfigurationJsonObject, TestSourceConfiguration> {
+
+    override fun makeWithoutExceptionHandling(
+        pojo: TestSourceConfigurationJsonObject
+    ): TestSourceConfiguration {
+        val sshConnectionOptions: SshConnectionOptions =
+            SshConnectionOptions.fromAdditionalProperties(pojo.getAdditionalProperties())
+        return TestSourceConfiguration(
+            realHost = pojo.host!!,
+            realPort = pojo.port!!,
+            sshTunnel = pojo.getTunnelMethodValue(),
+            sshConnectionOptions = sshConnectionOptions,
+            jdbcUrlFmt = "jdbc:h2:tcp://%s:%d/mem:${pojo.database!!}",
+            schemas = pojo.schemas.takeUnless { it.isEmpty() }!!.toSet(),
+            cursor = pojo.getCursorConfigurationValue(),
+            resumablePreferred = pojo.resumablePreferred != false,
+            workerConcurrency = 1,
+            workUnitSoftTimeout = Duration.parse(pojo.timeout),
+        )
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSourceConfigurationTest.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSourceConfigurationTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.test.source
+
+import io.airbyte.cdk.command.SourceConfiguration
+import io.airbyte.cdk.ssh.SshConnectionOptions
+import io.airbyte.cdk.ssh.SshPasswordAuthTunnelMethod
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(rebuildContext = true)
+class TestSourceConfigurationTest {
+
+    @Inject lateinit var actual: SourceConfiguration
+
+    @Test
+    @Property(name = "airbyte.connector.config.host", value = "localhost")
+    @Property(name = "airbyte.connector.config.database", value = "testdb")
+    @Property(name = "airbyte.connector.config.schemas", value = "PUBLIC,TESTSCHEMA")
+    @Property(
+        name = "airbyte.connector.config.tunnel_method.tunnel_method",
+        value = "SSH_PASSWORD_AUTH"
+    )
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_host", value = "localhost")
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_port", value = "22")
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_user", value = "sshuser")
+    @Property(
+        name = "airbyte.connector.config.tunnel_method.tunnel_user_password",
+        value = "secret"
+    )
+    fun testVanilla() {
+        val expected =
+            TestSourceConfiguration(
+                realHost = "localhost",
+                realPort = 9092,
+                sshTunnel = SshPasswordAuthTunnelMethod("localhost", 22, "sshuser", "secret"),
+                sshConnectionOptions =
+                    SshConnectionOptions(1_000.milliseconds, 2_000.milliseconds, Duration.ZERO),
+                jdbcUrlFmt = "jdbc:h2:tcp://%s:%d/mem:testdb",
+                schemas = setOf("PUBLIC", "TESTSCHEMA"),
+                cursor = UserDefinedCursor,
+                resumablePreferred = true,
+                workerConcurrency = 1,
+                workUnitSoftTimeout = java.time.Duration.ZERO,
+            )
+        Assertions.assertEquals(expected, actual)
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/main/kotlin/io/airbyte/integrations/source/oracle/OracleSourceConfiguration.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/main/kotlin/io/airbyte/integrations/source/oracle/OracleSourceConfiguration.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.oracle
+
+import io.airbyte.cdk.command.ConfigurationFactory
+import io.airbyte.cdk.command.SourceConfiguration
+import io.airbyte.cdk.ssh.SshConnectionOptions
+import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
+import io.airbyte.commons.io.IOs
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.inject.Singleton
+import java.io.File
+import java.io.FileOutputStream
+import java.io.StringReader
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.security.KeyStore
+import java.security.cert.Certificate
+import java.security.cert.CertificateFactory
+import java.time.Duration
+import java.util.UUID
+import org.bouncycastle.util.io.pem.PemReader
+
+private val log = KotlinLogging.logger {}
+
+/** Oracle-specific implementation of [SourceConfiguration] */
+data class OracleSourceConfiguration(
+    override val realHost: String,
+    override val realPort: Int,
+    override val sshTunnel: SshTunnelMethodConfiguration,
+    override val sshConnectionOptions: SshConnectionOptions,
+    override val jdbcUrlFmt: String,
+    override val jdbcProperties: Map<String, String>,
+    val defaultSchema: String,
+    override val schemas: Set<String>,
+    val cursorConfiguration: CursorConfiguration,
+    override val workerConcurrency: Int = 1,
+    override val workUnitSoftTimeout: Duration = Duration.ZERO,
+) : SourceConfiguration {
+
+    override val resumablePreferred: Boolean = true
+    override val global = cursorConfiguration is CdcCursor
+}
+
+@Singleton
+class OracleSourceConfigurationFactory :
+    ConfigurationFactory<OracleSourceConfigurationJsonObject, OracleSourceConfiguration> {
+
+    override fun makeWithoutExceptionHandling(
+        pojo: OracleSourceConfigurationJsonObject
+    ): OracleSourceConfiguration {
+        val realHost: String = pojo.host!!
+        val realPort: Int = pojo.port!!
+        val sshTunnel: SshTunnelMethodConfiguration = pojo.getTunnelMethodValue()
+        val jdbcProperties = mutableMapOf<String, String>()
+        jdbcProperties["user"] = pojo.username!!
+        pojo.password?.let { jdbcProperties["password"] = it }
+        /*
+         * The property useFetchSizeWithLongColumn required to select LONG or LONG RAW columns.
+         * Oracle recommends avoiding LONG and LONG RAW columns. Use LOB instead.
+         * They are included in Oracle only for legacy reasons.
+         *
+         * THIS IS A THIN ONLY PROPERTY. IT SHOULD NOT BE USED WITH ANY OTHER DRIVERS.
+         *
+         * See
+         * https://docs.oracle.com/cd/E11882_01/appdev.112/e13995/oracle/jdbc/OracleDriver.html
+         * https://docs.oracle.com/cd/B19306_01/java.102/b14355/jstreams.htm#i1014085
+         */
+        jdbcProperties["oracle.jdbc.useFetchSizeWithLongColumn"] = "true"
+        // Parse URL parameters.
+        val pattern = "^([^=]+)=(.*)$".toRegex()
+        for (pair in (pojo.jdbcUrlParams ?: "").trim().split("&".toRegex())) {
+            if (pair.isBlank()) {
+                continue
+            }
+            val result: MatchResult? = pattern.matchEntire(pair)
+            if (result == null) {
+                log.warn { "ignoring invalid JDBC URL param '$pair'" }
+            } else {
+                val key: String = result.groupValues[1].trim()
+                val urlEncodedValue: String = result.groupValues[2].trim()
+                jdbcProperties[key] = URLDecoder.decode(urlEncodedValue, StandardCharsets.UTF_8)
+            }
+        }
+        // Determine protocol and configure encryption.
+        val encryption: Encryption = pojo.getEncryptionValue()
+        if (encryption is SslCertificate) {
+            val pemFileContents: String = encryption.sslCertificate!!
+            val pemReader = PemReader(StringReader(pemFileContents))
+            val certDer = pemReader.readPemObject().content
+            val cf: CertificateFactory = CertificateFactory.getInstance("X.509")
+            val cert: Certificate = cf.generateCertificate(certDer.inputStream())
+            val keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
+            keyStore.load(null, null) // Initialize the KeyStore
+            keyStore.setCertificateEntry("rds-root", cert)
+            val keyStorePass: String = UUID.randomUUID().toString()
+            val keyStoreFile = File(IOs.writeFileToRandomTmpDir("clientkeystore.jks", ""))
+            keyStoreFile.deleteOnExit()
+            val fos = FileOutputStream(keyStoreFile)
+            keyStore.store(fos, keyStorePass.toCharArray())
+            fos.close()
+            jdbcProperties["javax.net.ssl.trustStore"] = keyStoreFile.toString()
+            jdbcProperties["javax.net.ssl.trustStoreType"] = "JKS"
+            jdbcProperties["javax.net.ssl.trustStorePassword"] = keyStorePass
+        } else if (encryption is EncryptionAlgorithm) {
+            val algorithm: String = encryption.encryptionAlgorithm!!
+            jdbcProperties["oracle.net.encryption_client"] = "REQUIRED"
+            jdbcProperties["oracle.net.encryption_types_client"] = "( $algorithm )"
+        }
+        val protocol: String = if (encryption is SslCertificate) "TCPS" else "TCP"
+        // Build JDBC URL
+        val address = "(ADDRESS=(PROTOCOL=${protocol})(HOST=%s)(PORT=%d))"
+        val connectionData: ConnectionData = pojo.getConnectionDataValue()
+        val (connectDataType: String, connectDataValue: String) =
+            when (connectionData) {
+                is ServiceName -> "SERVICE_NAME" to connectionData.serviceName!!
+                is Sid -> "SID" to connectionData.sid!!
+            }
+        val connectData = "(CONNECT_DATA=($connectDataType=$connectDataValue))"
+        val jdbcUrlFmt = "jdbc:oracle:thin:@(DESCRIPTION=${address}${connectData})"
+        val defaultSchema: String = pojo.username!!.uppercase()
+        val sshOpts = SshConnectionOptions.fromAdditionalProperties(pojo.getAdditionalProperties())
+        return OracleSourceConfiguration(
+            realHost = realHost,
+            realPort = realPort,
+            sshTunnel = sshTunnel,
+            sshConnectionOptions = sshOpts,
+            jdbcUrlFmt = jdbcUrlFmt,
+            jdbcProperties = jdbcProperties,
+            defaultSchema = defaultSchema,
+            schemas = pojo.schemas.toSet().ifEmpty { setOf(defaultSchema) },
+            cursorConfiguration = pojo.getCursorConfigurationValue(),
+        )
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/test/kotlin/io/airbyte/integrations/source/oracle/OracleSourceConfigurationTest.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/test/kotlin/io/airbyte/integrations/source/oracle/OracleSourceConfigurationTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.oracle
+
+import io.airbyte.cdk.command.ConfigurationFactory
+import io.airbyte.cdk.command.ConfigurationJsonObjectSupplier
+import io.airbyte.cdk.ssh.SshConnectionOptions
+import io.airbyte.cdk.ssh.SshNoTunnelMethod
+import io.airbyte.cdk.ssh.SshPasswordAuthTunnelMethod
+import io.airbyte.commons.exceptions.ConfigErrorException
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.env.Environment
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(environments = [Environment.TEST], rebuildContext = true)
+class OracleSourceConfigurationTest {
+
+    @Inject
+    lateinit var pojoSupplier: ConfigurationJsonObjectSupplier<OracleSourceConfigurationJsonObject>
+    @Inject
+    lateinit var factory:
+        ConfigurationFactory<OracleSourceConfigurationJsonObject, OracleSourceConfiguration>
+
+    @Test
+    @Property(name = "airbyte.connector.config.host", value = "localhost")
+    @Property(name = "airbyte.connector.config.port", value = "12345")
+    @Property(name = "airbyte.connector.config.username", value = "FOO")
+    @Property(name = "airbyte.connector.config.password", value = "BAR")
+    @Property(name = "airbyte.connector.config.schemas", value = "FOO")
+    @Property(
+        name = "airbyte.connector.config.connection_data.connection_type",
+        value = "service_name"
+    )
+    @Property(name = "airbyte.connector.config.connection_data.service_name", value = "FREEPDB1")
+    @Property(name = "airbyte.connector.config.encryption.encryption_method", value = "client_nne")
+    @Property(name = "airbyte.connector.config.encryption.encryption_algorithm", value = "3DES168")
+    @Property(
+        name = "airbyte.connector.config.tunnel_method.tunnel_method",
+        value = "SSH_PASSWORD_AUTH"
+    )
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_host", value = "localhost")
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_port", value = "2222")
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_user", value = "sshuser")
+    @Property(name = "airbyte.connector.config.tunnel_method.tunnel_user_password", value = "***")
+    fun testWithEncryptionAlgorithm() {
+        val conf: OracleSourceConfiguration = factory.make(pojoSupplier.get())
+        Assertions.assertEquals("localhost", conf.realHost)
+        Assertions.assertEquals(12345, conf.realPort)
+        val expectedSsh = SshPasswordAuthTunnelMethod("localhost", 2222, "sshuser", "***")
+        Assertions.assertEquals(expectedSsh, conf.sshTunnel)
+        val expectedSshOpts = SshConnectionOptions(1_000.milliseconds, 2_000.milliseconds, ZERO)
+        Assertions.assertEquals(expectedSshOpts, conf.sshConnectionOptions)
+        val expectedUrl =
+            "jdbc:oracle:thin:@(DESCRIPTION=" +
+                "(ADDRESS=(PROTOCOL=TCP)(HOST=%s)(PORT=%d))" +
+                "(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)))"
+        Assertions.assertEquals(expectedUrl, conf.jdbcUrlFmt)
+        val expectedProperties =
+            mapOf(
+                "user" to "FOO",
+                "password" to "BAR",
+                "oracle.jdbc.useFetchSizeWithLongColumn" to "true",
+                "oracle.net.encryption_client" to "REQUIRED",
+                "oracle.net.encryption_types_client" to "( 3DES168 )"
+            )
+        Assertions.assertEquals(expectedProperties, conf.jdbcProperties)
+        Assertions.assertEquals("FOO", conf.defaultSchema)
+        Assertions.assertEquals(setOf("FOO"), conf.schemas)
+    }
+
+    @Test
+    @Property(name = "airbyte.connector.config.host", value = "localhost")
+    @Property(name = "airbyte.connector.config.port", value = "12345")
+    @Property(name = "airbyte.connector.config.username", value = "FOO")
+    @Property(name = "airbyte.connector.config.password", value = "BAR")
+    @Property(name = "airbyte.connector.config.schemas", value = "FOO")
+    @Property(name = "airbyte.connector.config.connection_data.connection_type", value = "sid")
+    @Property(name = "airbyte.connector.config.connection_data.sid", value = "DB_SID")
+    @Property(
+        name = "airbyte.connector.config.encryption.encryption_method",
+        value = "encrypted_verify_certificate"
+    )
+    @Property(name = "airbyte.connector.config.encryption.ssl_certificate", value = PEM_FILE)
+    fun testWithValidSslCertificate() {
+        val conf: OracleSourceConfiguration = factory.make(pojoSupplier.get())
+        Assertions.assertEquals("localhost", conf.realHost)
+        Assertions.assertEquals(12345, conf.realPort)
+        Assertions.assertEquals(SshNoTunnelMethod, conf.sshTunnel)
+        val expectedUrl =
+            "jdbc:oracle:thin:@(DESCRIPTION=" +
+                "(ADDRESS=(PROTOCOL=TCPS)(HOST=%s)(PORT=%d))" +
+                "(CONNECT_DATA=(SID=DB_SID)))"
+        Assertions.assertEquals(expectedUrl, conf.jdbcUrlFmt)
+        Assertions.assertNotNull(conf.jdbcProperties["javax.net.ssl.trustStore"])
+        Assertions.assertNotNull(conf.jdbcProperties["javax.net.ssl.trustStorePassword"])
+    }
+
+    @Test
+    @Property(name = "airbyte.connector.config.host", value = "localhost")
+    @Property(name = "airbyte.connector.config.port", value = "12345")
+    @Property(name = "airbyte.connector.config.username", value = "FOO")
+    @Property(name = "airbyte.connector.config.password", value = "BAR")
+    @Property(name = "airbyte.connector.config.schemas", value = "FOO")
+    @Property(name = "airbyte.connector.config.connection_data.connection_type", value = "sid")
+    @Property(name = "airbyte.connector.config.connection_data.sid", value = "DB_SID")
+    @Property(
+        name = "airbyte.connector.config.encryption.encryption_method",
+        value = "encrypted_verify_certificate"
+    )
+    @Property(name = "airbyte.connector.config.encryption.ssl_certificate", value = "non-PEM trash")
+    fun testWithInvalidSslCertificate() {
+        val pojo: OracleSourceConfigurationJsonObject = pojoSupplier.get()
+        Assertions.assertThrows(ConfigErrorException::class.java) { factory.make(pojo) }
+    }
+}
+
+const val PEM_FILE =
+    """
+-----BEGIN CERTIFICATE-----
+MIIDizCCAnOgAwIBAgIUVWCfGs+uSa8Kcuzj3d/IkYbYMCwwDQYJKoZIhvcNAQEL
+BQAwVTELMAkGA1UEBhMCQ0ExCzAJBgNVBAgMAlFDMRYwFAYDVQQHDA1EcnVtbW9u
+ZHZpbGxlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMjQw
+NDA1MDMxNDA0WhcNMjUwNDA1MDMxNDA0WjBVMQswCQYDVQQGEwJDQTELMAkGA1UE
+CAwCUUMxFjAUBgNVBAcMDURydW1tb25kdmlsbGUxITAfBgNVBAoMGEludGVybmV0
+IFdpZGdpdHMgUHR5IEx0ZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AOW7ZXDcu27bT2HfyTkLZ1lwNKwVYLHirBorpdMWqlZucBqpflh9snijmapgEhkY
+EXdWtNW2kp5isrRB/AgwwqepbPFrsZGM7U9XDMzmRDENFF3+R3zYouyEONAzVl+P
+SJYmeRm6xIbz1+L/YXrtc4clRoQN9J1opmqMzeMi74ShHoBFVHyuJr1QZFC2otij
+Gw9IaJ3IWNThaXm+Txits5cyMkAKbUSkNJs4tjtbPpkOJsvhvZiWvQFHtaH+Cm9M
+i4bwnZlKCN/1Ubn40of/nsEsIQlzIfY90ydswPy68azxFDNFE22SxNw+gPF3sJ99
+Y9T61IqNV1VLhQfEheo2mHUCAwEAAaNTMFEwHQYDVR0OBBYEFCmUa/lmXwJxFN5A
+sRlVfzlcrs/uMB8GA1UdIwQYMBaAFCmUa/lmXwJxFN5AsRlVfzlcrs/uMA8GA1Ud
+EwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAFVnpF91oNhkIMg3cIJCFCIi
+WCtPdG9njY9S5zcH7S8ZsQyRiODRL7OEkqhT3frGWgjFiVHRNatuOyyra8KracpD
+hjyRWw/FMTT2+2zhf7cKqdB5kwAiDTr/CGcV8pYqy1YVjrHJ0SbkD+1i2AXJg6ks
+2NfdHiWiAG56+xygyu5k5kUpF2KAVQLK7oaIPsazP1aGiAckYKDNzt2to3dNq9B8
+DCDug44eK1q3ciBAojpbVjJO/sRLyXl5EGsJv2fAOFCC9NrcBhWqFulktQVZu7Wd
+kRj5zGaGRdL+l0Io1vHgJY7jNf3qp9F0uo4MIumj4CXRxq115zCbeznr0wr5/j0=
+-----END CERTIFICATE-----
+"""


### PR DESCRIPTION
In the previous PR we added support for config POJOs. While these are much nicer than messing with naked `JsonNode`s like we are used to, it's still not what we really want. What we really want from the config boils down, essentially, to a JDBC URL.

This PR adds the `Configuration` interface which is to be implemented by the "real" config object that the CDK and connector business logic will rely on.