### PR TITLE
cdk2: add integration tests and fixtures

### DIFF
--- a/airbyte-integrations/connectors/source-oracle-v2/build.gradle
+++ b/airbyte-integrations/connectors/source-oracle-v2/build.gradle
@@ -101,7 +101,12 @@ dependencies {
     cdkTestFixturesApi testFixtures(project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core'))
 
     cdkTestFixturesApi 'com.h2database:h2:2.2.224'
+    cdkTestFixturesApi 'io.github.deblockt:json-diff:1.0.1'
     cdkTestFixturesApi 'org.testcontainers:testcontainers:1.19.0'
+
+    cdkTestFixturesApi platform("org.junit:junit-bom:5.10.2")
+    cdkTestFixturesApi "org.junit.jupiter:junit-jupiter-api:5.10.2"
+    cdkTestFixturesApi "org.junit.jupiter:junit-jupiter-params:5.10.2"
 
     cdkTestImplementation 'com.h2database:h2:2.2.224'
     cdkTestImplementation 'io.github.deblockt:json-diff:1.0.1'

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSourceIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/test/kotlin/io/airbyte/cdk/test/source/TestSourceIntegrationTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.test.source
+
+import com.deblock.jsondiff.DiffGenerator
+import com.deblock.jsondiff.diff.JsonDiff
+import com.deblock.jsondiff.matcher.CompositeJsonMatcher
+import com.deblock.jsondiff.matcher.JsonMatcher
+import com.deblock.jsondiff.matcher.LenientJsonObjectPartialMatcher
+import com.deblock.jsondiff.matcher.StrictJsonArrayPartialMatcher
+import com.deblock.jsondiff.matcher.StrictPrimitivePartialMatcher
+import com.deblock.jsondiff.viewer.OnlyErrorDiffViewer
+import io.airbyte.cdk.command.CliRunner
+import io.airbyte.cdk.consumers.BufferingOutputConsumer
+import io.airbyte.commons.json.Jsons
+import io.airbyte.commons.resources.MoreResources
+import io.airbyte.protocol.models.v0.ConnectorSpecification
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class TestSourceIntegrationTest {
+
+    @Test
+    fun testSpec() {
+        val output: BufferingOutputConsumer = CliRunner.runSource("spec")
+        val actual: String = Jsons.serialize(output.specs().last())
+
+        val jsonMatcher: JsonMatcher =
+            CompositeJsonMatcher(
+                StrictJsonArrayPartialMatcher(),
+                LenientJsonObjectPartialMatcher(),
+                StrictPrimitivePartialMatcher(),
+            )
+        val diff: JsonDiff = DiffGenerator.diff(Jsons.serialize(expectedSpec), actual, jsonMatcher)
+        Assertions.assertEquals("", OnlyErrorDiffViewer.from(diff).toString())
+    }
+
+    val expectedSpec: ConnectorSpecification =
+        Jsons.deserialize(
+            MoreResources.readResource("test/source/expected-spec.json"),
+            ConnectorSpecification::class.java
+        )
+
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/testFixtures/kotlin/io/airbyte/cdk/command/CliRunner.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/testFixtures/kotlin/io/airbyte/cdk/command/CliRunner.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import io.airbyte.cdk.AirbyteConnectorRunnable
+import io.airbyte.cdk.AirbyteConnectorRunner
+import io.airbyte.cdk.AirbyteDestinationRunner
+import io.airbyte.cdk.AirbyteSourceRunner
+import io.airbyte.cdk.TestClockFactory
+import io.airbyte.cdk.consumers.BufferingOutputConsumer
+import io.airbyte.commons.json.Jsons
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteIfExists
+
+data object CliRunner {
+
+    /**
+     * Runs a source connector with the given arguments and returns the results.
+     *
+     * This is useful for writing connector integration tests:
+     * - the [config], [catalog] and [state] get written to temporary files;
+     * - the file names get passed with the `--config`, `--catalog` and `--state` CLI arguments;
+     * - an extra temporary file is created to store the output;
+     * - that file name gets passed with the test-only `--output` CLI argument;
+     * - [AirbyteSourceRunner] takes the CLI arguments and runs them in a new Micronaut context;
+     * - after it's done, the output file contents are read and parsed into [AirbyteMessage]s.
+     * - those are stored in a [BufferingOutputConsumer] which is returned.
+     */
+    fun runSource(
+        op: String,
+        config: ConfigurationJsonObjectBase? = null,
+        catalog: ConfiguredAirbyteCatalog? = null,
+        state: List<AirbyteStateMessage>? = null
+    ): BufferingOutputConsumer =
+        runConnector(op, config, catalog, state) { args: Array<String> ->
+            AirbyteSourceRunner(args)
+        }
+
+    /** Same as [runSource] but for destinations. */
+    fun runDestination(
+        op: String,
+        config: ConfigurationJsonObjectBase? = null,
+        catalog: ConfiguredAirbyteCatalog? = null,
+        state: List<AirbyteStateMessage>? = null
+    ): BufferingOutputConsumer =
+        runConnector(op, config, catalog, state) { args: Array<String> ->
+            AirbyteDestinationRunner(args)
+        }
+
+    private fun runConnector(
+        op: String,
+        config: ConfigurationJsonObjectBase?,
+        catalog: ConfiguredAirbyteCatalog?,
+        state: List<AirbyteStateMessage>?,
+        connectorRunnerConstructor: (Array<String>) -> AirbyteConnectorRunner,
+    ): BufferingOutputConsumer {
+        val result = BufferingOutputConsumer(TestClockFactory().fixed())
+        val configFile: Path? = inputFile(config)
+        val catalogFile: Path? = inputFile(catalog)
+        val stateFile: Path? = inputFile(state)
+        val outputFile: Path = Files.createTempFile(null, null)
+        val args: List<String> =
+            listOfNotNull(
+                "--$op",
+                configFile?.let { "--config=$it" },
+                catalogFile?.let { "--catalog=$it" },
+                stateFile?.let { "--state=$it" },
+                "--output=$outputFile"
+            )
+        try {
+            connectorRunnerConstructor(args.toTypedArray()).run<AirbyteConnectorRunnable>()
+            Files.readAllLines(outputFile)
+                .filter { it.isNotBlank() }
+                .map { Jsons.deserialize(it, AirbyteMessage::class.java) }
+                .forEach { result.accept(it) }
+            return result
+        } finally {
+            configFile?.deleteIfExists()
+            catalogFile?.deleteIfExists()
+            stateFile?.deleteIfExists()
+            outputFile.deleteIfExists()
+        }
+    }
+
+    private fun inputFile(contents: Any?): Path? =
+        contents?.let {
+            Files.createTempFile(null, null).also { file ->
+                Files.writeString(file, Jsons.serialize(contents))
+            }
+        }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/cdk/testFixtures/kotlin/io/airbyte/cdk/consumers/FileOutputConsumer.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/cdk/testFixtures/kotlin/io/airbyte/cdk/consumers/FileOutputConsumer.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.consumers
+
+import io.airbyte.commons.json.Jsons
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import io.micronaut.context.env.Environment
+import jakarta.inject.Singleton
+import java.io.FileOutputStream
+import java.nio.file.Path
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * [OutputConsumer] implementation for CLI integration tests. Writes [AirbyteMessage]s to a file
+ * instead of stdout.
+ */
+@Singleton
+@Requires(env = [Environment.TEST, Environment.CLI])
+@Requires(property = CONNECTOR_OUTPUT_FILE)
+@Replaces(OutputConsumer::class)
+class FileOutputConsumer(@Value("\${$CONNECTOR_OUTPUT_FILE}") filePath: Path, clock: Clock) :
+    OutputConsumer, AutoCloseable {
+
+    private val writer = FileOutputStream(filePath.toFile()).bufferedWriter()
+
+    override val emittedAt: Instant = Instant.now(clock)
+
+    override fun accept(msg: AirbyteMessage) {
+        synchronized(this) {
+            writer.appendLine(Jsons.serialize(msg))
+            writer.flush()
+        }
+    }
+
+    override fun close() {
+        synchronized(this) { writer.close() }
+    }
+}


### PR DESCRIPTION
Now that we support all CLI inputs, we can implement an integration test fixture, which we apply on an integration test for SPEC for the fake source connector.