### PR TITLE
✨ Source Salesforce: Adding bulk stream mock server tests

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b117307c-14b6-41aa-9422-947e34922962
-  dockerImageTag: 2.5.8
+  dockerImageTag: 2.5.9
   dockerRepository: airbyte/source-salesforce
   documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce
   githubIssueLabel: source-salesforce

--- a/airbyte-integrations/connectors/source-salesforce/pyproject.toml
+++ b/airbyte-integrations/connectors/source-salesforce/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.5.8"
+version = "2.5.9"
 name = "source-salesforce"
 description = "Source implementation for Salesforce."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/api_test.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/api_test.py
@@ -32,7 +32,7 @@ from airbyte_cdk.test.state_builder import StateBuilder
 from airbyte_cdk.utils import AirbyteTracedException
 from conftest import encoding_symbols_parameters, generate_stream
 from requests.exceptions import ChunkedEncodingError, HTTPError
-from salesforce_job_response_builder import SalesforceJobResponseBuilder
+from salesforce_job_response_builder import JobInfoResponseBuilder
 from source_salesforce.api import Salesforce
 from source_salesforce.exceptions import AUTHENTICATION_ERROR_MESSAGE_MAPPING
 from source_salesforce.source import SourceSalesforce
@@ -47,7 +47,7 @@ from source_salesforce.streams import (
 
 _A_CHUNKED_RESPONSE = [b"first chunk", b"second chunk"]
 _A_JSON_RESPONSE = {"id": "any id"}
-_A_SUCCESSFUL_JOB_CREATION_RESPONSE = SalesforceJobResponseBuilder().with_state("JobComplete").get_response()
+_A_SUCCESSFUL_JOB_CREATION_RESPONSE = JobInfoResponseBuilder().with_state("JobComplete").get_response()
 _A_PK = "a_pk"
 _A_STREAM_NAME = "a_stream_name"
 
@@ -456,7 +456,7 @@ def test_given_retryable_error_when_download_data_then_retry(send_http_request_p
 @patch("source_salesforce.source.BulkSalesforceStream._non_retryable_send_http_request")
 def test_given_first_download_fail_when_download_data_then_retry_job_only_once(send_http_request_patch):
     sf_api = Mock()
-    sf_api.generate_schema.return_value = SalesforceJobResponseBuilder().with_state("JobComplete").get_response()
+    sf_api.generate_schema.return_value = JobInfoResponseBuilder().with_state("JobComplete").get_response()
     sf_api.instance_url = "http://test_given_first_download_fail_when_download_data_then_retry_job.com"
     job_creation_return_values = [_A_JSON_RESPONSE, _A_SUCCESSFUL_JOB_CREATION_RESPONSE]
     send_http_request_patch.return_value.json.side_effect = job_creation_return_values * 2
@@ -844,13 +844,13 @@ def test_bulk_stream_request_params_states(stream_config_date_format, stream_api
     stream: BulkIncrementalSalesforceStream = generate_stream("Account", stream_config_date_format, stream_api, state=state, legacy=True)
 
     job_id_1 = "fake_job_1"
-    requests_mock.register_uri("GET", stream.path() + f"/{job_id_1}", [{"json": SalesforceJobResponseBuilder().with_id(job_id_1).with_state("JobComplete").get_response()}])
+    requests_mock.register_uri("GET", stream.path() + f"/{job_id_1}", [{"json": JobInfoResponseBuilder().with_id(job_id_1).with_state("JobComplete").get_response()}])
     requests_mock.register_uri("DELETE", stream.path() + f"/{job_id_1}")
     requests_mock.register_uri("GET", stream.path() + f"/{job_id_1}/results", text="Field1,LastModifiedDate,ID\ntest,2023-01-15,1")
     requests_mock.register_uri("PATCH", stream.path() + f"/{job_id_1}")
 
     job_id_2 = "fake_job_2"
-    requests_mock.register_uri("GET", stream.path() + f"/{job_id_2}", [{"json": SalesforceJobResponseBuilder().with_id(job_id_2).with_state("JobComplete").get_response()}])
+    requests_mock.register_uri("GET", stream.path() + f"/{job_id_2}", [{"json": JobInfoResponseBuilder().with_id(job_id_2).with_state("JobComplete").get_response()}])
     requests_mock.register_uri("DELETE", stream.path() + f"/{job_id_2}")
     requests_mock.register_uri(
         "GET", stream.path() + f"/{job_id_2}/results", text="Field1,LastModifiedDate,ID\ntest,2023-04-01,2\ntest,2023-02-20,22"
@@ -861,7 +861,7 @@ def test_bulk_stream_request_params_states(stream_config_date_format, stream_api
     queries_history = requests_mock.register_uri(
         "POST", stream.path(), [{"json": {"id": job_id_1}}, {"json": {"id": job_id_2}}, {"json": {"id": job_id_3}}]
     )
-    requests_mock.register_uri("GET", stream.path() + f"/{job_id_3}", [{"json": SalesforceJobResponseBuilder().with_id(job_id_3).with_state("JobComplete").get_response()}])
+    requests_mock.register_uri("GET", stream.path() + f"/{job_id_3}", [{"json": JobInfoResponseBuilder().with_id(job_id_3).with_state("JobComplete").get_response()}])
     requests_mock.register_uri("DELETE", stream.path() + f"/{job_id_3}")
     requests_mock.register_uri("GET", stream.path() + f"/{job_id_3}/results", text="Field1,LastModifiedDate,ID\ntest,2023-04-01,3")
     requests_mock.register_uri("PATCH", stream.path() + f"/{job_id_3}")
@@ -920,7 +920,7 @@ def test_stream_slices_for_substream(stream_config, stream_api, requests_mock):
 
     job_id = "fake_job"
     requests_mock.register_uri("POST", stream.path(), json={"id": job_id})
-    requests_mock.register_uri("GET", stream.path() + f"/{job_id}", json=SalesforceJobResponseBuilder().with_id(job_id).with_state("JobComplete").get_response())
+    requests_mock.register_uri("GET", stream.path() + f"/{job_id}", json=JobInfoResponseBuilder().with_id(job_id).with_state("JobComplete").get_response())
     requests_mock.register_uri(
         "GET",
         stream.path() + f"/{job_id}/results",

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -17,6 +17,7 @@ from salesforce_describe_response_builder import SalesforceDescribeResponseBuild
 from salesforce_job_response_builder import JobCreateResponseBuilder, JobInfoResponseBuilder
 from source_salesforce.streams import LOOKBACK_SECONDS
 
+
 _A_FIELD_NAME = "a_field"
 _ACCESS_TOKEN = "an_access_token"
 _CLIENT_ID = "a_client_id"
@@ -29,7 +30,8 @@ _JOB_ID = "a-job-id"
 _LOOKBACK_WINDOW = timedelta(seconds=LOOKBACK_SECONDS)
 _NOW = datetime.now(timezone.utc)
 _REFRESH_TOKEN = "a_refresh_token"
-_RETRYABLE_RESPONSE = HttpResponse("{}", 420)  # TODO: document what the body actually is on 420 errors
+_METHOD_FAILURE_HTTP_STATUS = 420
+_RETRYABLE_RESPONSE = HttpResponse("{}", _METHOD_FAILURE_HTTP_STATUS)  # TODO: document what the body actually is on 420 errors
 _SECOND_PAGE_LOCATOR = "second-page-locator"
 _STREAM_NAME = "a_stream_name"
 

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -8,23 +8,30 @@ from unittest import TestCase
 
 import freezegun
 from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
-from airbyte_protocol.models import SyncMode
+
+from airbyte_protocol.models import SyncMode, FailureType, AirbyteStreamStatus
 from config_builder import ConfigBuilder
 from integration.utils import create_base_url, given_authentication, given_stream, read
+from integration.test_rest_stream import create_http_request as create_standard_http_request, create_http_response as create_standard_http_response
 from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
 from salesforce_job_response_builder import SalesforceJobResponseBuilder
 from source_salesforce.streams import LOOKBACK_SECONDS
+
 
 _A_FIELD_NAME = "a_field"
 _ACCESS_TOKEN = "an_access_token"
 _CLIENT_ID = "a_client_id"
 _CLIENT_SECRET = "a_client_secret"
 _CURSOR_FIELD = "SystemModstamp"
+_INCREMENTAL_FIELDS = [_A_FIELD_NAME, _CURSOR_FIELD]
+_INCREMENTAL_SCHEMA_BUILDER = SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME).field(_CURSOR_FIELD, "datetime")  # re-using same fields as _INCREMENTAL_FIELDS
 _INSTANCE_URL = "https://instance.salesforce.com"
 _JOB_ID = "a-job-id"
 _LOOKBACK_WINDOW = timedelta(seconds=LOOKBACK_SECONDS)
 _NOW = datetime.now(timezone.utc)
 _REFRESH_TOKEN = "a_refresh_token"
+_RETRYABLE_RESPONSE = HttpResponse("{}", 420)  # TODO: document what the body actually is on 420 errors
+_SECOND_PAGE_LOCATOR = "second-page-locator"
 _STREAM_NAME = "a_stream_name"
 
 _BASE_URL = create_base_url(_INSTANCE_URL)
@@ -65,7 +72,167 @@ class BulkStreamTest(TestCase):
     def test_when_read_then_create_job_and_extract_records_from_result(self) -> None:
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            HttpRequest(f"{_BASE_URL}/jobs/query", body=json.dumps({"operation": "queryAll", "query": "SELECT a_field FROM a_stream_name", "contentType": "CSV", "columnDelimiter": "COMMA", "lineEnding": "LF"})),
+            self._create_full_job_creation_request([_A_FIELD_NAME]),
+            HttpResponse(json.dumps({"id": _JOB_ID})),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            [
+                SalesforceJobResponseBuilder().with_id(_JOB_ID).with_state("InProgress").build(),
+                SalesforceJobResponseBuilder().with_id(_JOB_ID).with_state("UploadComplete").build(),
+                SalesforceJobResponseBuilder().with_id(_JOB_ID).with_state("JobComplete").build(),
+            ],
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}/results"),
+            HttpResponse(f"{_A_FIELD_NAME}\nfield_value"),
+        )
+        self._mock_delete_job(_JOB_ID)
+
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
+
+        assert len(output.records) == 1
+
+    def test_given_locator_when_read_then_extract_records_from_both_pages(self):
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        self._http_mocker.post(
+            self._create_full_job_creation_request([_A_FIELD_NAME]),
+            HttpResponse(json.dumps({"id": _JOB_ID})),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            SalesforceJobResponseBuilder().with_id(_JOB_ID).with_state("JobComplete").build(),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}/results"),
+            HttpResponse(f"{_A_FIELD_NAME}\nfield_value", headers={"Sforce-Locator": _SECOND_PAGE_LOCATOR}),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}/results", query_params={"locator": _SECOND_PAGE_LOCATOR}),
+            HttpResponse(f"{_A_FIELD_NAME}\nanother_field_value"),
+        )
+        self._mock_delete_job(_JOB_ID)
+
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
+
+        assert len(output.records) == 2
+
+    def test_given_job_creation_have_transient_error_when_read_then_sync_properly(self):
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        self._http_mocker.post(
+            self._create_full_job_creation_request([_A_FIELD_NAME]),
+            [
+                _RETRYABLE_RESPONSE,
+                HttpResponse(json.dumps({"id": _JOB_ID})),
+            ],
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            SalesforceJobResponseBuilder().with_id(_JOB_ID).with_state("JobComplete").build(),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}/results"),
+            HttpResponse(f"{_A_FIELD_NAME}\nfield_value"),
+        )
+        self._mock_delete_job(_JOB_ID)
+
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
+
+        assert len(output.errors) == 0
+        assert len(output.records) == 1
+
+    def test_given_bulk_restrictions_when_read_then_switch_to_standard(self):
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        self._http_mocker.post(
+            self._create_full_job_creation_request([_A_FIELD_NAME]),
+            [
+                HttpResponse("[{}]", 403),
+                HttpResponse(json.dumps({"id": _JOB_ID})),
+            ],
+        )
+        self._http_mocker.get(
+            create_standard_http_request(_STREAM_NAME, [_A_FIELD_NAME]),
+            create_standard_http_response([_A_FIELD_NAME]),
+        )
+
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
+
+        assert len(output.records) == 1
+
+    def test_given_non_transient_error_on_job_creation_when_read_then_fail_sync(self):
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        self._http_mocker.post(
+            self._create_full_job_creation_request([_A_FIELD_NAME]),
+            HttpResponse(json.dumps([{"errorCode": "API_ERROR", "message": "Implementation restriction... <can't complete the error message as I can't reproduce this issue>"}]), 400),
+        )
+
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
+
+        assert output.get_stream_statuses(_STREAM_NAME)[-1] == AirbyteStreamStatus.INCOMPLETE
+
+    def test_given_job_is_aborted_when_read_then_fail_sync(self):
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        self._http_mocker.post(
+            self._create_full_job_creation_request([_A_FIELD_NAME]),
+            HttpResponse(json.dumps({"id": _JOB_ID})),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            SalesforceJobResponseBuilder().with_id(_JOB_ID).with_state("Aborted").build(),
+        )
+        self._mock_delete_job(_JOB_ID)
+
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
+
+        assert output.get_stream_statuses(_STREAM_NAME)[-1] == AirbyteStreamStatus.INCOMPLETE
+
+    def test_given_job_is_failed_when_read_then_switch_to_standard(self):
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        self._http_mocker.post(
+            self._create_full_job_creation_request([_A_FIELD_NAME]),
+            HttpResponse(json.dumps({"id": _JOB_ID})),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            SalesforceJobResponseBuilder().with_id(_JOB_ID).with_state("Failed").build(),
+        )
+        self._http_mocker.get(
+            create_standard_http_request(_STREAM_NAME, [_A_FIELD_NAME]),
+            create_standard_http_response([_A_FIELD_NAME]),
+        )
+        self._mock_delete_job(_JOB_ID)
+
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
+
+        assert len(output.records) == 1
+
+    def test_given_retryable_error_on_download_job_result_when_read_then_extract_records(self):
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        self._http_mocker.post(
+            self._create_full_job_creation_request([_A_FIELD_NAME]),
+            HttpResponse(json.dumps({"id": _JOB_ID})),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            SalesforceJobResponseBuilder().with_id(_JOB_ID).with_state("JobComplete").build(),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}/results"),
+            [
+                _RETRYABLE_RESPONSE,
+                HttpResponse(f"{_A_FIELD_NAME}\nfield_value"),
+            ],
+        )
+        self._mock_delete_job(_JOB_ID)
+
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
+
+        assert len(output.records) == 1
+
+    def test_given_retryable_error_on_delete_job_result_when_read_then_do_not_break(self):
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        self._http_mocker.post(
+            self._create_full_job_creation_request([_A_FIELD_NAME]),
             HttpResponse(json.dumps({"id": _JOB_ID})),
         )
         self._http_mocker.get(
@@ -76,18 +243,54 @@ class BulkStreamTest(TestCase):
             HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}/results"),
             HttpResponse(f"{_A_FIELD_NAME}\nfield_value"),
         )
