### PR TITLE
airbyte-ci: reduce required env var when running in CI (fixed)

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -745,6 +745,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.12.4  | [#37786](https://github.com/airbytehq/airbyte/pull/37786)  | (fixed 4.12.2): Do not upload dagger log to GCP when no credentials are available.                                           |
 | 4.12.3  | [#37783](https://github.com/airbytehq/airbyte/pull/37783)  | Revert 4.12.2                                                                                                                |
 | 4.12.2  | [#37778](https://github.com/airbytehq/airbyte/pull/37778)  | Do not upload dagger log to GCP when no credentials are available.                                                           |
 | 4.12.1  | [#37765](https://github.com/airbytehq/airbyte/pull/37765)  | Relax the required env var to run in CI and handle their absence gracefully.                                                 |

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/dagger_pipeline_command.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/dagger_pipeline_command.py
@@ -53,9 +53,8 @@ class DaggerPipelineCommand(click.Command):
             sys.exit(1)
         finally:
             if ctx.obj.get("dagger_logs_path"):
-                if ctx.obj["is_local"]:
-                    main_logger.info(f"Dagger logs saved to {ctx.obj['dagger_logs_path']}")
-                if ctx.obj["is_ci"]:
+                main_logger.info(f"Dagger logs saved to {ctx.obj['dagger_logs_path']}")
+                if ctx.obj["is_ci"] and ctx.obj["ci_gcs_credentials"] and ctx.obj["ci_report_bucket_name"]:
                     gcs_uri, public_url = upload_to_gcs(
                         ctx.obj["dagger_logs_path"], ctx.obj["ci_report_bucket_name"], dagger_logs_gcs_key, ctx.obj["ci_gcs_credentials"]
                     )

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
@@ -187,7 +187,11 @@ class PipelineContext:
         """Build a dictionary used as kwargs to the update_commit_status_check function."""
         target_url: Optional[str] = self.gha_workflow_run_url
 
-        if self.state not in [ContextState.RUNNING, ContextState.INITIALIZED] and isinstance(self.report, ConnectorReport):
+        if (
+            self.remote_storage_enabled
+            and self.state not in [ContextState.RUNNING, ContextState.INITIALIZED]
+            and isinstance(self.report, ConnectorReport)
+        ):
             target_url = self.report.html_report_url
 
         return {
@@ -219,7 +223,7 @@ class PipelineContext:
 
     @property
     def remote_storage_enabled(self) -> bool:
-        return self.is_ci is True and self.ci_report_bucket is not None and self.ci_gcs_credentials_secret is not None
+        return self.is_ci and bool(self.ci_report_bucket) and bool(self.ci_gcs_credentials)
 
     def get_repo_file(self, file_path: str) -> File:
         """Get a file from the current repository.

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.12.3"
+version = "4.12.4"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
Reading the `self.ci_gcs_credentials_secret` property in a context before the Dagger client instantiation led to `AssertionError: The dagger client was not set on this PipelineContext`.
This property used the `self.dagger_client` but it was used by `self.remote_storage_enabled` in a code path where the dagger client was not set on the `PipelineContext`.

Fixing it by accessing `self.ci_gcs_credentials` instead of `self.ci_gcs_credentials_secret` in the `self.remote_storage_enabled` property. 