### PR TITLE
[skip ci] Add connectorTestSuitesOptions to metadata

### DIFF
--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -22,4 +22,13 @@ data:
     sl: 100
     ql: 200
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-AMAZON-SQS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-astra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-astra/metadata.yaml
@@ -28,4 +28,20 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-ASTRA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION-ASTRA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-aws-datalake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-aws-datalake/metadata.yaml
@@ -24,4 +24,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-AWS-DATALAKE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -27,4 +27,23 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-AZURE-BLOB-STORAGE-GCS-STAGING__CREDS
+          fileName: config_gcs_staging.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-AZURE-BLOB-STORAGE-S3-STAGING__CREDS
+          fileName: config_s3_staging.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-AZURE-BLOB-STORAGE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -21,21 +21,7 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
-
-          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling, incremental delivery of data for large
-          syncs, and improved final table structures. To review the breaking changes,
-          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models,
-          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-
-          Selecting `Upgrade` will upgrade **all** connections using this destination
-          at their next sync. You can manually sync existing connections prior to
-          the next scheduled sync to start the upgrade early.
-
-          "
+        message: "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.\nThis version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).\nSelecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.\n"
         upgradeDeadline: "2023-11-07"
   resourceRequirements:
     jobSpecific:
@@ -47,4 +33,103 @@ data:
   supportsDbt: true
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_DISABLETD_GCS_RAW_OVERRIDE
+          fileName: credentials-1s1t-disabletd-gcs-raw-override.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_DISABLETD_STANDARD_OVERRIDE
+          fileName: credentials-1s1t-disabletd-standard-raw-override.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS
+          fileName: credentials-1s1t-gcs.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS_RAW_OVERRIDE
+          fileName: credentials-1s1t-gcs-raw-override.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_STANDARD
+          fileName: credentials-1s1t-standard.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_STANDARD_RAW_OVERRIDE
+          fileName: credentials-1s1t-standard-raw-override.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_BAD_PROJECT_CREDS
+          fileName: credentials-badproject.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_GCS_STAGING
+          fileName: credentials-gcs-staging.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_IMPERSONATE_FAIL_CREDS
+          fileName: credentials-impersonate-fail.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_IMPERSONATE__CREDS
+          fileName: credentials-impersonate.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_NO_GCS_CREATE_ROLE
+          fileName: copy_gcs_no_create_roles_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_NO_GCS_WRITE_ROLE
+          fileName: copy_gcs_no_write_roles_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_NO_PUBLIC_SCHEMA_EDIT_ROLE
+          fileName: credentials-no-edit-public-schema-role.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_STANDARD
+          fileName: credentials-standard.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_WITH_MISSED_DATASET_CREATION_ROLE__CREDS
+          fileName: credentials-with-missed-dataset-creation-role.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS__CREDS
+          fileName: credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS__CREDS_OAUTH
+          fileName: credentials_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_STANDARD-NO-DATASET-CREATION__CREDS
+          fileName: credentials-standard-no-dataset-creation.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-BIGQUERY_STANDARD_NON_BILLABLE_PROJECT__CREDS
+          fileName: credentials-standard-non-billable-project.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-chroma/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-chroma/metadata.yaml
@@ -22,4 +22,7 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/metadata.yaml
@@ -28,4 +28,7 @@ data:
   supportsDbt: false
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -33,4 +33,7 @@ data:
     sl: 100
     ql: 200
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-convex/metadata.yaml
@@ -22,4 +22,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-csv/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-csv/metadata.yaml
@@ -21,4 +21,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-cumulio/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cumulio/metadata.yaml
@@ -22,4 +22,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-CUMULIO_CREDENTIALS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-databend/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databend/metadata.yaml
@@ -22,4 +22,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION_DATABEND_CLOUD_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-databricks/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databricks/metadata.yaml
@@ -23,4 +23,28 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-DATABRICKS_AZURE__CREDS
+          fileName: azure_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-DATABRICKS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-DATABRICKS__STAGING_CREDS
+          fileName: staging_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_DATABRICKS_OAUTH_CONFIG
+          fileName: oauth_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -22,4 +22,7 @@ data:
     ql: 100
   supportLevel: community
   supportsRefreshes: true
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
@@ -39,4 +39,20 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION_DUCKDB__MOTHERDUCK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
@@ -21,4 +21,13 @@ data:
     sl: 100
     ql: 200
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-DYNAMODB__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
@@ -22,4 +22,7 @@ data:
     ql: 100
   supportLevel: community
   supportsRefreshes: true
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
@@ -17,4 +17,7 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/destinations/elasticsearch
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch/metadata.yaml
@@ -22,4 +22,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
@@ -25,4 +25,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-FIREBOLT_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-firestore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firestore/metadata.yaml
@@ -22,4 +22,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-FIRESTORE
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs/metadata.yaml
@@ -27,4 +27,17 @@ data:
     sl: 100
     ql: 300
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-GCS_NO_MULTIPART_ROLE_CREDS
+          fileName: insufficient_roles_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-GCS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
@@ -22,4 +22,13 @@ data:
     sl: 100
     ql: 200
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-GOOGLE_SHEETS_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
@@ -20,4 +20,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kafka/metadata.yaml
@@ -21,4 +21,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-kvdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kvdb/metadata.yaml
@@ -25,4 +25,6 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -29,4 +29,13 @@ data:
         message: >
           This version changes the way record ids are tracked internally. If you are using a stream in **append-dedup** mode, you need to reset the connection after doing the upgrade to avoid duplicates.
         upgradeDeadline: "2023-09-18"
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-LANGCHAIN_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-local-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-local-json/metadata.yaml
@@ -21,4 +21,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
@@ -22,4 +22,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION_MEILISEARCH_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-milvus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-milvus/metadata.yaml
@@ -38,4 +38,20 @@ data:
     sl: 200
     ql: 300
   supportLevel: certified
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-MILVUS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION-MILVUS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
@@ -17,4 +17,13 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mongodb
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-MONGODB-STRICT-ENCRYPT_CREDENTIALS__CREDS
+          fileName: credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
@@ -22,4 +22,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mssql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql-strict-encrypt/metadata.yaml
@@ -28,4 +28,6 @@ data:
   supportsDbt: true
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -33,4 +33,7 @@ data:
     sl: 100
     ql: 200
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
@@ -21,20 +21,9 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
-
-          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling, incremental delivery of data for large
-          syncs, and improved final table structures. To review the breaking changes,
-          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models,
-          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-
-          Selecting `Upgrade` will upgrade **all** connections using this destination
-          at their next sync. You can manually sync existing connections prior to
-          the next scheduled sync to start the upgrade early.
-
-          "
+        message: "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.\nThis version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).\nSelecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.\n"
         upgradeDeadline: "2024-05-15"
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql/metadata.yaml
@@ -26,17 +26,20 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
-
-          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling and improved final table structures. To review the breaking changes,
-          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models,
-          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-
-          Selecting `Upgrade` will upgrade **all** connections using this destination
-          at their next sync. You can manually sync existing connections prior to
-          the next scheduled sync to start the upgrade early."
+        message: "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.\nThis version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).\nSelecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early."
         upgradeDeadline: "2024-06-05"
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-MYSQL_SSH-KEY__CREDS
+          fileName: ssh-key-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-MYSQL_SSH-PWD__CREDS
+          fileName: ssh-pwd-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -28,4 +28,7 @@ data:
   supportsDbt: true
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -33,4 +33,13 @@ data:
     sl: 100
     ql: 200
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-ORACLE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -41,4 +41,20 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-PINECONE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION-PINECONE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -28,4 +28,7 @@ data:
   supportsDbt: true
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -32,4 +32,13 @@ data:
   supportsDbt: true
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-POSTGRES_CREDENTIALS__CREDS
+          fileName: credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-pubsub/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pubsub/metadata.yaml
@@ -21,4 +21,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-PUBSUB_CREDENTIALS__CREDS
+          fileName: credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
@@ -38,4 +38,6 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
@@ -22,4 +22,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-RABBITMQ__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-redis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redis/metadata.yaml
@@ -21,4 +21,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -35,4 +35,38 @@ data:
   supportsDbt: true
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG
+          fileName: 1s1t_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_RAW_SCHEMA_OVERRIDE_DISABLE_TYPING_DEDUPING
+          fileName: 1s1t_config_raw_schema_override.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_STAGING
+          fileName: 1s1t_config_staging.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-REDSHIFT_1S1T_CONFIG_STAGING_RAW_SCHEMA_OVERRIDE_DISABLE_TYPING_DEDUPING
+          fileName: 1s1t_config_staging_raw_schema_override.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-REDSHIFT_STAGING__CREDS
+          fileName: config_staging.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-REDSHIFT__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
@@ -21,4 +21,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-S3-GLUE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -27,4 +27,28 @@ data:
     sl: 300
     ql: 300
   supportLevel: certified
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-S3-ASSUME-ROLE-CONFIG
+          fileName: s3_dest_assume_role_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_DEST_IAM_ROLE_CREDENTIALS_FOR_ASSUME_ROLE_AUTH
+          fileName: s3_dest_iam_role_credentials_for_assume_role_auth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_MIN_REQUIRED_PERMISSIONS_CREDS
+          fileName: s3_dest_min_required_permissions_creds.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-sftp-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-sftp-json/metadata.yaml
@@ -22,4 +22,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -24,21 +24,7 @@ data:
         message: Remove GCS/S3 loading method support.
         upgradeDeadline: "2023-08-31"
       3.0.0:
-        message:
-          "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.
-
-          This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling, incremental delivery of data for large
-          syncs, and improved final table structures. To review the breaking changes,
-          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models,
-          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-
-          Selecting `Upgrade` will upgrade **all** connections using this destination
-          at their next sync. You can manually sync existing connections prior to
-          the next scheduled sync to start the upgrade early.
-
-          "
+        message: "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.\nThis version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).\nSelecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.\n"
         upgradeDeadline: "2023-11-07"
   resourceRequirements:
     jobSpecific:
