### PR TITLE
Destination dev null: support dedup

### DIFF
--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.3.2
+  dockerImageTag: 0.3.3
   dockerRepository: airbyte/destination-dev-null
   githubIssueLabel: destination-dev-null
   icon: airbyte.svg

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/java/io/airbyte/integrations/destination/dev_null/DevNullDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/java/io/airbyte/integrations/destination/dev_null/DevNullDestinationAcceptanceTest.java
@@ -59,8 +59,18 @@ public class DevNullDestinationAcceptanceTest extends DestinationAcceptanceTest 
   }
 
   @Override
-  public void testSyncNotFailsWithNewFields() {
-    // Skip because `retrieveRecords` returns an empty list at all times.
+  // Skip because `retrieveRecords` returns an empty list at all times.
+  @Disabled
+  @Test
+  public void testSyncNotFailsWithNewFields() {}
+
+  @Override
+  // This test assumes that dedup support means normalization support.
+  // Override it to do nothing.
+  @Disabled
+  @Test
+  public void testIncrementalDedupeSync() throws Exception {
+    super.testIncrementalDedupeSync();
   }
 
 }

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/java/io/airbyte/integrations/destination/dev_null/DevNullDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/java/io/airbyte/integrations/destination/dev_null/DevNullDestinationAcceptanceTest.java
@@ -14,6 +14,8 @@ import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class DevNullDestinationAcceptanceTest extends DestinationAcceptanceTest {
 

--- a/airbyte-integrations/connectors/destination-dev-null/src/test/resources/expected_spec.json
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test/resources/expected_spec.json
@@ -3,7 +3,7 @@
   "supportsIncremental": true,
   "supportsNormalization": false,
   "supportsDBT": false,
-  "supported_destination_sync_modes": ["overwrite", "append"],
+  "supported_destination_sync_modes": ["overwrite", "append", "append_dedup"],
   "protocol_version": "0.2.1",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -6,6 +6,7 @@ The Airbyte `dev-null` Destination. This destination is for testing and debuggin
 
 | Version | Date       | Pull Request                                             | Subject           |
 | :------ | :--------- | :------------------------------------------------------- | :---------------- |
+| 0.3.3   | 2023-05-08 | [38118](https://github.com/airbytehq/airbyte/pull/38118) | Support dedup     |
 | 0.3.2   | 2023-05-08 | [25776](https://github.com/airbytehq/airbyte/pull/25776) | Support Refreshes |
 | 0.3.0   | 2023-05-08 | [25776](https://github.com/airbytehq/airbyte/pull/25776) | Change Schema     |
 | 0.2.7   | 2022-08-08 | [13932](https://github.com/airbytehq/airbyte/pull/13932) | Bump version      |


### PR DESCRIPTION
this is the cloud variant of destination-e2e (TIL we have a cloud variant ?!). Followup to https://github.com/airbytehq/airbyte/pull/38097.

... we should eventually kill strict encrypt connectors, and apparently also this one :P