### PR TITLE
airbyte-ci: fix bug in `migrate-to-poetry`

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -649,6 +649,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                |
 |---------| ---------------------------------------------------------- |----------------------------------------------------------------------------------------------------------------------------|
+| 4.10.3   | [#37615](https://github.com/airbytehq/airbyte/pull/37615)      | Fix `KeyError` when running `migrate-to-poetry` |
 | 4.10.2   | [#37614](https://github.com/airbytehq/airbyte/pull/37614)      | Fix `UnboundLocalError: local variable 'add_changelog_entry_result' referenced before assignment` in `migrate_to_base_image` |
 | 4.10.1   | [#37622](https://github.com/airbytehq/airbyte/pull/37622)  | Temporarily disable regression tests in CI                                                    |
 | 4.10.0   | [#37616](https://github.com/airbytehq/airbyte/pull/37616)  | Improve modified files comparison when the target branch is from a fork.                                                                       |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
@@ -433,9 +433,9 @@ async def run_connector_migration_to_poetry_pipeline(context: ConnectorContext, 
                 step=RegressionTest(context),
                 depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
                 args=lambda results: {
-                    "new_connector_container": results["BUILD_CONNECTOR_IMAGE"].output[LOCAL_BUILD_PLATFORM],
-                    "original_dependencies": results["POETRY_INIT"].output[0],
-                    "original_dev_dependencies": results["POETRY_INIT"].output[1],
+                    "new_connector_container": results[CONNECTOR_TEST_STEP_ID.BUILD].output[LOCAL_BUILD_PLATFORM],
+                    "original_dependencies": results[CONNECTOR_TEST_STEP_ID.POETRY_INIT].output[0],
+                    "original_dev_dependencies": results[CONNECTOR_TEST_STEP_ID.POETRY_INIT].output[1],
                 },
             )
         ],

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.10.2"
+version = "4.10.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
For some reasons I was not able to identified the type of the keys in the `results` has changed...
I fixed the `KeyError` @cmm-airbyte faced by setting the result keys to the proper `enum` values.