### PR TITLE
[connectors_qa] Remove DOCKER_HUB_USERNAME check

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -105,17 +105,28 @@ poe type_check
 ```bash
 poe lint
 ```
+
 ## Changelog
+
+### 1.3.1
+
+- Removed `DOCKER_HUB_USERNAME` as a requirement from `connectors_qa` package. The actual medatada
+  validation will still fail if the env variables are not provided.
+- Removed a check on whether documentation file exists from `MetadataCheck` in favor of the existing
+  check in `DocumentationCheck`.
 
 ### 1.3.0
 
-Added `CheckConnectorMaxSecondsBetweenMessagesValue` check that verifies presence of `maxSecondsBetweenMessages` value in `metadata.yaml` file for all source certified connectors.
+Added `CheckConnectorMaxSecondsBetweenMessagesValue` check that verifies presence of
+`maxSecondsBetweenMessages` value in `metadata.yaml` file for all source certified connectors.
 
 ### 1.2.0
 
-Added `ValidateBreakingChangesDeadlines` check that verifies the minimal compliance of breaking change rollout deadline.
+Added `ValidateBreakingChangesDeadlines` check that verifies the minimal compliance of breaking
+change rollout deadline.
 
 ### 1.1.0
+
 Introduced the `Check.run_on_released_connectors` flag.
 
 ### 1.0.4
@@ -137,4 +148,5 @@ Fix access to connector types: it should be accessed from the `Connector.connect
 - Make `CheckPublishToPyPiIsEnabled` run on source connectors only.
 
 ### 1.0.0
+
 Initial release of `connectors-qa` package.

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -1,12 +1,10 @@
 [tool.poetry]
 name = "connectors-qa"
-version = "1.3.0"
+version = "1.3.1"
 description = "A package to run QA checks on Airbyte connectors, generate reports and documentation."
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"
-packages = [
-    { include = "connectors_qa", from = "src" },
-]
+packages = [{ include = "connectors_qa", from = "src" }]
 [tool.poetry.dependencies]
 python = "^3.10"
 airbyte-connectors-base-images = { path = "../base_images", develop = false }

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py
@@ -18,25 +18,8 @@ class MetadataCheck(Check):
 class ValidateMetadata(MetadataCheck):
     name = f"Connectors must have valid {consts.METADATA_FILE_NAME} file"
     description = f"Connectors must have a `{consts.METADATA_FILE_NAME}` file at the root of their directory. This file is used to build our connector registry. Its structure must follow our metadata schema. Field values are also validated. This is to ensure that all connectors have the required metadata fields and that the metadata is valid. More details in this [documentation]({consts.METADATA_DOCUMENTATION_URL})."
-    # Metadata lib required the following env var to be set
-    # to check if the base image is on DockerHub
-    required_env_vars = {
-        consts.DOCKER_HUB_USERNAME_ENV_VAR_NAME,
-        consts.DOCKER_HUB_PASSWORD_ENV_VAR_NAME,
-    }
-
-    def __init__(self) -> None:
-        for env_var in self.required_env_vars:
-            if env_var not in os.environ:
-                raise ValueError(f"Environment variable {env_var} is required for this check")
-        super().__init__()
 
     def _run(self, connector: Connector) -> CheckResult:
-        if not connector.documentation_file_path or not connector.documentation_file_path.exists():
-            return self.fail(
-                connector=connector,
-                message="User facing documentation file is missing. Please create it",
-            )
         deserialized_metadata, error = validate_and_load(
             connector.metadata_file_path,
             PRE_UPLOAD_VALIDATORS,
@@ -47,7 +30,7 @@ class ValidateMetadata(MetadataCheck):
 
         return self.pass_(
             connector=connector,
-            message="Metadata file valid.",
+            message="Metadata file is valid.",
         )
 
 

--- a/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_metadata.py
+++ b/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_metadata.py
@@ -9,47 +9,6 @@ from connectors_qa.models import CheckStatus
 
 
 class TestValidateMetadata:
-    def test_fail_init_when_required_env_vars_are_not_set(self, random_string, mocker):
-        # Arrange
-        mocker.patch.object(metadata.ValidateMetadata, "required_env_vars", new={random_string})
-
-        # Act
-        with pytest.raises(ValueError):
-            metadata.ValidateMetadata()
-
-    def test_init_when_required_env_vars_are_set(self, random_string, mocker):
-        # Arrange
-        os.environ[random_string] = "test"
-        mocker.patch.object(metadata.ValidateMetadata, "required_env_vars", new={random_string})
-
-        # Act
-        metadata.ValidateMetadata()
-
-        os.environ.pop(random_string)
-
-    def test_fail_when_documentation_file_path_is_none(self, mocker):
-        # Arrange
-        connector = mocker.MagicMock(documentation_file_path=None)
-
-        # Act
-        result = metadata.ValidateMetadata()._run(connector)
-
-        # Assert
-        assert result.status == CheckStatus.FAILED
-        assert result.message == "User facing documentation file is missing. Please create it"
-
-    def test_fail_when_documentation_file_path_does_not_exist(self, mocker, tmp_path):
-        # Arrange
-
-        connector = mocker.MagicMock(documentation_file_path=tmp_path / "doc.md")
-
-        # Act
-        result = metadata.ValidateMetadata()._run(connector)
-
-        # Assert
-        assert result.status == CheckStatus.FAILED
-        assert result.message == "User facing documentation file is missing. Please create it"
-
     def test_fail_when_deserialization_fails(self, mocker, tmp_path):
         # Arrange
         mocker.patch.object(metadata, "validate_and_load", return_value=(None, "error"))
@@ -76,7 +35,7 @@ class TestValidateMetadata:
 
         # Assert
         assert result.status == CheckStatus.PASSED
-        assert result.message == "Metadata file valid."
+        assert result.message == "Metadata file is valid."
 
 
 class TestCheckConnectorLanguageTag:
@@ -226,7 +185,7 @@ class TestCheckConnectorMaxSecondsBetweenMessagesValue:
     def test_pass_when_field_present(self, mocker):
         # Arrange
         connector = mocker.MagicMock(metadata={"supportLevel": "certified", "maxSecondsBetweenMessages": 1})
-        
+
         # Act
         result = metadata.CheckConnectorMaxSecondsBetweenMessagesValue()._run(connector)
 


### PR DESCRIPTION
## What

This PR cleans up `connectors_qa` a little bit, but does not change what it does functionally:

- Let DOCKER_HUB_USERNAME be checked in `metadata_lib` instead. It will error out if it's missing anyway.
- Remove redundant check on documentation file in MetadataValidator. It's already checked in `documentation_validator` separately.

## Why

I was trying to figure out CI failures in #37839, and one of them (documentation test of `connectors_qa` itself) led me to running connectors_qa checks locally, which did not work, because `DOCKER_HUB_USERNAME`. I filed #38011 to address this.

Also, closes #38011.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
