### PR TITLE
deploy metadata service on any changes to metadata service (including lib)

### DIFF
--- a/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
+++ b/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
     paths:
-      - "airbyte-ci/connectors/metadata_service/orchestrator/**"
+      - "airbyte-ci/connectors/metadata_service/**"
 jobs:
   connector_metadata_service_deploy_orchestrator:
     name: Connector metadata service deploy orchestrator


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
* Close https://github.com/airbytehq/airbyte/issues/37681
* The version bumping stuff i don't think should matter, as we both do a direct dev install and actually don't use the poetry lockfile (i forgot about this part - the thing we noticed where `poetry2setup` is actually more of a `pyproject2setup` and doesn't take into account the lockfile

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
