### PR TITLE
Expose cdk version as airbyte_cdk.__version__

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/__init__.py
@@ -5,5 +5,7 @@
 from .connector import AirbyteSpec, Connector
 from .entrypoint import AirbyteEntrypoint
 from .logger import AirbyteLogger
+from importlib import metadata
 
 __all__ = ["AirbyteEntrypoint", "AirbyteLogger", "AirbyteSpec", "Connector"]
+__version__ = metadata.version("airbyte_cdk")


### PR DESCRIPTION
## What
Expose the CDK version as `__version__`.

Example usage:
```
python
Python 3.9.18 (main, Aug 24 2023, 21:19:58)
[Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import airbyte_cdk
>>> airbyte_cdk.__version__
'0.83.1'
```

If testing locally, you might have to delete your local `airbyte_cdk.egg-info`  (`rm -r airbyte_cdk.egg-info`) because `importlib` uses that artefact. 

## How
`importlib.metadata.version("airbyte_cdk")`

## User Impact
Users will be able to tell which version of the CDK they use from their Python environment

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