+        self._http_mocker._mock_request_method(  # FIXME to add DELETE method in airbyte_cdk tests
+            "delete",
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            [
+                _RETRYABLE_RESPONSE,
+                HttpResponse(""),
+            ],
+        )
 
         output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
 
-        assert len(output.records) == 1
+        assert output.get_stream_statuses(_STREAM_NAME)[-1] == AirbyteStreamStatus.COMPLETE
+
+    def test_given_non_retryable_error_on_delete_job_result_when_read_then_fail_to_sync(self):
+        """
+        This is interesting: right now, we retry with the same policies has the other requests but it seems fair to just be a best effort,
+        catch everything and not retry
+        """
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        self._http_mocker.post(
+            self._create_full_job_creation_request([_A_FIELD_NAME]),
+            HttpResponse(json.dumps({"id": _JOB_ID})),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            SalesforceJobResponseBuilder().with_id(_JOB_ID).with_state("JobComplete").build(),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}/results"),
+            HttpResponse(f"{_A_FIELD_NAME}\nfield_value"),
+        )
+        self._http_mocker._mock_request_method(  # FIXME to add DELETE method in airbyte_cdk tests
+            "delete",
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            HttpResponse("", 429),
+        )
+
+        output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
+
+        assert output.get_stream_statuses(_STREAM_NAME)[-1] == AirbyteStreamStatus.INCOMPLETE
 
     def test_given_incremental_when_read_then_create_job_and_extract_records_from_result(self) -> None:
         start_date = (_NOW - timedelta(days=10)).replace(microsecond=0)
         first_upper_boundary = start_date + timedelta(days=7)
         self._config.start_date(start_date).stream_slice_step("P7D")
