### PR TITLE
airbyte-ci: add auto_merge as an internal package

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -745,7 +745,8 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.13.0  | [#32715](https://github.com/airbytehq/airbyte/pull/32715)  | Tag connector metadata with git info                                                                                       |
+| 4.13.1  | [#38020](https://github.com/airbytehq/airbyte/pull/38020)  | Add `auto_merge` as an internal package to test.                                                                             |
+| 4.13.0  | [#32715](https://github.com/airbytehq/airbyte/pull/32715)  | Tag connector metadata with git info                                                                                         |
 | 4.12.7  | [#37787](https://github.com/airbytehq/airbyte/pull/37787)  | Remove requirements on dockerhub credentials to run QA checks.                                                               |
 | 4.12.6  | [#36497](https://github.com/airbytehq/airbyte/pull/36497)  | Add airbyte-cdk to list of poetry packages for testing                                                                       |
 | 4.12.5  | [#37785](https://github.com/airbytehq/airbyte/pull/37785)  | Set the `--yes-auto-update` flag to `True` by default.                                                                       |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/__init__.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/__init__.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 
 INTERNAL_POETRY_PACKAGES = [
+    "airbyte-ci/connectors/auto_merge",
     "airbyte-ci/connectors/pipelines",
     "airbyte-ci/connectors/base_images",
     "airbyte-ci/connectors/common_utils",

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.13.0"
+version = "4.13.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
Relates to https://github.com/airbytehq/airbyte-internal-issues/issues/7554
This PR will add CI steps to check the health of the `auto_merge` package.
Only type checks and linting will run ATM according to the content of the `pyproject.toml` file of the `auto_merge` package.