@@ -50,4 +36,113 @@ data:
   supportsDbt: true
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-SNOWFLAKE_COPY_AZURE_BLOB__CREDS
+          fileName: copy_azure_blob_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_COPY_GCS__CREDS
+          fileName: copy_gcs_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_COPY_S3_ENCRYPTED__CREDS
+          fileName: copy_s3_encrypted_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_COPY_S3__CREDS
+          fileName: copy_s3_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_INSERT__CREDS
+          fileName: insert_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_INSUFFICIENT_GCS_ROLE__CREDS
+          fileName: copy_insufficient_gcs_roles_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_INTERNAL_STAGING_CONFIG_DISABLETD
+          fileName: 1s1t_disabletd_internal_staging_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_INTERNAL_STAGING_CONFIG_RAW_SCHEMA_OVERRIDE_DISABLETD
+          fileName: 1s1t_disabletd_internal_staging_config_raw_schema_override.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_IP_NOT_IN_WHITELIST_CREDS
+          fileName: insert_ip_not_in_whitelist_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_S3_WRONG_LOCATION__CREDS
+          fileName: copy_s3_wrong_location_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-SNOWFLAKE_WITHOUT_INTERNAL_STAGING__CREDS
+          fileName: copy_insufficient_staging_roles_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_1S1T_INTERNAL_STAGING_CREDS
+          fileName: 1s1t_internal_staging_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_1S1T_INTERNAL_STAGING_CREDS_RAW_SCHEMA_OVERRIDE
+          fileName: 1s1t_internal_staging_config_raw_schema_override.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_INSUFFICIENT_PERMISSIONS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_INTERNAL_STAGING_CREDS
+          fileName: internal_staging_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_KEY_PAIR_ENCRYPTED__CREDS
+          fileName: config_key_pair_encrypted.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_KEY_PAIR__CREDS
+          fileName: config_key_pair.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_NO_ACTIVE_WAREHOUSE_CREDS
+          fileName: internal_staging_config_no_active_warehouse.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE
+          fileName: no_create_schema_privilege.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_QUOTED_IDENTIFIERS_IGNORE_CASE_CREDS
+          fileName: 1s1t_case_insensitive.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION_SNOWFLAKE_TESTUSER_WITHOUT_TEXT_SCHEMA_PERMISSION_CREDS
+          fileName: config_no_text_schema_permission.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-sqlite/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-sqlite/metadata.yaml
@@ -22,4 +22,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
@@ -21,4 +21,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-STARBURST-GALAXY_CREDENTIALS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-teradata/metadata.yaml
@@ -21,4 +21,23 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-TERADATA_SSL__CREDS
+          fileName: sslconfig.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-TERADATA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-TERADATA__FAILURE_CREDS
+          fileName: failureconfig.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
@@ -22,4 +22,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-TIMEPLUS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-typesense/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-typesense/metadata.yaml
@@ -24,4 +24,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-TYPESENSE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-vectara/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-vectara/metadata.yaml
@@ -30,4 +30,12 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION_VECTARA_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -29,11 +29,7 @@ data:
   releases:
     breakingChanges:
       0.2.0:
-        message:
-          "After upgrading, you need to reconfigure the source. For more details
-          check out the migration guide.
-
-          "
+        message: "After upgrading, you need to reconfigure the source. For more details check out the migration guide.\n"
         upgradeDeadline: "2023-10-01"
   resourceRequirements:
     jobSpecific:
@@ -45,4 +41,20 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-WEAVIATE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_DESTINATION-WEAVIATE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-xata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-xata/metadata.yaml
@@ -22,4 +22,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-XATA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
@@ -23,4 +23,12 @@ data:
   supportsDbt: false
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-YELLOWBRICK_CREDENTIALS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
@@ -26,4 +26,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ACTIVECAMPAIGN__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-adjust/metadata.yaml
+++ b/airbyte-integrations/connectors/source-adjust/metadata.yaml
@@ -26,4 +26,6 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-aha/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aha/metadata.yaml
@@ -31,4 +31,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AHA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-aircall/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aircall/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AIRCALL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -32,14 +32,24 @@ data:
   releases:
     breakingChanges:
       4.0.0:
-        message:
-          This release introduces changes to columns with formula to parse
-          values directly from `array` to `string` or `number` (where it is possible).
-          Users should refresh the source schema and reset affected streams after
-          upgrading to ensure uninterrupted syncs.
+        message: This release introduces changes to columns with formula to parse values directly from `array` to `string` or `number` (where it is possible). Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs.
         upgradeDeadline: "2023-10-23"
   supportLevel: certified
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AIRTABLE_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AIRTABLE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-alpha-vantage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-alpha-vantage/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ALPHA-VANTAGE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -66,4 +66,18 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AMAZON-ADS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AMAZON-ADS__TEST_ACCOUNT_CREDS
+          fileName: config_report.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -42,29 +42,30 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          "Deprecated FBA reports will be removed permanently from Cloud and
-          Brand Analytics Reports will be removed temporarily. Updates on Brand Analytics
-          Reports can be tracked here: [#32353](https://github.com/airbytehq/airbyte/issues/32353)"
+        message: "Deprecated FBA reports will be removed permanently from Cloud and Brand Analytics Reports will be removed temporarily. Updates on Brand Analytics Reports can be tracked here: [#32353](https://github.com/airbytehq/airbyte/issues/32353)"
         upgradeDeadline: "2023-12-11"
       3.0.0:
-        message:
-          Streams `GET_FLAT_FILE_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL` and
-          `GET_FLAT_FILE_ALL_ORDERS_DATA_BY_LAST_UPDATE_GENERAL` now have updated
-          schemas. Streams `GET_AMAZON_FULFILLED_SHIPMENTS_DATA_GENERAL`, `GET_LEDGER_DETAIL_VIEW_DATA`,
-          `GET_MERCHANTS_LISTINGS_FYP_REPORT`, `GET_STRANDED_INVENTORY_UI_DATA`, and
-          `GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE` now have date-time formatted fields.
-          Users will need to refresh the source schemas and reset these streams after
-          upgrading.
+        message: Streams `GET_FLAT_FILE_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL` and `GET_FLAT_FILE_ALL_ORDERS_DATA_BY_LAST_UPDATE_GENERAL` now have updated schemas. Streams `GET_AMAZON_FULFILLED_SHIPMENTS_DATA_GENERAL`, `GET_LEDGER_DETAIL_VIEW_DATA`, `GET_MERCHANTS_LISTINGS_FYP_REPORT`, `GET_STRANDED_INVENTORY_UI_DATA`, and `GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE` now have date-time formatted fields. Users will need to refresh the source schemas and reset these streams after upgrading.
         upgradeDeadline: "2024-01-12"
       4.0.0:
-        message:
-          Stream `GET_FBA_STORAGE_FEE_CHARGES_DATA` schema has been updated
-          to match Amazon Seller Partner. Users will need to refresh the source schema
-          and reset this stream after upgrading.
+        message: Stream `GET_FBA_STORAGE_FEE_CHARGES_DATA` schema has been updated to match Amazon Seller Partner. Users will need to refresh the source schema and reset this stream after upgrading.
         upgradeDeadline: "2024-03-11"
   supportLevel: certified
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AMAZON-SELLER-PARTNER_OLD_DATA_CREDS
+          fileName: config_old_data.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AMAZON-SELLER-PARTNER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-sqs/metadata.yaml
@@ -26,4 +26,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AMAZON-SQS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -39,4 +39,20 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-AMPLITUDE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AMPLITUDE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-apify-dataset/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apify-dataset/metadata.yaml
@@ -27,10 +27,7 @@ data:
         message: Update spec to use token and ingest all 3 streams correctly
         upgradeDeadline: 2023-08-30
       2.0.0:
-        message:
-          This version introduces a new Item Collection (WCC) stream as a substitute
-          of the now-removed Item Collection stream in order to retain data for Web-Content-Crawler
-          datasets.
+        message: This version introduces a new Item Collection (WCC) stream as a substitute of the now-removed Item Collection stream in order to retain data for Web-Content-Crawler datasets.
         upgradeDeadline: 2023-09-18
   remoteRegistries:
     pypi:
@@ -40,4 +37,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-APIFY-DATASET__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-appfollow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appfollow/metadata.yaml
@@ -35,4 +35,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-APPFOLLOW__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-appsflyer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appsflyer/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-APPSFLYER_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-asana/metadata.yaml
+++ b/airbyte-integrations/connectors/source-asana/metadata.yaml
@@ -29,4 +29,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ASANA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-ashby/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ashby/metadata.yaml
@@ -26,4 +26,6 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-auth0/metadata.yaml
+++ b/airbyte-integrations/connectors/source-auth0/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AUTH0__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-avni/metadata.yaml
+++ b/airbyte-integrations/connectors/source-avni/metadata.yaml
@@ -29,4 +29,13 @@ data:
   tags:
     - cdk:low-code
     - language:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AVNI__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-aws-cloudtrail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aws-cloudtrail/metadata.yaml
@@ -28,4 +28,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AWS-CLOUDTRAIL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
@@ -34,4 +34,160 @@ data:
   tags:
     - language:python
     - cdk:python-file-based
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_AVRO__CREDS
+          fileName: avro_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_CUSTOM_ENCODING__CREDS
+          fileName: csv_custom_encoding_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_CUSTOM_FORMAT_ENCODING__CREDS
+          fileName: csv_custom_format_encoding_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_NO_HEADER_CONFIG__CREDS
+          fileName: csv_no_header_config_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_NO_HEADER__CREDS
+          fileName: csv_no_header_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_SKIP_ROWS_NO_HEADER__CREDS
+          fileName: csv_skip_rows_no_header_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_SKIP_ROWS__CREDS
+          fileName: csv_skip_rows_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_USER_SCHEMA__CREDS
+          fileName: csv_user_schema_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_WITH_NULLS__CREDS
+          fileName: csv_with_nulls_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_WITH_NULL_BOOLS__CREDS
+          fileName: csv_with_null_bools_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_JSONL_NEWLINES__CREDS
+          fileName: jsonl_newlines_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_JSONL__CREDS
+          fileName: jsonl_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_PARQUET__CREDS
+          fileName: parquet_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_UNSTRUCTURED__CREDS
+          fileName: unstructured_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_AVRO__CREDS
+          fileName: avro_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_CUSTOM_ENCODING__CREDS
+          fileName: csv_custom_encoding_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_CUSTOM_FORMAT_ENCODING__CREDS
+          fileName: csv_custom_format_encoding_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_NO_HEADER_CONFIG__CREDS
+          fileName: csv_no_header_config_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_NO_HEADER__CREDS
+          fileName: csv_no_header_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_SKIP_ROWS_NO_HEADER__CREDS
+          fileName: csv_skip_rows_no_header_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_SKIP_ROWS__CREDS
+          fileName: csv_skip_rows_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_USER_SCHEMA__CREDS
+          fileName: csv_user_schema_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_WITH_NULLS__CREDS
+          fileName: csv_with_nulls_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_CSV_WITH_NULL_BOOLS__CREDS
+          fileName: csv_with_null_bools_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_JSONL_NEWLINES__CREDS
+          fileName: jsonl_newlines_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_JSONL__CREDS
+          fileName: jsonl_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_PARQUET__CREDS
+          fileName: parquet_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE_UNSTRUCTURED__CREDS
+          fileName: unstructured_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-AZURE-BLOB-STORAGE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-azure-table/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-table/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_AZURE_TABLE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bamboo-hr/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bamboo-hr/metadata.yaml
@@ -28,4 +28,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-BAMBOO-HR__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bigcommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigcommerce/metadata.yaml
@@ -30,4 +30,12 @@ data:
   ab_internal:
     sl: 100
     ql: 200
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-BIGCOMMERCE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigquery/metadata.yaml
@@ -21,4 +21,18 @@ data:
   supportLevel: community
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-BIGQUERY_CREDENTIALS__CREDS
+          fileName: credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-BIGQUERY_SAT__CREDS
+          fileName: sat-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -37,12 +37,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          Version 1.0.0 removes the primary keys from the geographic performance
-          report streams. This will prevent the connector from losing data in the
-          incremental append+dedup sync mode because of deduplication and incorrect
-          primary keys. A data reset and schema refresh of all the affected streams
-          is required for the changes to take effect.
+        message: Version 1.0.0 removes the primary keys from the geographic performance report streams. This will prevent the connector from losing data in the incremental append+dedup sync mode because of deduplication and incorrect primary keys. A data reset and schema refresh of all the affected streams is required for the changes to take effect.
         upgradeDeadline: "2023-10-25"
       2.0.0:
         message: >
@@ -66,4 +61,33 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-BING-ADS_FULL_REFRESH__CREDS
+          fileName: config_full_refresh.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-BING-ADS_NO_DATE_CREDS
+          fileName: config_no_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-BING-ADS_NO_START_DATE__CREDS
+          fileName: config_no_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-BING-ADS_OLD__CREDS
+          fileName: config_old.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-BING-ADS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-braintree/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braintree/metadata.yaml
@@ -26,4 +26,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-BRAINTREE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-braze/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braze/metadata.yaml
@@ -26,4 +26,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_BRAZE_INTEGRATION_TESTS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-breezometer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-breezometer/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-BREEZOMETER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-callrail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-callrail/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CALLRAIL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-cart/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cart/metadata.yaml
@@ -28,4 +28,30 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-CART_CENTRAL_API__CREDS
+          fileName: config_central_api_router.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-CART__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CART_CENTRAL_API__CREDS
+          fileName: config_central_api_router.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-CART__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-chargebee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/metadata.yaml
@@ -45,4 +45,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CHARGEBEE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-chargify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargify/metadata.yaml
@@ -30,4 +30,12 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CHARGIFY_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-chartmogul/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chartmogul/metadata.yaml
@@ -34,4 +34,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CHARTMOGUL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
@@ -21,4 +21,6 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -27,4 +27,6 @@ data:
   supportLevel: community
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CLICKUP-API__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clockify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clockify/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CLOCKIFY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-close-com/metadata.yaml
+++ b/airbyte-integrations/connectors/source-close-com/metadata.yaml
@@ -29,4 +29,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CLOSE-COM__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
@@ -24,4 +24,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-coda/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coda/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CODA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-coin-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coin-api/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-COIN-API__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-COINGECKO-COINS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-coinmarketcap/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coinmarketcap/metadata.yaml
@@ -35,4 +35,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-COINMARKETCAP__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-commcare/metadata.yaml
+++ b/airbyte-integrations/connectors/source-commcare/metadata.yaml
@@ -25,4 +25,6 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-commercetools/metadata.yaml
+++ b/airbyte-integrations/connectors/source-commercetools/metadata.yaml
@@ -30,4 +30,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-COMMERCETOOLS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-configcat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-configcat/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CONFIGCAT__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-confluence/metadata.yaml
+++ b/airbyte-integrations/connectors/source-confluence/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CONFLUENCE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-convertkit/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convertkit/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_CONVERTKIT__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convex/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CONVEX__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-copper/metadata.yaml
+++ b/airbyte-integrations/connectors/source-copper/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-COPPER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/source-customer-io/metadata.yaml
@@ -27,4 +27,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-CUSTOMERIO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-datadog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datadog/metadata.yaml
@@ -34,4 +34,12 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-DATADOG__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-datascope/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datascope/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-DATASCOPE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-db2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-db2/metadata.yaml
@@ -24,4 +24,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
@@ -30,4 +30,6 @@ data:
   supportLevel: community
   tags:
     - language:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-delighted/metadata.yaml
+++ b/airbyte-integrations/connectors/source-delighted/metadata.yaml
@@ -31,4 +31,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-DELIGHTED__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dixa/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dixa/metadata.yaml
@@ -30,4 +30,12 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-DIXA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dockerhub/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dockerhub/metadata.yaml
@@ -33,4 +33,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-DOCKERHUB__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dremio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dremio/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_DREMIO_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-drift/metadata.yaml
+++ b/airbyte-integrations/connectors/source-drift/metadata.yaml
@@ -32,4 +32,17 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-DRIFT_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-DRIFT__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dynamodb/metadata.yaml
@@ -21,4 +21,13 @@ data:
   supportLevel: community
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-DYNAMODB__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/metadata.yaml
@@ -21,4 +21,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
@@ -21,4 +21,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
@@ -21,4 +21,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-emailoctopus/metadata.yaml
+++ b/airbyte-integrations/connectors/source-emailoctopus/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-EMAILOCTOPUS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-everhour/metadata.yaml
+++ b/airbyte-integrations/connectors/source-everhour/metadata.yaml
@@ -29,4 +29,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_EVERHOUR_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-EXCHANGE-RATES__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -31,12 +31,7 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          "All Ads-Insights-* streams now have updated schemas. Users will
-          need to retest source configuration, refresh the source schema and reset
-          affected streams after upgrading. Please pay attention that data older than
-          37 months will become unavailable due to FaceBook limitations. For more
-          information [visit](https://docs.airbyte.com/integrations/sources/facebook-marketing-migrations)"
+        message: "All Ads-Insights-* streams now have updated schemas. Users will need to retest source configuration, refresh the source schema and reset affected streams after upgrading. Please pay attention that data older than 37 months will become unavailable due to FaceBook limitations. For more information [visit](https://docs.airbyte.com/integrations/sources/facebook-marketing-migrations)"
         upgradeDeadline: "2024-03-17"
         scopedImpact:
           - scopeType: stream
@@ -69,4 +64,30 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-FACEBOOK-MARKETING_NO_DATE__CREDS
+          fileName: config_no_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FACEBOOK-MARKETING__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FACEBOOK-MARKETING_NO_DATE__CREDS
+          fileName: config_no_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FACEBOOK-MARKETING__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
@@ -40,4 +40,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FACEBOOK-PAGES__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -28,9 +28,7 @@ data:
         message: This is a breaking change message
         upgradeDeadline: "2023-07-19"
       5.0.0:
-        message:
-          ID and products.year fields are changing to be integers instead of
-          floats.
+        message: ID and products.year fields are changing to be integers instead of floats.
         upgradeDeadline: "2023-08-31"
       6.0.0:
         message: Declare 'id' columns as primary keys.
@@ -54,4 +52,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FAKER_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-fastbill/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fastbill/metadata.yaml
@@ -29,4 +29,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FASTBILL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-fauna/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fauna/metadata.yaml
@@ -26,4 +26,18 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FAUNA_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FAUNA_DELETION_CREDS
+          fileName: config-deletions.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -32,4 +32,60 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-FILE_AWS__CREDS
+          fileName: aws.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FILE_AZBLOB__CREDS
+          fileName: azblob.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FILE_BOX__CREDS
+          fileName: box_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FILE_GCS__CREDS
+          fileName: gcs.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FILE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FILE_AWS__CREDS
+          fileName: aws.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FILE_AZBLOB__CREDS
+          fileName: azblob.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FILE_BOX__CREDS
+          fileName: box_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FILE_GCS__CREDS
+          fileName: gcs.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-FILE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-firebase-realtime-database/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firebase-realtime-database/metadata.yaml
@@ -28,4 +28,6 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firebolt/metadata.yaml
@@ -36,4 +36,20 @@ data:
       2.0.0:
         message: "Use new firebolt-sdk version."
         upgradeDeadline: "2024-06-01"
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-FIREBOLT_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FIREBOLT_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
@@ -26,4 +26,12 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FRESHCALLER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -32,4 +32,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FRESHDESK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-freshsales/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshsales/metadata.yaml
@@ -34,4 +34,19 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-FRESHSALES__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FRESHSALES__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-freshservice/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshservice/metadata.yaml
@@ -29,4 +29,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FRESHSERVICE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-fullstory/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fullstory/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FULLSTORY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gainsight-px/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gainsight-px/metadata.yaml
@@ -31,4 +31,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GAINSIGHT-PX__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gcs/metadata.yaml
@@ -28,4 +28,17 @@ data:
   tags:
     - language:python
     - cdk:python-file-based
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GCS_OLD__CREDS
+          fileName: old_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GCS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-genesys/metadata.yaml
+++ b/airbyte-integrations/connectors/source-genesys/metadata.yaml
@@ -26,4 +26,6 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-getlago/metadata.yaml
+++ b/airbyte-integrations/connectors/source-getlago/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GETLAGO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -44,4 +44,18 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GITHUB_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GITHUB_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -31,11 +31,7 @@ data:
   releases:
     breakingChanges:
       4.0.0:
-        message:
-          In this release, several changes have been made to the Gitlab connector.
-          The primary key was changed for streams `group_members`, `group_labels`,
-          `project_members`, `project_labels`, `branches`, and `tags`. Users will
-          need to refresh schemas and reset the affected streams after upgrading.
+        message: In this release, several changes have been made to the Gitlab connector. The primary key was changed for streams `group_members`, `group_labels`, `project_members`, `project_labels`, `branches`, and `tags`. Users will need to refresh schemas and reset the affected streams after upgrading.
         upgradeDeadline: "2024-04-15"
         scopedImpact:
           - scopeType: stream
@@ -51,21 +47,13 @@ data:
               - "branches"
               - "tags"
       3.0.0:
-        message:
-          In this release, merge_request_commits stream schema has been fixed
-          so that it returns commits for each merge_request. Users will need to refresh
-          the source schema and reset merge_request_commits stream after upgrading.
+        message: In this release, merge_request_commits stream schema has been fixed so that it returns commits for each merge_request. Users will need to refresh the source schema and reset merge_request_commits stream after upgrading.
         upgradeDeadline: "2024-02-13"
         scopedImpact:
           - scopeType: stream
             impactedScopes: ["merge_request_commits"]
       2.0.0:
-        message:
-          In this release, several streams were updated to date-time field
-          format, as declared in the Gitlab API. These changes impact pipeline.created_at
-          and pipeline.updated_at fields for stream Deployments and expires_at field
-          for stream Group Members and stream Project Members. Users will need to
-          refresh the source schema and reset affected streams after upgrading.
+        message: In this release, several streams were updated to date-time field format, as declared in the Gitlab API. These changes impact pipeline.created_at and pipeline.updated_at fields for stream Deployments and expires_at field for stream Group Members and stream Project Members. Users will need to refresh the source schema and reset affected streams after upgrading.
         upgradeDeadline: "2023-11-09"
   suggestedStreams:
     streams:
@@ -78,4 +66,28 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GITLAB_CREDS_WITH_IDS
+          fileName: config_with_ids.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GITLAB_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GITLAB_WITH_IDS__CREDS
+          fileName: config_with_ids.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GITLAB__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-glassfrog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-glassfrog/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GLASSFROG_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gnews/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gnews/metadata.yaml
@@ -27,4 +27,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GNEWS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_GONG_CREDS_OAUTH
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -32,24 +32,13 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          This release introduces fixes to custom query schema creation. Users
-          should refresh the source schema and reset affected streams after upgrading
-          to ensure uninterrupted syncs.
+        message: This release introduces fixes to custom query schema creation. Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs.
         upgradeDeadline: "2023-10-31"
       2.0.0:
-        message:
-          This release updates the Source Google Ads connector so that its
-          default streams and stream names match the related resources in Google Ads
-          API. Users should refresh the source schema and reset affected streams after
-          upgrading to ensure uninterrupted syncs.
+        message: This release updates the Source Google Ads connector so that its default streams and stream names match the related resources in Google Ads API. Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs.
         upgradeDeadline: "2023-11-30"
       3.0.0:
-        message:
-          Google is deprecating v13 of the Google Ads API in January. This
-          release upgrades the Google Ads API to the latest version (v15), which causes
-          changes in several schemas. Users should refresh the source schema and reset
-          affected streams after upgrading to ensure uninterrupted syncs.
+        message: Google is deprecating v13 of the Google Ads API in January. This release upgrades the Google Ads API to the latest version (v15), which causes changes in several schemas. Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs.
         upgradeDeadline: "2024-01-12"
   suggestedStreams:
     streams:
@@ -73,4 +62,50 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-GOOGLE-ADS_CLICK_VIEW__CREDS
+          fileName: config_click_view.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE-ADS_INCREMENTAL__CREDS
+          fileName: incremental_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE-ADS_MANAGER_ACCOUNT_CREDS
+          fileName: config_manager_account.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE-ADS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GOOGLE-ADS_CLICK_VIEW__CREDS
+          fileName: config_click_view.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE-ADS_INCREMENTAL__CREDS
+          fileName: incremental_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE-ADS_MANAGER_ACCOUNT_CREDS
+          fileName: config_manager_account.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE-ADS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -33,11 +33,7 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          Version 2.0.0 introduces changes to stream names for those syncing
-          more than one Google Analytics 4 property. It allows streams from all properties
-          to sync successfully. Please upgrade the connector to enable this additional
-          functionality.
+        message: Version 2.0.0 introduces changes to stream names for those syncing more than one Google Analytics 4 property. It allows streams from all properties to sync successfully. Please upgrade the connector to enable this additional functionality.
         upgradeDeadline: "2023-10-16"
   suggestedStreams:
     streams:
@@ -54,4 +50,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GOOGLE-ANALYTICS-DATA-API__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
@@ -30,4 +30,12 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_GOOGLE_ANALYTICS_V4_CLOUD__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -35,4 +35,23 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GOOGLE-ANALYTICS-V4_OLD_CREDS
+          fileName: old_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE-ANALYTICS_V4_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE-ANALYTICS_V4_SRV_ACC_CREDS
+          fileName: service_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-google-directory/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-directory/metadata.yaml
@@ -27,4 +27,18 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GOOGLE-DIRECTORY_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE-DIRECTORY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GOOGLE-PAGESPEED-INSIGHTS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
@@ -41,4 +41,18 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_GOOGLE_SEARCH_CONSOLE_CDK_CREDS_3
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE-SEARCH-CONSOLE_SERVICE_ACCOUNT__CREDS
+          fileName: service_account_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -32,4 +32,23 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GOOGLE_SHEETS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE_SHEETS_SERVICE_CREDS
+          fileName: service_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GOOGLE_SHEETS_WITH_URL_CREDS
+          fileName: config_with_url.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-google-webfonts/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-webfonts/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GOOGLE-WEBFONTS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -32,4 +32,18 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GREENHOUSE_USERS_ONLY__CREDS
+          fileName: config_users_only.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-GREENHOUSE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gridly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gridly/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GRIDLY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-gutendex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gutendex/metadata.yaml
@@ -25,4 +25,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-GUTENDEX__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-harness/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harness/metadata.yaml
@@ -27,4 +27,62 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-HARNESS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_HARNESS_1M_CREDENTIALS
+          fileName: source-postgres_1m_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_HARNESS_20M_CREDENTIALS
+          fileName: source-postgres_20m_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_HARNESS_2B_CREDENTIALS
+          fileName: source-postgres_2b_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_HARNESS_BOTTLENECK_STREAM1_CREDENTIALS
+          fileName: source-postgres_bottleneck_stream1_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_HARNESS_CREDENTIALS
+          fileName: source-postgres_10m_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_HARNESS_SOURCE-MYSQL_10M_CREDENTIALS
+          fileName: source-mysql_10m_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_HARNESS_SOURCE-MYSQL_1M_CREDENTIALS
+          fileName: source-mysql_1m_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_HARNESS_SOURCE-MYSQL_20M_CREDENTIALS
+          fileName: source-mysql_20m_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_HARNESS_SOURCE-MYSQL_BOTTLENECK_STREAM1_CREDENTIALS
+          fileName: source-mysql_bottleneck_stream1_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_MONGODB_HARNESS_1M_CREDENTIALS
+          fileName: source-mongodb-v2_1m_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-hellobaton/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hellobaton/metadata.yaml
@@ -30,4 +30,12 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-HELLOBATON__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-hubplanner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubplanner/metadata.yaml
@@ -30,4 +30,12 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-HUBPLANNER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -67,4 +67,50 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-HUBSPOT_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE_CREDS
+          fileName: config_oauth_no_start_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE__CREDS
+          fileName: config_oauth_no_start_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-HUBSPOT_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE_CREDS
+          fileName: config_oauth_no_start_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE__CREDS
+          fileName: config_oauth_no_start_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-insightly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-insightly/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-INSIGHTLY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -27,23 +27,14 @@ data:
   releases:
     breakingChanges:
       3.0.0:
-        message:
-          "The existing Instagram API (v11) has been deprecated. Customers
-          who use streams `Media Insights`, `Story Insights` or `User Lifetime Insights`
-          must take action with their connections. Please follow the to update to
-          the latest Instagram API (v18). For more details, see our <a href='https://docs.airbyte.com/integrations/sources/instagram-migrations'>migration
-          guide</a>."
+        message: "The existing Instagram API (v11) has been deprecated. Customers who use streams `Media Insights`, `Story Insights` or `User Lifetime Insights` must take action with their connections. Please follow the to update to the latest Instagram API (v18). For more details, see our <a href='https://docs.airbyte.com/integrations/sources/instagram-migrations'>migration guide</a>."
         upgradeDeadline: "2024-01-05"
         scopedImpact:
           - scopeType: stream
             impactedScopes:
               ["media_insights", "story_insights", "user_lifetime_insights"]
       2.0.0:
-        message:
-          This release introduces a default primary key for the streams UserLifetimeInsights
-          and UserInsights. Additionally, the format of timestamp fields has been
-          updated in the UserLifetimeInsights, UserInsights, Media and Stories streams
-          to include timezone information.
+        message: This release introduces a default primary key for the streams UserLifetimeInsights and UserInsights. Additionally, the format of timestamp fields has been updated in the UserLifetimeInsights, UserInsights, Media and Stories streams to include timezone information.
         upgradeDeadline: "2023-12-11"
   suggestedStreams:
     streams:
@@ -62,4 +53,20 @@ data:
     sl: 200
     ql: 400
   supportLevel: certified
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-INSTAGRAM__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-INSTAGRAM__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-instatus/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instatus/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-INSTATUS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -39,4 +39,30 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-INTERCOM_APIKEY__CREDS
+          fileName: config_apikey.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-INTERCOM__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-INTERCOM_APIKEY__CREDS
+          fileName: config_apikey.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-INTERCOM__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-intruder/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intruder/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-INTRUDER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-ip2whois/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ip2whois/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-IP2WHOIS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-iterable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-iterable/metadata.yaml
@@ -32,4 +32,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ITERABLE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -37,10 +37,7 @@ data:
           - scopeType: stream
             impactedScopes: ["board_issues", "issues", "sprint_issues"]
       1.0.0:
-        message:
-          "Stream state will be saved for every board in stream `Boards Issues`.
-          Customers who use stream `Board Issues` in Incremental Sync mode must take
-          action with their connections."
+        message: "Stream state will be saved for every board in stream `Boards Issues`. Customers who use stream `Board Issues` in Incremental Sync mode must take action with their connections."
         upgradeDeadline: "2024-01-25"
         scopedImpact:
           - scopeType: stream
@@ -55,4 +52,30 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-JIRA_EMPTY_PROJECTS_CREDS
+          fileName: config_empty_projects.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-JIRA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-JIRA_EMPTY_PROJECTS_CREDS
+          fileName: config_empty_projects.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-JIRA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-k6-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-k6-cloud/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-K6-CLOUD__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kafka/metadata.yaml
@@ -21,4 +21,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-klarna/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klarna/metadata.yaml
@@ -35,4 +35,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-KLARNA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-klaus-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaus-api/metadata.yaml
@@ -29,4 +29,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-KLAUS-API__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -48,4 +48,13 @@ data:
     sl: 200
     ql: 400
   supportLevel: certified
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-KLAVIYO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-kyriba/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kyriba/metadata.yaml
@@ -28,4 +28,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_KYRIBA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-kyve/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kyve/metadata.yaml
@@ -27,4 +27,18 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SOURCE-KYVE-CONFIG__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SOURCE-KYVE-MULTIPLE-POOLS-CONFIG__CREDS
+          fileName: config_multiple_pools.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-launchdarkly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-launchdarkly/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-LAUNCHDARKLY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-lemlist/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lemlist/metadata.yaml
@@ -29,4 +29,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-LEMLIST__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-lever-hiring/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lever-hiring/metadata.yaml
@@ -38,4 +38,13 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-LEVER-HIRING__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -49,10 +49,7 @@ data:
               - "ad_member_region_analytics"
               - "ad_member_company_analytics"
       2.0.0:
-        message:
-          This upgrade changes primary key for *-analytics streams from pivotValues[array
-          of strings] to string_of_pivot_values[string] so that it is compatible with
-          more destination types.
+        message: This upgrade changes primary key for *-analytics streams from pivotValues[array of strings] to string_of_pivot_values[string] so that it is compatible with more destination types.
         upgradeDeadline: "2024-05-14"
         scopedImpact:
           - scopeType: stream
@@ -81,4 +78,28 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-LINKEDIN_ADS_OAUTH2_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-LINKEDIN_ADS_OAUTH2_MULTIPLE_IDS__CREDS
+          fileName: config_multiple_account_ids.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-LINKEDIN_ADS_OLD_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-LINKEDIN_ADS_TOKEN_CREDS
+          fileName: config_token.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-linkedin-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-pages/metadata.yaml
@@ -26,4 +26,12 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-LINKEDIN-PAGES__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-linnworks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linnworks/metadata.yaml
@@ -28,4 +28,23 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-LINNWORKS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-LINNWORKS_DSDSSDS_A-B_CREDS
+          fileName: dsdssds_a-b---_---_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-LINNWORKS_TEST
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-lokalise/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lokalise/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-LOKALISE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-looker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-looker/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-LOOKER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -31,23 +31,13 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          The source Mailchimp connector is being migrated from the Python
-          CDK to our declarative low-code CDK. Due to changes in primary key for streams
-          `Segment Members` and `List Members`, this migration constitutes a breaking
-          change. After updating, please reset your source before resuming syncs.
-          For more information, see our migration documentation for source Mailchimp.
+        message: The source Mailchimp connector is being migrated from the Python CDK to our declarative low-code CDK. Due to changes in primary key for streams `Segment Members` and `List Members`, this migration constitutes a breaking change. After updating, please reset your source before resuming syncs. For more information, see our migration documentation for source Mailchimp.
         upgradeDeadline: "2024-04-10"
         scopedImpact:
           - scopeType: stream
             impactedScopes: ["segment_members", "list_members"]
       1.0.0:
-        message:
-          Version 1.0.0 introduces schema changes to all incremental streams.
-          A full schema refresh and data reset are required to upgrade to this version.
-          For more details, see our <a
-          href='https://docs.airbyte.io/integrations/sources/mailchimp-migrations'>migration
-          guide</a>.
+        message: Version 1.0.0 introduces schema changes to all incremental streams. A full schema refresh and data reset are required to upgrade to this version. For more details, see our <a href='https://docs.airbyte.io/integrations/sources/mailchimp-migrations'>migration guide</a>.
         upgradeDeadline: "2024-01-10"
   releaseStage: generally_available
   suggestedStreams:
@@ -60,4 +50,18 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MAILCHIMP_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MAILCHIMP__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mailerlite/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailerlite/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MAILERLITE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mailersend/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailersend/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MAILERSEND__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mailgun/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailgun/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MAILGUN_CONFIG
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mailjet-mail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailjet-mail/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MAILJET-MAIL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mailjet-sms/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailjet-sms/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MAILJET-SMS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-marketo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-marketo/metadata.yaml
@@ -32,4 +32,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MARKETO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-merge/metadata.yaml
+++ b/airbyte-integrations/connectors/source-merge/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MERGE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-metabase/metadata.yaml
+++ b/airbyte-integrations/connectors/source-metabase/metadata.yaml
@@ -39,4 +39,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-METABASE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml
@@ -26,4 +26,6 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-microsoft-onedrive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-onedrive/metadata.yaml
@@ -32,4 +32,13 @@ data:
   tags:
     - language:python
     - cdk:python-file-based
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MICROSOFT-ONEDRIVE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
@@ -34,4 +34,13 @@ data:
   tags:
     - language:python
     - cdk:python-file-based
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MICROSOFT-SHAREPOINTS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-microsoft-teams/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-teams/metadata.yaml
@@ -30,14 +30,29 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          Version 1.0.0 introduces breaking schema changes to all streams.
-          A full schema refresh is required to upgrade to this version.
-          For more details, see our <a href='https://docs.airbyte.io/integrations/sources/microsoft-teams-migrations'>migration guide</a>.
+        message: Version 1.0.0 introduces breaking schema changes to all streams. A full schema refresh is required to upgrade to this version. For more details, see our <a href='https://docs.airbyte.io/integrations/sources/microsoft-teams-migrations'>migration guide</a>.
         upgradeDeadline: "2024-01-24"
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/microsoft-teams
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MICROSOFT-TEAMS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MICROSOFT-TEAMS_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MICROSOFT-TEAMS_OLD_CREDS
+          fileName: old_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -34,19 +34,10 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          In this release, the default primary key for stream Export has been
-          deleted, allowing users to select the key that best fits their data. Refreshing
-          the source schema and resetting affected streams is necessary only if new
-          primary keys are to be applied following the upgrade.
+        message: In this release, the default primary key for stream Export has been deleted, allowing users to select the key that best fits their data. Refreshing the source schema and resetting affected streams is necessary only if new primary keys are to be applied following the upgrade.
         upgradeDeadline: "2023-11-30"
       1.0.0:
-        message:
-          In this release, the datetime field of stream engage has had its
-          type changed from date-time to string due to inconsistent data from Mixpanel.
-          Additionally, the primary key for stream export has been fixed to uniquely
-          identify records. Users will need to refresh the source schema and reset
-          affected streams after upgrading.
+        message: In this release, the datetime field of stream engage has had its type changed from date-time to string due to inconsistent data from Mixpanel. Additionally, the primary key for stream export has been fixed to uniquely identify records. Users will need to refresh the source schema and reset affected streams after upgrading.
         upgradeDeadline: "2023-10-31"
   suggestedStreams:
     streams:
@@ -61,4 +52,28 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MIXPANEL_CONFIG_INCREMENTAL
+          fileName: config_incremental.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MIXPANEL_PROJECT_SECRET
+          fileName: config_project_secret.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MIXPANEL_SERVICE_ACCOUNT
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MIXPANEL__CREDS
+          fileName: config_old.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -49,4 +49,23 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_MONDAY_API_CREDS
+          fileName: config_api_token.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_MONDAY_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_MONDAY_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -31,4 +31,30 @@ data:
         message: >
           **We advise against upgrading until you have run a test upgrade as outlined [here](https://docs.airbyte.com/integrations/sources/mongodb-v2-migrations).**  This version brings a host of updates to the MongoDB source connector, significantly increasing its scalability and reliability, especially for large collections. As of this version with checkpointing, [CDC incremental updates](https://docs.airbyte.com/understanding-airbyte/cdc) and improved schema discovery, this connector is also now [certified](https://docs.airbyte.com/integrations/). Selecting `Upgrade` will upgrade **all** connections using this source, require you to reconfigure the source, then run a full reset on **all** of your connections.
         upgradeDeadline: "2023-12-01"
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-MONGODB-V2_CREDENTIALS__CREDS
+          fileName: credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MONGODB-V2__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MONGODB-V2_CREDENTIALS__CREDS
+          fileName: credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MONGODB-V2__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -37,4 +37,30 @@ data:
       2.0.0:
         message: "Add default cursor for cdc"
         upgradeDeadline: "2023-08-23"
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-MSSQL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_MSSQL_PERFORMANCE_TEST_CREDS
+          fileName: performance-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MSSQL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_MSSQL_PERFORMANCE_TEST_CREDS
+          fileName: performance-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-my-hours/metadata.yaml
+++ b/airbyte-integrations/connectors/source-my-hours/metadata.yaml
@@ -35,4 +35,12 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MY-HOURS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -31,4 +31,60 @@ data:
   supportLevel: certified
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-MYSQL_SSH-KEY-REPL__CREDS
+          fileName: ssh-key-repl-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MYSQL_SSH-KEY__CREDS
+          fileName: ssh-key-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MYSQL_SSH-PWD-REPL__CREDS
+          fileName: ssh-pwd-repl-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MYSQL_SSH-PWD__CREDS
+          fileName: ssh-pwd-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_MYSQL_PERFORMANCE_TEST_CREDS
+          fileName: performance-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-MYSQL_SSH-KEY-REPL__CREDS
+          fileName: ssh-key-repl-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MYSQL_SSH-KEY__CREDS
+          fileName: ssh-key-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MYSQL_SSH-PWD-REPL__CREDS
+          fileName: ssh-pwd-repl-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-MYSQL_SSH-PWD__CREDS
+          fileName: ssh-pwd-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_MYSQL_PERFORMANCE_TEST_CREDS
+          fileName: performance-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-n8n/metadata.yaml
+++ b/airbyte-integrations/connectors/source-n8n/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-N8N__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-nasa/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nasa/metadata.yaml
@@ -27,4 +27,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-NASA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-netsuite/metadata.yaml
+++ b/airbyte-integrations/connectors/source-netsuite/metadata.yaml
@@ -26,4 +26,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_NETSUITE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-news-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-news-api/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-NEWS-API__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-newsdata/metadata.yaml
+++ b/airbyte-integrations/connectors/source-newsdata/metadata.yaml
@@ -27,4 +27,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-NEWSDATA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -31,25 +31,13 @@ data:
   releases:
     breakingChanges:
       3.0.0:
-        message:
-          The source Notion connector is being migrated from the Python CDK
-          to our declarative low-code CDK. Due to changes in the handling of state
-          format between these CDKs, this migration constitutes a breaking change
-          for users syncing the `Comments` stream. To ensure a smooth migration, please
-          reset your data for this stream upon updating. This will facilitate a fresh
-          first sync. If you are not syncing the `Comments` stream, you can upgrade
-          without any further action. For more information, see our migration documentation
-          for source Notion.
+        message: The source Notion connector is being migrated from the Python CDK to our declarative low-code CDK. Due to changes in the handling of state format between these CDKs, this migration constitutes a breaking change for users syncing the `Comments` stream. To ensure a smooth migration, please reset your data for this stream upon updating. This will facilitate a fresh first sync. If you are not syncing the `Comments` stream, you can upgrade without any further action. For more information, see our migration documentation for source Notion.
         upgradeDeadline: "2024-04-29"
         scopedImpact:
           - scopeType: stream
             impactedScopes: ["comments"]
       2.0.0:
-        message:
-          Version 2.0.0 introduces schema changes to multiple properties shared
-          by the blocks, databases and pages streams. These changes were introduced
-          to reflect updates to the Notion API. A full schema refresh and data reset
-          are required to upgrade to this version.
+        message: Version 2.0.0 introduces schema changes to multiple properties shared by the blocks, databases and pages streams. These changes were introduced to reflect updates to the Notion API. A full schema refresh and data reset are required to upgrade to this version.
         upgradeDeadline: "2023-11-09"
   suggestedStreams:
     streams:
@@ -61,4 +49,18 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-NOTION__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-NOTION__CREDS_OAUTH
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-nytimes/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nytimes/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-NYTIMES__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-okta/metadata.yaml
+++ b/airbyte-integrations/connectors/source-okta/metadata.yaml
@@ -26,4 +26,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-OKTA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-omnisend/metadata.yaml
+++ b/airbyte-integrations/connectors/source-omnisend/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-OMNISEND__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-onesignal/metadata.yaml
+++ b/airbyte-integrations/connectors/source-onesignal/metadata.yaml
@@ -27,4 +27,12 @@ data:
     - language:python
     - cdk:low-code
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ONESIGNAL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
@@ -29,4 +29,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-OPEN-EXCHANGE-RATES__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-OPENWEATHER_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-opsgenie/metadata.yaml
+++ b/airbyte-integrations/connectors/source-opsgenie/metadata.yaml
@@ -27,4 +27,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-OPSGENIE_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/metadata.yaml
@@ -21,4 +21,7 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/sources/oracle
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle/metadata.yaml
@@ -27,4 +27,13 @@ data:
   supportLevel: community
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE_ORACLE_PERFORMANCE_TEST_CREDS
+          fileName: performance-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-orb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orb/metadata.yaml
@@ -28,4 +28,18 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ORB_CREDITS_CREDS
+          fileName: config_credits_ledger_entries.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-ORB_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-orbit/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orbit/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_ORBIT__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-outbrain-amplify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-outbrain-amplify/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-OUTBRAIN-AMPLIFY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-outreach/metadata.yaml
+++ b/airbyte-integrations/connectors/source-outreach/metadata.yaml
@@ -28,4 +28,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-OUTREACH_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pagerduty/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pagerduty/metadata.yaml
@@ -30,4 +30,12 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PAGERDUTY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pardot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pardot/metadata.yaml
@@ -26,4 +26,6 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -33,12 +33,7 @@ data:
   releases:
     breakingChanges:
       2.1.0:
-        message:
-          'Version 2.1.0 changes the format of the state. The format of the
-          cursor changed from "2021-06-18T16:24:13+03:00" to "2021-06-18T16:24:13Z".
-          The state key for the transactions stream changed to "transaction_updated_date"
-          and the key for the balances stream change to "as_of_time". The upgrade
-          is safe, but rolling back is not.'
+        message: 'Version 2.1.0 changes the format of the state. The format of the cursor changed from "2021-06-18T16:24:13+03:00" to "2021-06-18T16:24:13Z". The state key for the transactions stream changed to "transaction_updated_date" and the key for the balances stream change to "as_of_time". The upgrade is safe, but rolling back is not.'
         upgradeDeadline: "2023-09-18"
   suggestedStreams:
     streams:
@@ -49,4 +44,23 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PAYPAL-TRANSACTION_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-PAYPAL-TRANSACTION_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-PAYPAL-TRANSACTION_OAUTH_SANDBOX_CREDS
+          fileName: config_oauth_sandbox.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-paystack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paystack/metadata.yaml
@@ -29,4 +29,13 @@ data:
     sl: 100
     ql: 300
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PAYSTACK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pendo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pendo/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PENDO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-persistiq/metadata.yaml
+++ b/airbyte-integrations/connectors/source-persistiq/metadata.yaml
@@ -29,4 +29,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PERSISTIQ__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pexels-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pexels-api/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PEXELS-API__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pinterest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pinterest/metadata.yaml
@@ -27,15 +27,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          "This release updates the date-time fields to use the Airbyte format
-          `timestamp_without_timezone`. This change affects all streams where date-time
-          fields are present, ensuring more accurate and standardized time representations:
-          BoardPins, BoardSectionPins, Boards, Catalogs, and CatalogFeeds. Additionally,
-          the stream names AdvertizerReport and AdvertizerTargetingReport have been
-          renamed to AdvertiserReport and AdvertiserTargetingReport, respectively.
-          Users will need to refresh the source schema and reset affected streams
-          after upgrading."
+        message: "This release updates the date-time fields to use the Airbyte format `timestamp_without_timezone`. This change affects all streams where date-time fields are present, ensuring more accurate and standardized time representations: BoardPins, BoardSectionPins, Boards, Catalogs, and CatalogFeeds. Additionally, the stream names AdvertizerReport and AdvertizerTargetingReport have been renamed to AdvertiserReport and AdvertiserTargetingReport, respectively. Users will need to refresh the source schema and reset affected streams after upgrading."
         upgradeDeadline: "2023-12-14"
   suggestedStreams:
     streams:
@@ -56,4 +48,18 @@ data:
     sl: 200
     ql: 400
   supportLevel: certified
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PINTEREST__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-PINTEREST__OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
@@ -35,4 +35,23 @@ data:
   tags:
     - cdk:low-code
     - language:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PIPEDRIVE_OAUTH__CREDS
+          fileName: oauth_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-PIPEDRIVE_OLD__CREDS
+          fileName: old_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-PIPEDRIVE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pivotal-tracker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pivotal-tracker/metadata.yaml
@@ -35,4 +35,13 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PIVOTAL-TRACKER_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-plaid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-plaid/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PLAID__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pocket/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pocket/metadata.yaml
@@ -28,4 +28,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-POCKET__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -27,4 +27,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-POKEAPI__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-polygon-stock-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-polygon-stock-api/metadata.yaml
@@ -31,4 +31,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-POLYGON-STOCK-API__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -26,4 +26,40 @@ data:
   supportLevel: certified
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-POSTGRES_CDC__CREDS
+          fileName: config_cdc.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-POSTGRES__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_POSTGRES_PERFORMANCE_TEST_CREDS
+          fileName: performance-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-POSTGRES_CDC__CREDS
+          fileName: config_cdc.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-POSTGRES__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_POSTGRES_PERFORMANCE_TEST_CREDS
+          fileName: performance-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-posthog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-posthog/metadata.yaml
@@ -30,11 +30,25 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          The `event` field in the `events` stream has been corrected to the proper data type.
-          To apply this change, refresh the schema for the `events` stream and reset your data. For more information [visit](https://docs.airbyte.com/integrations/sources/posthog-migrations)
+        message: The `event` field in the `events` stream has been corrected to the proper data type. To apply this change, refresh the schema for the `events` stream and reset your data. For more information [visit](https://docs.airbyte.com/integrations/sources/posthog-migrations)
         upgradeDeadline: "2024-01-15"
   tags:
     - cdk:low-code
     - language:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-POSTHOG__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-POSTHOG__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-postmarkapp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postmarkapp/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-POSTMARKAPP__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-prestashop/metadata.yaml
+++ b/airbyte-integrations/connectors/source-prestashop/metadata.yaml
@@ -31,4 +31,7 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-primetric/metadata.yaml
+++ b/airbyte-integrations/connectors/source-primetric/metadata.yaml
@@ -15,9 +15,7 @@ data:
     breakingChanges:
       1.0.0:
         upgradeDeadline: "2024-05-30"
-        message:
-          "The verison migrates the Primetric connector to the low-code framework for greater maintainability.
-          !! Important: The uuid field now have a string format (without 'format: uuid') for all streams"
+        message: "The verison migrates the Primetric connector to the low-code framework for greater maintainability. !! Important: The uuid field now have a string format (without 'format: uuid') for all streams"
   connectorBuildOptions:
     # Please update to the latest version of the connector base image.
     # https://hub.docker.com/r/airbyte/python-connector-base
@@ -42,4 +40,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PRIMETRIC__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-public-apis/metadata.yaml
+++ b/airbyte-integrations/connectors/source-public-apis/metadata.yaml
@@ -29,4 +29,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PUBLIC-APIS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-punk-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-punk-api/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PUNK-API__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-pypi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pypi/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-PYPI__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-qonto/metadata.yaml
+++ b/airbyte-integrations/connectors/source-qonto/metadata.yaml
@@ -15,4 +15,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-QONTO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-qualaroo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-qualaroo/metadata.yaml
@@ -27,4 +27,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-QUALAROO_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -38,4 +38,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-QUICKBOOKS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-railz/metadata.yaml
+++ b/airbyte-integrations/connectors/source-railz/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-RAILZ-AI_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-rd-station-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rd-station-marketing/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-RD-STATION-MARKETING__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-recharge/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recharge/metadata.yaml
@@ -32,4 +32,18 @@ data:
     sl: 200
     ql: 400
   supportLevel: certified
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-RECHARGE_ORDERS_MODERN_API__CREDS
+          fileName: config_order_modern_api.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-RECHARGE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-recreation/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recreation/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-RECREATION__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-recruitee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recruitee/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-RECRUITEE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-recurly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recurly/metadata.yaml
@@ -22,10 +22,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          Version 1.0.0 introduces a number of schema updates to the Recurly
-          connector. To ensure a smooth upgrade, please refresh your schemas and reset
-          your data before resuming syncs.
+        message: Version 1.0.0 introduces a number of schema updates to the Recurly connector. To ensure a smooth upgrade, please refresh your schemas and reset your data before resuming syncs.
         upgradeDeadline: "2024-03-05"
   releaseStage: alpha
   remoteRegistries:
@@ -36,4 +33,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-RECURLY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/source-redshift/metadata.yaml
@@ -21,4 +21,13 @@ data:
   supportLevel: community
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-REDSHIFT__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-reply-io/metadata.yaml
+++ b/airbyte-integrations/connectors/source-reply-io/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-REPLY-IO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-retently/metadata.yaml
+++ b/airbyte-integrations/connectors/source-retently/metadata.yaml
@@ -31,4 +31,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-RETENTLY_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-ringcentral/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ringcentral/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-RINGCENTRAL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-rki-covid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rki-covid/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-RKI-COVID__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-rocket-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rocket-chat/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ROCKET-CHAT__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-rss/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rss/metadata.yaml
@@ -40,4 +40,12 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-RSS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -31,17 +31,251 @@ data:
   releases:
     breakingChanges:
       4.0.0:
-        message:
-          UX improvement, multi-stream support and deprecation of some parsing
-          features
+        message: UX improvement, multi-stream support and deprecation of some parsing features
         upgradeDeadline: "2023-10-05"
       4.0.4:
-        message:
-          Following 4.0.0 config change, we are eliminating the `streams.*.file_type`
-          field which was redundant with `streams.*.format`
+        message: Following 4.0.0 config change, we are eliminating the `streams.*.file_type` field which was redundant with `streams.*.format`
         upgradeDeadline: "2023-10-18"
   supportLevel: certified
   tags:
     - language:python
     - cdk:python-file-based
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-S3_AVRO__CREDS
+          fileName: avro_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_CREDS_V4
+          fileName: v4_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_IAM_ROLE__CREDS
+          fileName: config_iam_role.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_JSONL_NEWLINES__CREDS
+          fileName: jsonl_newlines_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_JSONL__CREDS
+          fileName: jsonl_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_AVRO_DECIMAL_CREDS
+          fileName: legacy_avro_decimal_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_AVRO_DURATIONS_CREDS
+          fileName: legacy_avro_duration_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_CSV_CUSTOM_ENCODING_CREDS
+          fileName: legacy_csv_custom_encoding_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_CSV_CUSTOM_FORMAT_CREDS
+          fileName: legacy_csv_custom_format_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_CSV_NO_HEADER_CREDS
+          fileName: legacy_csv_no_header_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_CSV_SKIP_ROWS_CREDS
+          fileName: legacy_csv_skip_rows_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_CSV_SKIP_ROWS_NO_HEADER_CREDS
+          fileName: legacy_csv_skip_rows_no_header_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_CSV_USER_SCHEMA_CAST_COMPLEX_CREDS
+          fileName: legacy_csv_user_schema_cast_complex.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_CSV_USER_SCHEMA_CREDS
+          fileName: legacy_csv_user_schema_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_CSV_WITH_NULLS_CREDS
+          fileName: legacy_csv_with_nulls_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_CSV_WITH_NULL_BOOLS_CREDS
+          fileName: legacy_csv_with_null_bools_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_PARQUET_DECIMAL_CREDS
+          fileName: legacy_parquet_decimal_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_LEGACY_PARQUET_DURATION_LIST_STRUCT_CREDS
+          fileName: legacy_parquet_duration_list_struct_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_PARQUET_DATASET__CREDS
+          fileName: parquet_dataset_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_PARQUET__CREDS
+          fileName: parquet_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_UNSTRUCTURED__CREDS
+          fileName: unstructured_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_AVRO_DECIMAL_AS_FLOAT__CREDS
+          fileName: v4_avro_decimal_as_float_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_AVRO_DECIMAL__CREDS
+          fileName: v4_avro_decimal_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_AVRO_DURATIONS__CREDS
+          fileName: v4_avro_duration_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_AVRO__CREDS
+          fileName: v4_avro_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_CSV_CUSTOM_ENCODING__CREDS
+          fileName: v4_csv_custom_encoding_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_CSV_CUSTOM_FORMAT__CREDS
+          fileName: v4_csv_custom_format_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_CSV_NO_HEADER__CREDS
+          fileName: v4_csv_no_header_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_CSV_SKIP_ROWS_NO_HEADER__CREDS
+          fileName: v4_csv_skip_rows_no_header_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_CSV_SKIP_ROWS__CREDS
+          fileName: v4_csv_skip_rows_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_CSV_USER_SCHEMA_CAST_COMPLEX__CREDS
+          fileName: v4_csv_user_schema_cast_complex_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_CSV_USER_SCHEMA__CREDS
+          fileName: v4_csv_user_schema_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_CSV_WITH_NULLS__CREDS
+          fileName: v4_csv_with_nulls_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_CSV_WITH_NULL_BOOLS__CREDS
+          fileName: v4_csv_with_null_bools_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_JSONL_NEWLINE__CREDS
+          fileName: v4_jsonl_newlines_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_JSONL__CREDS
+          fileName: v4_jsonl_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_PARQUET_DATASET__CREDS
+          fileName: v4_parquet_dataset_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_PARQUET_DECIMAL_AS_FLOAT__CREDS
+          fileName: v4_parquet_decimal_as_float_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_PARQUET_DECIMAL__CREDS
+          fileName: v4_parquet_decimal_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_PARQUET_DURATION_LIST_STRUCT__CREDS
+          fileName: v4_parquet_duration_list_struct_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_V4_PARQUET__CREDS
+          fileName: v4_parquet_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_ZIP_AVRO__CREDS
+          fileName: zip_config_avro.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_ZIP_CSV_CUSTOM_ENCODING__CREDS
+          fileName: zip_config_csv_custom_encoding.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_ZIP_CSV__CREDS
+          fileName: zip_config_csv.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_ZIP_JSONL__CREDS
+          fileName: zip_config_jsonl.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3_ZIP_PARQUET__CREDS
+          fileName: zip_config_parquet.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-S3__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -32,4 +32,40 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-SALESFORCE_BULK_CREDS
+          fileName: config_bulk.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SALESFORCE_REST_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SALESFORCE_SANDBOX_CREDS
+          fileName: config_sandbox.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SALESFORCE_BULK_CREDS
+          fileName: config_bulk.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SALESFORCE_REST_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SALESFORCE_SANDBOX_CREDS
+          fileName: config_sandbox.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-salesloft/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesloft/metadata.yaml
@@ -29,4 +29,18 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SALESLOFT_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SALESLOFT__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sap-fieldglass/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sap-fieldglass/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SAP-FIELDGLASS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-secoda/metadata.yaml
+++ b/airbyte-integrations/connectors/source-secoda/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SECODA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -14,13 +14,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          This release makes several changes that upgrade the Sendgrid connector.
-          The configuration options have been renamed to `api_key` and `start_date`. `start_date` is now required.
-          The `unsubscribe_groups` stream has been removed. It was the same as `suppression_groups`. You can use that and get the same data.
-          The `single_sends` stream has been renamed `singlesend_stats`. This is closer to the data and API.
-          The `segments` stream has been upgraded to use the Sendgrid 2.0 API because the older one has been deprecated. The schema has changed as a result.
-          To ensure a smooth upgrade, please refresh your schemas and reset your data before resuming syncs.
+        message: This release makes several changes that upgrade the Sendgrid connector. The configuration options have been renamed to `api_key` and `start_date`. `start_date` is now required. The `unsubscribe_groups` stream has been removed. It was the same as `suppression_groups`. You can use that and get the same data. The `single_sends` stream has been renamed `singlesend_stats`. This is closer to the data and API. The `segments` stream has been upgraded to use the Sendgrid 2.0 API because the older one has been deprecated. The schema has changed as a result. To ensure a smooth upgrade, please refresh your schemas and reset your data before resuming syncs.
         upgradeDeadline: "2024-04-29"
   dockerRepository: airbyte/source-sendgrid
   documentationUrl: https://docs.airbyte.com/integrations/sources/sendgrid
@@ -43,4 +37,28 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SENDGRID_LOWCODE__CREDS
+          fileName: lowcode_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SENDGRID_OLD__CREDS
+          fileName: old_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SENDGRID_PYTHON__CREDS
+          fileName: python_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SENDGRID__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sendinblue/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendinblue/metadata.yaml
@@ -26,4 +26,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SENDINBLUE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-senseforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-senseforce/metadata.yaml
@@ -30,4 +30,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SENSEFORCE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -36,4 +36,18 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SENTRY_LIMITED_SCOPE__CREDS
+          fileName: config_limited_scopes.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SENTRY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-serpstat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-serpstat/metadata.yaml
@@ -24,4 +24,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SERPSTAT__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -33,4 +33,20 @@ data:
   tags:
     - language:python
     - cdk:python-file-based
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-SFTP-BULK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SFTP-BULK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sftp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp/metadata.yaml
@@ -21,4 +21,7 @@ data:
   supportLevel: community
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -32,14 +32,10 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          "This upgrade brings changes to certain streams after migration to
-          Shopify API version `2023-07`, more details in this PR: https://github.com/airbytehq/airbyte/pull/29361."
+        message: "This upgrade brings changes to certain streams after migration to Shopify API version `2023-07`, more details in this PR: https://github.com/airbytehq/airbyte/pull/29361."
         upgradeDeadline: "2023-09-17"
       2.0.0:
-        message:
-          "This upgrade brings perfomance impovements and stream schema changes.
-          Details are available here: https://github.com/airbytehq/airbyte/pull/32345#issue-1985556333."
+        message: "This upgrade brings perfomance impovements and stream schema changes. Details are available here: https://github.com/airbytehq/airbyte/pull/32345#issue-1985556333."
         upgradeDeadline: "2024-03-18"
         scopedImpact:
           - scopeType: stream
@@ -109,4 +105,28 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SHOPIFY-TRANSACTIONS-WITH-USER-ID__CREDS
+          fileName: config_transactions_with_user_id.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SHOPIFY_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SHOPIFY_OLD_CREDS
+          fileName: config_old.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SHOPIFY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-shortio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shortio/metadata.yaml
@@ -33,4 +33,12 @@ data:
   ab_internal:
     sl: 100
     ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SHORTIO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -31,14 +31,7 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          The source Slack connector is being migrated from the Python CDK
-          to our declarative low-code CDK. Due to changes in the handling of state
-          format for incremental substreams, this migration constitutes a breaking
-          change for the channel_messages stream. Users will need to reset source
-          configuration, refresh the source schema and reset the channel_messages
-          stream after upgrading. For more information, see our migration documentation
-          for source Slack.
+        message: The source Slack connector is being migrated from the Python CDK to our declarative low-code CDK. Due to changes in the handling of state format for incremental substreams, this migration constitutes a breaking change for the channel_messages stream. Users will need to reset source configuration, refresh the source schema and reset the channel_messages stream after upgrading. For more information, see our migration documentation for source Slack.
         upgradeDeadline: "2024-04-29"
         scopedImpact:
           - scopeType: stream
@@ -55,4 +48,18 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SLACK_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SLACK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-smaily/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smaily/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SMAILY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-smartengage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smartengage/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SMARTENGAGE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-smartsheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smartsheets/metadata.yaml
@@ -30,4 +30,18 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SMARTSHEETS_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SMARTSHEETS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -33,4 +33,13 @@ data:
     sl: 200
     ql: 400
   supportLevel: certified
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_SNAPCHAT_MARKETING_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -24,4 +24,30 @@ data:
   supportLevel: community
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-SNOWFLAKE_OAUTH__CREDS
+          fileName: config_auth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SNOWFLAKE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SNOWFLAKE_OAUTH__CREDS
+          fileName: config_auth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SNOWFLAKE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-sonar-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sonar-cloud/metadata.yaml
@@ -31,4 +31,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SONAR-CLOUD__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-spacex-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-spacex-api/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SPACEX-API__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-square/metadata.yaml
+++ b/airbyte-integrations/connectors/source-square/metadata.yaml
@@ -32,4 +32,18 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SQUARE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_SQUARE_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-statuspage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-statuspage/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-STATUSPAGE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-strava/metadata.yaml
+++ b/airbyte-integrations/connectors/source-strava/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-STRAVA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -31,20 +31,10 @@ data:
   releases:
     breakingChanges:
       4.0.0:
-        message:
-          Version 4.0.0 changes the cursors in most of the Stripe streams that
-          support incremental sync mode. This is done to not only sync the data that
-          was created since previous sync, but also the data that was modified. A
-          schema refresh of all effected streams is required to use the new cursor
-          format.
+        message: Version 4.0.0 changes the cursors in most of the Stripe streams that support incremental sync mode. This is done to not only sync the data that was created since previous sync, but also the data that was modified. A schema refresh of all effected streams is required to use the new cursor format.
         upgradeDeadline: "2023-09-14"
       5.0.0:
-        message:
-          Version 5.0.0 introduces fixes for the `CheckoutSessions`, `CheckoutSessionsLineItems`
-          and `Refunds` streams. The cursor field is changed for the `CheckoutSessionsLineItems`
-          and `Refunds` streams. This will prevent data loss during incremental syncs.
-          Also, the `Invoices`, `Subscriptions` and `SubscriptionSchedule` stream
-          schemas have been updated.
+        message: Version 5.0.0 introduces fixes for the `CheckoutSessions`, `CheckoutSessionsLineItems` and `Refunds` streams. The cursor field is changed for the `CheckoutSessionsLineItems` and `Refunds` streams. This will prevent data loss during incremental syncs. Also, the `Invoices`, `Subscriptions` and `SubscriptionSchedule` stream schemas have been updated.
         upgradeDeadline: "2023-12-11"
   suggestedStreams:
     streams:
@@ -57,4 +47,23 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-STRIPE_CONNECTED_ACCOUNT__CREDS
+          fileName: connected_account_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-STRIPE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-STRIPE__PERFORMANCE
+          fileName: performance-config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-survey-sparrow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-survey-sparrow/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SURVEY-SPARROW__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-surveycto/metadata.yaml
+++ b/airbyte-integrations/connectors/source-surveycto/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SURVEYCTO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-surveymonkey/metadata.yaml
+++ b/airbyte-integrations/connectors/source-surveymonkey/metadata.yaml
@@ -32,4 +32,18 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-SURVEYMONKEY_OLD__CREDS
+          fileName: config_old.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-SURVEYMONKEY__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-tempo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tempo/metadata.yaml
@@ -29,4 +29,17 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TEMPO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_TEMPO_LIMITED_SCOPES
+          fileName: accounts_only_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/source-teradata/metadata.yaml
@@ -24,4 +24,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-TERADATA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-the-guardian-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-the-guardian-api/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-THE-GUARDIAN-API__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-tidb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tidb/metadata.yaml
@@ -25,4 +25,7 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -42,4 +42,53 @@ data:
       - ad_groups
       - ad_groups_reports_daily
       - advertisers_reports_daily
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_NEW_CREDS
+          fileName: new_config_sandbox.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_NEW_PROD_CREDS
+          fileName: new_config_prod.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS
+          fileName: prod_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS_WITH_DAY_GRANULARITY
+          fileName: prod_config_with_day_granularity.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_CREDS_WITH_LIFETIME_GRANULARITY
+          fileName: prod_config_with_lifetime_granularity.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_PROD_DAY_CREDS
+          fileName: prod_config_day.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TIKTOK-MARKETING_SANDBOX_CREDS
+          fileName: sandbox_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-timely/metadata.yaml
+++ b/airbyte-integrations/connectors/source-timely/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TIMELY_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-tmdb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tmdb/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TMDB__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-todoist/metadata.yaml
+++ b/airbyte-integrations/connectors/source-todoist/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TODOIST__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-toggl/metadata.yaml
+++ b/airbyte-integrations/connectors/source-toggl/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TOGGL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-tplcentral/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tplcentral/metadata.yaml
@@ -25,4 +25,6 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-trello/metadata.yaml
+++ b/airbyte-integrations/connectors/source-trello/metadata.yaml
@@ -37,4 +37,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TRELLO_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-trustpilot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-trustpilot/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TRUSTPILOT__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-tvmaze-schedule/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tvmaze-schedule/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TVMAZE-SCHEDULE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-twilio-taskrouter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio-taskrouter/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TWILIO-TASKROUTER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -35,4 +35,18 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TWILIO_LOOKBACK_WINDOW__CREDS
+          fileName: config_with_lookback.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TWILIO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-twitter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twitter/metadata.yaml
@@ -29,4 +29,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TWITTER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -32,15 +32,34 @@ data:
   releases:
     breakingChanges:
       1.1.0:
-        message:
-          This version migrates the Typeform connector to the low-code framework
-          for greater maintainability. This introduces a breaking change to the state
-          format for the `responses` stream. If you are using the incremental sync
-          mode for this stream, you will need to reset affected connections after
-          upgrading to prevent sync failures.
+        message: This version migrates the Typeform connector to the low-code framework for greater maintainability. This introduces a breaking change to the state format for the `responses` stream. If you are using the incremental sync mode for this stream, you will need to reset affected connections after upgrading to prevent sync failures.
         upgradeDeadline: "2023-09-25"
   supportLevel: certified
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-TYPEFORM_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TYPEFORM__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TYPEFORM__CREDS_INCREMENTAL
+          fileName: incremental_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-TYPEFORM__CREDS_TOKEN
+          fileName: config_token.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-unleash/metadata.yaml
+++ b/airbyte-integrations/connectors/source-unleash/metadata.yaml
@@ -27,4 +27,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-UNLEASH_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-us-census/metadata.yaml
+++ b/airbyte-integrations/connectors/source-us-census/metadata.yaml
@@ -26,4 +26,20 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-US-CENSUS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-US-CENSUS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-vantage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-vantage/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-VANTAGE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-visma-economic/metadata.yaml
+++ b/airbyte-integrations/connectors/source-visma-economic/metadata.yaml
@@ -29,4 +29,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-VISMA-ECONOMIC__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-weatherstack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-weatherstack/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-WEATHERSTACK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-webflow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-webflow/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_WEBFLOW__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-whisky-hunter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-whisky-hunter/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-WHISKY-HUNTER__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-wikipedia-pageviews/metadata.yaml
+++ b/airbyte-integrations/connectors/source-wikipedia-pageviews/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-WIKIPEDIA-PAGEVIEWS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
@@ -29,4 +29,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-WOOCOMMERCE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-wrike/metadata.yaml
+++ b/airbyte-integrations/connectors/source-wrike/metadata.yaml
@@ -31,4 +31,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-WRIKE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -29,4 +29,13 @@ data:
     sl: 100
     ql: 300
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-XERO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-xkcd/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xkcd/metadata.yaml
@@ -26,4 +26,13 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-XKCD__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-yahoo-finance-price/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yahoo-finance-price/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-YAHOO-FINANCE-PRICES__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-yandex-metrica/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yandex-metrica/metadata.yaml
@@ -31,4 +31,13 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-YANDEX-METRICA__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-yotpo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yotpo/metadata.yaml
@@ -26,4 +26,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_YOTPO_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-younium/metadata.yaml
+++ b/airbyte-integrations/connectors/source-younium/metadata.yaml
@@ -29,4 +29,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-YOUNIUM__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-youtube-analytics/metadata.yaml
+++ b/airbyte-integrations/connectors/source-youtube-analytics/metadata.yaml
@@ -29,4 +29,6 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zapier-supported-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zapier-supported-storage/metadata.yaml
@@ -28,4 +28,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ZAPIER-SUPPORTED-STORAGE__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
@@ -32,4 +32,22 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE_ZENDESK_CHAT_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_ZENDESK_CHAT_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE_ZENDESK_CHAT_OLD_CREDS
+          fileName: config_old.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
@@ -29,4 +29,12 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ZENDESK-SELL__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zendesk-sunshine/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-sunshine/metadata.yaml
@@ -32,4 +32,17 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ZENDESK-SUNSHINE_API_TOKEN__CREDS
+          fileName: config_api_token.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-ZENDESK-SUNSHINE_OAUTH__CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -35,9 +35,7 @@ data:
         message: "`cursor_field` for `Tickets` stream is changed to `generated_timestamp`"
         upgradeDeadline: "2023-07-19"
       2.0.0:
-        message:
-          The `Deleted Tickets` stream was removed. Deleted tickets are still
-          available from the Tickets stream.
+        message: The `Deleted Tickets` stream was removed. Deleted tickets are still available from the Tickets stream.
         upgradeDeadline: "2023-10-04"
   suggestedStreams:
     streams:
@@ -58,4 +56,23 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ZENDESK-SUPPORT_OAUTH_CRED
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-ZENDESK-SUPPORT_TOKEN_CRED
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_ZENDESK_SUPPORT_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -35,11 +35,22 @@ data:
       1.0.0:
         upgradeDeadline: "2024-05-31"
         message: >-
-          The source Zendesk Talk connector is being migrated from the Python CDK to our declarative low-code CDK. 
-          Due to changes to the incremental stream state message format and the removal of a nonexistent field from 
-          the ivrs stream schema, this migration constitutes a breaking change. After updating, please reset your source 
-          before resuming syncs. For more information, see our migration documentation for source Zendesk Talk.
+          The source Zendesk Talk connector is being migrated from the Python CDK to our declarative low-code CDK.  Due to changes to the incremental stream state message format and the removal of a nonexistent field from  the ivrs stream schema, this migration constitutes a breaking change. After updating, please reset your source  before resuming syncs. For more information, see our migration documentation for source Zendesk Talk.
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ZENDESK-TALK_OLD__CREDS
+          fileName: config_old.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-ZENDESK-TALK__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zenefits/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenefits/metadata.yaml
@@ -32,4 +32,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ZENEFITS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zenloop/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/metadata.yaml
@@ -31,4 +31,12 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ZENLOOP__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
@@ -26,4 +26,20 @@ data:
   tags:
     - language:python
     - cdk:python
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-ZOHO-CRM_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ZOHO-CRM_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zoom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoom/metadata.yaml
@@ -23,10 +23,7 @@ data:
   releases:
     breakingChanges:
       1.1.0:
-        message:
-          Zoom has deprecated JWT authentication in favor of OAuth. To successfully
-          migrate, users will need to create a new server-to-server OAuth app and
-          update their credentials in the Airbyte UI.
+        message: Zoom has deprecated JWT authentication in favor of OAuth. To successfully migrate, users will need to create a new server-to-server OAuth app and update their credentials in the Airbyte UI.
         upgradeDeadline: 2023-09-08
         scopedImpact:
           - scopeType: stream
@@ -39,4 +36,13 @@ data:
   tags:
     - language:python
     - cdk:low-code
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-ZOOM__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/7549
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/7550

This PR seeds the `connectortTestSuitesOptions` new metadata field on all our connectors

## How
I generated the values with an ad-hoc `airbyte-ci` command (that might not be merged).
I checked test suite existence in the following manner:
#### For python connectors
A connector has unit tests or integration tests if these test folders have files with the `test` substring in it. This is how pytest discovers tests/

#### For java connectors
If a connector has `src/test` I consider they have unit test. If a connector has `src/test-integration` I consider that have integration test

I considered a connector has `acceptanceTest` if they have a file named `acceptance-test-config.yml` in their folder.

#### Secret validation
I pulled secrets from GSM and mapped a secret to a connector thanks to the `connector` secret label.
I ran a `check` with the secret config against a connector to validate that the secret configuration are valid.
Invalid secrets are not declared in the metadata files.

## User Impact
None as it field it not yet used.
They'll be used when work on the following issues will be done:
https://github.com/airbytehq/airbyte-internal-issues/issues/7551
https://github.com/airbytehq/airbyte-internal-issues/issues/7552

## Safe to merge without CI?
Yes I think so. I don't want to run CI on all our connectors as it will not pass on a lot of connectors.
This field introduction is not changing the connector behavior and I manually tested that the metadata files are valid.

@bnchrch merging this will trigger metadata upload of 335 connectors. Just warning you that we might observe an heavy load on Dagster.