### PR TITLE
cdk2: add ConfiguredAirbyteCatalog support

### DIFF
--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/ConfiguredCatalogFactory.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/main/kotlin/io/airbyte/cdk/command/ConfiguredCatalogFactory.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import io.airbyte.commons.exceptions.ConfigErrorException
+import io.airbyte.commons.resources.MoreResources
+import io.airbyte.protocol.models.v0.AirbyteStream
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import io.micronaut.context.env.Environment
+import jakarta.inject.Singleton
+
+/**
+ * Micronaut factory for the [ConfiguredAirbyteCatalog] singleton.
+ *
+ * The value may be defined via two Micronaut properties:
+ * - `airbyte.connector.catalog.json` for use by [ConnectorCommandLinePropertySource],
+ * - `airbyte.connector.catalog.resource` for use in unit tests.
+ */
+@Factory
+class ConfiguredCatalogFactory {
+
+    @Singleton
+    @Requires(missingProperty = "${CONNECTOR_CATALOG_PREFIX}.resource")
+    fun make(
+        @Value("\${${CONNECTOR_CATALOG_PREFIX}.json}") json: String?
+    ): ConfiguredAirbyteCatalog =
+        JsonUtils.parseOne(ConfiguredAirbyteCatalog::class.java, json ?: "{}").also {
+            for (configuredStream in it.streams) {
+                validateConfiguredStream(configuredStream)
+            }
+        }
+
+    private fun validateConfiguredStream(configuredStream: ConfiguredAirbyteStream) {
+        val stream: AirbyteStream = configuredStream.stream
+        if (stream.name == null) {
+            throw ConfigErrorException("Configured catalog is missing stream name.")
+        }
+        // TODO: add more validation?
+    }
+
+    @Singleton
+    @Requires(env = [Environment.TEST])
+    @Requires(notEnv = [Environment.CLI])
+    @Requires(property = "${CONNECTOR_CATALOG_PREFIX}.resource")
+    fun makeFromTestResource(
+        @Value("\${${CONNECTOR_CATALOG_PREFIX}.resource}") resource: String
+    ): ConfiguredAirbyteCatalog = make(MoreResources.readResource(resource))
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/command/ConfiguredCatalogTest.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/command/ConfiguredCatalogTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import io.airbyte.commons.json.Jsons
+import io.airbyte.commons.resources.MoreResources
+import io.airbyte.protocol.models.Field
+import io.airbyte.protocol.models.JsonSchemaType
+import io.airbyte.protocol.models.v0.CatalogHelpers
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream
+import io.airbyte.protocol.models.v0.DestinationSyncMode
+import io.airbyte.protocol.models.v0.SyncMode
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(rebuildContext = true)
+class ConfiguredAirbyteCatalogTest {
+
+    @Inject lateinit var actual: ConfiguredAirbyteCatalog
+
+    @Test
+    fun testEmpty() {
+        Assertions.assertEquals(ConfiguredAirbyteCatalog(), actual)
+    }
+
+    @Test
+    @Property(name = "airbyte.connector.catalog.resource", value = CATALOG_RESOURCE)
+    fun testInjectedCatalog() {
+        val expected =
+            ConfiguredAirbyteCatalog()
+                .withStreams(
+                    listOf(
+                        ConfiguredAirbyteStream()
+                            .withSyncMode(SyncMode.INCREMENTAL)
+                            .withCursorField(listOf("id"))
+                            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+                            .withStream(
+                                CatalogHelpers.createAirbyteStream(
+                                        "bar",
+                                        "foo",
+                                        Field.of("id", JsonSchemaType.NUMBER),
+                                        Field.of("name", JsonSchemaType.STRING)
+                                    )
+                                    .withSupportedSyncModes(
+                                        listOf(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)
+                                    )
+                            ),
+                        ConfiguredAirbyteStream()
+                            .withSyncMode(SyncMode.INCREMENTAL)
+                            .withCursorField(listOf("id"))
+                            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+                            .withStream(
+                                CatalogHelpers.createAirbyteStream(
+                                        "baz",
+                                        "foo",
+                                        Field.of("id", JsonSchemaType.NUMBER),
+                                        Field.of("name", JsonSchemaType.STRING)
+                                    )
+                                    .withSupportedSyncModes(listOf(SyncMode.FULL_REFRESH))
+                            )
+                    )
+                )
+        Assertions.assertEquals(
+            Jsons.deserialize(MoreResources.readResource(CATALOG_RESOURCE)),
+            Jsons.jsonNode(expected)
+        )
+        Assertions.assertEquals(expected, actual)
+    }
+
+    companion object {
+        const val CATALOG_RESOURCE = "command/catalog.json"
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/catalog.json
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/resources/command/catalog.json
@@ -1,0 +1,52 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "bar",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "foo"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["id"],
+      "destination_sync_mode": "append",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "baz",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "foo"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["id"],
+      "destination_sync_mode": "append",
+      "primary_key": []
+    }
+  ]
+}


### PR DESCRIPTION
We've done `--config` and `--state` so far, there remains `--catalog`, which is handled here.