### PR TITLE
community-ci: check no changes are made to protected path

### DIFF
--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -14,19 +14,37 @@ on:
   # It guarantees that the workflow logic is not altered by the PR.
   pull_request_target:
     types: [opened, synchronize]
-    # We only accept PRs touching connectors
-    paths:
-      - "airbyte-integrations/connectors/**"
-    branches:
-      - "master"
 
 jobs:
+  fail_on_protected_path_changes:
+    name: "Check fork do not change protected paths"
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check for changes in protected paths
+        id: check_for_changes_in_protected_paths
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            protected_paths:
+              - '.github/**'
+              - 'airbyte-ci/**'
+
+      - name: Fail if changes in protected paths
+        if: steps.check_for_changes_in_protected_paths.outputs.protected_paths == 'true'
+        run: |
+          echo "The fork has changes in protected paths. This is not allowed."
+          exit 1
+
   format_check:
     # IMPORTANT: This name must match the require check name on the branch protection settings
     name: "Check for formatting errors"
     if: github.event.pull_request.head.repo.fork == true
     environment: community-ci-auto
     runs-on: community-tooling-test-small
+    needs: fail_on_protected_path_changes
     timeout-minutes: 30
     env:
       MAIN_BRANCH_NAME: "master"
@@ -41,7 +59,7 @@ jobs:
           fetch-depth: 1
 
       # This will sync the .github folder of the main repo with the fork
-      # This allows us to use up to date actions from the main repo
+      # This allows us to use up to date actions and CI logic from the main repo
       - name: Pull .github folder and internal packages from main repository
         id: pull_github_folder
         run: |
@@ -62,6 +80,7 @@ jobs:
   connectors_early_ci:
     name: Run connectors early CI on fork
     if: github.event.pull_request.head.repo.fork == true
+    needs: fail_on_protected_path_changes
     environment: community-ci-auto
     runs-on: community-tooling-test-small
     timeout-minutes: 10
@@ -80,8 +99,7 @@ jobs:
           fetch-depth: 1
 
       # This will sync the .github folder of the main repo with the fork
-      # This allows us to use up to date actions and internal packages logic from the main repo
-      # It will also prevent forks from changing CI logic
+      # This allows us to use up to date actions and CI logic from the main repo
       - name: Pull .github folder from main repository
         id: pull_github_folder
         run: |
@@ -114,12 +132,13 @@ jobs:
           retention-days: 7
 
   connectors_full_ci:
-    name: Run all connectors tests on fork
+    name: Run connectors full CI on fork
     if: github.event.pull_request.head.repo.fork == true
     # Deployment of jobs on the community-ci environment requires manual approval
     # This is something we set up in the GitHub environment settings:
     # https://github.com/airbytehq/airbyte/settings/environments/2091483613/edit
     # This is a safety measure to make sure the code running on our infrastructure has been reviewed before running on it
+    needs: fail_on_protected_path_changes
     environment: community-ci
     runs-on: community-connector-test-large
     timeout-minutes: 180 # 3 hours
@@ -138,9 +157,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
-        # This will sync the .github folder of the main repo with the fork
-        # This allows us to use up to date actions and internal packages logic from the main repo
-        # It will also prevent forks from changing CI logic      - name: Pull .github folder from main repository
+      # This will sync the .github folder of the main repo with the fork
+      # This allows us to use up to date actions and CI logic from the main repo
       - name: Pull .github folder from main repository
         id: pull_github_folder
         run: |


### PR DESCRIPTION
We want to make community CI fail if changes were made to some protected paths. Protected paths are currently the one containaing our CI logic (.github, airbyte-ci)