-        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME).field(_CURSOR_FIELD, "datetime"))
-        self._create_sliced_job(start_date, first_upper_boundary, "first_slice_job_id", self._generate_csv([_A_FIELD_NAME, _CURSOR_FIELD], count=2))
-        self._create_sliced_job(first_upper_boundary, _NOW, "second_slice_job_id", self._generate_csv([_A_FIELD_NAME, _CURSOR_FIELD], count=1))
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, _INCREMENTAL_SCHEMA_BUILDER)
+        self._create_sliced_job(start_date, first_upper_boundary, _INCREMENTAL_FIELDS, "first_slice_job_id", record_count=2)
+        self._create_sliced_job(first_upper_boundary, _NOW, _INCREMENTAL_FIELDS, "second_slice_job_id", record_count=1)
 
         output = read(_STREAM_NAME, SyncMode.incremental, self._config)
 
@@ -99,22 +302,22 @@ class BulkStreamTest(TestCase):
         first_upper_boundary = start_date + slice_range
         second_upper_boundary = first_upper_boundary + slice_range
         self._config.start_date(start_date).stream_slice_step("P7D")
-        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME).field(_CURSOR_FIELD, "datetime"))
-        self._create_sliced_job(start_date, first_upper_boundary, "first_slice_job_id", self._generate_csv([_A_FIELD_NAME, _CURSOR_FIELD], count=2))
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, _INCREMENTAL_SCHEMA_BUILDER)
+        self._create_sliced_job(start_date, first_upper_boundary, _INCREMENTAL_FIELDS, "first_slice_job_id", record_count=2)
         self._http_mocker.post(
-            self._create_job_creation_request(first_upper_boundary, second_upper_boundary),
+            self._create_sliced_job_creation_request(first_upper_boundary, second_upper_boundary, _INCREMENTAL_FIELDS),
             HttpResponse("", status_code=400),
         )
