### PR TITLE
Regression tests: display stdout/stderr even if there was an exception before the report could be created.

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -420,13 +420,14 @@ class RegressionTests(Step):
 
         exit_code, stdout, stderr = await get_exec_result(container)
 
-        try:
+        if "report.html" not in await container.directory(f"{regression_tests_artifacts_dir}/session_{self.run_id}").entries():
+            main_logger.exception(
+                "The report file was not generated, an unhandled error likely happened during regression test execution, please check the step stderr and stdout for more details")
+            regression_test_report = None
+        else:
             await container.file(path_to_report).export(path_to_report)
             with open(path_to_report, "r") as fp:
                 regression_test_report = fp.read()
-        except Exception as exc:
-            main_logger.exception(f"Could not export or read report due to exception. traceback={traceback.format_exc()}", exc_info=exc)
-            regression_test_report = None
 
         return StepResult(
             step=self,

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -422,7 +422,8 @@ class RegressionTests(Step):
 
         if "report.html" not in await container.directory(f"{regression_tests_artifacts_dir}/session_{self.run_id}").entries():
             main_logger.exception(
-                "The report file was not generated, an unhandled error likely happened during regression test execution, please check the step stderr and stdout for more details")
+                "The report file was not generated, an unhandled error likely happened during regression test execution, please check the step stderr and stdout for more details"
+            )
             regression_test_report = None
         else:
             await container.file(path_to_report).export(path_to_report)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -7,6 +7,7 @@
 import datetime
 import os
 import time
+import traceback
 from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
@@ -17,7 +18,7 @@ import requests  # type: ignore
 import semver
 import yaml  # type: ignore
 from dagger import Container, Directory
-from pipelines import hacks
+from pipelines import hacks, main_logger
 from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.airbyte_ci.steps.docker import SimpleDockerStep
@@ -416,12 +417,16 @@ class RegressionTests(Step):
         container = container.with_(hacks.never_fail_exec(self.regression_tests_command()))
         regression_tests_artifacts_dir = str(self.regression_tests_artifacts_dir)
         path_to_report = f"{regression_tests_artifacts_dir}/session_{self.run_id}/report.html"
-        await container.file(path_to_report).export(path_to_report)
 
         exit_code, stdout, stderr = await get_exec_result(container)
 
-        with open(path_to_report, "r") as fp:
-            regression_test_report = fp.read()
+        try:
+            await container.file(path_to_report).export(path_to_report)
+            with open(path_to_report, "r") as fp:
+                regression_test_report = fp.read()
+        except Exception as exc:
+            main_logger.exception(f"Could not export or read report due to exception. traceback={traceback.format_exc()}", exc_info=exc)
+            regression_test_report = None
 
         return StepResult(
             step=self,


### PR DESCRIPTION
Currently if there's an exception running regression tests before the report is written, we get a generic exception that the report couldn't be exported from the container because it does not exist.

However, this causes us to not be able to see the stderr/stdout.

This code change makes a small modification so to handle the exception exporting the report so we can still see the stderr/stdout of the container.