### PR TITLE
java-cdk: fix ContainerFactory logging

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/testFixtures/kotlin/io/airbyte/cdk/testutils/ContainerFactory.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/testFixtures/kotlin/io/airbyte/cdk/testutils/ContainerFactory.kt
@@ -73,7 +73,7 @@ abstract class ContainerFactory<C : GenericContainer<*>> {
                 "testcontainer %s (%s[%s]):".formatted(
                     containerId!!.incrementAndGet(),
                     imageName,
-                    StringUtils.join(containerModifiers, ",")
+                    StringUtils.join(containerModifiers.map { it.name() }, ",")
                 )
             )
             .setPrefixColor(LoggingHelper.Color.RED_BACKGROUND)


### PR DESCRIPTION
Shortens and prettifies the testcontainer logging prefix by printing out the name of the modifier instead of its ugly `.toString()` value.