-        self._create_sliced_job(second_upper_boundary, _NOW, "third_slice_job_id", self._generate_csv([_A_FIELD_NAME, _CURSOR_FIELD], count=1))
+        self._create_sliced_job(second_upper_boundary, _NOW, _INCREMENTAL_FIELDS, "third_slice_job_id", record_count=1)
 
         output = read(_STREAM_NAME, SyncMode.incremental, self._config)
 
         assert len(output.records) == 3
         assert len(output.most_recent_state.stream_state.dict()["slices"]) == 2
 
-    def _create_sliced_job(self, start_date: datetime, first_upper_boundary: datetime, job_id: str, job_result: str) -> None:
+    def _create_sliced_job(self, lower_boundary: datetime, upper_boundary: datetime, fields: List[str], job_id: str, record_count: int) -> None:
         self._http_mocker.post(
-            self._create_job_creation_request(start_date, first_upper_boundary),
+            self._create_sliced_job_creation_request(lower_boundary, upper_boundary, fields),
             HttpResponse(json.dumps({"id": job_id})),
         )
         self._http_mocker.get(
@@ -123,24 +326,37 @@ class BulkStreamTest(TestCase):
         )
         self._http_mocker.get(
             HttpRequest(f"{_BASE_URL}/jobs/query/{job_id}/results"),
-            HttpResponse(job_result),
+            HttpResponse(self._generate_csv(fields, count=record_count)),
         )
