### PR TITLE
Airbyte CDK: Add delete method to HttpMocker

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.88.3
+Add Delete method to HttpMocker
+
 ## 0.88.2
 Fix dependency for pytz
 

--- a/airbyte-cdk/python/airbyte_cdk/test/mock_http/mocker.py
+++ b/airbyte-cdk/python/airbyte_cdk/test/mock_http/mocker.py
@@ -13,6 +13,7 @@ from airbyte_cdk.test.mock_http import HttpRequest, HttpRequestMatcher, HttpResp
 class SupportedHttpMethods(str, Enum):
     GET = "get"
     POST = "post"
+    DELETE = "delete"
 
 
 class HttpMocker(contextlib.ContextDecorator):
@@ -70,6 +71,9 @@ class HttpMocker(contextlib.ContextDecorator):
 
     def post(self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]) -> None:
         self._mock_request_method(SupportedHttpMethods.POST, request, responses)
+
+    def delete(self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]) -> None:
+        self._mock_request_method(SupportedHttpMethods.DELETE, request, responses)
 
     @staticmethod
     def _matches_wrapper(matcher: HttpRequestMatcher) -> Callable[[requests_mock.request._RequestObjectProxy], bool]:

--- a/airbyte-cdk/python/pyproject.toml
+++ b/airbyte-cdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "airbyte-cdk"
-version = "0.88.2"
+version = "0.88.3"
 description = "A framework for writing Airbyte Connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-cdk/python/unit_tests/test/mock_http/test_mocker.py
+++ b/airbyte-cdk/python/unit_tests/test/mock_http/test_mocker.py
@@ -35,6 +35,19 @@ class HttpMockerTest(TestCase):
         assert response.headers == _OTHER_HEADERS
 
     @HttpMocker()
+    def test_given_delete_request_match_when_decorate_then_return_response(self, http_mocker):
+        http_mocker.delete(
+            HttpRequest(_A_URL, headers=_SOME_HEADERS),
+            HttpResponse(_A_RESPONSE_BODY, 204, _OTHER_HEADERS),
+        )
+
+        response = requests.delete(_A_URL, headers=_SOME_HEADERS)
+
+        assert response.text == _A_RESPONSE_BODY
+        assert response.status_code == 204
+        assert response.headers == _OTHER_HEADERS
+
+    @HttpMocker()
     def test_given_loose_headers_matching_when_decorate_then_match(self, http_mocker):
         http_mocker.get(
             HttpRequest(_A_URL, _SOME_QUERY_PARAMS, _SOME_HEADERS),
@@ -64,6 +77,21 @@ class HttpMockerTest(TestCase):
 
         first_response = requests.get(_A_URL, params=_SOME_QUERY_PARAMS, headers=_SOME_HEADERS)
         second_response = requests.get(_A_URL, params=_SOME_QUERY_PARAMS, headers=_SOME_HEADERS)
+
+        assert first_response.text == _A_RESPONSE_BODY
+        assert first_response.status_code == 1
+        assert second_response.text == _ANOTHER_RESPONSE_BODY
+        assert second_response.status_code == 2
+
+    @HttpMocker()
+    def test_given_multiple_responses_when_decorate_delete_request_then_return_response(self, http_mocker):
+        http_mocker.delete(
+            HttpRequest(_A_URL, headers=_SOME_HEADERS),
+            [HttpResponse(_A_RESPONSE_BODY, 1), HttpResponse(_ANOTHER_RESPONSE_BODY, 2)],
+        )
+
+        first_response = requests.delete(_A_URL, headers=_SOME_HEADERS)
+        second_response = requests.delete(_A_URL, headers=_SOME_HEADERS)
 
         assert first_response.text == _A_RESPONSE_BODY
         assert first_response.status_code == 1


### PR DESCRIPTION
## What
Resolving [Mock server tests: Support mocking `delete`](https://app.zenhub.com/workspaces/critical-connectors-659c693d906fcd00178900cf/issues/gh/airbytehq/airbyte-internal-issues/7268)

## How
Added delete method in HttpMocker and unit tests


## User Impact
Developers can now mock the delete method with HttpMocker instead of directly using `_mock_request_method`

e.g.
instead of 
```
        HttpMocker()._mock_request_method(  
            "delete",
            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
            [
                _RETRYABLE_RESPONSE,
                HttpResponse(""),
            ],
        )
```
Now you can:
```
        HttpMocker().delete(
            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
            [
                _RETRYABLE_RESPONSE,
                HttpResponse(""),
            ],
        )

```
## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
