### PR TITLE
CI: Skip `airbyte-ci` version check in `format_check`, already a fresh binary install

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -121,4 +121,4 @@ jobs:
           sudo chmod +x /usr/local/bin/airbyte-ci
       - name: Run format checks
         run: |
-          /usr/local/bin/airbyte-ci format check all
+          /usr/local/bin/airbyte-ci --disable-update-check format check all


### PR DESCRIPTION
## What

Skip version check on CI format check.

This resolves an issue where checks immediately fail when a new version of `airbyte-ci` becomes available.

The problem is that the CLi is newer than what is on the branch.

Since the execution of `airbyte-ci` comes from the binary download, and because it does not depend on the local branch being up to date, we should not fail the check because the running version (binary download) is newer than the local branch version (not used anyway).

Lmk if I'm missing anything here.

Example PR affected by this now:

- https://github.com/airbytehq/airbyte/pull/37601

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
