### PR TITLE
airbyte-ci: reduce required env var when running in CI

### DIFF
--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -103,6 +103,8 @@ jobs:
           git_branch: ${{ github.head_ref }}
           git_revision: ${{ github.event.pull_request.head.sha }}
           github_token: ${{ github.token }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       - name: Upload pipeline reports
         id: upload-artifact
         uses: actions/upload-artifact@v4

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -676,6 +676,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                |
 |---------| ---------------------------------------------------------- |----------------------------------------------------------------------------------------------------------------------------|
+| 4.12.1  | [#37765](https://github.com/airbytehq/airbyte/pull/37765)  | Relax the required env var to run in CI and handle their absence gracefully.                                                                               |
 | 4.12.0  | [#37690](https://github.com/airbytehq/airbyte/pull/37690)  | Pass custom CI status name in `connectors test`                                                                               |
 | 4.11.0  | [#37641](https://github.com/airbytehq/airbyte/pull/37641)  | Updates to run regression tests in GitHub Actions.                                                                               |
 | 4.10.5  | [#37641](https://github.com/airbytehq/airbyte/pull/37641)  | Reintroduce changes from 4.10.0 with a fix.                                                                               |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
@@ -99,8 +99,6 @@ def validate_environment(is_local: bool) -> None:
             raise click.UsageError("You need to run this command from the repository root.")
     else:
         required_env_vars_for_ci = [
-            "GCP_GSM_CREDENTIALS",
-            "CI_REPORT_BUCKET_NAME",
             "CI_GITHUB_ACCESS_TOKEN",
             "DOCKER_HUB_USERNAME",
             "DOCKER_HUB_PASSWORD",

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/reports.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/reports.py
@@ -147,12 +147,12 @@ class ConnectorReport(Report):
         await html_report_artifact.save_to_local_path(html_report_path)
         absolute_path = html_report_path.absolute()
         self.pipeline_context.logger.info(f"Report saved locally at {absolute_path}")
-        if self.remote_storage_enabled and self.pipeline_context.ci_gcs_credentials_secret and self.pipeline_context.ci_report_bucket:
+        if self.pipeline_context.remote_storage_enabled:
             gcs_url = await html_report_artifact.upload_to_gcs(
                 dagger_client=self.pipeline_context.dagger_client,
-                bucket=self.pipeline_context.ci_report_bucket,
+                bucket=self.pipeline_context.ci_report_bucket,  # type: ignore
                 key=self.html_report_remote_storage_key,
-                gcs_credentials=self.pipeline_context.ci_gcs_credentials_secret,
+                gcs_credentials=self.pipeline_context.ci_gcs_credentials_secret,  # type: ignore
             )
             self.pipeline_context.logger.info(f"HTML report uploaded to {gcs_url}")
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -380,7 +380,7 @@ class RegressionTests(Step):
         exit $pytest_exit
         """
         )
-        return [f"bash", "-c", f"'{run_pytest_with_proxy}'"]
+        return ["bash", "-c", f"'{run_pytest_with_proxy}'"]
 
     def __init__(self, context: ConnectorContext) -> None:
         """Create a step to run regression tests for a connector.

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
@@ -160,9 +160,10 @@ class PipelineContext:
         self._report = report
 
     @property
-    def ci_gcs_credentials_secret(self) -> Secret:
-        assert self.ci_gcs_credentials is not None, "The ci_gcs_credentials was not set on this PipelineContext."
-        return self.dagger_client.set_secret("ci_gcs_credentials", self.ci_gcs_credentials)
+    def ci_gcs_credentials_secret(self) -> Secret | None:
+        if self.ci_gcs_credentials is not None:
+            return self.dagger_client.set_secret("ci_gcs_credentials", self.ci_gcs_credentials)
+        return None
 
     @property
     def ci_github_access_token_secret(self) -> Secret:
@@ -209,6 +210,10 @@ class PipelineContext:
             return None
 
         return f"https://alpha.dagger.cloud/changeByPipelines?filter=dagger.io/git.ref:{self.git_revision}"
+
+    @property
+    def remote_storage_enabled(self) -> bool:
+        return self.is_ci is True and self.ci_report_bucket is not None and self.ci_gcs_credentials_secret is not None
 
     def get_repo_file(self, file_path: str) -> File:
         """Get a file from the current repository.

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.12.0"
+version = "4.12.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
To run "early CI" on community PR we have to make some env vars with secret values optionals.

This PR removes the requirement for the following env vars in CI:
* GCP_GSM_CREDENTIALS
* CI_REPORT_BUCKET_NAME

If `CI_REPORT_BUCKET_NAME` is not set reports will simply not be uploaded to GCS, which is fine as they are attached as artifacts to worfklow runs.

If `GCP_GSM_CREDENTIALS` is not set the test pipeline won't be able to fetch our sandbox credentials. Which is fine in "early CI" as we're not running steps that require secret access.
