### PR TITLE
🚨🐛 Fix Clickhouse name limitation

### DIFF
--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/destination_name_transformer.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/destination_name_transformer.py
@@ -26,7 +26,7 @@ DESTINATION_SIZE_LIMITS = {
     # https://docs.microsoft.com/en-us/sql/odbc/microsoft/column-name-limitations?view=sql-server-ver15
     DestinationType.MSSQL.value: 64,
     # https://stackoverflow.com/questions/68358686/what-is-the-maximum-length-of-a-column-in-clickhouse-can-it-be-modified
-    DestinationType.CLICKHOUSE.value: 63,
+    DestinationType.CLICKHOUSE.value: 254,
     # https://docs.pingcap.com/tidb/stable/tidb-limitations
     DestinationType.TIDB.value: 64,
     # According to the DuckDB team there no restriction: We don't enforce a maximum right now but I would not recommend having column names


### PR DESCRIPTION
## What
Airbyte integration with dbt is broken because even if you pick mirror source name, there is a table name truncation process that breaks the data lineage (as the name of the table is not the same that the name of the stream).

## How
Although this solution does not fix the problem 100%, it will reduce a lot the impact of truncated table names.
This commit just add the maximum size an identifier name can have taking into consideration table name in case it lands in an ext4 filesystem. For any other filesystem, there is no limitation.
The details were already in the comment link, but for an unknown reason it was kept as standard 64 limit...

## Review guide
Single file, it's easy

## User Impact
Anyone using any source that has an stream name > 64 bytes will be able to create a lineage with dbt allowing to auto-refresh dbt models.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
