### PR TITLE
Update the destination template not to use AirbyteLogger

### DIFF
--- a/airbyte-integrations/connector-templates/destination-python/destination_{{snakeCase name}}/destination.py.hbs
+++ b/airbyte-integrations/connector-templates/destination-python/destination_{{snakeCase name}}/destination.py.hbs
@@ -2,10 +2,10 @@
 # Copyright (c) {{currentYear}} Airbyte, Inc., all rights reserved.
 #
 
+import logging
 
 from typing import Any, Iterable, Mapping
 
-from airbyte_cdk import AirbyteLogger
 from airbyte_cdk.destinations import Destination
 from airbyte_cdk.models import AirbyteConnectionStatus, AirbyteMessage, ConfiguredAirbyteCatalog, Status
 
@@ -33,7 +33,7 @@ class Destination{{properCase name}}(Destination):
 
         pass
 
-    def check(self, logger: AirbyteLogger, config: Mapping[str, Any]) -> AirbyteConnectionStatus:
+    def check(self, logger: logging.Logger, config: Mapping[str, Any]) -> AirbyteConnectionStatus:
         """
         Tests if the input configuration can be used to successfully connect to the destination with the needed permissions
             e.g: if a provided API token or password can be used to connect and write to the destination.


### PR DESCRIPTION
## What
The `AirbyteLogger` class has been deprecated for a very long time and will be removed from the CDK shortly. This PR updates the destination template to use `logging.Logger` instead.

Existing destinations will be updated in follow up PRs

## User Impact
The destination template uses `logging.Logger` in its method signature

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
