### PR TITLE
Destinations: Refreshes: Track stream statuses in async framework

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -174,6 +174,7 @@ corresponds to that version.
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.37.1  | 2024-06-10 | [\#38075](https://github.com/airbytehq/airbyte/pull/38075) | Destinations: Track stream statuses in async framework |
 | 0.37.0  | 2024-06-10 | [\#38121](https://github.com/airbytehq/airbyte/pull/38121) | Destinations: Set default namespace via CatalogParser |
 | 0.36.8  | 2024-06-07 | [\#38763](https://github.com/airbytehq/airbyte/pull/38763) | Increase Jackson message length limit |
 | 0.36.7  | 2024-06-06 | [\#39220](https://github.com/airbytehq/airbyte/pull/39220) | Handle null messages in ConnectorExceptionUtil |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/StreamSyncSummary.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/StreamSyncSummary.kt
@@ -3,17 +3,9 @@
  */
 package io.airbyte.cdk.integrations.destination
 
-import java.util.*
+import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage.AirbyteStreamStatus
 
-/**
- * @param recordsWritten The number of records written to the stream, or empty if the caller does
- * not track this information. (this is primarily for backwards-compatibility with the legacy
- * destinations framework; new implementations should always provide this information). If this
- * value is empty, consumers should assume that the sync wrote nonzero records for this stream.
- */
-data class StreamSyncSummary(val recordsWritten: Optional<Long>) {
-
-    companion object {
-        @JvmField val DEFAULT: StreamSyncSummary = StreamSyncSummary(Optional.empty())
-    }
-}
+data class StreamSyncSummary(
+    val recordsWritten: Long,
+    val terminalStatus: AirbyteStreamStatus,
+)

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/buffers/BufferEnqueue.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/buffers/BufferEnqueue.kt
@@ -33,10 +33,14 @@ class BufferEnqueue(
         message: PartialAirbyteMessage,
         sizeInBytes: Int,
     ) {
-        if (message.type == AirbyteMessage.Type.RECORD) {
-            handleRecord(message, sizeInBytes)
-        } else if (message.type == AirbyteMessage.Type.STATE) {
-            stateManager.trackState(message, sizeInBytes.toLong())
+        when (message.type) {
+            AirbyteMessage.Type.RECORD -> {
+                handleRecord(message, sizeInBytes)
+            }
+            AirbyteMessage.Type.STATE -> {
+                stateManager.trackState(message, sizeInBytes.toLong())
+            }
+            else -> {}
         }
     }
 
@@ -44,7 +48,7 @@ class BufferEnqueue(
         message: PartialAirbyteMessage,
         sizeInBytes: Int,
     ) {
-        val streamDescriptor = extractStateFromRecord(message)
+        val streamDescriptor = extractStreamDescriptorFromRecord(message)
         val queue =
             buffers.computeIfAbsent(
                 streamDescriptor,
@@ -87,7 +91,9 @@ class BufferEnqueue(
     }
 
     companion object {
-        private fun extractStateFromRecord(message: PartialAirbyteMessage): StreamDescriptor {
+        private fun extractStreamDescriptorFromRecord(
+            message: PartialAirbyteMessage
+        ): StreamDescriptor {
             return StreamDescriptor()
                 .withNamespace(message.record?.namespace)
                 .withName(message.record?.stream)

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/deser/AirbyteMessageDeserializer.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/deser/AirbyteMessageDeserializer.kt
@@ -6,6 +6,9 @@ package io.airbyte.cdk.integrations.destination.async.deser
 import io.airbyte.cdk.integrations.destination.async.model.PartialAirbyteMessage
 import io.airbyte.commons.json.Jsons
 import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
 
 class AirbyteMessageDeserializer(
     private val dataTransformer: StreamAwareDataTransformer = IdentityDataTransformer(),
@@ -53,8 +56,8 @@ class AirbyteMessageDeserializer(
             partial.record?.data = null
         } else if (AirbyteMessage.Type.STATE == msgType) {
             partial.withSerialized(message)
-        } else {
-            throw RuntimeException(String.format("Unsupported message type: %s", msgType))
+        } else if (AirbyteMessage.Type.TRACE != msgType) {
+            logger.warn { "Unsupported message type: $msgType" }
         }
 
         return partial

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/model/PartialAirbyteMessage.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/model/PartialAirbyteMessage.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.integrations.destination.async.model
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteTraceMessage
 import java.util.Objects
 
 class PartialAirbyteMessage {
@@ -25,6 +26,12 @@ class PartialAirbyteMessage {
     @set:JsonProperty("state")
     @JsonProperty("state")
     var state: PartialAirbyteStateMessage? = null
+
+    @get:JsonProperty("trace")
+    @set:JsonProperty("trace")
+    @JsonProperty("trace")
+    // These messages don't contain arbitrary blobs, so just directly reference the protocol struct.
+    var trace: AirbyteTraceMessage? = null
 
     /**
      * For record messages, this stores the serialized data blob (i.e.

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.kt
@@ -286,7 +286,8 @@ internal constructor(
                  * hasFailed=false, then it could be full success. if hasFailed=true, then going for partial
                  * success.
                  */
-                onClose.accept(false, null)
+                // TODO what to do here?
+                onClose.accept(false, HashMap())
             }
 
             stateManager.listCommitted()!!.forEach(outputRecordCollector)

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/buffered_stream_consumer/OnCloseFunction.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/buffered_stream_consumer/OnCloseFunction.kt
@@ -5,20 +5,21 @@
 package io.airbyte.cdk.integrations.destination.buffered_stream_consumer
 
 import io.airbyte.cdk.integrations.destination.StreamSyncSummary
-import io.airbyte.commons.functional.CheckedBiConsumer
 import io.airbyte.protocol.models.v0.StreamDescriptor
 
 /**
  * Interface allowing destination to specify clean up logic that must be executed after all
  * record-related logic has finished.
  *
- * The map of StreamSyncSummaries MUST be non-null, but MAY be empty. Streams not present in the map
- * will be treated as equivalent to [StreamSyncSummary.DEFAULT].
- *
  * The @JvmSuppressWildcards is here so that the 2nd parameter of accept stays a java
  * Map<StreamDescriptor, StreamSyncSummary> rather than becoming a Map<StreamDescriptor, ? extends
  * StreamSyncSummary>
  */
-fun interface OnCloseFunction :
-    CheckedBiConsumer<
-        Boolean, @JvmSuppressWildcards Map<StreamDescriptor, StreamSyncSummary>, Exception>
+fun interface OnCloseFunction {
+    @JvmSuppressWildcards
+    @Throws(Exception::class)
+    fun accept(
+        hasFailed: Boolean,
+        streamSyncSummaries: Map<StreamDescriptor, StreamSyncSummary>,
+    )
+}

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.37.0
+version=0.37.1

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumerTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumerTest.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.integrations.destination.async
 
 import com.fasterxml.jackson.databind.JsonNode
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.integrations.destination.StreamSyncSummary
 import io.airbyte.cdk.integrations.destination.async.buffers.BufferManager
 import io.airbyte.cdk.integrations.destination.async.deser.AirbyteMessageDeserializer
 import io.airbyte.cdk.integrations.destination.async.deser.StreamAwareDataTransformer
@@ -25,6 +26,8 @@ import io.airbyte.protocol.models.v0.AirbyteRecordMessage
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import io.airbyte.protocol.models.v0.AirbyteStateStats
 import io.airbyte.protocol.models.v0.AirbyteStreamState
+import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
+import io.airbyte.protocol.models.v0.AirbyteTraceMessage
 import io.airbyte.protocol.models.v0.CatalogHelpers
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
 import io.airbyte.protocol.models.v0.StreamDescriptor
@@ -44,15 +47,20 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.ArgumentCaptor
 import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
 
 class AsyncStreamConsumerTest {
     companion object {
         private const val RECORD_SIZE_20_BYTES = 20
         private const val SCHEMA_NAME = "public"
+        private const val DEFAULT_NAMESPACE = "default_ns"
         private const val STREAM_NAME = "id_and_name"
         private const val STREAM_NAME2 = STREAM_NAME + 2
+        private const val STREAM_NAME3 = "stream_with_no_namespace"
         private val STREAM1_DESC: StreamDescriptor =
             StreamDescriptor().withNamespace(SCHEMA_NAME).withName(STREAM_NAME)
 
@@ -69,6 +77,12 @@ class AsyncStreamConsumerTest {
                         CatalogHelpers.createConfiguredAirbyteStream(
                             STREAM_NAME2,
                             SCHEMA_NAME,
+                            Field.of("id", JsonSchemaType.NUMBER),
+                            Field.of("name", JsonSchemaType.STRING),
+                        ),
+                        CatalogHelpers.createConfiguredAirbyteStream(
+                            STREAM_NAME3,
+                            null,
                             Field.of("id", JsonSchemaType.NUMBER),
                             Field.of("name", JsonSchemaType.STRING),
                         ),
@@ -113,6 +127,68 @@ class AsyncStreamConsumerTest {
                                 .withStreamState(Jsons.jsonNode(2)),
                         ),
                 )
+
+        private val STREAM1_SUCCESS_MESSAGE =
+            Jsons.serialize(
+                AirbyteMessage()
+                    .withType(AirbyteMessage.Type.TRACE)
+                    .withTrace(
+                        AirbyteTraceMessage()
+                            .withType(AirbyteTraceMessage.Type.STREAM_STATUS)
+                            .withStreamStatus(
+                                AirbyteStreamStatusTraceMessage()
+                                    .withStreamDescriptor(
+                                        StreamDescriptor()
+                                            .withName(STREAM_NAME)
+                                            .withNamespace(SCHEMA_NAME),
+                                    )
+                                    .withStatus(
+                                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE
+                                    ),
+                            ),
+                    ),
+            )
+        private val STREAM2_FAILURE_MESSAGE =
+            Jsons.serialize(
+                AirbyteMessage()
+                    .withType(AirbyteMessage.Type.TRACE)
+                    .withTrace(
+                        AirbyteTraceMessage()
+                            .withType(AirbyteTraceMessage.Type.STREAM_STATUS)
+                            .withStreamStatus(
+                                AirbyteStreamStatusTraceMessage()
+                                    .withStreamDescriptor(
+                                        StreamDescriptor()
+                                            .withName(STREAM_NAME2)
+                                            .withNamespace(SCHEMA_NAME),
+                                    )
+                                    .withStatus(
+                                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus
+                                            .INCOMPLETE
+                                    ),
+                            ),
+                    ),
+            )
+        private val STREAM3_SUCCESS_MESSAGE =
+            Jsons.serialize(
+                AirbyteMessage()
+                    .withType(AirbyteMessage.Type.TRACE)
+                    .withTrace(
+                        AirbyteTraceMessage()
+                            .withType(AirbyteTraceMessage.Type.STREAM_STATUS)
+                            .withStreamStatus(
+                                AirbyteStreamStatusTraceMessage()
+                                    .withStreamDescriptor(
+                                        StreamDescriptor()
+                                            // Note: no namespace.
+                                            .withName(STREAM_NAME3),
+                                    )
+                                    .withStatus(
+                                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE
+                                    ),
+                            ),
+                    ),
+            )
     }
 
     private lateinit var consumer: AsyncStreamConsumer
@@ -144,13 +220,38 @@ class AsyncStreamConsumerTest {
                 onClose = onClose,
                 onFlush = flushFunction,
                 catalog = CATALOG,
-                bufferManager = BufferManager("default_ns"),
+                bufferManager = BufferManager(DEFAULT_NAMESPACE),
                 flushFailure = flushFailure,
                 airbyteMessageDeserializer = airbyteMessageDeserializer,
                 workerPool = Executors.newFixedThreadPool(5),
             )
 
         Mockito.`when`(flushFunction.optimalBatchSizeBytes).thenReturn(10000L)
+    }
+
+    /**
+     * This test verifies that we don't throw on unusual message types.
+     *
+     * TODO Add a test for completely unrecognized message type (i.e. not present in
+     * [AirbyteMessage.Type]). Currently Jackson fails to deser that.
+     */
+    @Test
+    @Throws(Exception::class)
+    internal fun testAcceptUnexpectedMessage() {
+        val weirdMessage =
+            Jsons.serialize(
+                AirbyteMessage()
+                    .withType(AirbyteMessage.Type.LOG)
+                    .withLog(
+                        AirbyteLogMessage()
+                            .withLevel(AirbyteLogMessage.Level.INFO)
+                            .withMessage("foo")
+                            .withStackTrace("bar"),
+                    ),
+            )
+
+        consumer.start()
+        assertDoesNotThrow { consumer.accept(weirdMessage, weirdMessage.length) }
     }
 
     @Test
@@ -376,20 +477,6 @@ class AsyncStreamConsumerTest {
     }
 
     @Test
-    internal fun deserializeAirbyteMessageWithNoStateOrRecord() {
-        val airbyteMessage =
-            AirbyteMessage().withType(AirbyteMessage.Type.LOG).withLog(AirbyteLogMessage())
-        val serializedAirbyteMessage = Jsons.serialize(airbyteMessage)
-        assertThrows(
-            RuntimeException::class.java,
-        ) {
-            airbyteMessageDeserializer.deserializeAirbyteMessage(
-                serializedAirbyteMessage,
-            )
-        }
-    }
-
-    @Test
     internal fun deserializeAirbyteMessageWithAirbyteState() {
         val serializedAirbyteMessage = Jsons.serialize(STATE_MESSAGE1)
         val partial =
@@ -400,28 +487,78 @@ class AsyncStreamConsumerTest {
     }
 
     @Test
-    internal fun deserializeAirbyteMessageWithBadAirbyteState() {
-        val badState =
-            AirbyteMessage()
-                .withState(
-                    AirbyteStateMessage()
-                        .withType(AirbyteStateMessage.AirbyteStateType.STREAM)
-                        .withStream(
-                            AirbyteStreamState()
-                                .withStreamDescriptor(
-                                    STREAM1_DESC,
-                                )
-                                .withStreamState(Jsons.jsonNode(1)),
-                        ),
-                )
-        val serializedAirbyteMessage = Jsons.serialize(badState)
-        assertThrows(
-            RuntimeException::class.java,
-        ) {
-            airbyteMessageDeserializer.deserializeAirbyteMessage(
-                serializedAirbyteMessage,
-            )
-        }
+    @Throws(Exception::class)
+    internal fun testStreamStatusHandling() {
+        val expectedRecords = generateRecords(1000)
+
+        consumer.start()
+        consumeRecords(consumer, expectedRecords)
+        consumer.accept(STREAM1_SUCCESS_MESSAGE, STREAM1_SUCCESS_MESSAGE.length)
+        consumer.accept(STREAM2_FAILURE_MESSAGE, STREAM2_FAILURE_MESSAGE.length)
+        consumer.accept(STREAM3_SUCCESS_MESSAGE, STREAM3_SUCCESS_MESSAGE.length)
+        consumer.close()
+
+        val captor: ArgumentCaptor<Map<StreamDescriptor, StreamSyncSummary>> =
+            ArgumentCaptor.captor()
+        Mockito.verify(onClose).accept(any(), capture(captor))
+        assertEquals(
+            mapOf(
+                StreamDescriptor().withNamespace(SCHEMA_NAME).withName(STREAM_NAME) to
+                    StreamSyncSummary(
+                        expectedRecords.size.toLong(),
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+                    ),
+                StreamDescriptor().withNamespace(SCHEMA_NAME).withName(STREAM_NAME2) to
+                    StreamSyncSummary(
+                        0,
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.INCOMPLETE,
+                    ),
+                // Note that we set the default namespace, since the original namespace was null.
+                StreamDescriptor().withNamespace(DEFAULT_NAMESPACE).withName(STREAM_NAME3) to
+                    StreamSyncSummary(
+                        0,
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+                    ),
+            ),
+            captor.value,
+        )
+    }
+
+    @Test
+    @Throws(Exception::class)
+    internal fun testDefaultStreamStatusHandling() {
+        val expectedRecords = generateRecords(1000)
+
+        consumer.start()
+        consumeRecords(consumer, expectedRecords)
+        // Note: no stream status messages
+        consumer.close()
+
+        val captor: ArgumentCaptor<Map<StreamDescriptor, StreamSyncSummary>> =
+            ArgumentCaptor.captor()
+        Mockito.verify(onClose).accept(any(), capture(captor))
+        assertEquals(
+            // All streams have a COMPLETE status.
+            // TODO: change this to INCOMPLETE after we switch the default behavior.
+            mapOf(
+                StreamDescriptor().withNamespace(SCHEMA_NAME).withName(STREAM_NAME) to
+                    StreamSyncSummary(
+                        expectedRecords.size.toLong(),
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+                    ),
+                StreamDescriptor().withNamespace(SCHEMA_NAME).withName(STREAM_NAME2) to
+                    StreamSyncSummary(
+                        0,
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+                    ),
+                StreamDescriptor().withNamespace(DEFAULT_NAMESPACE).withName(STREAM_NAME3) to
+                    StreamSyncSummary(
+                        0,
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+                    ),
+            ),
+            captor.value,
+        )
     }
 
     @Nested
@@ -526,7 +663,7 @@ class AsyncStreamConsumerTest {
     @Throws(Exception::class)
     private fun verifyStartAndClose() {
         Mockito.verify(onStart).call()
-        Mockito.verify(onClose).accept(ArgumentMatchers.any(), ArgumentMatchers.any())
+        Mockito.verify(onClose).accept(any(), any())
     }
 
     @Throws(Exception::class)

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/kotlin/io/airbyte/integrations/base/destination/typing_deduping/DefaultTyperDeduper.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/kotlin/io/airbyte/integrations/base/destination/typing_deduping/DefaultTyperDeduper.kt
@@ -287,18 +287,8 @@ class DefaultTyperDeduper<DestinationState : MinimumDestinationState>(
                     return@filter false
                 }
                 // Skip if we don't have any records for this stream.
-                val streamSyncSummary =
-                    streamSyncSummaries.getOrDefault(
-                        streamConfig.id.asStreamDescriptor(),
-                        StreamSyncSummary.DEFAULT
-                    )
-                val nonzeroRecords =
-                    streamSyncSummary.recordsWritten
-                        .map { r: Long ->
-                            r > 0
-                        } // If we didn't track record counts during the sync, assume we had nonzero
-                        // records for this stream
-                        .orElse(true)
+                val streamSyncSummary = streamSyncSummaries[streamConfig.id.asStreamDescriptor()]!!
+                val nonzeroRecords = streamSyncSummary.recordsWritten > 0
                 val unprocessedRecordsPreexist =
                     initialRawTableStateByStream[streamConfig.id]!!.hasUnprocessedRecords
                 // If this sync emitted records, or the previous sync left behind some unprocessed

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/kotlin/io/airbyte/integrations/base/destination/typing_deduping/TyperDeduper.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/kotlin/io/airbyte/integrations/base/destination/typing_deduping/TyperDeduper.kt
@@ -70,9 +70,7 @@ interface TyperDeduper {
      *
      * @param streamSyncSummaries Information about what happened during the sync. Implementations
      * SHOULD use this information to skip T+D when possible (this is not a requirement for
-     * correctness, but does allow us to save time/money). This parameter MUST NOT be null. Streams
-     * MAY be omitted, which will be treated as though they were mapped to
-     * [StreamSyncSummary.DEFAULT].
+     * correctness, but does allow us to save time/money). This parameter MUST NOT be null.
      */
     @Throws(Exception::class)
     fun typeAndDedupe(streamSyncSummaries: Map<StreamDescriptor, StreamSyncSummary>)

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/test/kotlin/io/airbyte/integrations/base/destination/operation/DefaultSyncOperationTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/test/kotlin/io/airbyte/integrations/base/destination/operation/DefaultSyncOperationTest.kt
@@ -15,6 +15,7 @@ import io.airbyte.integrations.base.destination.typing_deduping.StreamConfig
 import io.airbyte.integrations.base.destination.typing_deduping.StreamId
 import io.airbyte.integrations.base.destination.typing_deduping.migrators.Migration
 import io.airbyte.integrations.base.destination.typing_deduping.migrators.MinimumDestinationState
+import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage.AirbyteStreamStatus
 import io.airbyte.protocol.models.v0.DestinationSyncMode
 import io.mockk.clearMocks
 import io.mockk.confirmVerified
@@ -140,12 +141,18 @@ class DefaultSyncOperationTest {
         streamOperations.values.onEach { clearMocks(it) }
 
         syncOperation.finalizeStreams(
-            mapOf(appendStreamConfig.id.asStreamDescriptor() to StreamSyncSummary(Optional.of(42)))
+            mapOf(
+                appendStreamConfig.id.asStreamDescriptor() to
+                    StreamSyncSummary(42, AirbyteStreamStatus.COMPLETE)
+            )
         )
 
         verify(exactly = 1) {
             streamOperations.values.onEach {
-                it.finalizeTable(appendStreamConfig, StreamSyncSummary(Optional.of(42)))
+                it.finalizeTable(
+                    appendStreamConfig,
+                    StreamSyncSummary(42, AirbyteStreamStatus.COMPLETE)
+                )
             }
         }
         confirmVerified(destinationHandler)


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/7608; closes #7621

* track stream statuses
* pass stream status into the StreamSyncSummary
* AbstractStreamOperation skips `overwriteFinalTable` if the status was not COMPLETE

this PR has "safe" default behavior, i.e. if platform doesn't send a stream status message then we assume success. This is compatible with older platform versions. See https://github.com/airbytehq/airbyte/pull/38067 for how we switch to the backwards-incompatible behavior (which is required for no data downtime).