### PR TITLE
fix tagging for api sources (required reviewers)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,3 +51,10 @@
 /airbyte-integrations/connectors/destination-s3/ @airbytehq/destinations
 /airbyte-integrations/connectors/destination-snowflake/ @airbytehq/destinations
 /airbyte-integrations/connectors/destination-redshift/ @airbytehq/destinations
+
+# Python critical connectors
+/airbyte-integrations/connectors/source-facebook-marketing/ @airbytehq/critical-connectors
+/airbyte-integrations/connectors/source-hubspot/ @airbytehq/critical-connectors
+/airbyte-integrations/connectors/source-salesforce/ @airbytehq/critical-connectors
+/airbyte-integrations/connectors/source-shopify/ @airbytehq/critical-connectors
+/airbyte-integrations/connectors/source-stripe/ @airbytehq/critical-connectors

--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -7,37 +7,13 @@ from typing import Dict, List, Set, Tuple, Union
 import yaml
 from connector_ops import utils
 
-# TODO: Check to see if GL still wants to get tagged in this. If so,
-# the logic needs to be audited to make sure its actually just python.
-STRATEGIC_PYTHON_CONNECTOR_REVIEWERS = {"gl-python"}
 # The breaking change reviewers is still in active use.
 BREAKING_CHANGE_REVIEWERS = {"breaking-change-reviewers"}
 REVIEW_REQUIREMENTS_FILE_PATH = ".github/connector_org_review_requirements.yaml"
 
 
-def find_changed_strategic_connectors(
-    languages: Tuple[utils.ConnectorLanguage] = (
-        utils.ConnectorLanguage.JAVA,
-        utils.ConnectorLanguage.LOW_CODE,
-        utils.ConnectorLanguage.PYTHON,
-    )
-) -> Set[utils.Connector]:
-    """Find important connectors modified on the current branch.
-
-    Returns:
-        Set[utils.Connector]: The set of important connectors that were modified on the current branch.
-    """
-    changed_connectors = utils.get_changed_connectors(destination=False, third_party=False)
-    return {connector for connector in changed_connectors if connector.is_strategic_connector and connector.language in languages}
-
-
 def find_mandatory_reviewers() -> List[Dict[str, Union[str, Dict[str, List]]]]:
     requirements = [
-        {
-            "name": "Strategic python connectors",
-            "teams": list(STRATEGIC_PYTHON_CONNECTOR_REVIEWERS),
-            "is_required": find_changed_strategic_connectors((utils.ConnectorLanguage.PYTHON, utils.ConnectorLanguage.LOW_CODE)),
-        },
         {
             "name": "Breaking changes",
             "teams": list(BREAKING_CHANGE_REVIEWERS),

--- a/airbyte-ci/connectors/connector_ops/tests/test_required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/tests/test_required_reviewer_checks.py
@@ -20,45 +20,19 @@ def mock_diffed_branched(mocker):
 
 
 @pytest.fixture
-def pokeapi_acceptance_test_config_path():
-    return "airbyte-integrations/connectors/source-pokeapi/acceptance-test-config.yml"
-
-
-@pytest.fixture
 def pokeapi_metadata_path():
     return "airbyte-integrations/connectors/source-pokeapi/metadata.yaml"
 
 
 @pytest.fixture
-def strategic_connector_file():
-    return "airbyte-integrations/connectors/source-amplitude/acceptance-test-config.yml"
-
-
-@pytest.fixture
-def strategic_connector_metadata_path():
-    return "airbyte-integrations/connectors/source-amplitude/metadata.yaml"
-
-
-@pytest.fixture
-def not_strategic_not_tracked_change_expected_team(tmp_path, pokeapi_acceptance_test_config_path):
+def not_tracked_change_expected_team(tmp_path, pokeapi_metadata_path):
     expected_teams = []
     backup_path = tmp_path / "non_strategic_acceptance_test_config.backup"
-    shutil.copyfile(pokeapi_acceptance_test_config_path, backup_path)
-    with open(pokeapi_acceptance_test_config_path, "a") as acceptance_test_config_file:
-        acceptance_test_config_file.write("not_tracked")
+    shutil.copyfile(pokeapi_metadata_path, backup_path)
+    with open(pokeapi_metadata_path, "a") as metadata_file:
+        metadata_file.write("not_tracked")
     yield expected_teams
-    shutil.copyfile(backup_path, pokeapi_acceptance_test_config_path)
-
-
-@pytest.fixture
-def strategic_connector_file_change_expected_team(tmp_path, strategic_connector_file):
-    expected_teams = list(required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS)
-    backup_path = tmp_path / "strategic_acceptance_test_config.backup"
-    shutil.copyfile(strategic_connector_file, backup_path)
-    with open(strategic_connector_file, "a") as strategic_acceptance_test_config_file:
-        strategic_acceptance_test_config_file.write("foobar")
-    yield expected_teams
-    shutil.copyfile(backup_path, strategic_connector_file)
+    shutil.copyfile(backup_path, pokeapi_metadata_path)
 
 
 @pytest.fixture
@@ -72,21 +46,6 @@ def test_breaking_change_release_expected_team(tmp_path, pokeapi_metadata_path) 
         )
     yield expected_teams
     shutil.copyfile(backup_path, pokeapi_metadata_path)
-
-
-@pytest.fixture
-def strategic_connector_breaking_change_release_expected_teams(tmp_path, strategic_connector_metadata_path):
-    expected_teams = list(
-        required_reviewer_checks.STRATEGIC_PYTHON_CONNECTOR_REVIEWERS.union(required_reviewer_checks.BREAKING_CHANGE_REVIEWERS)
-    )
-    backup_path = tmp_path / "strategic_acceptance_test_config.backup"
-    shutil.copyfile(strategic_connector_metadata_path, backup_path)
-    with open(strategic_connector_metadata_path, "a") as strategic_connector_metadata_file:
-        strategic_connector_metadata_file.write(
-            "releases:\n  breakingChanges:\n    23.0.0:\n      message: hi\n      upgradeDeadline: 2025-01-01"
-        )
-    yield expected_teams
-    shutil.copyfile(backup_path, strategic_connector_metadata_path)
 
 
 def verify_no_requirements_file_was_generated(captured: str):
@@ -115,19 +74,9 @@ def check_review_requirements_file(capsys, expected_teams: List):
         verify_review_requirements_file_contains_expected_teams(requirements_file_path, expected_teams)
 
 
-def test_find_mandatory_reviewers_ga(capsys, strategic_connector_file_change_expected_team):
-    check_review_requirements_file(capsys, strategic_connector_file_change_expected_team)
-
-
 def test_find_mandatory_reviewers_breaking_change_release(capsys, test_breaking_change_release_expected_team):
     check_review_requirements_file(capsys, test_breaking_change_release_expected_team)
 
 
-def test_find_mandatory_reviewers_no_tracked_changed(capsys, not_strategic_not_tracked_change_expected_team):
-    check_review_requirements_file(capsys, not_strategic_not_tracked_change_expected_team)
-
-
-def test_find_mandatory_reviewers_strategic_connector_breaking_change_release(
-    capsys, strategic_connector_breaking_change_release_expected_teams
-):
-    check_review_requirements_file(capsys, strategic_connector_breaking_change_release_expected_teams)
+def test_find_mandatory_reviewers_no_tracked_changed(capsys, not_tracked_change_expected_team):
+    check_review_requirements_file(capsys, not_tracked_change_expected_team)


### PR DESCRIPTION
## What
* Handle tagging for API sources

## How
* critical connectors auto-tagged via CODEOWNERS
* other api sources not auto-tagged at the moment, we can re-evaluate if we want it back

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
