### PR TITLE
[connectors-qa] Remove unrelated docs check

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -105,7 +105,12 @@ poe type_check
 ```bash
 poe lint
 ```
+
 ## Changelog
+
+### 1.3.2
+
+Removed documentation checks in `MedatadaCheck` since it's already verified in `DocumentationCheck`.
 
 ### 1.3.1
 
@@ -113,13 +118,16 @@ Remove requirements on DockerHub credentials to run metadata validation.
 
 ### 1.3.0
 
-Added `CheckConnectorMaxSecondsBetweenMessagesValue` check that verifies presence of `maxSecondsBetweenMessages` value in `metadata.yaml` file for all source certified connectors.
+Added `CheckConnectorMaxSecondsBetweenMessagesValue` check that verifies presence of
+`maxSecondsBetweenMessages` value in `metadata.yaml` file for all source certified connectors.
 
 ### 1.2.0
 
-Added `ValidateBreakingChangesDeadlines` check that verifies the minimal compliance of breaking change rollout deadline.
+Added `ValidateBreakingChangesDeadlines` check that verifies the minimal compliance of breaking
+change rollout deadline.
 
 ### 1.1.0
+
 Introduced the `Check.run_on_released_connectors` flag.
 
 ### 1.0.4
@@ -141,4 +149,5 @@ Fix access to connector types: it should be accessed from the `Connector.connect
 - Make `CheckPublishToPyPiIsEnabled` run on source connectors only.
 
 ### 1.0.0
+
 Initial release of `connectors-qa` package.

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -1,12 +1,10 @@
 [tool.poetry]
 name = "connectors-qa"
-version = "1.3.1"
+version = "1.3.2"
 description = "A package to run QA checks on Airbyte connectors, generate reports and documentation."
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"
-packages = [
-    { include = "connectors_qa", from = "src" },
-]
+packages = [{ include = "connectors_qa", from = "src" }]
 [tool.poetry.dependencies]
 python = "^3.10"
 airbyte-connectors-base-images = { path = "../base_images", develop = false }

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/metadata.py
@@ -20,11 +20,6 @@ class ValidateMetadata(MetadataCheck):
     description = f"Connectors must have a `{consts.METADATA_FILE_NAME}` file at the root of their directory. This file is used to build our connector registry. Its structure must follow our metadata schema. Field values are also validated. This is to ensure that all connectors have the required metadata fields and that the metadata is valid. More details in this [documentation]({consts.METADATA_DOCUMENTATION_URL})."
 
     def _run(self, connector: Connector) -> CheckResult:
-        if not connector.documentation_file_path or not connector.documentation_file_path.exists():
-            return self.fail(
-                connector=connector,
-                message="User facing documentation file is missing. Please create it",
-            )
         deserialized_metadata, error = validate_and_load(
             connector.metadata_file_path,
             PRE_UPLOAD_VALIDATORS,

--- a/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_metadata.py
+++ b/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_metadata.py
@@ -10,29 +10,6 @@ from connectors_qa.models import CheckStatus
 
 class TestValidateMetadata:
 
-    def test_fail_when_documentation_file_path_is_none(self, mocker):
-        # Arrange
-        connector = mocker.MagicMock(documentation_file_path=None)
-
-        # Act
-        result = metadata.ValidateMetadata()._run(connector)
-
-        # Assert
-        assert result.status == CheckStatus.FAILED
-        assert result.message == "User facing documentation file is missing. Please create it"
-
-    def test_fail_when_documentation_file_path_does_not_exist(self, mocker, tmp_path):
-        # Arrange
-
-        connector = mocker.MagicMock(documentation_file_path=tmp_path / "doc.md")
-
-        # Act
-        result = metadata.ValidateMetadata()._run(connector)
-
-        # Assert
-        assert result.status == CheckStatus.FAILED
-        assert result.message == "User facing documentation file is missing. Please create it"
-
     def test_fail_when_deserialization_fails(self, mocker, tmp_path):
         # Arrange
         mocker.patch.object(metadata, "validate_and_load", return_value=(None, "error"))
@@ -209,7 +186,7 @@ class TestCheckConnectorMaxSecondsBetweenMessagesValue:
     def test_pass_when_field_present(self, mocker):
         # Arrange
         connector = mocker.MagicMock(metadata={"supportLevel": "certified", "maxSecondsBetweenMessages": 1})
-        
+
         # Act
         result = metadata.CheckConnectorMaxSecondsBetweenMessagesValue()._run(connector)
 


### PR DESCRIPTION
## What

This PR only removes a check of whether docs exist for a connector in `MetadataCheck`, because it's already validated in `DocumentationCheck`. 

It's extracted from #38017.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