+        self._mock_delete_job(job_id)
+
+    def _mock_delete_job(self, job_id: str) -> None:
         self._http_mocker._mock_request_method(  # FIXME to add DELETE method in airbyte_cdk tests
             "delete",
             HttpRequest(f"{_BASE_URL}/jobs/query/{job_id}"),
-            HttpResponse(job_result),
+            HttpResponse(""),
         )
 
-    def _create_job_creation_request(self, start_date: datetime, first_upper_boundary: datetime) -> HttpRequest:
+    def _create_sliced_job_creation_request(self, lower_boundary: datetime, upper_boundary: datetime, fields: List[str]) -> HttpRequest:
+        return self._build_job_creation_request(f"SELECT {', '.join(fields)} FROM a_stream_name WHERE SystemModstamp >= {lower_boundary.isoformat(timespec='milliseconds')} AND SystemModstamp < {upper_boundary.isoformat(timespec='milliseconds')}")
+
+    def _create_full_job_creation_request(self, fields: List[str]) -> HttpRequest:
+        return self._build_job_creation_request(f"SELECT {', '.join(fields)} FROM a_stream_name")
+
+    def _generate_csv(self, fields: List[str], count: int = 1) -> str:
+        """
+        This method does not handle field types for now which may cause some test failures on change if we start considering using some
+        fields for calculation. One example of that would be cursor field parsing to datetime.
+        """
+        record = ','.join([f"{field}_value" for field in fields])
+        records = '\n'.join([record for _ in range(count)])
+        return f"{','.join(fields)}\n{records}"
+
+    def _build_job_creation_request(self, query: str) -> HttpRequest:
         return HttpRequest(f"{_BASE_URL}/jobs/query", body=json.dumps({
             "operation": "queryAll",
-            "query": f"SELECT a_field, SystemModstamp FROM a_stream_name WHERE SystemModstamp >= {start_date.isoformat(timespec='milliseconds')} AND SystemModstamp < {first_upper_boundary.isoformat(timespec='milliseconds')}",
+            "query": query,
             "contentType": "CSV",
             "columnDelimiter": "COMMA",
             "lineEnding": "LF"
         }))
