### PR TITLE
cdk2: add InputState support

### DIFF
--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/InputState.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/InputState.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair
+
+/** Union type of the state passed as input to a READ for a source connector. */
+sealed interface InputState
+
+data object EmptyInputState : InputState
+
+data class GlobalInputState(
+    val global: GlobalStateValue,
+    val globalStreams: Map<AirbyteStreamNameNamespacePair, StreamStateValue>,
+    /** Conceivably, some streams may undergo a full refresh alongside independently of the rest. */
+    val nonGlobalStreams: Map<AirbyteStreamNameNamespacePair, StreamStateValue>,
+) : InputState
+
+data class StreamInputState(
+    val streams: Map<AirbyteStreamNameNamespacePair, StreamStateValue>,
+) : InputState
+
+/** State value for a STATE message of type STREAM. */
+data class StreamStateValue(
+    @JsonProperty("primary_key") val primaryKey: Map<String, String> = mapOf(),
+    @JsonProperty("cursors") val cursors: Map<String, String> = mapOf(),
+)
+
+/** State value for a STATE message of type GLOBAL. */
+data class GlobalStateValue(@JsonProperty("cdc") val cdc: JsonNode)

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/InputStateFactory.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/InputStateFactory.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.commons.exceptions.ConfigErrorException
+import io.airbyte.commons.json.Jsons
+import io.airbyte.commons.resources.MoreResources
+import io.airbyte.protocol.models.v0.AirbyteGlobalState
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair
+import io.airbyte.protocol.models.v0.AirbyteStreamState
+import io.airbyte.protocol.models.v0.StreamDescriptor
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import io.micronaut.context.env.Environment
+import jakarta.inject.Singleton
+
+/**
+ * Micronaut factory for the [InputState] singleton.
+ *
+ * The value may be defined via two Micronaut properties:
+ * - `airbyte.connector.state.json` for use by [ConnectorCommandLinePropertySource],
+ * - `airbyte.connector.state.resource` for use in unit tests.
+ */
+@Factory
+class InputStateFactory {
+
+    private val log = KotlinLogging.logger {}
+
+    @Singleton
+    @Requires(missingProperty = "${CONNECTOR_STATE_PREFIX}.resource")
+    fun make(@Value("\${${CONNECTOR_STATE_PREFIX}.json}") json: String?): InputState {
+        val list: List<AirbyteStateMessage> =
+            JsonUtils.parseList(AirbyteStateMessage::class.java, json ?: "[]")
+        if (list.isEmpty()) {
+            return EmptyInputState
+        }
+        for (message in list) {
+            validateStateMessage(message)
+        }
+        val deduped: List<AirbyteStateMessage> =
+            list
+                .groupBy { msg: AirbyteStateMessage ->
+                    if (msg.stream == null) {
+                        msg.type.toString()
+                    } else {
+                        val desc: StreamDescriptor = msg.stream.streamDescriptor
+                        AirbyteStreamNameNamespacePair(desc.name, desc.namespace).toString()
+                    }
+                }
+                .mapNotNull { (groupKey, groupValues) ->
+                    if (groupValues.size > 1) {
+                        log.warn {
+                            "Discarded duplicated ${groupValues.size - 1} state message(s) " +
+                                "for '$groupKey'."
+                        }
+                    }
+                    groupValues.last()
+                }
+        val nonGlobalStreams: Map<AirbyteStreamNameNamespacePair, StreamStateValue> =
+            streamStates(deduped.mapNotNull { it.stream })
+        val globalState: AirbyteGlobalState? =
+            deduped.find { it.type == AirbyteStateMessage.AirbyteStateType.GLOBAL }?.global
+        if (globalState == null) {
+            return StreamInputState(nonGlobalStreams)
+        }
+        val globalStateValue: GlobalStateValue =
+            JsonUtils.parseUnvalidated(globalState.sharedState, GlobalStateValue::class.java)
+        val globalStreams: Map<AirbyteStreamNameNamespacePair, StreamStateValue> =
+            streamStates(globalState.streamStates)
+        return GlobalInputState(globalStateValue, globalStreams, nonGlobalStreams)
+    }
+
+    private fun streamStates(
+        streamStates: List<AirbyteStreamState>?
+    ): Map<AirbyteStreamNameNamespacePair, StreamStateValue> =
+        (streamStates ?: listOf()).associate { msg: AirbyteStreamState ->
+            val sd: StreamDescriptor = msg.streamDescriptor
+            val key = AirbyteStreamNameNamespacePair(sd.name, sd.namespace)
+            val jsonValue: JsonNode = msg.streamState ?: Jsons.emptyObject()
+            key to JsonUtils.parseUnvalidated(jsonValue, StreamStateValue::class.java)
+        }
+
+    private fun validateStateMessage(message: AirbyteStateMessage) {
+        when (message.type) {
+            AirbyteStateMessage.AirbyteStateType.GLOBAL,
+            AirbyteStateMessage.AirbyteStateType.STREAM -> Unit
+            AirbyteStateMessage.AirbyteStateType.LEGACY ->
+                throw ConfigErrorException("Unsupported LEGACY state type in $message.")
+            null -> throw ConfigErrorException("State type not set in $message.")
+        }
+        // TODO: add more validation?
+    }
+
+    @Singleton
+    @Requires(env = [Environment.TEST])
+    @Requires(notEnv = [Environment.CLI])
+    @Requires(property = "${CONNECTOR_STATE_PREFIX}.resource")
+    fun makeFromTestResource(
+        @Value("\${${CONNECTOR_STATE_PREFIX}.resource}") resource: String
+    ): InputState = make(MoreResources.readResource(resource))
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/command/InputStateTest.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/command/InputStateTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import io.airbyte.commons.json.Jsons
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(rebuildContext = true)
+class InputStateTest {
+
+    @Inject lateinit var actual: InputState
+
+    @Test
+    fun testEmpty() {
+        Assertions.assertEquals(EmptyInputState, actual)
+    }
+
+    @Test
+    @Property(
+        name = "airbyte.connector.state.resource",
+        value = "command/vanilla-stream-states.json"
+    )
+    fun testVanillaStreamStates() {
+        val expected =
+            StreamInputState(
+                mapOf(
+                    AirbyteStreamNameNamespacePair("bar", "foo") to
+                        StreamStateValue(primaryKey = mapOf("k1" to "10", "k2" to "20")),
+                    AirbyteStreamNameNamespacePair("baz", "foo") to
+                        StreamStateValue(cursors = mapOf("c" to "30")),
+                )
+            )
+        Assertions.assertEquals(expected, actual)
+    }
+
+    @Test
+    @Property(
+        name = "airbyte.connector.state.resource",
+        value = "command/vanilla-global-states.json"
+    )
+    fun testVanillaGlobalStates() {
+        val expected =
+            GlobalInputState(
+                global = GlobalStateValue(Jsons.emptyObject()),
+                globalStreams =
+                    mapOf(
+                        AirbyteStreamNameNamespacePair("bar", "foo") to
+                            StreamStateValue(primaryKey = mapOf("k1" to "10", "k2" to "20"))
+                    ),
+                nonGlobalStreams = mapOf()
+            )
+        Assertions.assertEquals(expected, actual)
+    }
+
+    @Test
+    @Property(
+        name = "airbyte.connector.state.resource",
+        value = "command/vanilla-mixed-states.json"
+    )
+    fun testVanillaMixedStates() {
+        val expected =
+            GlobalInputState(
+                global = GlobalStateValue(Jsons.emptyObject()),
+                globalStreams =
+                    mapOf(
+                        AirbyteStreamNameNamespacePair("bar", "foo") to
+                            StreamStateValue(primaryKey = mapOf("k1" to "10", "k2" to "20"))
+                    ),
+                nonGlobalStreams =
+                    mapOf(
+                        AirbyteStreamNameNamespacePair("baz", "foo") to
+                            StreamStateValue(primaryKey = mapOf("k" to "1"))
+                    )
+            )
+        Assertions.assertEquals(expected, actual)
+    }
+
+    @Test
+    @Property(name = "airbyte.connector.state.resource", value = "command/duplicate-states.json")
+    fun testDuplicates() {
+        val expected =
+            GlobalInputState(
+                global = GlobalStateValue(Jsons.emptyObject()),
+                globalStreams =
+                    mapOf(
+                        AirbyteStreamNameNamespacePair("bar", "foo") to
+                            StreamStateValue(primaryKey = mapOf("k1" to "10", "k2" to "20"))
+                    ),
+                nonGlobalStreams =
+                    mapOf(
+                        AirbyteStreamNameNamespacePair("baz", "foo") to
+                            StreamStateValue(primaryKey = mapOf("k" to "10"))
+                    )
+            )
+        Assertions.assertEquals(expected, actual)
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/duplicate-states.json
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/duplicate-states.json
@@ -1,0 +1,52 @@
+[
+  {
+    "type": "GLOBAL",
+    "global": {
+      "shared_state": { "cdc": {} },
+      "stream_states": [
+        {
+          "stream_descriptor": {
+            "name": "bar",
+            "namespace": "foo"
+          },
+          "stream_state": { "primary_key": { "k1": "1", "k2": "2" } }
+        }
+      ]
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_descriptor": {
+        "name": "baz",
+        "namespace": "foo"
+      },
+      "stream_state": { "primary_key": { "k": "1" } }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_descriptor": {
+        "name": "baz",
+        "namespace": "foo"
+      },
+      "stream_state": { "primary_key": { "k": "10" } }
+    }
+  },
+  {
+    "type": "GLOBAL",
+    "global": {
+      "shared_state": { "cdc": {} },
+      "stream_states": [
+        {
+          "stream_descriptor": {
+            "name": "bar",
+            "namespace": "foo"
+          },
+          "stream_state": { "primary_key": { "k1": "10", "k2": "20" } }
+        }
+      ]
+    }
+  }
+]

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/vanilla-global-states.json
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/vanilla-global-states.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "GLOBAL",
+    "global": {
+      "shared_state": { "cdc": {} },
+      "stream_states": [
+        {
+          "stream_descriptor": {
+            "name": "bar",
+            "namespace": "foo"
+          },
+          "stream_state": { "primary_key": { "k1": "10", "k2": "20" } }
+        }
+      ]
+    }
+  }
+]

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/vanilla-mixed-states.json
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/vanilla-mixed-states.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_descriptor": {
+        "name": "baz",
+        "namespace": "foo"
+      },
+      "stream_state": { "primary_key": { "k": "1" } }
+    }
+  },
+  {
+    "type": "GLOBAL",
+    "global": {
+      "shared_state": { "cdc": {} },
+      "stream_states": [
+        {
+          "stream_descriptor": {
+            "name": "bar",
+            "namespace": "foo"
+          },
+          "stream_state": { "primary_key": { "k1": "10", "k2": "20" } }
+        }
+      ]
+    }
+  }
+]

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/vanilla-stream-states.json
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/vanilla-stream-states.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_descriptor": {
+        "name": "bar",
+        "namespace": "foo"
+      },
+      "stream_state": { "primary_key": { "k1": "10", "k2": "20" } }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_descriptor": {
+        "name": "baz",
+        "namespace": "foo"
+      },
+      "stream_state": { "cursors": { "c": "30" } }
+    }
+  }
+]


### PR DESCRIPTION
While previous PRs addressed the `--config` argument value, this one does `--state`.

This is still somewhat incomplete, for instance `GlobalStateValue` just wraps a `JsonNode` instead of Debezium stuff. That's OK because the parsing of the input is independent of these state values anyway.