### PR TITLE
auto-merge: fix permissions

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -9,17 +9,11 @@ jobs:
   run_auto_merge:
     name: Run auto-merge
     runs-on: ubuntu-latest
-    permissions:
-      checks: read
-      actions: read
-      statuses: read
-      contents: read
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install and configure Poetry
@@ -28,8 +22,11 @@ jobs:
         shell: bash
         working-directory: airbyte-ci/connectors/auto_merge
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AUTO_MERGE_PRODUCTION: "true"
+          # We need a custom Github Token as some API endpoints
+          # are not available from GHA auto generated tokens
+          # like the one to list branch protection rules...
+          GITHUB_TOKEN: ${{ secrets.AUTO_MERGE_GITHUB_TOKEN }}
+          AUTO_MERGE_PRODUCTION: ${{ vars.ENABLE_CONNECTOR_AUTO_MERGE }}
         run: |
           poetry install
           poetry run auto-merge


### PR DESCRIPTION
## What
The auto-merge package calls specific Github API endpoint (like the one to check which protection rules are applied to a branch). Some endpoints are readable by the Github token auto generated in the scope of the workflow execution.
To workaround this issue I created a custom PAT token stored in a GHA secret.

## Other goodies
* Improving logging
* Fix job summary output: we have to write the summary to a file whose path is in the `GITHUB_STEP_SUMMARY` env var, it's not the env var that we have to set with the markdown... 
* Enable or disable the auto-merge production flag through GHA variables. Will allow enabling or disabling the run without modifying the workflow file.