### PR TITLE
allow BaseTypingDedupingTest to be interrupted

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.kt
@@ -1112,7 +1112,7 @@ abstract class BaseTypingDedupingTest {
         // TODO Eventually we'll want to somehow extract the state messages while a sync is running,
         // to
         // verify checkpointing.
-        destinationOutputFuture.join()
+        destinationOutputFuture.get()
         destination.close()
     }
 


### PR DESCRIPTION
When timing out, the LoggingInterceptor attempts to interrupt the test-executing thread. Unfortunately, the `CompletableFuture.join()` call is non-interruptible, which means we still had tests that were hanging forever. This changes it with `CompletableFuture.get()`, which is interruptible (even though the difference in behavior is not clearly documented. One has to notice that `get()` throws an `InterruptedException` while `join()` doesn't).