### PR TITLE
bug(airbyte-ci): Ensure we always track an explicit branch

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/containers/git.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/containers/git.py
@@ -45,5 +45,5 @@ async def checked_out_git_container(
         )
         .with_exec(["fetch", "origin", diffed_branch])
         .with_exec(["fetch", "target", current_git_branch])
-        .with_exec(["checkout", current_git_branch])
+        .with_exec(["checkout", "--track", f"origin/{current_git_branch}", current_git_branch])
     )


### PR DESCRIPTION
## What
Fix the failing publish connector pipeline
https://github.com/airbytehq/airbyte/actions/runs/8853928263/job/24316542022

Related regression #37616


## How
By explicitly targeting origin on checkout

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