-
-    def _generate_csv(self, fields: List[str], count: int = 1) -> str:
-        record = ','.join([f"{field}_value" for field in fields])
-        records = '\n'.join([record for _ in range(count)])
-        return f"{','.join(fields)}\n{records}"

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -17,7 +17,6 @@ from salesforce_describe_response_builder import SalesforceDescribeResponseBuild
 from salesforce_job_response_builder import JobCreateResponseBuilder, JobInfoResponseBuilder
 from source_salesforce.streams import LOOKBACK_SECONDS
 
-
 _A_FIELD_NAME = "a_field"
 _ACCESS_TOKEN = "an_access_token"
 _CLIENT_ID = "a_client_id"

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_rest_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_rest_stream.py
@@ -3,7 +3,7 @@
 import json
 import urllib.parse
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 from unittest import TestCase
 
 import freezegun

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_rest_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_rest_stream.py
@@ -3,7 +3,7 @@
 import json
 import urllib.parse
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 from unittest import TestCase
 
 import freezegun
@@ -26,6 +26,19 @@ _LOOKBACK_WINDOW = timedelta(seconds=LOOKBACK_SECONDS)
 _NOW = datetime.now(timezone.utc)
 _REFRESH_TOKEN = "a_refresh_token"
 _STREAM_NAME = UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS[0]
+
+
+def create_http_request(stream_name: str, field_names: List[str]) -> HttpRequest:
+    return HttpRequest(f"{_BASE_URL}/queryAll?q=SELECT+{','.join(field_names)}+FROM+{stream_name}+")
+
+
+def create_http_response(field_names: List[str], record_count: int = 1) -> HttpResponse:
+    """
+    This method does not handle field types for now which may cause some test failures on change if we start considering using some
+    fields for calculation. One example of that would be cursor field parsing to datetime.
+    """
+    records = [{field_name: f"{field_name}_{i}" for field_name in field_names} for i in range(record_count)]
+    return HttpResponse(json.dumps({"records": records}))
 
 
 def _create_field(name: str, _type: Optional[str] = None) -> Dict[str, Any]:
