### PR TITLE
remove extensibility from required reviewers checks

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -7,10 +7,14 @@ from typing import Dict, List, Set, Tuple, Union
 import yaml
 from connector_ops import utils
 
-BACKWARD_COMPATIBILITY_REVIEWERS = {"connector-extensibility"}
-TEST_STRICTNESS_LEVEL_REVIEWERS = {"connector-extensibility"}
-BYPASS_REASON_REVIEWERS = {"connector-extensibility"}
-STRATEGIC_PYTHON_CONNECTOR_REVIEWERS = {"gl-python", "connector-extensibility"}
+# We are toying with removing these as requirements.
+BACKWARD_COMPATIBILITY_REVIEWERS = set()
+TEST_STRICTNESS_LEVEL_REVIEWERS = set()
+BYPASS_REASON_REVIEWERS = set()
+# TODO: Check to see if GL still wants to get tagged in this. If so,
+# the logic needs to be audited to make sure its actually just python.
+STRATEGIC_PYTHON_CONNECTOR_REVIEWERS = {"gl-python"}
+# The breaking change reviewers is still in active use.
 BREAKING_CHANGE_REVIEWERS = {"breaking-change-reviewers"}
 REVIEW_REQUIREMENTS_FILE_PATH = ".github/connector_org_review_requirements.yaml"
 
@@ -66,7 +70,9 @@ def find_mandatory_reviewers() -> List[Dict[str, Union[str, Dict[str, List]]]]:
         },
     ]
 
-    return [{"name": r["name"], "teams": r["teams"]} for r in requirements if r["is_required"]]
+    required_reviewer_groups = [r for r in requirements if r["is_required"]]
+    # Don't return a group if there are no teams assigned to it.
+    return [{"name": r["name"], "teams": r["teams"]} for r in required_reviewer_groups if r["teams"]]
 
 
 def write_review_requirements_file():

--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -7,11 +7,6 @@ from typing import Dict, List, Set, Tuple, Union
 import yaml
 from connector_ops import utils
 
-# We are toying with removing these as requirements.
-# BACKWARD_COMPATIBILITY_REVIEWERS = {"connector-extensibility"}
-# TEST_STRICTNESS_LEVEL_REVIEWERS = {"connector-extensibility"}
-# BYPASS_REASON_REVIEWERS = {"connector-extensibility"}
-
 # TODO: Check to see if GL still wants to get tagged in this. If so,
 # the logic needs to be audited to make sure its actually just python.
 STRATEGIC_PYTHON_CONNECTOR_REVIEWERS = {"gl-python"}
