### PR TITLE
rollback source-mysql to 3.3.25

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -19,8 +19,10 @@ data:
   name: MySQL
   registries:
     cloud:
+      dockerImageTag: 3.3.25
       enabled: true
     oss:
+      dockerImageTag: 3.3.25
       enabled: true
   releaseStage: generally_available
   releases:


### PR DESCRIPTION
Roll back source-mysql to 3.3.25 on cloud and OSS