### PR TITLE
source-oracle: add CHECK and DISCOVER implementations

### DIFF
--- a/airbyte-integrations/connectors/source-oracle-v2/src/main/kotlin/io/airbyte/integrations/source/oracle/OracleJdbcMetadataQuerier.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/main/kotlin/io/airbyte/integrations/source/oracle/OracleJdbcMetadataQuerier.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.oracle
+
+import io.airbyte.cdk.command.SourceConfiguration
+import io.airbyte.cdk.discover.ColumnMetadata
+import io.airbyte.cdk.discover.DiscoverMapper
+import io.airbyte.cdk.discover.GenericUserDefinedType
+import io.airbyte.cdk.discover.MetadataQuerier
+import io.airbyte.cdk.discover.SourceType
+import io.airbyte.cdk.discover.SystemType
+import io.airbyte.cdk.discover.TableName
+import io.airbyte.cdk.discover.UserDefinedArray
+import io.airbyte.cdk.discover.UserDefinedType
+import io.airbyte.cdk.jdbc.JdbcConnectionFactory
+import io.airbyte.cdk.jdbc.JdbcMetadataQuerier
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Primary
+import jakarta.inject.Singleton
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Statement
+import java.sql.Types
+import oracle.jdbc.OracleArray
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Delegates to [JdbcMetadataQuerier] except for [columnMetadata].
+ *
+ * Oracle is annoying when it comes to array types. All array types are user-defined VARRAYS. These
+ * do NOT show up in a [java.sql.DatabaseMetaData.getUDTs] query. We therefore need to query
+ * Oracle's system tables like ALL_COLL_TYPES to retrieve type info. Furthermore, other user-defined
+ * object types also need to be handled somewhat properly: even though we're going to map them to
+ * some generic type like STRING or JSONB we still need to deal with arrays of UDTs.
+ *
+ * We cache the results of these UDT-related queries as they are not column-specific.
+ */
+class OracleJdbcMetadataQuerier(val base: JdbcMetadataQuerier) : MetadataQuerier by base {
+
+    override fun columnMetadata(table: TableName): List<ColumnMetadata> =
+        base.columnMetadata(table).map {
+            it.copy(
+                type =
+                    when (it.type) {
+                        is SystemType -> allUDTsByFQName[it.type.typeName] ?: it.type
+                        else -> it.type
+                    }
+            )
+        }
+
+    val allUDTsByFQName: Map<String, UserDefinedType> by lazy {
+        val otherUDTs: List<UserDefinedType> =
+            base.memoizedUserDefinedTypes + collectExtraGenericTypes()
+        val allUDTs: List<UserDefinedType> = collectVarrayTypes(otherUDTs) + otherUDTs
+        allUDTs.reversed().associateBy { "${it.schema}.${it.typeName}" }
+    }
+
+    private fun collectExtraGenericTypes(): List<GenericUserDefinedType> =
+        collectAllTypesRows().map { row: AllTypesRow ->
+            GenericUserDefinedType(
+                catalog = null,
+                schema = row.owner,
+                typeName = row.typeName,
+                klazz = null,
+                typeCode = systemTypeMap[row.typeName]?.typeCode ?: Types.JAVA_OBJECT,
+                remarks = null,
+                baseTypeCode = null
+            )
+        }
+
+    private fun collectAllTypesRows(): List<AllTypesRow> {
+        val results = mutableListOf<AllTypesRow>()
+        try {
+            base.conn.createStatement().use { stmt: Statement ->
+                stmt.executeQuery(TYPES_QUERY).use { rs: ResultSet ->
+                    while (rs.next()) {
+                        results.add(AllTypesRow(rs.getString("OWNER"), rs.getString("TYPE_NAME")))
+                    }
+                }
+            }
+        } catch (e: SQLException) {
+            throw RuntimeException("Oracle ALL_TYPES discovery query failed: ${e.message}", e)
+        }
+        return results
+    }
+
+    data class AllTypesRow(
+        val owner: String,
+        val typeName: String,
+    )
+
+    val systemTypeMap: Map<String, SystemType> by lazy {
+        val systemTypes = mutableListOf<SystemType>()
+        try {
+            base.conn.metaData.typeInfo.use { rs: ResultSet ->
+                while (rs.next()) {
+                    systemTypes.add(
+                        SystemType(
+                            typeName = rs.getString("TYPE_NAME"),
+                            typeCode = rs.getInt("DATA_TYPE")
+                        )
+                    )
+                }
+            }
+        } catch (e: SQLException) {
+            log.info {
+                "Failed to query type info: " +
+                    "sqlState = '${e.sqlState ?: ""}', errorCode = ${e.errorCode}, ${e.message}"
+            }
+        }
+        systemTypes.filter { it.typeName != null }.associateBy { it.typeName!! }
+    }
+
+    private fun collectVarrayTypes(otherUDTs: List<UserDefinedType>): List<UserDefinedType> {
+        val allRows: List<AllCollTypesRow> = collectAllCollTypesRows()
+        val otherUDTsByFQName: Map<String, UserDefinedType> =
+            otherUDTs
+                .filter { it.schema != null && it.typeName != null }
+                .associateBy { "${it.schema}.${it.typeName}" }
+        val varrayFQNameSet: Set<String> = allRows.map { "${it.owner}.${it.typeName}" }.toSet()
+        val parentRowByFQName: Map<String, AllCollTypesRow> =
+            allRows
+                .filter { it.elemTypeOwner != null && it.elemTypeName != null }
+                .associateBy { "${it.elemTypeOwner!!}.${it.elemTypeName!!}" }
+        fun recurse(elementType: SourceType, row: AllCollTypesRow): UserDefinedArray {
+            val type =
+                UserDefinedArray(
+                    catalog = null,
+                    schema = row.owner,
+                    typeName = row.typeName,
+                    klazz = OracleArray::class.java,
+                    elementType = elementType
+                )
+            val parentRow: AllCollTypesRow =
+                parentRowByFQName["${row.owner}.${row.typeName}"] ?: return type
+            return recurse(type, parentRow)
+        }
+
+        return allRows
+            .filter { it.elemTypeName != null }
+            .filterNot { varrayFQNameSet.contains("${it.elemTypeOwner}.${it.elemTypeName}") }
+            .map { row ->
+                val leaf: SourceType =
+                    otherUDTsByFQName["${row.elemTypeOwner}.${row.elemTypeName}"]
+                        ?: SystemType(
+                            typeName = row.elemTypeName!!,
+                            klazz = null,
+                            typeCode =
+                                when (row.scale) {
+                                    null -> systemTypeMap[row.elemTypeName]?.typeCode
+                                            ?: Types.JAVA_OBJECT
+                                    0 -> Types.BIGINT
+                                    else -> Types.NUMERIC
+                                }
+                        )
+                recurse(leaf, row)
+            }
+    }
+
+    private fun collectAllCollTypesRows(): List<AllCollTypesRow> {
+        val results = mutableListOf<AllCollTypesRow>()
+        try {
+            base.conn.createStatement().use { stmt: Statement ->
+                stmt.executeQuery(VARRAY_QUERY).use { rs: ResultSet ->
+                    while (rs.next()) {
+                        results.add(
+                            AllCollTypesRow(
+                                rs.getString("OWNER"),
+                                rs.getString("TYPE_NAME"),
+                                rs.getString("ELEM_TYPE_OWNER").takeUnless { rs.wasNull() },
+                                rs.getString("ELEM_TYPE_NAME").takeUnless { rs.wasNull() },
+                                rs.getInt("SCALE").takeUnless { rs.wasNull() }
+                            )
+                        )
+                    }
+                }
+            }
+        } catch (e: SQLException) {
+            throw RuntimeException("Oracle VARRAY discovery query failed: ${e.message}", e)
+        }
+        return results
+    }
+
+    data class AllCollTypesRow(
+        val owner: String,
+        val typeName: String,
+        val elemTypeOwner: String?,
+        val elemTypeName: String?,
+        val scale: Int?,
+    )
+
+    companion object {
+        const val VARRAY_QUERY =
+            """
+SELECT OWNER, TYPE_NAME, ELEM_TYPE_OWNER, ELEM_TYPE_NAME, SCALE
+FROM ALL_COLL_TYPES
+WHERE COLL_TYPE = 'VARYING ARRAY'
+        """
+
+        const val TYPES_QUERY =
+            """
+SELECT OWNER, TYPE_NAME
+FROM ALL_TYPES 
+WHERE OWNER IS NOT NULL AND TYPE_NAME IS NOT NULL           
+        """
+    }
+
+    /** Oracle implementation of [MetadataQuerier.Factory]. */
+    @Singleton
+    @Primary
+    class Factory(override val discoverMapper: DiscoverMapper) : MetadataQuerier.Factory {
+
+        /** The [SourceConfiguration] is deliberately not injected in order to support tests. */
+        override fun session(config: SourceConfiguration): MetadataQuerier {
+            val jdbcConnectionFactory = JdbcConnectionFactory(config)
+            val base = JdbcMetadataQuerier(config, discoverMapper, jdbcConnectionFactory)
+            return OracleJdbcMetadataQuerier(base)
+        }
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/main/kotlin/io/airbyte/integrations/source/oracle/OracleSourceDiscoverMapper.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/main/kotlin/io/airbyte/integrations/source/oracle/OracleSourceDiscoverMapper.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.oracle
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.airbyte.cdk.discover.ArrayColumnType
+import io.airbyte.cdk.discover.ColumnMetadata
+import io.airbyte.cdk.discover.ColumnType
+import io.airbyte.cdk.discover.DiscoverMapper
+import io.airbyte.cdk.discover.DiscoveredStream
+import io.airbyte.cdk.discover.GenericUserDefinedType
+import io.airbyte.cdk.discover.LeafType
+import io.airbyte.cdk.discover.SystemType
+import io.airbyte.cdk.discover.TableName
+import io.airbyte.cdk.discover.UserDefinedArray
+import io.airbyte.protocol.models.v0.AirbyteStream
+import io.airbyte.protocol.models.v0.SyncMode
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.inject.Singleton
+import java.sql.Types
+
+private val log = KotlinLogging.logger {}
+
+@Singleton
+class OracleSourceDiscoverMapper : DiscoverMapper {
+
+    override fun selectFromTableLimit0(table: TableName, columns: List<String>): String =
+        // Oracle doesn't do LIMIT, instead we need to involve ROWNUM.
+        "SELECT ${columns.joinToString()} FROM ${table.fullyQualifiedName()} WHERE ROWNUM < 1"
+
+    override fun columnType(c: ColumnMetadata) =
+        when (val type = c.type) {
+            is UserDefinedArray -> ArrayColumnType(recursiveArrayType(type))
+            is GenericUserDefinedType ->
+                // TODO: revisit this
+                // Representing Oracle object types as JSON is convenient to do in 19c+
+                // but not in earlier releases.
+                // https://asktom.oracle.com/ords/f?p=100:11:::::P11_QUESTION_ID:9539152100346578907
+                LeafType.JSONB
+            is SystemType -> leafType(c.type.typeName, c.scale != 0) ?: LeafType.STRING
+        }
+
+    private fun recursiveArrayType(type: UserDefinedArray): ColumnType =
+        when (val elementType = type.elementType) {
+            is UserDefinedArray -> ArrayColumnType(recursiveArrayType(elementType))
+            is GenericUserDefinedType -> LeafType.JSONB
+            is SystemType -> leafType(elementType.typeName, Types.INTEGER != elementType.typeCode)
+                    ?: LeafType.STRING
+        }
+
+    private fun leafType(typeName: String?, notInteger: Boolean): LeafType? =
+        // This mapping includes literals returned by the JDBC driver as well as
+        // *_TYPE_NAME column values from queries to ALL_* system tables.
+        when (typeName) {
+            "FLOAT",
+            "BINARY_FLOAT",
+            "BINARY_DOUBLE",
+            "DOUBLE PRECISION",
+            "REAL" -> LeafType.NUMBER
+            "NUMBER",
+            "NUMERIC",
+            "DECIMAL",
+            "DEC" -> if (notInteger) LeafType.NUMBER else LeafType.INTEGER
+            "INTEGER",
+            "INT",
+            "SMALLINT" -> LeafType.INTEGER
+            "BOOLEAN",
+            "BOOL" -> LeafType.BOOLEAN
+            "CHAR",
+            "NCHAR",
+            "NVARCHAR2",
+            "VARCHAR2",
+            "VARCHAR",
+            "CHARACTER",
+            "CHARACTER VARYING",
+            "CHAR VARYING",
+            "NCHAR VARYING",
+            "NATIONAL CHARACTER VARYING",
+            "NATIONAL CHARACTER",
+            "NATIONAL CHAR VARYING",
+            "NATIONAL CHAR" -> LeafType.STRING
+            "BLOB",
+            "CLOB",
+            "NCLOB",
+            "BFILE" -> LeafType.BINARY
+            "DATE" -> LeafType.DATE
+            "INTERVALDS",
+            "INTERVAL DAY TO SECOND",
+            "INTERVALYM",
+            "INTERVAL YEAR TO MONTH" -> LeafType.STRING
+            "JSON" -> LeafType.JSONB
+            "LONG",
+            "LONG RAW",
+            "RAW",
+            "ROWID" -> LeafType.BINARY
+            "TIMESTAMP" -> LeafType.TIMESTAMP_WITHOUT_TIMEZONE
+            "TIMESTAMP WITH LOCAL TIME ZONE",
+            "TIMESTAMP WITH LOCAL TZ",
+            "TIMESTAMP WITH TIME ZONE",
+            "TIMESTAMP WITH TZ" -> LeafType.TIMESTAMP_WITH_TIMEZONE
+            else -> null
+        }
+
+    override fun isPossibleCursor(c: ColumnMetadata): Boolean =
+        // No surprises here.
+        when (val type = columnType(c)) {
+            is ArrayColumnType -> false
+            is LeafType ->
+                when (type) {
+                    LeafType.BOOLEAN,
+                    LeafType.BINARY,
+                    LeafType.NULL,
+                    LeafType.JSONB -> false
+                    LeafType.STRING,
+                    LeafType.DATE,
+                    LeafType.TIME_WITH_TIMEZONE,
+                    LeafType.TIME_WITHOUT_TIMEZONE,
+                    LeafType.TIMESTAMP_WITH_TIMEZONE,
+                    LeafType.TIMESTAMP_WITHOUT_TIMEZONE,
+                    LeafType.INTEGER,
+                    LeafType.NUMBER -> true
+                }
+        }
+
+    private fun TableName.fullyQualifiedName(): String =
+        // The catalog never comes into play with Oracle.
+        if (schema == null) name else "${schema}.${name}"
+
+    override fun globalAirbyteStream(stream: DiscoveredStream): AirbyteStream =
+        DiscoverMapper.basicAirbyteStream(this, stream).apply {
+            namespace = stream.table.schema
+            supportedSyncModes = listOf(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)
+            (jsonSchema["properties"] as ObjectNode).apply {
+                set<ObjectNode>("_ab_cdc_lsn", LeafType.NUMBER.asJsonSchema())
+                set<ObjectNode>(
+                    "_ab_cdc_updated_at",
+                    LeafType.TIMESTAMP_WITH_TIMEZONE.asJsonSchema()
+                )
+                set<ObjectNode>(
+                    "_ab_cdc_deleted_at",
+                    LeafType.TIMESTAMP_WITH_TIMEZONE.asJsonSchema()
+                )
+            }
+            defaultCursorField = listOf("_ab_cdc_lsn")
+            sourceDefinedCursor = true
+        }
+
+    override fun nonGlobalAirbyteStream(stream: DiscoveredStream): AirbyteStream =
+        DiscoverMapper.basicAirbyteStream(this, stream).apply {
+            namespace = stream.table.schema
+            supportedSyncModes = listOf(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)
+            if (defaultCursorField.isEmpty()) {
+                supportedSyncModes = listOf(SyncMode.FULL_REFRESH)
+            }
+        }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/test/kotlin/io/airbyte/integrations/source/oracle/OracleContainerFactory.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/test/kotlin/io/airbyte/integrations/source/oracle/OracleContainerFactory.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.oracle
+
+import io.airbyte.cdk.testutils.ContainerFactory
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.OracleContainer
+import org.testcontainers.utility.DockerImageName
+
+class OracleContainerFactory : ContainerFactory<OracleContainer>() {
+
+    override fun createNewContainer(imageName: DockerImageName?): OracleContainer =
+        OracleContainer(imageName?.asCompatibleSubstituteFor("gvenzl/oracle-xe"))
+
+    companion object {
+        val withNetwork: NamedContainerModifier<OracleContainer> =
+            NamedContainerModifierImpl("withNetwork") { it.withNetwork(Network.newNetwork()) }
+
+        @JvmStatic
+        fun config(dbContainer: OracleContainer): OracleSourceConfigurationJsonObject =
+            OracleSourceConfigurationJsonObject().apply {
+                host = dbContainer.host
+                port = dbContainer.oraclePort
+                username = dbContainer.username
+                password = dbContainer.password
+                jdbcUrlParams = ""
+                schemas = listOf(dbContainer.username)
+                setConnectionDataValue(ServiceName().apply { serviceName = "FREEPDB1" })
+            }
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/test/kotlin/io/airbyte/integrations/source/oracle/OracleDatatypesTestFixture.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/test/kotlin/io/airbyte/integrations/source/oracle/OracleDatatypesTestFixture.kt
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.oracle
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.commons.json.Jsons
+
+/**
+ * Reference: https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html
+ */
+data object OracleDatatypesTestFixture {
+
+    val testCases: List<TestCase> =
+        listOf(
+            // character datatypes
+            TestCase("CHAR(10 BYTE)"),
+            TestCase("CHAR(10 CHAR)"),
+            TestCase("CHAR(10)"),
+            TestCase("CHAR"),
+            TestCase("VARCHAR2(10 BYTE)"),
+            TestCase("VARCHAR2(10 CHAR)"),
+            TestCase("VARCHAR2(10)"),
+            TestCase("NCHAR(10)"),
+            TestCase("NCHAR"),
+            TestCase("NVARCHAR2(10)"),
+            // number datatypes
+            TestCase("NUMBER(10,2)"),
+            TestCase("NUMBER(10)"),
+            TestCase("NUMBER"),
+            TestCase("FLOAT(10)"),
+            TestCase("FLOAT"),
+            TestCase("BINARY_FLOAT"),
+            TestCase("BINARY_DOUBLE"),
+            // long and raw datatypes
+            TestCase("LONG", noPK = true, noVarray = true),
+            TestCase("LONG RAW", noPK = true, noVarray = true),
+            TestCase("RAW(10)"),
+            // datetime datatypes
+            TestCase("DATE"),
+            TestCase("TIMESTAMP(2) WITH LOCAL TIME ZONE", noPK = true),
+            TestCase("TIMESTAMP(2) WITH TIME ZONE", noPK = true),
+            TestCase("TIMESTAMP(2)", noPK = true),
+            TestCase("TIMESTAMP WITH LOCAL TIME ZONE", noPK = true),
+            TestCase("TIMESTAMP WITH TIME ZONE", noPK = true),
+            TestCase("TIMESTAMP", noPK = true),
+            TestCase("INTERVAL YEAR(4) TO MONTH"),
+            TestCase("INTERVAL YEAR TO MONTH"),
+            TestCase("INTERVAL DAY(1) TO SECOND(2)"),
+            TestCase("INTERVAL DAY(1) TO SECOND"),
+            TestCase("INTERVAL DAY TO SECOND(2)"),
+            TestCase("INTERVAL DAY TO SECOND"),
+            // large object datatypes
+            TestCase("BLOB", noPK = true, noVarray = true),
+            TestCase("CLOB", noPK = true, noVarray = true),
+            TestCase("NCLOB", noPK = true, noVarray = true),
+            TestCase("BFILE", noPK = true),
+            // rowid datatypes
+            TestCase("ROWID", noVarray = true),
+            TestCase("UROWID(100)", noVarray = true),
+            TestCase("UROWID", noVarray = true),
+            // json datatype
+            TestCase("JSON", noPK = true, noVarray = true),
+            // boolean datatype
+            TestCase("BOOLEAN"),
+            TestCase("BOOL"),
+            // ANSI supported datatypes
+            TestCase("CHARACTER VARYING (10)"),
+            TestCase("CHARACTER (10)"),
+            TestCase("CHAR VARYING (10)"),
+            TestCase("NCHAR VARYING (10)"),
+            TestCase("VARCHAR(10)"),
+            TestCase("NATIONAL CHARACTER VARYING (10)"),
+            TestCase("NATIONAL CHARACTER (10)"),
+            TestCase("NATIONAL CHAR VARYING (10)"),
+            TestCase("NATIONAL CHAR (10)"),
+            TestCase("NUMERIC(10,2)"),
+            TestCase("NUMERIC(10)"),
+            TestCase("NUMERIC"),
+            TestCase("DECIMAL(10,2)"),
+            TestCase("DECIMAL(10)"),
+            TestCase("DECIMAL"),
+            TestCase("DEC(10,2)"),
+            TestCase("DEC(10)"),
+            TestCase("DEC"),
+            TestCase("INTEGER"),
+            TestCase("INT"),
+            TestCase("SMALLINT", mapOf("1" to "1")),
+            TestCase("FLOAT(10)"),
+            TestCase("FLOAT"),
+            TestCase("DOUBLE PRECISION"),
+            TestCase("REAL"),
+            // any types
+            TestCase("SYS.AnyData", noPK = true, noVarray = true),
+            TestCase("SYS.AnyType", noPK = true, noVarray = true),
+            TestCase("SYS.AnyDataSet", noPK = true, noVarray = true),
+            // xml types
+            TestCase("XMLType", noPK = true, noVarray = true),
+            TestCase("URItype", noPK = true),
+            // spatial types
+            TestCase("SDO_Geometry", noPK = true),
+            TestCase("SDO_Topo_Geometry", noPK = true),
+            // user-defined types
+            TestCase(
+                "fibo_objtyp",
+                noPK = true,
+                customDDL =
+                    listOf(
+                        """
+    CREATE TYPE IF NOT EXISTS fibo_objtyp AS OBJECT (
+        predecessor INTEGER, 
+        n INTEGER,
+        MEMBER FUNCTION getSuccessor RETURN INTEGER)""",
+                        """
+    CREATE TYPE BODY IF NOT EXISTS fibo_objtyp AS
+        MEMBER FUNCTION getSuccessor RETURN INTEGER AS
+        BEGIN
+            RETURN predecessor + n;
+        END getSuccessor;
+    END""",
+                        """
+    CREATE TABLE IF NOT EXISTS tbl_fibo_objtyp (col_fibo_objtyp fibo_objtyp)""",
+                        """
+    CREATE TYPE IF NOT EXISTS varray_fibo_objtyp AS VARRAY(2) OF fibo_objtyp""",
+                        """
+    CREATE TABLE IF NOT EXISTS tbl_varray_fibo_objtyp (
+        col_varray_fibo_objtyp varray_fibo_objtyp
+    )""",
+                        """
+    TRUNCATE TABLE tbl_varray_fibo_objtyp CASCADE""",
+                    )
+            ),
+            TestCase(
+                "fibo_tbltyp",
+                noPK = true,
+                noVarray = true,
+                customDDL =
+                    listOf(
+                        """
+    CREATE TYPE IF NOT EXISTS fibo_tbltyp AS TABLE OF fibo_objtyp""",
+                        """
+    CREATE TABLE IF NOT EXISTS tbl_fibo_tbltyp (
+        col_fibo_tbltyp fibo_tbltyp
+    ) NESTED TABLE col_fibo_tbltyp STORE AS fibo_nt""",
+                        """
+    TRUNCATE TABLE tbl_fibo_tbltyp CASCADE"""
+                    )
+            ),
+            TestCase(
+                "REF fibo_objtyp",
+                noPK = true,
+                noVarray = true,
+                customDDL =
+                    listOf(
+                        """
+    CREATE TABLE IF NOT EXISTS fibo_ref_source OF fibo_objtyp""",
+                        """
+    CREATE TABLE IF NOT EXISTS tbl_fibo_tbltyp (
+        col_ref_fibo_objtyp_scope_is_fibo_ref_source REF fibo_objtyp SCOPE IS fibo_ref_source
+    )""",
+                        """
+    TRUNCATE TABLE tbl_fibo_tbltyp CASCADE""",
+                    )
+            ),
+        )
+
+    data class TestCase(
+        val sqlType: String,
+        val sqlToAirbyte: Map<String, String> = mapOf(),
+        val noPK: Boolean = false,
+        val noVarray: Boolean = false,
+        val customDDL: List<String>? = null,
+    ) {
+
+        val id: String
+            get() =
+                sqlType
+                    .replace("[^a-zA-Z0-9]".toRegex(), " ")
+                    .trim()
+                    .replace(" +".toRegex(), "_")
+                    .lowercase()
+
+        val tableName: String
+            get() = "tbl_$id"
+
+        val varraySqlType: String
+            get() = "varray_$id"
+
+        val varrayTableName: String
+            get() = "tbl_varray_$id"
+
+        val columnName: String
+            get() = "col_$id"
+
+        val varrayColumnName: String
+            get() = "col_varray_$id"
+
+        val sqlStatements: List<String>
+            get() {
+                val vanillaDDL: List<String> =
+                    listOf(
+                        "CREATE TABLE IF NOT EXISTS $tableName " +
+                            "($columnName $sqlType ${if (noPK) "" else "PRIMARY KEY"})",
+                        "TRUNCATE TABLE $tableName CASCADE"
+                    )
+                val vanillaDML: List<String> =
+                    sqlToAirbyte.keys.map { "INSERT INTO $tableName ($columnName) VALUES (${it})" }
+                val varrayDDL: List<String> =
+                    listOf(
+                        "CREATE TYPE IF NOT EXISTS $varraySqlType " + "AS VARRAY(2) OF $sqlType",
+                        "CREATE TABLE IF NOT EXISTS $varrayTableName " +
+                            "($varrayColumnName $varraySqlType)",
+                        "TRUNCATE TABLE $varrayTableName"
+                    )
+                val varrayDML: List<String> =
+                    sqlToAirbyte.keys.map {
+                        "INSERT INTO $varrayTableName ($varrayColumnName) " +
+                            "VALUES ($varraySqlType(${it}, ${it}))"
+                    }
+                val ddl: List<String> =
+                    if (customDDL != null) {
+                        customDDL
+                    } else if (noVarray) {
+                        vanillaDDL
+                    } else {
+                        vanillaDDL + varrayDDL
+                    }
+                val dml: List<String> =
+                    if (noVarray) {
+                        vanillaDML
+                    } else {
+                        vanillaDML + varrayDML
+                    }
+                return ddl + dml
+            }
+
+        val recordData: List<JsonNode>
+            get() =
+                sqlToAirbyte.values.toList().map { Jsons.deserialize("""{"$columnName":${it}}""") }
+
+        val varrayRecordData: List<JsonNode>
+            get() =
+                sqlToAirbyte.values.toList().map {
+                    Jsons.deserialize("""{"$varrayColumnName":[${it},${it}]}""")
+                }
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/test/kotlin/io/airbyte/integrations/source/oracle/OracleSourceDatatypeIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/test/kotlin/io/airbyte/integrations/source/oracle/OracleSourceDatatypeIntegrationTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.oracle
+
+import io.airbyte.cdk.command.SyncsTestFixture
+import io.airbyte.cdk.jdbc.JdbcConnectionFactory
+import io.airbyte.cdk.ssh.SshBastionContainer
+import io.airbyte.protocol.models.v0.AirbyteCatalog
+import io.airbyte.protocol.models.v0.AirbyteStream
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.sql.Connection
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.testcontainers.containers.OracleContainer
+
+private val log = KotlinLogging.logger {}
+
+class OracleSourceDatatypeIntegrationTest {
+
+    @Test
+    fun testSpec() {
+        SyncsTestFixture.testSpec("expected-spec.json")
+    }
+
+    /** This test ensures that the contents of the two resources stay in sync. */
+    @Test
+    fun testConfiguredCatalogHasAllStreams() {
+        val catalog: AirbyteCatalog = SyncsTestFixture.catalogFromResource("expected-catalog.json")
+        val configuredCatalog: ConfiguredAirbyteCatalog =
+            SyncsTestFixture.configuredCatalogFromResource("configured-catalog.json")
+        val streamMap: Map<AirbyteStreamNameNamespacePair, AirbyteStream> =
+            catalog.streams.associateBy(AirbyteStreamNameNamespacePair::fromAirbyteStream)
+        for (cs in configuredCatalog.streams) {
+            Assertions.assertEquals(
+                streamMap[AirbyteStreamNameNamespacePair.fromConfiguredAirbyteSteam(cs)],
+                cs.stream
+            )
+        }
+    }
+
+    @Test
+    @Timeout(value = 300) // A high timeout value is required for Apple Silicon + colima.
+    fun testSyncs() {
+        SyncsTestFixture.testSyncs(
+            config(),
+            { connectionFactory.get() }, // stay lazy
+            ::prelude,
+            "expected-catalog.json",
+            "configured-catalog.json",
+            // TODO add READs
+            )
+        SshBastionContainer(dbContainer.network).use { sshBastionContainer: SshBastionContainer ->
+            log.info { "testing key auth" }
+            SyncsTestFixture.testCheck(
+                config().apply {
+                    setTunnelMethodValue(sshBastionContainer.outerKeyAuthTunnelMethod)
+                }
+            )
+            log.info { "testing password auth" }
+            SyncsTestFixture.testCheck(
+                config().apply {
+                    setTunnelMethodValue(sshBastionContainer.outerPasswordAuthTunnelMethod)
+                }
+            )
+        }
+    }
+
+    companion object {
+
+        lateinit var dbContainer: OracleContainer
+
+        fun config(): OracleSourceConfigurationJsonObject =
+            OracleContainerFactory.config(dbContainer)
+
+        val connectionFactory: JdbcConnectionFactory by lazy {
+            JdbcConnectionFactory(OracleSourceConfigurationFactory().make(config()))
+        }
+
+        @JvmStatic
+        @BeforeAll
+        @Timeout(value = 300) // A high timeout value is required for Apple Silicon + colima.
+        fun startTestContainer() {
+            dbContainer =
+                OracleContainerFactory()
+                    .exclusive(
+                        "gvenzl/oracle-free:latest-faststart",
+                        OracleContainerFactory.withNetwork
+                    )
+        }
+
+        fun prelude(connection: Connection) {
+            for (case in OracleDatatypesTestFixture.testCases) {
+                for (sql in case.sqlStatements) {
+                    log.info { "executing $sql" }
+                    connection.createStatement().use { stmt -> stmt.execute(sql) }
+                }
+            }
+        }
+    }
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/test/resources/configured-catalog.json
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/test/resources/configured-catalog.json
@@ -1,0 +1,3320 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "FIBO_REF_SOURCE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "PREDECESSOR": {
+              "type": "number",
+              "airbyte_type": "integer"
+            },
+            "N": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["PREDECESSOR", "N"],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["PREDECESSOR", "N"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_BFILE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_BFILE": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_BINARY_DOUBLE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_BINARY_DOUBLE": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_BINARY_DOUBLE"],
+        "source_defined_primary_key": [["COL_BINARY_DOUBLE"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_BINARY_DOUBLE"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_BINARY_DOUBLE"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_BINARY_FLOAT",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_BINARY_FLOAT": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_BINARY_FLOAT"],
+        "source_defined_primary_key": [["COL_BINARY_FLOAT"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_BINARY_FLOAT"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_BINARY_FLOAT"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_BLOB",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_BLOB": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_BOOL",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_BOOL": {
+              "type": "boolean"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [["COL_BOOL"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_BOOL"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_BOOLEAN",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_BOOLEAN": {
+              "type": "boolean"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [["COL_BOOLEAN"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_BOOLEAN"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_CHAR",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_CHAR": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_CHAR"],
+        "source_defined_primary_key": [["COL_CHAR"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_CHAR"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_CHAR"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_CHARACTER_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_CHARACTER_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_CHARACTER_10"],
+        "source_defined_primary_key": [["COL_CHARACTER_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_CHARACTER_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_CHARACTER_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_CHARACTER_VARYING_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_CHARACTER_VARYING_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_CHARACTER_VARYING_10"],
+        "source_defined_primary_key": [["COL_CHARACTER_VARYING_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_CHARACTER_VARYING_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_CHARACTER_VARYING_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_CHAR_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_CHAR_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_CHAR_10"],
+        "source_defined_primary_key": [["COL_CHAR_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_CHAR_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_CHAR_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_CHAR_10_BYTE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_CHAR_10_BYTE": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_CHAR_10_BYTE"],
+        "source_defined_primary_key": [["COL_CHAR_10_BYTE"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_CHAR_10_BYTE"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_CHAR_10_BYTE"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_CHAR_10_CHAR",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_CHAR_10_CHAR": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_CHAR_10_CHAR"],
+        "source_defined_primary_key": [["COL_CHAR_10_CHAR"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_CHAR_10_CHAR"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_CHAR_10_CHAR"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_CHAR_VARYING_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_CHAR_VARYING_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_CHAR_VARYING_10"],
+        "source_defined_primary_key": [["COL_CHAR_VARYING_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_CHAR_VARYING_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_CHAR_VARYING_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_CLOB",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_CLOB": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_DATE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_DATE": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_DATE"],
+        "source_defined_primary_key": [["COL_DATE"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_DATE"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_DATE"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_DEC",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_DEC": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_DEC"],
+        "source_defined_primary_key": [["COL_DEC"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_DEC"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_DEC"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_DECIMAL",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_DECIMAL": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_DECIMAL"],
+        "source_defined_primary_key": [["COL_DECIMAL"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_DECIMAL"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_DECIMAL"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_DECIMAL_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_DECIMAL_10": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_DECIMAL_10"],
+        "source_defined_primary_key": [["COL_DECIMAL_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_DECIMAL_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_DECIMAL_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_DECIMAL_10_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_DECIMAL_10_2": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_DECIMAL_10_2"],
+        "source_defined_primary_key": [["COL_DECIMAL_10_2"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_DECIMAL_10_2"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_DECIMAL_10_2"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_DEC_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_DEC_10": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_DEC_10"],
+        "source_defined_primary_key": [["COL_DEC_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_DEC_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_DEC_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_DEC_10_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_DEC_10_2": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_DEC_10_2"],
+        "source_defined_primary_key": [["COL_DEC_10_2"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_DEC_10_2"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_DEC_10_2"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_DOUBLE_PRECISION",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_DOUBLE_PRECISION": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_DOUBLE_PRECISION"],
+        "source_defined_primary_key": [["COL_DOUBLE_PRECISION"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_DOUBLE_PRECISION"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_DOUBLE_PRECISION"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_FIBO_OBJTYP",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_FIBO_OBJTYP": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_FIBO_TBLTYP",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_FIBO_TBLTYP": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_FLOAT",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_FLOAT": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_FLOAT"],
+        "source_defined_primary_key": [["COL_FLOAT"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_FLOAT"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_FLOAT"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_FLOAT_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_FLOAT_10": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_FLOAT_10"],
+        "source_defined_primary_key": [["COL_FLOAT_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_FLOAT_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_FLOAT_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_INT",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_INT": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_INT"],
+        "source_defined_primary_key": [["COL_INT"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_INT"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_INT"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_INTEGER",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_INTEGER": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_INTEGER"],
+        "source_defined_primary_key": [["COL_INTEGER"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_INTEGER"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_INTEGER"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_INTERVAL_DAY_1_TO_SECOND",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_INTERVAL_DAY_1_TO_SECOND": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_INTERVAL_DAY_1_TO_SECOND"],
+        "source_defined_primary_key": [["COL_INTERVAL_DAY_1_TO_SECOND"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_INTERVAL_DAY_1_TO_SECOND"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_INTERVAL_DAY_1_TO_SECOND"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_INTERVAL_DAY_1_TO_SECOND_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_INTERVAL_DAY_1_TO_SECOND_2": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_INTERVAL_DAY_1_TO_SECOND_2"],
+        "source_defined_primary_key": [["COL_INTERVAL_DAY_1_TO_SECOND_2"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_INTERVAL_DAY_1_TO_SECOND_2"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_INTERVAL_DAY_1_TO_SECOND_2"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_INTERVAL_DAY_TO_SECOND",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_INTERVAL_DAY_TO_SECOND": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_INTERVAL_DAY_TO_SECOND"],
+        "source_defined_primary_key": [["COL_INTERVAL_DAY_TO_SECOND"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_INTERVAL_DAY_TO_SECOND"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_INTERVAL_DAY_TO_SECOND"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_INTERVAL_DAY_TO_SECOND_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_INTERVAL_DAY_TO_SECOND_2": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_INTERVAL_DAY_TO_SECOND_2"],
+        "source_defined_primary_key": [["COL_INTERVAL_DAY_TO_SECOND_2"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_INTERVAL_DAY_TO_SECOND_2"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_INTERVAL_DAY_TO_SECOND_2"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_INTERVAL_YEAR_4_TO_MONTH",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_INTERVAL_YEAR_4_TO_MONTH": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_INTERVAL_YEAR_4_TO_MONTH"],
+        "source_defined_primary_key": [["COL_INTERVAL_YEAR_4_TO_MONTH"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_INTERVAL_YEAR_4_TO_MONTH"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_INTERVAL_YEAR_4_TO_MONTH"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_INTERVAL_YEAR_TO_MONTH",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_INTERVAL_YEAR_TO_MONTH": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_INTERVAL_YEAR_TO_MONTH"],
+        "source_defined_primary_key": [["COL_INTERVAL_YEAR_TO_MONTH"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_INTERVAL_YEAR_TO_MONTH"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_INTERVAL_YEAR_TO_MONTH"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_JSON",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_JSON": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_LONG",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_LONG": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_LONG_RAW",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_LONG_RAW": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_NATIONAL_CHARACTER_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NATIONAL_CHARACTER_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NATIONAL_CHARACTER_10"],
+        "source_defined_primary_key": [["COL_NATIONAL_CHARACTER_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NATIONAL_CHARACTER_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NATIONAL_CHARACTER_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NATIONAL_CHARACTER_VARYING_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NATIONAL_CHARACTER_VARYING_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NATIONAL_CHARACTER_VARYING_10"],
+        "source_defined_primary_key": [["COL_NATIONAL_CHARACTER_VARYING_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NATIONAL_CHARACTER_VARYING_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NATIONAL_CHARACTER_VARYING_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NATIONAL_CHAR_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NATIONAL_CHAR_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NATIONAL_CHAR_10"],
+        "source_defined_primary_key": [["COL_NATIONAL_CHAR_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NATIONAL_CHAR_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NATIONAL_CHAR_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NATIONAL_CHAR_VARYING_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NATIONAL_CHAR_VARYING_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NATIONAL_CHAR_VARYING_10"],
+        "source_defined_primary_key": [["COL_NATIONAL_CHAR_VARYING_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NATIONAL_CHAR_VARYING_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NATIONAL_CHAR_VARYING_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NCHAR",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NCHAR": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NCHAR"],
+        "source_defined_primary_key": [["COL_NCHAR"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NCHAR"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NCHAR"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NCHAR_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NCHAR_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NCHAR_10"],
+        "source_defined_primary_key": [["COL_NCHAR_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NCHAR_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NCHAR_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NCHAR_VARYING_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NCHAR_VARYING_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NCHAR_VARYING_10"],
+        "source_defined_primary_key": [["COL_NCHAR_VARYING_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NCHAR_VARYING_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NCHAR_VARYING_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NCLOB",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NCLOB": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_NUMBER",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NUMBER": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NUMBER"],
+        "source_defined_primary_key": [["COL_NUMBER"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NUMBER"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NUMBER"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NUMBER_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NUMBER_10": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NUMBER_10"],
+        "source_defined_primary_key": [["COL_NUMBER_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NUMBER_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NUMBER_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NUMBER_10_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NUMBER_10_2": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NUMBER_10_2"],
+        "source_defined_primary_key": [["COL_NUMBER_10_2"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NUMBER_10_2"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NUMBER_10_2"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NUMERIC",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NUMERIC": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NUMERIC"],
+        "source_defined_primary_key": [["COL_NUMERIC"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NUMERIC"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NUMERIC"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NUMERIC_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NUMERIC_10": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NUMERIC_10"],
+        "source_defined_primary_key": [["COL_NUMERIC_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NUMERIC_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NUMERIC_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NUMERIC_10_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NUMERIC_10_2": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NUMERIC_10_2"],
+        "source_defined_primary_key": [["COL_NUMERIC_10_2"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NUMERIC_10_2"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NUMERIC_10_2"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_NVARCHAR2_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_NVARCHAR2_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_NVARCHAR2_10"],
+        "source_defined_primary_key": [["COL_NVARCHAR2_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_NVARCHAR2_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_NVARCHAR2_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_RAW_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_RAW_10": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [["COL_RAW_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_RAW_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_REAL",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_REAL": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_REAL"],
+        "source_defined_primary_key": [["COL_REAL"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_REAL"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_REAL"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_ROWID",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_ROWID": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [["COL_ROWID"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_ROWID"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_SDO_GEOMETRY",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_SDO_GEOMETRY": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_SDO_TOPO_GEOMETRY",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_SDO_TOPO_GEOMETRY": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_SMALLINT",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_SMALLINT": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_SMALLINT"],
+        "source_defined_primary_key": [["COL_SMALLINT"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_SMALLINT"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_SMALLINT"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_SYS_ANYDATA",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_SYS_ANYDATA": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_SYS_ANYDATASET",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_SYS_ANYDATASET": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_SYS_ANYTYPE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_SYS_ANYTYPE": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_TIMESTAMP",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_TIMESTAMP": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_without_timezone"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_TIMESTAMP"],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_TIMESTAMP"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_TIMESTAMP_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_TIMESTAMP_2": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_without_timezone"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_TIMESTAMP_2"],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_TIMESTAMP_2"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_with_timezone"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE"],
+        "source_defined_primary_key": [
+          ["COL_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE"]
+        ],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_TIMESTAMP_2_WITH_TIME_ZONE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_TIMESTAMP_2_WITH_TIME_ZONE": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_with_timezone"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_TIMESTAMP_2_WITH_TIME_ZONE"],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_TIMESTAMP_2_WITH_TIME_ZONE"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_TIMESTAMP_WITH_LOCAL_TIME_ZONE": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_with_timezone"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_TIMESTAMP_WITH_LOCAL_TIME_ZONE"],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_TIMESTAMP_WITH_LOCAL_TIME_ZONE"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_TIMESTAMP_WITH_TIME_ZONE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_TIMESTAMP_WITH_TIME_ZONE": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_with_timezone"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_TIMESTAMP_WITH_TIME_ZONE"],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_TIMESTAMP_WITH_TIME_ZONE"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_URITYPE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_URITYPE": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_UROWID",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_UROWID": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [["COL_UROWID"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_UROWID"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_UROWID_100",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_UROWID_100": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [["COL_UROWID_100"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_UROWID_100"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_VARCHAR2_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARCHAR2_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_VARCHAR2_10"],
+        "source_defined_primary_key": [["COL_VARCHAR2_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_VARCHAR2_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_VARCHAR2_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_VARCHAR2_10_BYTE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARCHAR2_10_BYTE": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_VARCHAR2_10_BYTE"],
+        "source_defined_primary_key": [["COL_VARCHAR2_10_BYTE"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_VARCHAR2_10_BYTE"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_VARCHAR2_10_BYTE"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_VARCHAR2_10_CHAR",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARCHAR2_10_CHAR": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_VARCHAR2_10_CHAR"],
+        "source_defined_primary_key": [["COL_VARCHAR2_10_CHAR"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_VARCHAR2_10_CHAR"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_VARCHAR2_10_CHAR"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_VARCHAR_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARCHAR_10": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": ["COL_VARCHAR_10"],
+        "source_defined_primary_key": [["COL_VARCHAR_10"]],
+        "namespace": "FOO"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["COL_VARCHAR_10"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["COL_VARCHAR_10"]]
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_BFILE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_BFILE": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "contentEncoding": "base64"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_BINARY_DOUBLE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_BINARY_DOUBLE": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_BINARY_FLOAT",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_BINARY_FLOAT": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_BOOL",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_BOOL": {
+              "type": "array",
+              "items": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_BOOLEAN",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_BOOLEAN": {
+              "type": "array",
+              "items": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_CHAR",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_CHAR": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_CHARACTER_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_CHARACTER_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_CHARACTER_VARYING_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_CHARACTER_VARYING_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_CHAR_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_CHAR_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_CHAR_10_BYTE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_CHAR_10_BYTE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_CHAR_10_CHAR",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_CHAR_10_CHAR": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_CHAR_VARYING_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_CHAR_VARYING_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_DATE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_DATE": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "date"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_DEC",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_DEC": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_DECIMAL",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_DECIMAL": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_DECIMAL_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_DECIMAL_10": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_DECIMAL_10_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_DECIMAL_10_2": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_DEC_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_DEC_10": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_DEC_10_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_DEC_10_2": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_DOUBLE_PRECISION",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_DOUBLE_PRECISION": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_FIBO_OBJTYP",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_FIBO_OBJTYP": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "oneOf": [
+                  {
+                    "type": "array"
+                  },
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "airbyte_type": "json"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_FLOAT",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_FLOAT": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_FLOAT_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_FLOAT_10": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_INT",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_INT": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "airbyte_type": "integer"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_INTEGER",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_INTEGER": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "airbyte_type": "integer"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_INTERVAL_DAY_1_TO_SECOND",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_INTERVAL_DAY_1_TO_SECOND": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_INTERVAL_DAY_1_TO_SECOND_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_INTERVAL_DAY_1_TO_SECOND_2": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_INTERVAL_DAY_TO_SECOND",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_INTERVAL_DAY_TO_SECOND": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_INTERVAL_DAY_TO_SECOND_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_INTERVAL_DAY_TO_SECOND_2": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_INTERVAL_YEAR_4_TO_MONTH",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_INTERVAL_YEAR_4_TO_MONTH": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_INTERVAL_YEAR_TO_MONTH",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_INTERVAL_YEAR_TO_MONTH": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NATIONAL_CHARACTER_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NATIONAL_CHARACTER_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NATIONAL_CHARACTER_VARYING_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NATIONAL_CHARACTER_VARYING_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NATIONAL_CHAR_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NATIONAL_CHAR_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NATIONAL_CHAR_VARYING_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NATIONAL_CHAR_VARYING_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NCHAR",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NCHAR": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NCHAR_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NCHAR_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NCHAR_VARYING_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NCHAR_VARYING_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NUMBER",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NUMBER": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NUMBER_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NUMBER_10": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NUMBER_10_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NUMBER_10_2": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NUMERIC",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NUMERIC": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NUMERIC_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NUMERIC_10": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NUMERIC_10_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NUMERIC_10_2": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_NVARCHAR2_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_NVARCHAR2_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_RAW_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_RAW_10": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "contentEncoding": "base64"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_REAL",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_REAL": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_SDO_GEOMETRY",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_SDO_GEOMETRY": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_SDO_TOPO_GEOMETRY",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_SDO_TOPO_GEOMETRY": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_SMALLINT",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_SMALLINT": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "airbyte_type": "integer"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_TIMESTAMP",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_TIMESTAMP": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "date-time",
+                "airbyte_type": "timestamp_without_timezone"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_TIMESTAMP_2",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_TIMESTAMP_2": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "date-time",
+                "airbyte_type": "timestamp_without_timezone"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "date-time",
+                "airbyte_type": "timestamp_with_timezone"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_TIMESTAMP_2_WITH_TIME_ZONE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_TIMESTAMP_2_WITH_TIME_ZONE": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "date-time",
+                "airbyte_type": "timestamp_with_timezone"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_TIMESTAMP_WITH_LOCAL_TIME_ZONE": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "date-time",
+                "airbyte_type": "timestamp_with_timezone"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_TIMESTAMP_WITH_TIME_ZONE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_TIMESTAMP_WITH_TIME_ZONE": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "date-time",
+                "airbyte_type": "timestamp_with_timezone"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_URITYPE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_URITYPE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_VARCHAR2_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_VARCHAR2_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_VARCHAR2_10_BYTE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_VARCHAR2_10_BYTE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_VARCHAR2_10_CHAR",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_VARCHAR2_10_CHAR": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_VARRAY_VARCHAR_10",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_VARRAY_VARCHAR_10": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    },
+    {
+      "stream": {
+        "name": "TBL_XMLTYPE",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "COL_XMLTYPE": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "FOO"
+      },
+      "sync_mode": "full_refresh",
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-oracle-v2/src/test/resources/expected-catalog.json
+++ b/airbyte-integrations/connectors/source-oracle-v2/src/test/resources/expected-catalog.json
@@ -1,0 +1,2496 @@
+{
+  "streams": [
+    {
+      "name": "FIBO_REF_SOURCE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "PREDECESSOR": {
+            "type": "number",
+            "airbyte_type": "integer"
+          },
+          "N": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["PREDECESSOR", "N"],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_BFILE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_BFILE": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_BINARY_DOUBLE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_BINARY_DOUBLE": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_BINARY_DOUBLE"],
+      "source_defined_primary_key": [["COL_BINARY_DOUBLE"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_BINARY_FLOAT",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_BINARY_FLOAT": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_BINARY_FLOAT"],
+      "source_defined_primary_key": [["COL_BINARY_FLOAT"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_BLOB",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_BLOB": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_BOOL",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_BOOL": {
+            "type": "boolean"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [["COL_BOOL"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_BOOLEAN",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_BOOLEAN": {
+            "type": "boolean"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [["COL_BOOLEAN"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_CHAR",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_CHAR": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_CHAR"],
+      "source_defined_primary_key": [["COL_CHAR"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_CHARACTER_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_CHARACTER_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_CHARACTER_10"],
+      "source_defined_primary_key": [["COL_CHARACTER_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_CHARACTER_VARYING_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_CHARACTER_VARYING_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_CHARACTER_VARYING_10"],
+      "source_defined_primary_key": [["COL_CHARACTER_VARYING_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_CHAR_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_CHAR_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_CHAR_10"],
+      "source_defined_primary_key": [["COL_CHAR_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_CHAR_10_BYTE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_CHAR_10_BYTE": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_CHAR_10_BYTE"],
+      "source_defined_primary_key": [["COL_CHAR_10_BYTE"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_CHAR_10_CHAR",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_CHAR_10_CHAR": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_CHAR_10_CHAR"],
+      "source_defined_primary_key": [["COL_CHAR_10_CHAR"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_CHAR_VARYING_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_CHAR_VARYING_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_CHAR_VARYING_10"],
+      "source_defined_primary_key": [["COL_CHAR_VARYING_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_CLOB",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_CLOB": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_DATE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_DATE": {
+            "type": "string",
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_DATE"],
+      "source_defined_primary_key": [["COL_DATE"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_DEC",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_DEC": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_DEC"],
+      "source_defined_primary_key": [["COL_DEC"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_DECIMAL",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_DECIMAL": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_DECIMAL"],
+      "source_defined_primary_key": [["COL_DECIMAL"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_DECIMAL_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_DECIMAL_10": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_DECIMAL_10"],
+      "source_defined_primary_key": [["COL_DECIMAL_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_DECIMAL_10_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_DECIMAL_10_2": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_DECIMAL_10_2"],
+      "source_defined_primary_key": [["COL_DECIMAL_10_2"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_DEC_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_DEC_10": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_DEC_10"],
+      "source_defined_primary_key": [["COL_DEC_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_DEC_10_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_DEC_10_2": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_DEC_10_2"],
+      "source_defined_primary_key": [["COL_DEC_10_2"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_DOUBLE_PRECISION",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_DOUBLE_PRECISION": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_DOUBLE_PRECISION"],
+      "source_defined_primary_key": [["COL_DOUBLE_PRECISION"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_FIBO_OBJTYP",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_FIBO_OBJTYP": {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "airbyte_type": "json"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_FIBO_TBLTYP",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_FIBO_TBLTYP": {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "airbyte_type": "json"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_FLOAT",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_FLOAT": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_FLOAT"],
+      "source_defined_primary_key": [["COL_FLOAT"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_FLOAT_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_FLOAT_10": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_FLOAT_10"],
+      "source_defined_primary_key": [["COL_FLOAT_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_INT",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_INT": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_INT"],
+      "source_defined_primary_key": [["COL_INT"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_INTEGER",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_INTEGER": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_INTEGER"],
+      "source_defined_primary_key": [["COL_INTEGER"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_INTERVAL_DAY_1_TO_SECOND",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_INTERVAL_DAY_1_TO_SECOND": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_INTERVAL_DAY_1_TO_SECOND"],
+      "source_defined_primary_key": [["COL_INTERVAL_DAY_1_TO_SECOND"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_INTERVAL_DAY_1_TO_SECOND_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_INTERVAL_DAY_1_TO_SECOND_2": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_INTERVAL_DAY_1_TO_SECOND_2"],
+      "source_defined_primary_key": [["COL_INTERVAL_DAY_1_TO_SECOND_2"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_INTERVAL_DAY_TO_SECOND",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_INTERVAL_DAY_TO_SECOND": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_INTERVAL_DAY_TO_SECOND"],
+      "source_defined_primary_key": [["COL_INTERVAL_DAY_TO_SECOND"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_INTERVAL_DAY_TO_SECOND_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_INTERVAL_DAY_TO_SECOND_2": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_INTERVAL_DAY_TO_SECOND_2"],
+      "source_defined_primary_key": [["COL_INTERVAL_DAY_TO_SECOND_2"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_INTERVAL_YEAR_4_TO_MONTH",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_INTERVAL_YEAR_4_TO_MONTH": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_INTERVAL_YEAR_4_TO_MONTH"],
+      "source_defined_primary_key": [["COL_INTERVAL_YEAR_4_TO_MONTH"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_INTERVAL_YEAR_TO_MONTH",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_INTERVAL_YEAR_TO_MONTH": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_INTERVAL_YEAR_TO_MONTH"],
+      "source_defined_primary_key": [["COL_INTERVAL_YEAR_TO_MONTH"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_JSON",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_JSON": {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "airbyte_type": "json"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_LONG",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_LONG": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_LONG_RAW",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_LONG_RAW": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NATIONAL_CHARACTER_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NATIONAL_CHARACTER_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NATIONAL_CHARACTER_10"],
+      "source_defined_primary_key": [["COL_NATIONAL_CHARACTER_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NATIONAL_CHARACTER_VARYING_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NATIONAL_CHARACTER_VARYING_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NATIONAL_CHARACTER_VARYING_10"],
+      "source_defined_primary_key": [["COL_NATIONAL_CHARACTER_VARYING_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NATIONAL_CHAR_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NATIONAL_CHAR_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NATIONAL_CHAR_10"],
+      "source_defined_primary_key": [["COL_NATIONAL_CHAR_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NATIONAL_CHAR_VARYING_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NATIONAL_CHAR_VARYING_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NATIONAL_CHAR_VARYING_10"],
+      "source_defined_primary_key": [["COL_NATIONAL_CHAR_VARYING_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NCHAR",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NCHAR": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NCHAR"],
+      "source_defined_primary_key": [["COL_NCHAR"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NCHAR_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NCHAR_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NCHAR_10"],
+      "source_defined_primary_key": [["COL_NCHAR_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NCHAR_VARYING_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NCHAR_VARYING_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NCHAR_VARYING_10"],
+      "source_defined_primary_key": [["COL_NCHAR_VARYING_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NCLOB",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NCLOB": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NUMBER",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NUMBER": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NUMBER"],
+      "source_defined_primary_key": [["COL_NUMBER"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NUMBER_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NUMBER_10": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NUMBER_10"],
+      "source_defined_primary_key": [["COL_NUMBER_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NUMBER_10_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NUMBER_10_2": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NUMBER_10_2"],
+      "source_defined_primary_key": [["COL_NUMBER_10_2"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NUMERIC",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NUMERIC": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NUMERIC"],
+      "source_defined_primary_key": [["COL_NUMERIC"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NUMERIC_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NUMERIC_10": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NUMERIC_10"],
+      "source_defined_primary_key": [["COL_NUMERIC_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NUMERIC_10_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NUMERIC_10_2": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NUMERIC_10_2"],
+      "source_defined_primary_key": [["COL_NUMERIC_10_2"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_NVARCHAR2_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_NVARCHAR2_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_NVARCHAR2_10"],
+      "source_defined_primary_key": [["COL_NVARCHAR2_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_RAW_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_RAW_10": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [["COL_RAW_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_REAL",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_REAL": {
+            "type": "number"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_REAL"],
+      "source_defined_primary_key": [["COL_REAL"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_ROWID",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_ROWID": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [["COL_ROWID"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_SDO_GEOMETRY",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_SDO_GEOMETRY": {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "airbyte_type": "json"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_SDO_TOPO_GEOMETRY",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_SDO_TOPO_GEOMETRY": {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "airbyte_type": "json"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_SMALLINT",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_SMALLINT": {
+            "type": "number",
+            "airbyte_type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_SMALLINT"],
+      "source_defined_primary_key": [["COL_SMALLINT"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_SYS_ANYDATA",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_SYS_ANYDATA": {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "airbyte_type": "json"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_SYS_ANYDATASET",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_SYS_ANYDATASET": {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "airbyte_type": "json"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_SYS_ANYTYPE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_SYS_ANYTYPE": {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "airbyte_type": "json"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_TIMESTAMP",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_TIMESTAMP": {
+            "type": "string",
+            "format": "date-time",
+            "airbyte_type": "timestamp_without_timezone"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_TIMESTAMP"],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_TIMESTAMP_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_TIMESTAMP_2": {
+            "type": "string",
+            "format": "date-time",
+            "airbyte_type": "timestamp_without_timezone"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_TIMESTAMP_2"],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE": {
+            "type": "string",
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE"],
+      "source_defined_primary_key": [["COL_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_TIMESTAMP_2_WITH_TIME_ZONE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_TIMESTAMP_2_WITH_TIME_ZONE": {
+            "type": "string",
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_TIMESTAMP_2_WITH_TIME_ZONE"],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_TIMESTAMP_WITH_LOCAL_TIME_ZONE": {
+            "type": "string",
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_TIMESTAMP_WITH_LOCAL_TIME_ZONE"],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_TIMESTAMP_WITH_TIME_ZONE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_TIMESTAMP_WITH_TIME_ZONE": {
+            "type": "string",
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_TIMESTAMP_WITH_TIME_ZONE"],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_URITYPE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_URITYPE": {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "airbyte_type": "json"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_UROWID",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_UROWID": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [["COL_UROWID"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_UROWID_100",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_UROWID_100": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [["COL_UROWID_100"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARCHAR2_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARCHAR2_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_VARCHAR2_10"],
+      "source_defined_primary_key": [["COL_VARCHAR2_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARCHAR2_10_BYTE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARCHAR2_10_BYTE": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_VARCHAR2_10_BYTE"],
+      "source_defined_primary_key": [["COL_VARCHAR2_10_BYTE"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARCHAR2_10_CHAR",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARCHAR2_10_CHAR": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_VARCHAR2_10_CHAR"],
+      "source_defined_primary_key": [["COL_VARCHAR2_10_CHAR"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARCHAR_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARCHAR_10": {
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "default_cursor_field": ["COL_VARCHAR_10"],
+      "source_defined_primary_key": [["COL_VARCHAR_10"]],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_BFILE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_BFILE": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_BINARY_DOUBLE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_BINARY_DOUBLE": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_BINARY_FLOAT",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_BINARY_FLOAT": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_BOOL",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_BOOL": {
+            "type": "array",
+            "items": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_BOOLEAN",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_BOOLEAN": {
+            "type": "array",
+            "items": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_CHAR",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_CHAR": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_CHARACTER_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_CHARACTER_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_CHARACTER_VARYING_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_CHARACTER_VARYING_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_CHAR_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_CHAR_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_CHAR_10_BYTE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_CHAR_10_BYTE": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_CHAR_10_CHAR",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_CHAR_10_CHAR": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_CHAR_VARYING_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_CHAR_VARYING_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_DATE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_DATE": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_DEC",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_DEC": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_DECIMAL",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_DECIMAL": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_DECIMAL_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_DECIMAL_10": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_DECIMAL_10_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_DECIMAL_10_2": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_DEC_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_DEC_10": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_DEC_10_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_DEC_10_2": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_DOUBLE_PRECISION",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_DOUBLE_PRECISION": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_FIBO_OBJTYP",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_FIBO_OBJTYP": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "airbyte_type": "json"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_FLOAT",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_FLOAT": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_FLOAT_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_FLOAT_10": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_INT",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_INT": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_INTEGER",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_INTEGER": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_INTERVAL_DAY_1_TO_SECOND",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_INTERVAL_DAY_1_TO_SECOND": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_INTERVAL_DAY_1_TO_SECOND_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_INTERVAL_DAY_1_TO_SECOND_2": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_INTERVAL_DAY_TO_SECOND",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_INTERVAL_DAY_TO_SECOND": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_INTERVAL_DAY_TO_SECOND_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_INTERVAL_DAY_TO_SECOND_2": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_INTERVAL_YEAR_4_TO_MONTH",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_INTERVAL_YEAR_4_TO_MONTH": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_INTERVAL_YEAR_TO_MONTH",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_INTERVAL_YEAR_TO_MONTH": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NATIONAL_CHARACTER_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NATIONAL_CHARACTER_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NATIONAL_CHARACTER_VARYING_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NATIONAL_CHARACTER_VARYING_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NATIONAL_CHAR_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NATIONAL_CHAR_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NATIONAL_CHAR_VARYING_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NATIONAL_CHAR_VARYING_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NCHAR",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NCHAR": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NCHAR_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NCHAR_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NCHAR_VARYING_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NCHAR_VARYING_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NUMBER",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NUMBER": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NUMBER_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NUMBER_10": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NUMBER_10_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NUMBER_10_2": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NUMERIC",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NUMERIC": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NUMERIC_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NUMERIC_10": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NUMERIC_10_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NUMERIC_10_2": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_NVARCHAR2_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_NVARCHAR2_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_RAW_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_RAW_10": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "contentEncoding": "base64"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_REAL",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_REAL": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_SDO_GEOMETRY",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_SDO_GEOMETRY": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_SDO_TOPO_GEOMETRY",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_SDO_TOPO_GEOMETRY": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_SMALLINT",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_SMALLINT": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "airbyte_type": "integer"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_TIMESTAMP",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_TIMESTAMP": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_without_timezone"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_TIMESTAMP_2",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_TIMESTAMP_2": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_without_timezone"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_TIMESTAMP_2_WITH_LOCAL_TIME_ZONE": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_with_timezone"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_TIMESTAMP_2_WITH_TIME_ZONE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_TIMESTAMP_2_WITH_TIME_ZONE": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_with_timezone"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_TIMESTAMP_WITH_LOCAL_TIME_ZONE": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_with_timezone"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_TIMESTAMP_WITH_TIME_ZONE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_TIMESTAMP_WITH_TIME_ZONE": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_with_timezone"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_URITYPE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_URITYPE": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_VARCHAR2_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_VARCHAR2_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_VARCHAR2_10_BYTE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_VARCHAR2_10_BYTE": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_VARCHAR2_10_CHAR",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_VARCHAR2_10_CHAR": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_VARRAY_VARCHAR_10",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_VARRAY_VARCHAR_10": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    },
+    {
+      "name": "TBL_XMLTYPE",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "COL_XMLTYPE": {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "airbyte_type": "json"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "default_cursor_field": [],
+      "source_defined_primary_key": [],
+      "namespace": "FOO"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Oracle-specific code for CHECK and DISCOVER. This is fairly comprehensive as far as all oracle-specific types are concerned.