@@ -57,10 +70,10 @@ class FullRefreshTest(TestCase):
         given_authentication(http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN, _INSTANCE_URL)
         given_stream(http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         http_mocker.get(
-            HttpRequest(f"{_BASE_URL}/queryAll?q=SELECT+{_A_FIELD_NAME}+FROM+{_STREAM_NAME}+"),
+            create_http_request(_STREAM_NAME, [_A_FIELD_NAME]),
             [
                 HttpResponse("", status_code=406),
-                HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
+                create_http_response([_A_FIELD_NAME], record_count=1),
             ]
         )
 
@@ -91,7 +104,7 @@ class IncrementalTest(TestCase):
 
         self._http_mocker.get(
             HttpRequest(f"{_BASE_URL}/queryAll?q=SELECT+{_A_FIELD_NAME},{_CURSOR_FIELD}+FROM+{_STREAM_NAME}+WHERE+SystemModstamp+%3E%3D+{start_format_url}+AND+SystemModstamp+%3C+{_to_url(_NOW)}"),
-            HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
+            create_http_response([_A_FIELD_NAME], record_count=1),
         )
 
         read(_STREAM_NAME, SyncMode.incremental, self._config, StateBuilder().with_stream_state(_STREAM_NAME, {}))
@@ -104,7 +117,7 @@ class IncrementalTest(TestCase):
         self._config.stream_slice_step("P30D").start_date(start)
         self._http_mocker.get(
             HttpRequest(f"{_BASE_URL}/queryAll?q=SELECT+{_A_FIELD_NAME},{_CURSOR_FIELD}+FROM+{_STREAM_NAME}+WHERE+SystemModstamp+%3E%3D+{_to_url(cursor_value - _LOOKBACK_WINDOW)}+AND+SystemModstamp+%3C+{_to_url(_NOW)}"),
-            HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
+            create_http_response([_A_FIELD_NAME], record_count=1),
         )
 
         output = read(_STREAM_NAME, SyncMode.incremental, self._config, StateBuilder().with_stream_state(_STREAM_NAME, {_CURSOR_FIELD: cursor_value.isoformat(timespec="milliseconds")}))
@@ -129,11 +142,11 @@ class IncrementalTest(TestCase):
 
         self._http_mocker.get(
             HttpRequest(f"{_BASE_URL}/queryAll?q=SELECT+{_A_FIELD_NAME},{_CURSOR_FIELD}+FROM+{_STREAM_NAME}+WHERE+SystemModstamp+%3E%3D+{_to_url(missing_chunk[0])}+AND+SystemModstamp+%3C+{_to_url(missing_chunk[1])}"),
-            HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
+            create_http_response([_A_FIELD_NAME], record_count=1),
         )
         self._http_mocker.get(
             HttpRequest(f"{_BASE_URL}/queryAll?q=SELECT+{_A_FIELD_NAME},{_CURSOR_FIELD}+FROM+{_STREAM_NAME}+WHERE+SystemModstamp+%3E%3D+{_to_url(most_recent_state_value - _LOOKBACK_WINDOW)}+AND+SystemModstamp+%3C+{_to_url(_NOW)}"),
-            HttpResponse(json.dumps({"records": [{"a_field": "a_value"}]})),
+            create_http_response([_A_FIELD_NAME], record_count=1),
         )
 
         output = read(_STREAM_NAME, SyncMode.incremental, self._config, state)

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/salesforce_job_response_builder.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/salesforce_job_response_builder.py
@@ -6,24 +6,54 @@ from airbyte_cdk.test.mock_http import HttpResponse
 from airbyte_cdk.test.mock_http.response_builder import HttpResponseBuilder, find_template
 
 
-class SalesforceJobResponseBuilder:
+class JobCreateResponseBuilder:
+    def __init__(self):
+        self._response = {
+           "id": "any_id",
+           "operation": "query",
+           "object": "Account",
+           "createdById": "005R0000000GiwjIAC",
+           "createdDate": "2018-12-17T21:00:17.000+0000",
+           "systemModstamp": "2018-12-17T21:00:17.000+0000",
+           "state": "UploadComplete",
+           "concurrencyMode": "Parallel",
+           "contentType": "CSV",
+           "apiVersion": 46.0,
+           "lineEnding": "LF",
+           "columnDelimiter": "COMMA"
+        }
+        self._status_code = 200
+
+    def with_id(self, id: str) -> "JobCreateResponseBuilder":
+        self._response["id"] = id
+        return self
+
+    def with_state(self, state: str) -> "JobCreateResponseBuilder":
+        self._response["state"] = state
+        return self
+
+    def build(self) -> HttpResponse:
+        return HttpResponse(json.dumps(self._response), self._status_code)
+
+
+class JobInfoResponseBuilder:
     def __init__(self):
         self._response = find_template("job_response", __file__)
         self._status_code = 200
 
-    def with_id(self, id: str) -> "HttpResponseBuilder":
+    def with_id(self, id: str) -> "JobInfoResponseBuilder":
         self._response["id"] = id
         return self
 
-    def with_state(self, state: str) -> "HttpResponseBuilder":
+    def with_state(self, state: str) -> "JobInfoResponseBuilder":
         self._response["state"] = state
         return self
 
-    def with_status_code(self, status_code: int) -> "HttpResponseBuilder":
+    def with_status_code(self, status_code: int) -> "JobInfoResponseBuilder":
         self._status_code = status_code
         return self
     
-    def with_error_message(self, error_message: int) -> "HttpResponseBuilder":
+    def with_error_message(self, error_message: int) -> "JobInfoResponseBuilder":
         self._response["errorMessage"] = error_message
         return self
     
@@ -32,4 +62,3 @@ class SalesforceJobResponseBuilder:
 
     def build(self) -> HttpResponse:
         return HttpResponse(json.dumps(self._response), self._status_code)
-    

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/salesforce_job_response_builder.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/salesforce_job_response_builder.py
@@ -53,7 +53,7 @@ class JobInfoResponseBuilder:
         self._status_code = status_code
         return self
     
-    def with_error_message(self, error_message: int) -> "JobInfoResponseBuilder":
+    def with_error_message(self, error_message: str) -> "JobInfoResponseBuilder":
         self._response["errorMessage"] = error_message
         return self
     

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -193,7 +193,8 @@ Now that you have set up the Salesforce source connector, check out the followin
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| 2.5.8   | 2024-04-16 | [37340](https://github.com/airbytehq/airbyte/pull/37340) | Source Salesforce: reduce info logs                                                      |
+| 2.5.9   | 2024-05-02 | [37749](https://github.com/airbytehq/airbyte/pull/37749) | Adding mock server tests for bulk streams                                                                                            |
+| 2.5.8   | 2024-04-30 | [37340](https://github.com/airbytehq/airbyte/pull/37340) | Source Salesforce: reduce info logs                                                                                                  |
 | 2.5.7   | 2024-04-24 | [36657](https://github.com/airbytehq/airbyte/pull/36657) | Schema descriptions                                                                                                                  |
 | 2.5.6   | 2024-04-19 | [37448](https://github.com/airbytehq/airbyte/pull/37448) | Ensure AirbyteTracedException in concurrent CDK are emitted with the right type                                                      |
 | 2.5.5   | 2024-04-18 | [37392](https://github.com/airbytehq/airbyte/pull/37419) | Ensure python return code != 0 in case of error                                                                                      |


### PR DESCRIPTION
## What
Before integrating the HttpClient that @pnilan is working on, we want to add a good safety need to identify issues without having to test manually before and after.

## How
Adding mock server tests

## User Impact
No customer impact. However, developer won't have to test manually before and after to ensure the behavior is the same.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
