### PR TITLE
Regression tests GHA: remove defaults

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -16,13 +16,13 @@ on:
     inputs:
       connector_name:
         description: "Connector name (e.g. source-faker)"
-        default: "source-s3"
+        required: true
       connection_id:
         description: "ID of the connection to test"
-        default: "06c4ea16-b57d-4ca5-8adb-36414e350be0"
+        required: true
       pr_url:
         description: "URL of the PR containing the code change"
-        default: "none"
+        required: true
 
 jobs:
   regression_tests:

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -27,8 +27,7 @@ pydash = "~=7.0.7"
 docker = ">=6,<7"
 asyncclick = "^8.1.7.1"
 # TODO: when this is open-sourced, don't require connection-retriever
-# TODO: get rid of rev when https://github.com/airbytehq/airbyte-platform-internal/pull/12286 is merged
-connection-retriever = {git = "git@github.com:airbytehq/airbyte-platform-internal", subdirectory = "tools/connection-retriever", rev = "catherine/connection-retriever-proxy"}
+connection-retriever = {git = "git@github.com:airbytehq/airbyte-platform-internal", subdirectory = "tools/connection-retriever"}
 duckdb = "^0.10.0"
 pandas = "^2.2.1"
 pytest-sugar = "^1.0.0"


### PR DESCRIPTION
Forgot to remove the default `inputs` (which were just for ease of testing) before merging.