### PR TITLE
Destinations: Refreshes: CDK updates

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -174,6 +174,7 @@ corresponds to that version.
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.39.0  | 2024-06-17 | [\#38067](https://github.com/airbytehq/airbyte/pull/38067) | Destinations: Breaking changes for refreshes (fail on INCOMPLETE stream status; ignore OVERWRITE sync mode)                                                    |
 | 0.38.2  | 2024-06-14 | [\#39460](https://github.com/airbytehq/airbyte/pull/39460) | Bump postgres JDBC driver version                                                                                                                              |
 | 0.38.1  | 2024-06-13 | [\#39445](https://github.com/airbytehq/airbyte/pull/39445) | Sources: More CDK changes to handle big initial snapshots.                                                                                                     |
 | 0.38.0  | 2024-06-11 | [\#39405](https://github.com/airbytehq/airbyte/pull/39405) | Sources: Debezium properties manager interface changed to accept a list of streams to scope to                                                                 |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumer.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumer.kt
@@ -162,13 +162,16 @@ constructor(
 
         bufferManager.close()
 
+        val unsuccessfulStreams = ArrayList<StreamDescriptor>()
         val streamSyncSummaries =
             streamNames.associate { streamDescriptor ->
-                // If we didn't receive a stream status message, assume success.
-                // Platform won't send us any stream status messages yet (since we're not declaring
-                // supportsRefresh in metadata), so we will always hit this case.
+                // If we didn't receive a stream status message, assume failure.
+                // This is possible if e.g. the orchestrator crashes before sending us the message.
                 val terminalStatusFromSource =
-                    terminalStatusesFromSource[streamDescriptor] ?: AirbyteStreamStatus.COMPLETE
+                    terminalStatusesFromSource[streamDescriptor] ?: AirbyteStreamStatus.INCOMPLETE
+                if (terminalStatusFromSource == AirbyteStreamStatus.INCOMPLETE) {
+                    unsuccessfulStreams.add(streamDescriptor)
+                }
                 StreamDescriptorUtils.withDefaultNamespace(
                     streamDescriptor,
                     bufferManager.defaultNamespace,
@@ -183,6 +186,17 @@ constructor(
         // as this throws an exception, we need to be after all other close functions.
         propagateFlushWorkerExceptionIfPresent()
         logger.info { "${AsyncStreamConsumer::class.java} closed" }
+
+        // In principle, platform should detect this.
+        // However, as a backstop, the destination should still do this check.
+        // This handles e.g. platform bugs where we don't receive a stream status message.
+        // In this case, it would be misleading to mark the sync as successful, because e.g. we
+        // maybe didn't commit a truncate.
+        if (unsuccessfulStreams.isNotEmpty()) {
+            throw RuntimeException(
+                "Some streams were unsuccessful due to a source error: $unsuccessfulStreams"
+            )
+        }
     }
 
     private fun getRecordCounter(streamDescriptor: StreamDescriptor): AtomicLong {

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.38.2
+version=0.39.0

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumerTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumerTest.kt
@@ -148,6 +148,26 @@ class AsyncStreamConsumerTest {
                             ),
                     ),
             )
+        private val STREAM2_SUCCESS_MESSAGE =
+            Jsons.serialize(
+                AirbyteMessage()
+                    .withType(AirbyteMessage.Type.TRACE)
+                    .withTrace(
+                        AirbyteTraceMessage()
+                            .withType(AirbyteTraceMessage.Type.STREAM_STATUS)
+                            .withStreamStatus(
+                                AirbyteStreamStatusTraceMessage()
+                                    .withStreamDescriptor(
+                                        StreamDescriptor()
+                                            .withName(STREAM_NAME2)
+                                            .withNamespace(SCHEMA_NAME),
+                                    )
+                                    .withStatus(
+                                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE
+                                    ),
+                            ),
+                    ),
+            )
         private val STREAM2_FAILURE_MESSAGE =
             Jsons.serialize(
                 AirbyteMessage()
@@ -262,6 +282,9 @@ class AsyncStreamConsumerTest {
         consumer.start()
         consumeRecords(consumer, expectedRecords)
         consumer.accept(Jsons.serialize(STATE_MESSAGE1), RECORD_SIZE_20_BYTES)
+        consumer.accept(STREAM1_SUCCESS_MESSAGE, STREAM1_SUCCESS_MESSAGE.length)
+        consumer.accept(STREAM2_SUCCESS_MESSAGE, STREAM2_SUCCESS_MESSAGE.length)
+        consumer.accept(STREAM3_SUCCESS_MESSAGE, STREAM3_SUCCESS_MESSAGE.length)
         consumer.close()
 
         verifyStartAndClose()
@@ -298,6 +321,9 @@ class AsyncStreamConsumerTest {
         consumeRecords(consumer, expectedRecords)
         consumer.accept(Jsons.serialize(STATE_MESSAGE1), RECORD_SIZE_20_BYTES)
         consumer.accept(Jsons.serialize(STATE_MESSAGE2), RECORD_SIZE_20_BYTES)
+        consumer.accept(STREAM1_SUCCESS_MESSAGE, STREAM1_SUCCESS_MESSAGE.length)
+        consumer.accept(STREAM2_SUCCESS_MESSAGE, STREAM2_SUCCESS_MESSAGE.length)
+        consumer.accept(STREAM3_SUCCESS_MESSAGE, STREAM3_SUCCESS_MESSAGE.length)
         consumer.close()
 
         verifyStartAndClose()
@@ -334,6 +360,9 @@ class AsyncStreamConsumerTest {
 
         consumer.start()
         consumeRecords(consumer, allRecords)
+        consumer.accept(STREAM1_SUCCESS_MESSAGE, STREAM1_SUCCESS_MESSAGE.length)
+        consumer.accept(STREAM2_SUCCESS_MESSAGE, STREAM2_SUCCESS_MESSAGE.length)
+        consumer.accept(STREAM3_SUCCESS_MESSAGE, STREAM3_SUCCESS_MESSAGE.length)
         consumer.close()
 
         verifyStartAndClose()
@@ -496,7 +525,8 @@ class AsyncStreamConsumerTest {
         consumer.accept(STREAM1_SUCCESS_MESSAGE, STREAM1_SUCCESS_MESSAGE.length)
         consumer.accept(STREAM2_FAILURE_MESSAGE, STREAM2_FAILURE_MESSAGE.length)
         consumer.accept(STREAM3_SUCCESS_MESSAGE, STREAM3_SUCCESS_MESSAGE.length)
-        consumer.close()
+        // We had a failure, so expect an exception
+        assertThrows(RuntimeException::class.java) { consumer.close() }
 
         val captor: ArgumentCaptor<Map<StreamDescriptor, StreamSyncSummary>> =
             ArgumentCaptor.captor()
@@ -532,29 +562,29 @@ class AsyncStreamConsumerTest {
         consumer.start()
         consumeRecords(consumer, expectedRecords)
         // Note: no stream status messages
-        consumer.close()
+        // We assume stream failure, so expect an exception
+        assertThrows(RuntimeException::class.java) { consumer.close() }
 
         val captor: ArgumentCaptor<Map<StreamDescriptor, StreamSyncSummary>> =
             ArgumentCaptor.captor()
         Mockito.verify(onClose).accept(any(), capture(captor))
         assertEquals(
-            // All streams have a COMPLETE status.
-            // TODO: change this to INCOMPLETE after we switch the default behavior.
+            // All streams have an INCOMPLETE status.
             mapOf(
                 StreamDescriptor().withNamespace(SCHEMA_NAME).withName(STREAM_NAME) to
                     StreamSyncSummary(
                         expectedRecords.size.toLong(),
-                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.INCOMPLETE,
                     ),
                 StreamDescriptor().withNamespace(SCHEMA_NAME).withName(STREAM_NAME2) to
                     StreamSyncSummary(
                         0,
-                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.INCOMPLETE,
                     ),
                 StreamDescriptor().withNamespace(DEFAULT_NAMESPACE).withName(STREAM_NAME3) to
                     StreamSyncSummary(
                         0,
-                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.INCOMPLETE,
                     ),
             ),
             captor.value,


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/7606

These are the changes that break platform compatibility. We shouldn't release this until platform is ready for it, and we can turn on the `supportsRefreshes` metadata in destinations.