### PR TITLE
community-ci: fix typo in workflow

### DIFF
--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == true
     environment: community-ci-auto
     runs-on: community-tooling-test-small
-    timeout-minutes: 30s
+    timeout-minutes: 30
     env:
       MAIN_BRANCH_NAME: "master"
     steps:


### PR DESCRIPTION
There was a typo in the timeout_minutes field...