### PR TITLE
:bug: Source Marketo: Add new empty stream `activities_create_buying_group`

### DIFF
--- a/airbyte-integrations/connectors/source-marketo/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-marketo/acceptance-test-config.yml
@@ -101,6 +101,8 @@ acceptance_tests:
             bypass_reason: "Marketo does not provide a way to populate this stream without outside interaction"
           - name: "activities_interactedwith_documentin_conversational_flow"
             bypass_reason: "Marketo does not provide a way to populate this stream without outside interaction"
+          - name: "activities_create_buying_group"
+            bypass_reason: "Marketo does not provide a way to populate this stream without outside interaction"
         # 52 streams, most of them use BULK API therefore it takes much time to run a sync
         timeout_seconds: 9000
         fail_on_extra_columns: false


### PR DESCRIPTION
## What
Add the newly discovered stream `activities_create_buying_group` to the `acceptance-test-config.yaml` as `empty_streams`.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
