### PR TITLE
:bug: Source Amazon Seller Partner/Google Analytics Data API/Microsoft Sharepoint: Set maxSecondsBetweenMessages

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -21,6 +21,7 @@ data:
   githubIssueLabel: source-amazon-seller-partner
   icon: amazonsellerpartner.svg
   license: MIT
+  maxSecondsBetweenMessages: 5400
   name: Amazon Seller Partner
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -18,6 +18,7 @@ data:
   githubIssueLabel: source-google-analytics-data-api
   icon: google-analytics.svg
   license: Elv2
+  maxSecondsBetweenMessages: 86400
   name: Google Analytics 4 (GA4)
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
@@ -25,6 +25,7 @@ data:
   githubIssueLabel: source-microsoft-sharepoint
   icon: microsoft-sharepoint.svg
   license: MIT
+  maxSecondsBetweenMessages: 5400
   name: Microsoft SharePoint
   supportLevel: certified
   releaseStage: alpha


### PR DESCRIPTION
## What
Set maxSecondsBetweenMessages for Certified connectors:
- **source-amazon-seller-partner** - 90 minutes, as max time for report timeout is 1 hour
- **source-google-analytics-data-api** - copied max possible time from Google Analytics V4
- **source-microsoft-sharepoint** - 90 minutes, as iterating over the file tree may take some time between files


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
