### PR TITLE
airbyte-ci: fix dagger log upload attempt when no gcp creds are available

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -676,6 +676,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                |
 |---------| ---------------------------------------------------------- |----------------------------------------------------------------------------------------------------------------------------|
+| 4.12.2  | [#37778](https://github.com/airbytehq/airbyte/pull/37778)  | Do not upload dagger log to GCP when no credentials are available.                                                                               |
 | 4.12.1  | [#37765](https://github.com/airbytehq/airbyte/pull/37765)  | Relax the required env var to run in CI and handle their absence gracefully.                                                                               |
 | 4.12.0  | [#37690](https://github.com/airbytehq/airbyte/pull/37690)  | Pass custom CI status name in `connectors test`                                                                               |
 | 4.11.0  | [#37641](https://github.com/airbytehq/airbyte/pull/37641)  | Updates to run regression tests in GitHub Actions.                                                                               |

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/dagger_pipeline_command.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/dagger_pipeline_command.py
@@ -53,9 +53,8 @@ class DaggerPipelineCommand(click.Command):
             sys.exit(1)
         finally:
             if ctx.obj.get("dagger_logs_path"):
-                if ctx.obj["is_local"]:
-                    main_logger.info(f"Dagger logs saved to {ctx.obj['dagger_logs_path']}")
-                if ctx.obj["is_ci"]:
+                main_logger.info(f"Dagger logs saved to {ctx.obj['dagger_logs_path']}")
+                if ctx.obj["is_ci"] and ctx.obj["ci_gcs_credentials"] and ctx.obj["ci_report_bucket_name"]:
                     gcs_uri, public_url = upload_to_gcs(
                         ctx.obj["dagger_logs_path"], ctx.obj["ci_report_bucket_name"], dagger_logs_gcs_key, ctx.obj["ci_gcs_credentials"]
                     )

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
@@ -181,7 +181,11 @@ class PipelineContext:
         """Build a dictionary used as kwargs to the update_commit_status_check function."""
         target_url: Optional[str] = self.gha_workflow_run_url
 
-        if self.state not in [ContextState.RUNNING, ContextState.INITIALIZED] and isinstance(self.report, ConnectorReport):
+        if (
+            self.remote_storage_enabled
+            and self.state not in [ContextState.RUNNING, ContextState.INITIALIZED]
+            and isinstance(self.report, ConnectorReport)
+        ):
             target_url = self.report.html_report_url
 
         return {

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.12.1"
+version = "4.12.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
In community CI we don't want to upload dagger logs to GCS on early ci.
This continuation of https://github.com/airbytehq/airbyte/pull/37765