@@ -36,30 +31,8 @@ def find_changed_strategic_connectors(
     return {connector for connector in changed_connectors if connector.is_strategic_connector and connector.language in languages}
 
 
-def get_bypass_reason_changes() -> Set[utils.Connector]:
-    """Find connectors that have modified bypass_reasons.
-
-    Returns:
-        Set[str]: Set of connector names e.g {"source-github"}: The set of important connectors that have changed bypass_reasons.
-    """
-    bypass_reason_changes = utils.get_changed_acceptance_test_config(diff_regex="bypass_reason")
-    return bypass_reason_changes.intersection(find_changed_strategic_connectors())
-
-
 def find_mandatory_reviewers() -> List[Dict[str, Union[str, Dict[str, List]]]]:
     requirements = [
-        # We are toying with removing these as requirements.
-        # {
-        #     "name": "Backwards compatibility test skip",
-        #     "teams": list(BACKWARD_COMPATIBILITY_REVIEWERS),
-        #     "is_required": utils.get_changed_acceptance_test_config(diff_regex="disable_for_version"),
-        # },
-        # {
-        #     "name": "Acceptance test strictness level",
-        #     "teams": list(TEST_STRICTNESS_LEVEL_REVIEWERS),
-        #     "is_required": utils.get_changed_acceptance_test_config(diff_regex="test_strictness_level"),
-        # },
-        # {"name": "Strategic connector bypass reasons", "teams": list(BYPASS_REASON_REVIEWERS), "is_required": get_bypass_reason_changes()},
         {
             "name": "Strategic python connectors",
             "teams": list(STRATEGIC_PYTHON_CONNECTOR_REVIEWERS),

--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -8,9 +8,10 @@ import yaml
 from connector_ops import utils
 
 # We are toying with removing these as requirements.
-BACKWARD_COMPATIBILITY_REVIEWERS = set()
-TEST_STRICTNESS_LEVEL_REVIEWERS = set()
-BYPASS_REASON_REVIEWERS = set()
+# BACKWARD_COMPATIBILITY_REVIEWERS = {"connector-extensibility"}
+# TEST_STRICTNESS_LEVEL_REVIEWERS = {"connector-extensibility"}
+# BYPASS_REASON_REVIEWERS = {"connector-extensibility"}
+
 # TODO: Check to see if GL still wants to get tagged in this. If so,
 # the logic needs to be audited to make sure its actually just python.
 STRATEGIC_PYTHON_CONNECTOR_REVIEWERS = {"gl-python"}
@@ -47,17 +48,18 @@ def get_bypass_reason_changes() -> Set[utils.Connector]:
 
 def find_mandatory_reviewers() -> List[Dict[str, Union[str, Dict[str, List]]]]:
     requirements = [
-        {
-            "name": "Backwards compatibility test skip",
-            "teams": list(BACKWARD_COMPATIBILITY_REVIEWERS),
-            "is_required": utils.get_changed_acceptance_test_config(diff_regex="disable_for_version"),
-        },
-        {
-            "name": "Acceptance test strictness level",
-            "teams": list(TEST_STRICTNESS_LEVEL_REVIEWERS),
-            "is_required": utils.get_changed_acceptance_test_config(diff_regex="test_strictness_level"),
-        },
-        {"name": "Strategic connector bypass reasons", "teams": list(BYPASS_REASON_REVIEWERS), "is_required": get_bypass_reason_changes()},
+        # We are toying with removing these as requirements.
+        # {
+        #     "name": "Backwards compatibility test skip",
+        #     "teams": list(BACKWARD_COMPATIBILITY_REVIEWERS),
+        #     "is_required": utils.get_changed_acceptance_test_config(diff_regex="disable_for_version"),
+        # },
+        # {
+        #     "name": "Acceptance test strictness level",
+        #     "teams": list(TEST_STRICTNESS_LEVEL_REVIEWERS),
+        #     "is_required": utils.get_changed_acceptance_test_config(diff_regex="test_strictness_level"),
+        # },
+        # {"name": "Strategic connector bypass reasons", "teams": list(BYPASS_REASON_REVIEWERS), "is_required": get_bypass_reason_changes()},
         {
             "name": "Strategic python connectors",
             "teams": list(STRATEGIC_PYTHON_CONNECTOR_REVIEWERS),
@@ -70,9 +72,7 @@ def find_mandatory_reviewers() -> List[Dict[str, Union[str, Dict[str, List]]]]:
         },
     ]
 
-    required_reviewer_groups = [r for r in requirements if r["is_required"]]
-    # Don't return a group if there are no teams assigned to it.
-    return [{"name": r["name"], "teams": r["teams"]} for r in required_reviewer_groups if r["teams"]]
+    return [{"name": r["name"], "teams": r["teams"]} for r in requirements if r["is_required"]]
 
 
 def write_review_requirements_file():

--- a/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
@@ -81,18 +81,6 @@ def get_connector_name_from_path(path):
     return path.split("/")[2]
 
 
-def get_changed_acceptance_test_config(diff_regex: Optional[str] = None) -> Set[str]:
-    """Retrieve the set of connectors for which the acceptance_test_config file was changed in the current branch (compared to master).
-
-    Args:
-        diff_regex (str): Find the edited files that contain the following regex in their change.
-
-    Returns:
-        Set[Connector]: Set of connectors that were changed
-    """
-    return get_changed_file(ACCEPTANCE_TEST_CONFIG_FILE_NAME, diff_regex)
-
-
 def get_changed_metadata(diff_regex: Optional[str] = None) -> Set[str]:
     """Retrieve the set of connectors for which the metadata file was changed in the current branch (compared to master).
 

--- a/airbyte-ci/connectors/connector_ops/tests/test_required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/tests/test_required_reviewer_checks.py
@@ -36,7 +36,7 @@ def strategic_connector_file():
 
 @pytest.fixture
 def not_strategic_backward_compatibility_change_expected_team(tmp_path, pokeapi_acceptance_test_config_path) -> List:
-    expected_teams = list(required_reviewer_checks.BACKWARD_COMPATIBILITY_REVIEWERS)
+    expected_teams = []
     backup_path = tmp_path / "backup_poke_acceptance"
     shutil.copyfile(pokeapi_acceptance_test_config_path, backup_path)
     with open(pokeapi_acceptance_test_config_path, "a") as acceptance_test_config_file:
@@ -47,7 +47,7 @@ def not_strategic_backward_compatibility_change_expected_team(tmp_path, pokeapi_
 
 @pytest.fixture
 def not_strategic_test_strictness_level_change_expected_team(tmp_path, pokeapi_acceptance_test_config_path) -> List:
-    expected_teams = list(required_reviewer_checks.TEST_STRICTNESS_LEVEL_REVIEWERS)
+    expected_teams = []
     backup_path = tmp_path / "non_strategic_acceptance_test_config.backup"
     shutil.copyfile(pokeapi_acceptance_test_config_path, backup_path)
     with open(pokeapi_acceptance_test_config_path, "a") as acceptance_test_config_file:
@@ -92,9 +92,7 @@ def strategic_connector_file_change_expected_team(tmp_path, strategic_connector_
 
 @pytest.fixture
 def strategic_connector_backward_compatibility_file_change_expected_team(tmp_path, strategic_connector_file):
-    expected_teams = list(
-        required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS.union(required_reviewer_checks.BACKWARD_COMPATIBILITY_REVIEWERS)
-    )
+    expected_teams = list(required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS)
     backup_path = tmp_path / "strategic_acceptance_test_config.backup"
     shutil.copyfile(strategic_connector_file, backup_path)
     with open(strategic_connector_file, "a") as strategic_acceptance_test_config_file:
@@ -105,9 +103,7 @@ def strategic_connector_backward_compatibility_file_change_expected_team(tmp_pat
 
 @pytest.fixture
 def strategic_connector_bypass_reason_file_change_expected_team(tmp_path, strategic_connector_file):
-    expected_teams = list(
-        required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS.union(required_reviewer_checks.BYPASS_REASON_REVIEWERS)
-    )
+    expected_teams = list(required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS)
     backup_path = tmp_path / "strategic_acceptance_test_config.backup"
     shutil.copyfile(strategic_connector_file, backup_path)
     with open(strategic_connector_file, "a") as strategic_acceptance_test_config_file:
@@ -118,9 +114,7 @@ def strategic_connector_bypass_reason_file_change_expected_team(tmp_path, strate
 
 @pytest.fixture
 def strategic_connector_test_strictness_level_file_change_expected_team(tmp_path, strategic_connector_file):
-    expected_teams = list(
-        required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS.union(required_reviewer_checks.TEST_STRICTNESS_LEVEL_REVIEWERS)
-    )
+    expected_teams = list(required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS)
     backup_path = tmp_path / "strategic_acceptance_test_config.backup"
     shutil.copyfile(strategic_connector_file, backup_path)
     with open(strategic_connector_file, "a") as strategic_acceptance_test_config_file:

--- a/airbyte-ci/connectors/connector_ops/tests/test_required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/tests/test_required_reviewer_checks.py
@@ -35,37 +35,8 @@ def strategic_connector_file():
 
 
 @pytest.fixture
-def not_strategic_backward_compatibility_change_expected_team(tmp_path, pokeapi_acceptance_test_config_path) -> List:
-    expected_teams = []
-    backup_path = tmp_path / "backup_poke_acceptance"
-    shutil.copyfile(pokeapi_acceptance_test_config_path, backup_path)
-    with open(pokeapi_acceptance_test_config_path, "a") as acceptance_test_config_file:
-        acceptance_test_config_file.write("disable_for_version: 0.0.0")
-    yield expected_teams
-    shutil.copyfile(backup_path, pokeapi_acceptance_test_config_path)
-
-
-@pytest.fixture
-def not_strategic_test_strictness_level_change_expected_team(tmp_path, pokeapi_acceptance_test_config_path) -> List:
-    expected_teams = []
-    backup_path = tmp_path / "non_strategic_acceptance_test_config.backup"
-    shutil.copyfile(pokeapi_acceptance_test_config_path, backup_path)
-    with open(pokeapi_acceptance_test_config_path, "a") as acceptance_test_config_file:
-        acceptance_test_config_file.write("test_strictness_level: foo")
-    yield expected_teams
-    shutil.copyfile(backup_path, pokeapi_acceptance_test_config_path)
-
-
-@pytest.fixture
-def not_strategic_bypass_reason_file_change_expected_team(tmp_path, pokeapi_acceptance_test_config_path):
-    # The bypass reason logic explicitly only checks for bypass reasons on strategic connectors
-    expected_teams = []
-    backup_path = tmp_path / "non_strategic_acceptance_test_config.backup"
-    shutil.copyfile(pokeapi_acceptance_test_config_path, backup_path)
-    with open(pokeapi_acceptance_test_config_path, "a") as acceptance_test_config_file:
-        acceptance_test_config_file.write("bypass_reason:")
-    yield expected_teams
-    shutil.copyfile(backup_path, pokeapi_acceptance_test_config_path)
+def strategic_connector_metadata_path():
+    return "airbyte-integrations/connectors/source-amplitude/metadata.yaml"
 
 
 @pytest.fixture
@@ -91,39 +62,6 @@ def strategic_connector_file_change_expected_team(tmp_path, strategic_connector_
 
 
 @pytest.fixture
-def strategic_connector_backward_compatibility_file_change_expected_team(tmp_path, strategic_connector_file):
-    expected_teams = list(required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS)
-    backup_path = tmp_path / "strategic_acceptance_test_config.backup"
-    shutil.copyfile(strategic_connector_file, backup_path)
-    with open(strategic_connector_file, "a") as strategic_acceptance_test_config_file:
-        strategic_acceptance_test_config_file.write("disable_for_version: 0.0.0")
-    yield expected_teams
-    shutil.copyfile(backup_path, strategic_connector_file)
-
-
-@pytest.fixture
-def strategic_connector_bypass_reason_file_change_expected_team(tmp_path, strategic_connector_file):
-    expected_teams = list(required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS)
-    backup_path = tmp_path / "strategic_acceptance_test_config.backup"
-    shutil.copyfile(strategic_connector_file, backup_path)
-    with open(strategic_connector_file, "a") as strategic_acceptance_test_config_file:
-        strategic_acceptance_test_config_file.write("bypass_reason:")
-    yield expected_teams
-    shutil.copyfile(backup_path, strategic_connector_file)
-
-
-@pytest.fixture
-def strategic_connector_test_strictness_level_file_change_expected_team(tmp_path, strategic_connector_file):
-    expected_teams = list(required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS)
-    backup_path = tmp_path / "strategic_acceptance_test_config.backup"
-    shutil.copyfile(strategic_connector_file, backup_path)
-    with open(strategic_connector_file, "a") as strategic_acceptance_test_config_file:
-        strategic_acceptance_test_config_file.write("test_strictness_level: 0.0.0")
-    yield expected_teams
-    shutil.copyfile(backup_path, strategic_connector_file)
-
-
-@pytest.fixture
 def test_breaking_change_release_expected_team(tmp_path, pokeapi_metadata_path) -> List:
     expected_teams = list(required_reviewer_checks.BREAKING_CHANGE_REVIEWERS)
     backup_path = tmp_path / "backup_poke_metadata"
@@ -134,6 +72,21 @@ def test_breaking_change_release_expected_team(tmp_path, pokeapi_metadata_path) 
         )
     yield expected_teams
     shutil.copyfile(backup_path, pokeapi_metadata_path)
+
+
+@pytest.fixture
+def strategic_connector_breaking_change_release_expected_teams(tmp_path, strategic_connector_metadata_path):
+    expected_teams = list(
+        required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS.union(required_reviewer_checks.BREAKING_CHANGE_REVIEWERS)
+    )
+    backup_path = tmp_path / "strategic_acceptance_test_config.backup"
+    shutil.copyfile(strategic_connector_metadata_path, backup_path)
+    with open(strategic_connector_metadata_path, "a") as strategic_connector_metadata_file:
+        strategic_connector_metadata_file.write(
+            "releases:\n  breakingChanges:\n    23.0.0:\n      message: hi\n      upgradeDeadline: 2025-01-01"
+        )
+    yield expected_teams
+    shutil.copyfile(backup_path, strategic_connector_metadata_path)
 
 
 def verify_no_requirements_file_was_generated(captured: str):
@@ -162,36 +115,8 @@ def check_review_requirements_file(capsys, expected_teams: List):
         verify_review_requirements_file_contains_expected_teams(requirements_file_path, expected_teams)
 
 
-def test_find_mandatory_reviewers_backward_compatibility(capsys, not_strategic_backward_compatibility_change_expected_team):
-    check_review_requirements_file(capsys, not_strategic_backward_compatibility_change_expected_team)
-
-
-def test_find_mandatory_reviewers_test_strictness_level(capsys, not_strategic_test_strictness_level_change_expected_team):
-    check_review_requirements_file(capsys, not_strategic_test_strictness_level_change_expected_team)
-
-
-def test_find_mandatory_reviewers_not_strategic_bypass_reason(capsys, not_strategic_bypass_reason_file_change_expected_team):
-    check_review_requirements_file(capsys, not_strategic_bypass_reason_file_change_expected_team)
-
-
 def test_find_mandatory_reviewers_ga(capsys, strategic_connector_file_change_expected_team):
     check_review_requirements_file(capsys, strategic_connector_file_change_expected_team)
-
-
-def test_find_mandatory_reviewers_strategic_backward_compatibility(
-    capsys, strategic_connector_backward_compatibility_file_change_expected_team
-):
-    check_review_requirements_file(capsys, strategic_connector_backward_compatibility_file_change_expected_team)
-
-
-def test_find_mandatory_reviewers_strategic_bypass_reason(capsys, strategic_connector_bypass_reason_file_change_expected_team):
-    check_review_requirements_file(capsys, strategic_connector_bypass_reason_file_change_expected_team)
-
-
-def test_find_mandatory_reviewers_strategic_test_strictness_level(
-    capsys, strategic_connector_test_strictness_level_file_change_expected_team
-):
-    check_review_requirements_file(capsys, strategic_connector_test_strictness_level_file_change_expected_team)
 
 
 def test_find_mandatory_reviewers_breaking_change_release(capsys, test_breaking_change_release_expected_team):
@@ -200,3 +125,9 @@ def test_find_mandatory_reviewers_breaking_change_release(capsys, test_breaking_
 
 def test_find_mandatory_reviewers_no_tracked_changed(capsys, not_strategic_not_tracked_change_expected_team):
     check_review_requirements_file(capsys, not_strategic_not_tracked_change_expected_team)
+
+
+def test_find_mandatory_reviewers_strategic_connector_breaking_change_release(
+    capsys, strategic_connector_breaking_change_release_expected_teams
+):
+    check_review_requirements_file(capsys, strategic_connector_breaking_change_release_expected_teams)


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
* Reduce PR noise of automatic review requesting on things that we don't actually review. 
* Close https://github.com/airbytehq/airbyte/issues/37662

Notes:
* Kat still wants the breaking change reviewer tags
* investigating what API sources wants out of this autotagger [separately](https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1714499322978079) and will follow up in a separate PR based on that 

## How
<!--
* Describe how code changes achieve the solution.
-->
* Remove these checks. This made more sense conceptually for code and testing than having empty sets, becuase we would still output an empty requirements file. instead of hacking that apart, I think this makes more sense, but am open to other ideas


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
