### PR TITLE
CI 🧹: clean up workflow naming

### DIFF
--- a/.github/workflows/airbyte-ci-release.yml
+++ b/.github/workflows/airbyte-ci-release.yml
@@ -1,4 +1,4 @@
-name: Connector Ops CI - Airbyte CI Release
+name: Airbyte CI Release
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -17,6 +17,7 @@ on:
       - synchronize
 jobs:
   changes:
+    name: Check for changes in internal poetry packages
     runs-on: ubuntu-latest
     outputs:
       internal_poetry_packages: ${{ steps.changes.outputs.internal_poetry_packages }}
@@ -25,7 +26,8 @@ jobs:
       - name: Checkout Airbyte
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
-      - id: changes
+      - name: Check for changes in internal poetry packages
+        id: changes
         uses: dorny/paths-filter@v2
         with:
           # Note: expressions within a filter are OR'ed
@@ -43,12 +45,12 @@ jobs:
             - airbyte-integrations/bases/connector-acceptance-test/**
 
   run-tests:
+    name: Run Airbyte CI tests # This is a required check for the branch protection rule, do not change the job name
     needs: changes
     # We only run the Connectors CI job if there are changes to the connectors on a non-forked PR
     if: needs.changes.outputs.internal_poetry_packages == 'true'
     #name: Internal Poetry packages CI
     # To rename in a follow up PR
-    name: Run Airbyte CI tests
     runs-on: tooling-test-large
     permissions:
       pull-requests: read

--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -39,8 +39,7 @@ jobs:
           exit 1
 
   format_check:
-    # IMPORTANT: This name must match the require check name on the branch protection settings
-    name: "Check for formatting errors"
+    name: "Check for formatting errors" # This is a required check for the branch protection rule, do not change the job name
     if: github.event.pull_request.head.repo.fork == true
     environment: community-ci-auto
     runs-on: community-tooling-test-small

--- a/.github/workflows/connector_teams_review_requirements.yml
+++ b/.github/workflows/connector_teams_review_requirements.yml
@@ -1,4 +1,4 @@
-name: Connector Ops CI - Check review requirements
+name: Check review requirements
 
 on:
   pull_request:

--- a/.github/workflows/connectors_nightly_build.yml
+++ b/.github/workflows/connectors_nightly_build.yml
@@ -1,4 +1,4 @@
-name: Connector Ops CI - Connectors Nightly Tests
+name: Connectors Nightly Tests
 
 on:
   schedule:

--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -1,4 +1,4 @@
-name: Connectors Tests
+name: Connector testing [Non Forked PRs]
 
 concurrency:
   # This is the name of the concurrency group. It is used to prevent concurrent runs of the same workflow.
@@ -23,6 +23,7 @@ on:
       - synchronize
 jobs:
   changes:
+    name: Check for changes in connectors
     runs-on: ubuntu-latest
     outputs:
       connectors: ${{ steps.changes.outputs.connectors }}
@@ -32,7 +33,8 @@ jobs:
       - name: Checkout Airbyte
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
-      - id: changes
+      - name: Check for changes in connectors
+        id: changes
         uses: dorny/paths-filter@v2
         with:
           # Note: expressions within a filter are OR'ed
@@ -58,13 +60,13 @@ jobs:
             "target_url": "${{ github.event.workflow_run.html_url }}"
             }' \
 
-  connectors_ci:
+  airbyte_ci_connectors_tests:
     needs: changes
     # We only run the Connectors CI job if there are changes to the connectors on a non-forked PR
     # Forked PRs are handled by the community_ci.yml workflow
     # If the condition is not met the job will be skipped (it will not fail)
     if: (github.event_name == 'pull_request' && needs.changes.outputs.connectors == 'true' && github.event.pull_request.head.repo.fork != true) || github.event_name == 'workflow_dispatch'
-    name: Connectors CI
+    name: Run airbyte-ci connectors test
     runs-on: connector-test-large
     timeout-minutes: 360 # 6 hours
     steps:

--- a/.github/workflows/connectors_weekly_build.yml
+++ b/.github/workflows/connectors_weekly_build.yml
@@ -1,4 +1,4 @@
-name: Connector Ops CI - Connectors Weekly Tests
+name: Connectors Weekly Tests
 
 on:
   schedule:

--- a/.github/workflows/contractors_review_requirements.yml
+++ b/.github/workflows/contractors_review_requirements.yml
@@ -1,4 +1,4 @@
-name: Connector Ops CI - Check contractors review requirements
+name: Check contractors review requirements
 
 on:
   pull_request:

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -10,8 +10,7 @@ on:
 
 jobs:
   format-check:
-    # IMPORTANT: This name must match the require check name on the branch protection settings
-    name: "Check for formatting errors"
+    name: "Check for formatting errors" # This is a required check for the branch protection rule, do not change the job name
     # Do not run this job on forks
     # Forked PRs are handled by the community_ci.yml workflow
     if: github.event.pull_request.head.repo.fork != true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Connector Ops CI - Gradle Check
+name: Gradle Check
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,6 +21,7 @@ on:
 
 jobs:
   changes:
+    name: Check for changes in java files
     runs-on: ubuntu-latest
     outputs:
       java: ${{ steps.changes.outputs.java }}
@@ -29,7 +30,8 @@ jobs:
       - name: Checkout Airbyte
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
-      - id: changes
+      - name: Check for changes in java files
+        id: changes
         uses: dorny/paths-filter@v2
         with:
           # Note: expressions within a filter are OR'ed
@@ -41,6 +43,7 @@ jobs:
               - 'airbyte-cdk/java/**/*'
 
   run-check:
+    name: Gradle Check # This is a required check for the branch protection rule, do not change the job name
     needs:
       - changes
     if: needs.changes.outputs.java == 'true'
@@ -49,7 +52,6 @@ jobs:
     # See https://github.com/airbytehq/airbyte/pull/36055 for an example of this,
     # which explains why which we went down from 64 cores to 16.
     runs-on: connector-test-large
-    name: Gradle Check
     timeout-minutes: 30
     steps:
       - name: Checkout Airbyte

--- a/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
+++ b/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
@@ -1,4 +1,4 @@
-name: Connector Ops CI - Metadata Service Deploy Orchestrator
+name: Metadata Service Deploy Orchestrator
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -1,4 +1,4 @@
-name: Connector Ops CI - Publish Connectors
+name: Publish Connectors
 
 on:
   push:

--- a/.github/workflows/python_cdk_tests.yml
+++ b/.github/workflows/python_cdk_tests.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   changes:
+    name: Check for changes in Python CDK
     runs-on: ubuntu-latest
     outputs:
       python_cdk: ${{ steps.changes.outputs.python_cdk }}
@@ -24,7 +25,8 @@ jobs:
       - name: Checkout Airbyte
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v3
-      - id: changes
+      - name: Check for changes in Python CDK
+        id: changes
         uses: dorny/paths-filter@v2
         with:
           # Note: expressions within a filter are OR'ed
@@ -37,7 +39,7 @@ jobs:
       - changes
     if: needs.changes.outputs.python_cdk == 'true'
     runs-on: ubuntu-latest
-    name: Python CDK Tests
+    name: Python CDK Tests # This is a required check for the branch protection rule, do not change the job name
     timeout-minutes: 30
     steps:
       # The run-python-cdk-check job will be triggered if a fork made changes to Python CDK.

--- a/.github/workflows/upload-metadata-files.yml
+++ b/.github/workflows/upload-metadata-files.yml
@@ -1,4 +1,4 @@
-name: "Connector Ops CI - Upload Changed Metadata Files [Emergency Use!]"
+name: Upload Changed Metadata Files [Emergency Use!]
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
An attempt at making our workflow and job names simpler and more explicit for clearer CI checks on PRs
