### PR TITLE
gradle.yml: make it run on forks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,18 +52,6 @@ jobs:
     name: Gradle Check
     timeout-minutes: 30
     steps:
-      # The run-check job will be triggered if a fork made changes to gradle projects.
-      # We don't want forks to make changes to gradle projects.
-      # So we fail the job if the PR is from a fork, it will make the required CI check fail.
-      - name: Check if PR is from a fork
-        id: check-if-pr-is-from-fork
-        if: github.event_name == 'pull_request'
-        shell: bash
-        run: |
-          if [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
-            echo "PR is from a fork. Exiting workflow..."
-            exit 78
-          fi
       - name: Checkout Airbyte
         uses: actions/checkout@v4
       - uses: actions/setup-java@v3
@@ -71,8 +59,10 @@ jobs:
           distribution: "zulu"
           java-version: "21"
       - name: Docker login
-        # Some tests use testcontainers which pull images from DockerHub.
-        uses: docker/login-action@v1
+        # We login to benefit from increased rate limits for docker pulls
+        # We can't do it on forks as pull_requests events on forks do not have access to GH secrets
+        if: github.event.pull_request.head.repo.fork != true
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -148,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - run-check
-    if: success()
+    if: ${{ success() && github.event.pull_request.head.repo.fork != true }}
     steps:
       - name: Get Previous Workflow Status
         uses: Mercymeilya/last-workflow-status@v0.3


### PR DESCRIPTION
The `gradle.yml` workflow has a required `Gradle Check` job. If we want to accept contributions from forks on Java connectors we should make it run on forks.
It should be possible as this workflow does not require secret access.
On forks the workflow will not benefit from our S3 gradle cache nor docker login, it might have a performance impact but its tolerable given the small amount of java connectors contribution.
