### PR TITLE
airbyte-ci: set `--yes-auto-update` by default

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -180,7 +180,7 @@ options to the `airbyte-ci` command group.**
 | Option                                         | Default value                   | Mapped environment variable   | Description                                                                                 |
 | ---------------------------------------------- | ------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
 | `--yes/--y`                                    | False                           |                               | Agrees to all prompts.                                                                      |
-| `--yes-auto-update`                            | False                           |                               | Agrees to the auto update prompts.                                                          |
+| `--yes-auto-update/--no-auto-update`           | True                            |                               | Agrees to the auto update prompts.                                                          |
 | `--enable-update-check/--disable-update-check` | True                            |                               | Turns on the update check feature                                                           |
 | `--enable-dagger-run/--disable-dagger-run`     | `--enable-dagger-run`           |                               | Disables the Dagger terminal UI.                                                            |
 | `--is-local/--is-ci`                           | `--is-local`                    |                               | Determines the environment in which the CLI runs: local environment or CI environment.      |
@@ -745,6 +745,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.12.5  | [#37785](https://github.com/airbytehq/airbyte/pull/37785)  | Set the `--yes-auto-update` flag to `True` by default.                                                                       |
 | 4.12.4  | [#37786](https://github.com/airbytehq/airbyte/pull/37786)  | (fixed 4.12.2): Do not upload dagger log to GCP when no credentials are available.                                           |
 | 4.12.3  | [#37783](https://github.com/airbytehq/airbyte/pull/37783)  | Revert 4.12.2                                                                                                                |
 | 4.12.2  | [#37778](https://github.com/airbytehq/airbyte/pull/37778)  | Do not upload dagger log to GCP when no credentials are available.                                                           |

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/auto_update.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/auto_update.py
@@ -31,7 +31,11 @@ AUTO_UPDATE_AGREE_KEY = "yes_auto_update"
 def pre_confirm_auto_update_flag(f: Callable) -> Callable:
     """Decorator to add a --yes-auto-update flag to a command."""
     return click.option(
-        "--yes-auto-update", AUTO_UPDATE_AGREE_KEY, is_flag=True, default=False, help="Skip prompts and automatically upgrade pipelines"
+        "--yes-auto-update/--no-auto-update",
+        AUTO_UPDATE_AGREE_KEY,
+        is_flag=True,
+        default=True,
+        help="Skip prompts and automatically upgrade pipelines",
     )(f)
 
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.12.4"
+version = "4.12.5"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
This PR's sets the `--yes-auto-update`  as `True` by default to avoid bothering folks with new versions upgrade approval. It's annoying when we ship new versions a couple of times a week/day.