### PR TITLE
java-cdk: fix LoggingInvocationInterceptor for dynamic tests

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/testFixtures/kotlin/io/airbyte/cdk/extensions/LoggingInvocationInterceptor.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/testFixtures/kotlin/io/airbyte/cdk/extensions/LoggingInvocationInterceptor.kt
@@ -36,16 +36,19 @@ class LoggingInvocationInterceptor : InvocationInterceptor {
     private class LoggingInvocationInterceptorHandler : InvocationHandler {
         @Throws(Throwable::class)
         override fun invoke(proxy: Any, method: Method, args: Array<Any>): Any? {
-            if (
-                LoggingInvocationInterceptor::class
-                    .java
-                    .getDeclaredMethod(
+            val methodName = method.name
+            val invocationContextClass: Class<*> = when (methodName) {
+                "interceptDynamicTest" -> DynamicTestInvocationContext::class.java
+                else -> ReflectiveInvocationContext::class.java
+            }
+            try {
+                LoggingInvocationInterceptor::class.java.getDeclaredMethod(
                         method.name,
                         InvocationInterceptor.Invocation::class.java,
-                        ReflectiveInvocationContext::class.java,
+                        invocationContextClass,
                         ExtensionContext::class.java
-                    ) == null
-            ) {
+                    )
+            } catch (_: NoSuchMethodException) {
                 LOGGER.error(
                     "Junit LoggingInvocationInterceptor executing unknown interception point {}",
                     method.name
@@ -53,9 +56,8 @@ class LoggingInvocationInterceptor : InvocationInterceptor {
                 return method.invoke(proxy, *(args))
             }
             val invocation = args[0] as InvocationInterceptor.Invocation<*>?
-            val invocationContext = args[1] as ReflectiveInvocationContext<*>
+            val reflectiveInvocationContext = args[1] as? ReflectiveInvocationContext<*>
             val extensionContext = args[2] as ExtensionContext?
-            val methodName = method.name
             val logLineSuffix: String
             val methodMatcher = methodPattern.matcher(methodName)
             if (methodName == "interceptDynamicTest") {
@@ -63,12 +65,12 @@ class LoggingInvocationInterceptor : InvocationInterceptor {
                     "execution of DynamicTest %s".formatted(extensionContext!!.displayName)
             } else if (methodName == "interceptTestClassConstructor") {
                 logLineSuffix =
-                    "instance creation for %s".formatted(invocationContext!!.targetClass)
+                    "instance creation for %s".formatted(reflectiveInvocationContext!!.targetClass)
             } else if (methodMatcher.matches()) {
                 val interceptedEvent = methodMatcher.group(1)
-                val methodRealClassName = invocationContext!!.executable!!.declaringClass.simpleName
-                val methodName = invocationContext.executable!!.name
-                val targetClassName = invocationContext!!.targetClass.simpleName
+                val methodRealClassName = reflectiveInvocationContext!!.executable!!.declaringClass.simpleName
+                val methodName = reflectiveInvocationContext.executable!!.name
+                val targetClassName = reflectiveInvocationContext.targetClass.simpleName
                 val methodDisplayName =
                     if (targetClassName == methodRealClassName) methodName
                     else "$methodName($methodRealClassName)"
@@ -86,7 +88,7 @@ class LoggingInvocationInterceptor : InvocationInterceptor {
             val timeoutTask = TimeoutInteruptor(currentThread)
             val start = Instant.now()
             try {
-                val timeout = getTimeout(invocationContext)
+                val timeout = reflectiveInvocationContext?.let(::getTimeout)
                 if (timeout != null) {
                     LOGGER.info(
                         "Junit starting {} with timeout of {}",

--- a/airbyte-cdk/java/airbyte-cdk/core/src/testFixtures/kotlin/io/airbyte/cdk/extensions/LoggingInvocationInterceptor.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/testFixtures/kotlin/io/airbyte/cdk/extensions/LoggingInvocationInterceptor.kt
@@ -37,12 +37,15 @@ class LoggingInvocationInterceptor : InvocationInterceptor {
         @Throws(Throwable::class)
         override fun invoke(proxy: Any, method: Method, args: Array<Any>): Any? {
             val methodName = method.name
-            val invocationContextClass: Class<*> = when (methodName) {
-                "interceptDynamicTest" -> DynamicTestInvocationContext::class.java
-                else -> ReflectiveInvocationContext::class.java
-            }
+            val invocationContextClass: Class<*> =
+                when (methodName) {
+                    "interceptDynamicTest" -> DynamicTestInvocationContext::class.java
+                    else -> ReflectiveInvocationContext::class.java
+                }
             try {
-                LoggingInvocationInterceptor::class.java.getDeclaredMethod(
+                LoggingInvocationInterceptor::class
+                    .java
+                    .getDeclaredMethod(
                         method.name,
                         InvocationInterceptor.Invocation::class.java,
                         invocationContextClass,
@@ -68,7 +71,8 @@ class LoggingInvocationInterceptor : InvocationInterceptor {
                     "instance creation for %s".formatted(reflectiveInvocationContext!!.targetClass)
             } else if (methodMatcher.matches()) {
                 val interceptedEvent = methodMatcher.group(1)
-                val methodRealClassName = reflectiveInvocationContext!!.executable!!.declaringClass.simpleName
+                val methodRealClassName =
+                    reflectiveInvocationContext!!.executable!!.declaringClass.simpleName
                 val methodName = reflectiveInvocationContext.executable!!.name
                 val targetClassName = reflectiveInvocationContext.targetClass.simpleName
                 val methodDisplayName =


### PR DESCRIPTION
This broke when I tried to write junit dynamic tests. This patch fixes things.