### PR TITLE
Snowflake Cortex destination : Bug fixes  

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/config.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/config.py
@@ -32,7 +32,6 @@ class SnowflakeCortexIndexingModel(BaseModel):
         order=1,
         description="Enter the account name you want to use to access the database. This is usually the identifier before .snowflakecomputing.com",
         examples=["AIRBYTE_ACCOUNT"],
-        
     )
     role: str = Field(
         ...,

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/config.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/config.py
@@ -17,6 +17,7 @@ class PasswordBasedAuthorizationModel(BaseModel):
         airbyte_secret=True,
         description="Enter the password you want to use to access the database",
         examples=["AIRBYTE_PASSWORD"],
+        order=7,
     )
 
     class Config:
@@ -28,42 +29,43 @@ class SnowflakeCortexIndexingModel(BaseModel):
     host: str = Field(
         ...,
         title="Host",
-        airbyte_secret=True,
+        order=1,
         description="Enter the account name you want to use to access the database. This is usually the identifier before .snowflakecomputing.com",
         examples=["AIRBYTE_ACCOUNT"],
+        
     )
     role: str = Field(
         ...,
         title="Role",
-        airbyte_secret=True,
+        order=2,
         description="Enter the role that you want to use to access Snowflake",
         examples=["AIRBYTE_ROLE", "ACCOUNTADMIN"],
     )
     warehouse: str = Field(
         ...,
         title="Warehouse",
-        airbyte_secret=True,
+        order=3,
         description="Enter the name of the warehouse that you want to sync data into",
         examples=["AIRBYTE_WAREHOUSE"],
     )
     database: str = Field(
         ...,
         title="Database",
-        airbyte_secret=True,
+        order=4,
         description="Enter the name of the database that you want to sync data into",
         examples=["AIRBYTE_DATABASE"],
     )
     default_schema: str = Field(
         ...,
         title="Default Schema",
-        airbyte_secret=True,
+        order=5,
         description="Enter the name of the default schema",
         examples=["AIRBYTE_SCHEMA"],
     )
     username: str = Field(
         ...,
         title="Username",
-        airbyte_secret=True,
+        order=6,
         description="Enter the name of the user you want to use to access the database",
         examples=["AIRBYTE_USER"],
     )

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/destination.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/destination.py
@@ -18,6 +18,7 @@ from destination_snowflake_cortex.indexer import SnowflakeCortexIndexer
 
 BATCH_SIZE = 150
 
+
 class DestinationSnowflakeCortex(Destination):
     indexer: Indexer
     embedder: Embedder

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/destination.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/destination.py
@@ -16,8 +16,7 @@ from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode
 from destination_snowflake_cortex.config import ConfigModel
 from destination_snowflake_cortex.indexer import SnowflakeCortexIndexer
 
-BATCH_SIZE = 32
-
+BATCH_SIZE = 150
 
 class DestinationSnowflakeCortex(Destination):
     indexer: Indexer

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/integration_tests/integration_test.py
@@ -124,16 +124,22 @@ class SnowflakeCortexIntegrationTest(BaseIntegrationTest):
         assert(len(result) == 1)
         result[0] == "str_col: Cats are nice"
 
-    # Fix: Trying to write records > batch size in overwrite mode does not work currently
-    def _test_write_record_count_200(self):  
+   
+    def test_overwrite_mode_deletes_records(self):  
+        self._delete_table("mystream")
         catalog = self._get_configured_catalog(DestinationSyncMode.overwrite)
         first_state_message = self._state({"state": "1"})
-        first_record_chunk = [self._record("mystream", f"Dogs are number {i}", i) for i in range(200)]
+        first_record_chunk = [self._record("mystream", f"Dogs are number {i}", i) for i in range(4)]
 
         # initial sync with replace 
         destination = DestinationSnowflakeCortex()
         list(destination.write(self.config, catalog, [*first_record_chunk, first_state_message]))
-        assert(self._get_record_count("mystream") == 200)
+        assert(self._get_record_count("mystream") == 4)
+
+        # following should replace existing records
+        append_catalog = self._get_configured_catalog(DestinationSyncMode.overwrite) 
+        list(destination.write(self.config, append_catalog, [self._record("mystream", "Cats are nice", 6), first_state_message]))
+        assert(self._get_record_count("mystream") == 1)
 
     """
     Following tests are not code specific, but are useful to confirm that the Cortex functions are available and behaving as expcected

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/integration_tests/integration_test.py
@@ -124,6 +124,16 @@ class SnowflakeCortexIntegrationTest(BaseIntegrationTest):
         assert(len(result) == 1)
         result[0] == "str_col: Cats are nice"
 
+    # Fix: Trying to write records > batch size in overwrite mode does not work currently
+    def _test_write_record_count_200(self):  
+        catalog = self._get_configured_catalog(DestinationSyncMode.overwrite)
+        first_state_message = self._state({"state": "1"})
+        first_record_chunk = [self._record("mystream", f"Dogs are number {i}", i) for i in range(200)]
+
+        # initial sync with replace 
+        destination = DestinationSnowflakeCortex()
+        list(destination.write(self.config, catalog, [*first_record_chunk, first_state_message]))
+        assert(self._get_record_count("mystream") == 200)
 
     """
     Following tests are not code specific, but are useful to confirm that the Cortex functions are available and behaving as expcected

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/integration_tests/spec.json
@@ -1,411 +1,506 @@
 {
-  "documentationUrl": "https://docs.airbyte.com/integrations/destinations/snowflake-cortex",
-  "connectionSpecification": {
-    "title": "Destination Config",
-    "description": "The configuration model for the Vector DB based destinations. This model is used to generate the UI for the destination configuration,\nas well as to provide type safety for the configuration passed to the destination.\n\nThe configuration model is composed of four parts:\n* Processing configuration\n* Embedding configuration\n* Indexing configuration\n* Advanced configuration\n\nProcessing, embedding and advanced configuration are provided by this base class, while the indexing configuration is provided by the destination connector in the sub class.",
-    "type": "object",
-    "properties": {
-      "embedding": {
-        "title": "Embedding",
-        "description": "Embedding configuration",
-        "group": "embedding",
-        "type": "object",
-        "oneOf": [
-          {
-            "title": "OpenAI",
-            "type": "object",
-            "properties": {
-              "mode": {
-                "title": "Mode",
-                "default": "openai",
-                "const": "openai",
-                "enum": ["openai"],
-                "type": "string"
-              },
-              "openai_key": {
-                "title": "OpenAI API key",
-                "airbyte_secret": true,
-                "type": "string"
-              }
-            },
-            "required": ["openai_key", "mode"],
-            "description": "Use the OpenAI API to embed text. This option is using the text-embedding-ada-002 model with 1536 embedding dimensions."
-          },
-          {
-            "title": "Cohere",
-            "type": "object",
-            "properties": {
-              "mode": {
-                "title": "Mode",
-                "default": "cohere",
-                "const": "cohere",
-                "enum": ["cohere"],
-                "type": "string"
-              },
-              "cohere_key": {
-                "title": "Cohere API key",
-                "airbyte_secret": true,
-                "type": "string"
-              }
-            },
-            "required": ["cohere_key", "mode"],
-            "description": "Use the Cohere API to embed text."
-          },
-          {
-            "title": "Fake",
-            "type": "object",
-            "properties": {
-              "mode": {
-                "title": "Mode",
-                "default": "fake",
-                "const": "fake",
-                "enum": ["fake"],
-                "type": "string"
-              }
-            },
-            "description": "Use a fake embedding made out of random vectors with 1536 embedding dimensions. This is useful for testing the data pipeline without incurring any costs.",
-            "required": ["mode"]
-          },
-          {
-            "title": "Azure OpenAI",
-            "type": "object",
-            "properties": {
-              "mode": {
-                "title": "Mode",
-                "default": "azure_openai",
-                "const": "azure_openai",
-                "enum": ["azure_openai"],
-                "type": "string"
-              },
-              "openai_key": {
-                "title": "Azure OpenAI API key",
-                "description": "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
-                "airbyte_secret": true,
-                "type": "string"
-              },
-              "api_base": {
-                "title": "Resource base URL",
-                "description": "The base URL for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
-                "examples": ["https://your-resource-name.openai.azure.com"],
-                "type": "string"
-              },
-              "deployment": {
-                "title": "Deployment",
-                "description": "The deployment for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
-                "examples": ["your-resource-name"],
-                "type": "string"
-              }
-            },
-            "required": ["openai_key", "api_base", "deployment", "mode"],
-            "description": "Use the Azure-hosted OpenAI API to embed text. This option is using the text-embedding-ada-002 model with 1536 embedding dimensions."
-          },
-          {
-            "title": "OpenAI-compatible",
-            "type": "object",
-            "properties": {
-              "mode": {
-                "title": "Mode",
-                "default": "openai_compatible",
-                "const": "openai_compatible",
-                "enum": ["openai_compatible"],
-                "type": "string"
-              },
-              "api_key": {
-                "title": "API key",
-                "default": "",
-                "airbyte_secret": true,
-                "type": "string"
-              },
-              "base_url": {
-                "title": "Base URL",
-                "description": "The base URL for your OpenAI-compatible service",
-                "examples": ["https://your-service-name.com"],
-                "type": "string"
-              },
-              "model_name": {
-                "title": "Model name",
-                "description": "The name of the model to use for embedding",
-                "default": "text-embedding-ada-002",
-                "examples": ["text-embedding-ada-002"],
-                "type": "string"
-              },
-              "dimensions": {
-                "title": "Embedding dimensions",
-                "description": "The number of dimensions the embedding model is generating",
-                "examples": [1536, 384],
-                "type": "integer"
-              }
-            },
-            "required": ["base_url", "dimensions", "mode"],
-            "description": "Use a service that's compatible with the OpenAI API to embed text."
-          }
-        ]
-      },
-      "processing": {
-        "title": "ProcessingConfigModel",
-        "type": "object",
-        "properties": {
-          "chunk_size": {
-            "title": "Chunk size",
-            "description": "Size of chunks in tokens to store in vector store (make sure it is not too big for the context if your LLM)",
-            "maximum": 8191,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "chunk_overlap": {
-            "title": "Chunk overlap",
-            "description": "Size of overlap between chunks in tokens to store in vector store to better capture relevant context",
-            "default": 0,
-            "type": "integer"
-          },
-          "text_fields": {
-            "title": "Text fields to embed",
-            "description": "List of fields in the record that should be used to calculate the embedding. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered text fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array.",
-            "default": [],
-            "always_show": true,
-            "examples": ["text", "user.name", "users.*.name"],
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "metadata_fields": {
-            "title": "Fields to store as metadata",
-            "description": "List of fields in the record that should be stored as metadata. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered metadata fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array. When specifying nested paths, all matching values are flattened into an array set to a field named by the path.",
-            "default": [],
-            "always_show": true,
-            "examples": ["age", "user", "user.name"],
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "text_splitter": {
-            "title": "Text splitter",
-            "description": "Split text fields into chunks based on the specified method.",
-            "type": "object",
-            "oneOf": [
-              {
-                "title": "By Separator",
-                "type": "object",
-                "properties": {
-                  "mode": {
-                    "title": "Mode",
-                    "default": "separator",
-                    "const": "separator",
-                    "enum": ["separator"],
-                    "type": "string"
-                  },
-                  "separators": {
-                    "title": "Separators",
-                    "description": "List of separator strings to split text fields by. The separator itself needs to be wrapped in double quotes, e.g. to split by the dot character, use \".\". To split by a newline, use \"\\n\".",
-                    "default": ["\"\\n\\n\"", "\"\\n\"", "\" \"", "\"\""],
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "keep_separator": {
-                    "title": "Keep separator",
-                    "description": "Whether to keep the separator in the resulting chunks",
-                    "default": false,
-                    "type": "boolean"
-                  }
-                },
-                "description": "Split the text by the list of separators until the chunk size is reached, using the earlier mentioned separators where possible. This is useful for splitting text fields by paragraphs, sentences, words, etc.",
-                "required": ["mode"]
-              },
-              {
-                "title": "By Markdown header",
-                "type": "object",
-                "properties": {
-                  "mode": {
-                    "title": "Mode",
-                    "default": "markdown",
-                    "const": "markdown",
-                    "enum": ["markdown"],
-                    "type": "string"
-                  },
-                  "split_level": {
-                    "title": "Split level",
-                    "description": "Level of markdown headers to split text fields by. Headings down to the specified level will be used as split points",
-                    "default": 1,
-                    "minimum": 1,
-                    "maximum": 6,
-                    "type": "integer"
-                  }
-                },
-                "description": "Split the text by Markdown headers down to the specified header level. If the chunk size fits multiple sections, they will be combined into a single chunk.",
-                "required": ["mode"]
-              },
-              {
-                "title": "By Programming Language",
-                "type": "object",
-                "properties": {
-                  "mode": {
-                    "title": "Mode",
-                    "default": "code",
-                    "const": "code",
-                    "enum": ["code"],
-                    "type": "string"
-                  },
-                  "language": {
-                    "title": "Language",
-                    "description": "Split code in suitable places based on the programming language",
-                    "enum": [
-                      "cpp",
-                      "go",
-                      "java",
-                      "js",
-                      "php",
-                      "proto",
-                      "python",
-                      "rst",
-                      "ruby",
-                      "rust",
-                      "scala",
-                      "swift",
-                      "markdown",
-                      "latex",
-                      "html",
-                      "sol"
-                    ],
-                    "type": "string"
-                  }
-                },
-                "required": ["language", "mode"],
-                "description": "Split the text by suitable delimiters based on the programming language. This is useful for splitting code into chunks."
-              }
-            ]
-          },
-          "field_name_mappings": {
-            "title": "Field name mappings",
-            "description": "List of fields to rename. Not applicable for nested fields, but can be used to rename fields already flattened via dot notation.",
-            "default": [],
-            "type": "array",
-            "items": {
-              "title": "FieldNameMappingConfigModel",
+    "documentationUrl": "https://docs.airbyte.com/integrations/destinations/snowflake-cortex",
+    "connectionSpecification": {
+      "title": "Destination Config",
+      "description": "The configuration model for the Vector DB based destinations. This model is used to generate the UI for the destination configuration,\nas well as to provide type safety for the configuration passed to the destination.\n\nThe configuration model is composed of four parts:\n* Processing configuration\n* Embedding configuration\n* Indexing configuration\n* Advanced configuration\n\nProcessing, embedding and advanced configuration are provided by this base class, while the indexing configuration is provided by the destination connector in the sub class.",
+      "type": "object",
+      "properties": {
+        "embedding": {
+          "title": "Embedding",
+          "description": "Embedding configuration",
+          "group": "embedding",
+          "type": "object",
+          "oneOf": [
+            {
+              "title": "OpenAI",
               "type": "object",
               "properties": {
-                "from_field": {
-                  "title": "From field name",
-                  "description": "The field name in the source",
+                "mode": {
+                  "title": "Mode",
+                  "default": "openai",
+                  "const": "openai",
+                  "enum": [
+                    "openai"
+                  ],
                   "type": "string"
                 },
-                "to_field": {
-                  "title": "To field name",
-                  "description": "The field name to use in the destination",
+                "openai_key": {
+                  "title": "OpenAI API key",
+                  "airbyte_secret": true,
                   "type": "string"
                 }
               },
-              "required": ["from_field", "to_field"]
+              "required": [
+                "openai_key",
+                "mode"
+              ],
+              "description": "Use the OpenAI API to embed text. This option is using the text-embedding-ada-002 model with 1536 embedding dimensions."
+            },
+            {
+              "title": "Cohere",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "title": "Mode",
+                  "default": "cohere",
+                  "const": "cohere",
+                  "enum": [
+                    "cohere"
+                  ],
+                  "type": "string"
+                },
+                "cohere_key": {
+                  "title": "Cohere API key",
+                  "airbyte_secret": true,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "cohere_key",
+                "mode"
+              ],
+              "description": "Use the Cohere API to embed text."
+            },
+            {
+              "title": "Fake",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "title": "Mode",
+                  "default": "fake",
+                  "const": "fake",
+                  "enum": [
+                    "fake"
+                  ],
+                  "type": "string"
+                }
+              },
+              "description": "Use a fake embedding made out of random vectors with 1536 embedding dimensions. This is useful for testing the data pipeline without incurring any costs.",
+              "required": [
+                "mode"
+              ]
+            },
+            {
+              "title": "Azure OpenAI",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "title": "Mode",
+                  "default": "azure_openai",
+                  "const": "azure_openai",
+                  "enum": [
+                    "azure_openai"
+                  ],
+                  "type": "string"
+                },
+                "openai_key": {
+                  "title": "Azure OpenAI API key",
+                  "description": "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                  "airbyte_secret": true,
+                  "type": "string"
+                },
+                "api_base": {
+                  "title": "Resource base URL",
+                  "description": "The base URL for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                  "examples": [
+                    "https://your-resource-name.openai.azure.com"
+                  ],
+                  "type": "string"
+                },
+                "deployment": {
+                  "title": "Deployment",
+                  "description": "The deployment for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                  "examples": [
+                    "your-resource-name"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "openai_key",
+                "api_base",
+                "deployment",
+                "mode"
+              ],
+              "description": "Use the Azure-hosted OpenAI API to embed text. This option is using the text-embedding-ada-002 model with 1536 embedding dimensions."
+            },
+            {
+              "title": "OpenAI-compatible",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "title": "Mode",
+                  "default": "openai_compatible",
+                  "const": "openai_compatible",
+                  "enum": [
+                    "openai_compatible"
+                  ],
+                  "type": "string"
+                },
+                "api_key": {
+                  "title": "API key",
+                  "default": "",
+                  "airbyte_secret": true,
+                  "type": "string"
+                },
+                "base_url": {
+                  "title": "Base URL",
+                  "description": "The base URL for your OpenAI-compatible service",
+                  "examples": [
+                    "https://your-service-name.com"
+                  ],
+                  "type": "string"
+                },
+                "model_name": {
+                  "title": "Model name",
+                  "description": "The name of the model to use for embedding",
+                  "default": "text-embedding-ada-002",
+                  "examples": [
+                    "text-embedding-ada-002"
+                  ],
+                  "type": "string"
+                },
+                "dimensions": {
+                  "title": "Embedding dimensions",
+                  "description": "The number of dimensions the embedding model is generating",
+                  "examples": [
+                    1536,
+                    384
+                  ],
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "base_url",
+                "dimensions",
+                "mode"
+              ],
+              "description": "Use a service that's compatible with the OpenAI API to embed text."
             }
-          }
+          ]
         },
-        "required": ["chunk_size"],
-        "group": "processing"
-      },
-      "omit_raw_text": {
-        "title": "Do not store raw text",
-        "description": "Do not store the text that gets embedded along with the vector and the metadata in the destination. If set to true, only the vector and the metadata will be stored - in this case raw text for LLM use cases needs to be retrieved from another source.",
-        "default": false,
-        "group": "advanced",
-        "type": "boolean"
-      },
-      "indexing": {
-        "title": "Indexing",
-        "type": "object",
-        "properties": {
-          "host": {
-            "title": "Host",
-            "description": "Enter the account name you want to use to access the database. This is usually the identifier before .snowflakecomputing.com",
-            "airbyte_secret": true,
-            "examples": ["AIRBYTE_ACCOUNT"],
-            "type": "string"
-          },
-          "role": {
-            "title": "Role",
-            "description": "Enter the role that you want to use to access Snowflake",
-            "airbyte_secret": true,
-            "examples": ["AIRBYTE_ROLE", "ACCOUNTADMIN"],
-            "type": "string"
-          },
-          "warehouse": {
-            "title": "Warehouse",
-            "description": "Enter the name of the warehouse that you want to sync data into",
-            "airbyte_secret": true,
-            "examples": ["AIRBYTE_WAREHOUSE"],
-            "type": "string"
-          },
-          "database": {
-            "title": "Database",
-            "description": "Enter the name of the database that you want to sync data into",
-            "airbyte_secret": true,
-            "examples": ["AIRBYTE_DATABASE"],
-            "type": "string"
-          },
-          "default_schema": {
-            "title": "Default Schema",
-            "description": "Enter the name of the default schema",
-            "airbyte_secret": true,
-            "examples": ["AIRBYTE_SCHEMA"],
-            "type": "string"
-          },
-          "username": {
-            "title": "Username",
-            "description": "Enter the name of the user you want to use to access the database",
-            "airbyte_secret": true,
-            "examples": ["AIRBYTE_USER"],
-            "type": "string"
-          },
-          "credentials": {
-            "title": "Credentials",
-            "type": "object",
-            "properties": {
-              "password": {
-                "title": "Password",
-                "description": "Enter the password you want to use to access the database",
-                "airbyte_secret": true,
-                "examples": ["AIRBYTE_PASSWORD"],
+        "processing": {
+          "title": "ProcessingConfigModel",
+          "type": "object",
+          "properties": {
+            "chunk_size": {
+              "title": "Chunk size",
+              "description": "Size of chunks in tokens to store in vector store (make sure it is not too big for the context if your LLM)",
+              "maximum": 8191,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "chunk_overlap": {
+              "title": "Chunk overlap",
+              "description": "Size of overlap between chunks in tokens to store in vector store to better capture relevant context",
+              "default": 0,
+              "type": "integer"
+            },
+            "text_fields": {
+              "title": "Text fields to embed",
+              "description": "List of fields in the record that should be used to calculate the embedding. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered text fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array.",
+              "default": [],
+              "always_show": true,
+              "examples": [
+                "text",
+                "user.name",
+                "users.*.name"
+              ],
+              "type": "array",
+              "items": {
                 "type": "string"
               }
             },
-            "required": ["password"]
-          }
+            "metadata_fields": {
+              "title": "Fields to store as metadata",
+              "description": "List of fields in the record that should be stored as metadata. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered metadata fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array. When specifying nested paths, all matching values are flattened into an array set to a field named by the path.",
+              "default": [],
+              "always_show": true,
+              "examples": [
+                "age",
+                "user",
+                "user.name"
+              ],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "text_splitter": {
+              "title": "Text splitter",
+              "description": "Split text fields into chunks based on the specified method.",
+              "type": "object",
+              "oneOf": [
+                {
+                  "title": "By Separator",
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "title": "Mode",
+                      "default": "separator",
+                      "const": "separator",
+                      "enum": [
+                        "separator"
+                      ],
+                      "type": "string"
+                    },
+                    "separators": {
+                      "title": "Separators",
+                      "description": "List of separator strings to split text fields by. The separator itself needs to be wrapped in double quotes, e.g. to split by the dot character, use \".\". To split by a newline, use \"\\n\".",
+                      "default": [
+                        "\"\\n\\n\"",
+                        "\"\\n\"",
+                        "\" \"",
+                        "\"\""
+                      ],
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "keep_separator": {
+                      "title": "Keep separator",
+                      "description": "Whether to keep the separator in the resulting chunks",
+                      "default": false,
+                      "type": "boolean"
+                    }
+                  },
+                  "description": "Split the text by the list of separators until the chunk size is reached, using the earlier mentioned separators where possible. This is useful for splitting text fields by paragraphs, sentences, words, etc.",
+                  "required": [
+                    "mode"
+                  ]
+                },
+                {
+                  "title": "By Markdown header",
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "title": "Mode",
+                      "default": "markdown",
+                      "const": "markdown",
+                      "enum": [
+                        "markdown"
+                      ],
+                      "type": "string"
+                    },
+                    "split_level": {
+                      "title": "Split level",
+                      "description": "Level of markdown headers to split text fields by. Headings down to the specified level will be used as split points",
+                      "default": 1,
+                      "minimum": 1,
+                      "maximum": 6,
+                      "type": "integer"
+                    }
+                  },
+                  "description": "Split the text by Markdown headers down to the specified header level. If the chunk size fits multiple sections, they will be combined into a single chunk.",
+                  "required": [
+                    "mode"
+                  ]
+                },
+                {
+                  "title": "By Programming Language",
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "title": "Mode",
+                      "default": "code",
+                      "const": "code",
+                      "enum": [
+                        "code"
+                      ],
+                      "type": "string"
+                    },
+                    "language": {
+                      "title": "Language",
+                      "description": "Split code in suitable places based on the programming language",
+                      "enum": [
+                        "cpp",
+                        "go",
+                        "java",
+                        "js",
+                        "php",
+                        "proto",
+                        "python",
+                        "rst",
+                        "ruby",
+                        "rust",
+                        "scala",
+                        "swift",
+                        "markdown",
+                        "latex",
+                        "html",
+                        "sol"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "language",
+                    "mode"
+                  ],
+                  "description": "Split the text by suitable delimiters based on the programming language. This is useful for splitting code into chunks."
+                }
+              ]
+            },
+            "field_name_mappings": {
+              "title": "Field name mappings",
+              "description": "List of fields to rename. Not applicable for nested fields, but can be used to rename fields already flattened via dot notation.",
+              "default": [],
+              "type": "array",
+              "items": {
+                "title": "FieldNameMappingConfigModel",
+                "type": "object",
+                "properties": {
+                  "from_field": {
+                    "title": "From field name",
+                    "description": "The field name in the source",
+                    "type": "string"
+                  },
+                  "to_field": {
+                    "title": "To field name",
+                    "description": "The field name to use in the destination",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "from_field",
+                  "to_field"
+                ]
+              }
+            }
+          },
+          "required": [
+            "chunk_size"
+          ],
+          "group": "processing"
         },
-        "required": [
-          "host",
-          "role",
-          "warehouse",
-          "database",
-          "default_schema",
-          "username",
-          "credentials"
-        ],
-        "description": "Snowflake can be used to store vector data and retrieve embeddings.",
-        "group": "indexing"
-      }
+        "omit_raw_text": {
+          "title": "Do not store raw text",
+          "description": "Do not store the text that gets embedded along with the vector and the metadata in the destination. If set to true, only the vector and the metadata will be stored - in this case raw text for LLM use cases needs to be retrieved from another source.",
+          "default": false,
+          "group": "advanced",
+          "type": "boolean"
+        },
+        "indexing": {
+          "title": "Indexing",
+          "type": "object",
+          "properties": {
+            "host": {
+              "title": "Host",
+              "description": "Enter the account name you want to use to access the database. This is usually the identifier before .snowflakecomputing.com",
+              "order": 1,
+              "examples": [
+                "AIRBYTE_ACCOUNT"
+              ],
+              "type": "string"
+            },
+            "role": {
+              "title": "Role",
+              "description": "Enter the role that you want to use to access Snowflake",
+              "order": 2,
+              "examples": [
+                "AIRBYTE_ROLE",
+                "ACCOUNTADMIN"
+              ],
+              "type": "string"
+            },
+            "warehouse": {
+              "title": "Warehouse",
+              "description": "Enter the name of the warehouse that you want to sync data into",
+              "order": 3,
+              "examples": [
+                "AIRBYTE_WAREHOUSE"
+              ],
+              "type": "string"
+            },
+            "database": {
+              "title": "Database",
+              "description": "Enter the name of the database that you want to sync data into",
+              "order": 4,
+              "examples": [
+                "AIRBYTE_DATABASE"
+              ],
+              "type": "string"
+            },
+            "default_schema": {
+              "title": "Default Schema",
+              "description": "Enter the name of the default schema",
+              "order": 5,
+              "examples": [
+                "AIRBYTE_SCHEMA"
+              ],
+              "type": "string"
+            },
+            "username": {
+              "title": "Username",
+              "description": "Enter the name of the user you want to use to access the database",
+              "order": 6,
+              "examples": [
+                "AIRBYTE_USER"
+              ],
+              "type": "string"
+            },
+            "credentials": {
+              "title": "Credentials",
+              "type": "object",
+              "properties": {
+                "password": {
+                  "title": "Password",
+                  "description": "Enter the password you want to use to access the database",
+                  "airbyte_secret": true,
+                  "examples": [
+                    "AIRBYTE_PASSWORD"
+                  ],
+                  "order": 7,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "password"
+              ]
+            }
+          },
+          "required": [
+            "host",
+            "role",
+            "warehouse",
+            "database",
+            "default_schema",
+            "username",
+            "credentials"
+          ],
+          "description": "Snowflake can be used to store vector data and retrieve embeddings.",
+          "group": "indexing"
+        }
+      },
+      "required": [
+        "embedding",
+        "processing",
+        "indexing"
+      ],
+      "groups": [
+        {
+          "id": "processing",
+          "title": "Processing"
+        },
+        {
+          "id": "embedding",
+          "title": "Embedding"
+        },
+        {
+          "id": "indexing",
+          "title": "Indexing"
+        },
+        {
+          "id": "advanced",
+          "title": "Advanced"
+        }
+      ]
     },
-    "required": ["embedding", "processing", "indexing"],
-    "groups": [
-      {
-        "id": "processing",
-        "title": "Processing"
-      },
-      {
-        "id": "embedding",
-        "title": "Embedding"
-      },
-      {
-        "id": "indexing",
-        "title": "Indexing"
-      },
-      {
-        "id": "advanced",
-        "title": "Advanced"
-      }
+    "supportsIncremental": true,
+    "supported_destination_sync_modes": [
+      "overwrite",
+      "append",
+      "append_dedup"
     ]
-  },
-  "supportsIncremental": true,
-  "supported_destination_sync_modes": ["overwrite", "append", "append_dedup"]
 }

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/integration_tests/spec.json
@@ -1,506 +1,412 @@
 {
-    "documentationUrl": "https://docs.airbyte.com/integrations/destinations/snowflake-cortex",
-    "connectionSpecification": {
-      "title": "Destination Config",
-      "description": "The configuration model for the Vector DB based destinations. This model is used to generate the UI for the destination configuration,\nas well as to provide type safety for the configuration passed to the destination.\n\nThe configuration model is composed of four parts:\n* Processing configuration\n* Embedding configuration\n* Indexing configuration\n* Advanced configuration\n\nProcessing, embedding and advanced configuration are provided by this base class, while the indexing configuration is provided by the destination connector in the sub class.",
-      "type": "object",
-      "properties": {
-        "embedding": {
-          "title": "Embedding",
-          "description": "Embedding configuration",
-          "group": "embedding",
-          "type": "object",
-          "oneOf": [
-            {
-              "title": "OpenAI",
-              "type": "object",
-              "properties": {
-                "mode": {
-                  "title": "Mode",
-                  "default": "openai",
-                  "const": "openai",
-                  "enum": [
-                    "openai"
-                  ],
-                  "type": "string"
-                },
-                "openai_key": {
-                  "title": "OpenAI API key",
-                  "airbyte_secret": true,
-                  "type": "string"
-                }
+  "documentationUrl": "https://docs.airbyte.com/integrations/destinations/snowflake-cortex",
+  "connectionSpecification": {
+    "title": "Destination Config",
+    "description": "The configuration model for the Vector DB based destinations. This model is used to generate the UI for the destination configuration,\nas well as to provide type safety for the configuration passed to the destination.\n\nThe configuration model is composed of four parts:\n* Processing configuration\n* Embedding configuration\n* Indexing configuration\n* Advanced configuration\n\nProcessing, embedding and advanced configuration are provided by this base class, while the indexing configuration is provided by the destination connector in the sub class.",
+    "type": "object",
+    "properties": {
+      "embedding": {
+        "title": "Embedding",
+        "description": "Embedding configuration",
+        "group": "embedding",
+        "type": "object",
+        "oneOf": [
+          {
+            "title": "OpenAI",
+            "type": "object",
+            "properties": {
+              "mode": {
+                "title": "Mode",
+                "default": "openai",
+                "const": "openai",
+                "enum": ["openai"],
+                "type": "string"
               },
-              "required": [
-                "openai_key",
-                "mode"
-              ],
-              "description": "Use the OpenAI API to embed text. This option is using the text-embedding-ada-002 model with 1536 embedding dimensions."
+              "openai_key": {
+                "title": "OpenAI API key",
+                "airbyte_secret": true,
+                "type": "string"
+              }
             },
-            {
-              "title": "Cohere",
-              "type": "object",
-              "properties": {
-                "mode": {
-                  "title": "Mode",
-                  "default": "cohere",
-                  "const": "cohere",
-                  "enum": [
-                    "cohere"
-                  ],
-                  "type": "string"
-                },
-                "cohere_key": {
-                  "title": "Cohere API key",
-                  "airbyte_secret": true,
-                  "type": "string"
-                }
+            "required": ["openai_key", "mode"],
+            "description": "Use the OpenAI API to embed text. This option is using the text-embedding-ada-002 model with 1536 embedding dimensions."
+          },
+          {
+            "title": "Cohere",
+            "type": "object",
+            "properties": {
+              "mode": {
+                "title": "Mode",
+                "default": "cohere",
+                "const": "cohere",
+                "enum": ["cohere"],
+                "type": "string"
               },
-              "required": [
-                "cohere_key",
-                "mode"
-              ],
-              "description": "Use the Cohere API to embed text."
+              "cohere_key": {
+                "title": "Cohere API key",
+                "airbyte_secret": true,
+                "type": "string"
+              }
             },
-            {
-              "title": "Fake",
-              "type": "object",
-              "properties": {
-                "mode": {
-                  "title": "Mode",
-                  "default": "fake",
-                  "const": "fake",
-                  "enum": [
-                    "fake"
-                  ],
-                  "type": "string"
-                }
-              },
-              "description": "Use a fake embedding made out of random vectors with 1536 embedding dimensions. This is useful for testing the data pipeline without incurring any costs.",
-              "required": [
-                "mode"
-              ]
+            "required": ["cohere_key", "mode"],
+            "description": "Use the Cohere API to embed text."
+          },
+          {
+            "title": "Fake",
+            "type": "object",
+            "properties": {
+              "mode": {
+                "title": "Mode",
+                "default": "fake",
+                "const": "fake",
+                "enum": ["fake"],
+                "type": "string"
+              }
             },
-            {
-              "title": "Azure OpenAI",
-              "type": "object",
-              "properties": {
-                "mode": {
-                  "title": "Mode",
-                  "default": "azure_openai",
-                  "const": "azure_openai",
-                  "enum": [
-                    "azure_openai"
-                  ],
-                  "type": "string"
-                },
-                "openai_key": {
-                  "title": "Azure OpenAI API key",
-                  "description": "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
-                  "airbyte_secret": true,
-                  "type": "string"
-                },
-                "api_base": {
-                  "title": "Resource base URL",
-                  "description": "The base URL for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
-                  "examples": [
-                    "https://your-resource-name.openai.azure.com"
-                  ],
-                  "type": "string"
-                },
-                "deployment": {
-                  "title": "Deployment",
-                  "description": "The deployment for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
-                  "examples": [
-                    "your-resource-name"
-                  ],
-                  "type": "string"
-                }
+            "description": "Use a fake embedding made out of random vectors with 1536 embedding dimensions. This is useful for testing the data pipeline without incurring any costs.",
+            "required": ["mode"]
+          },
+          {
+            "title": "Azure OpenAI",
+            "type": "object",
+            "properties": {
+              "mode": {
+                "title": "Mode",
+                "default": "azure_openai",
+                "const": "azure_openai",
+                "enum": ["azure_openai"],
+                "type": "string"
               },
-              "required": [
-                "openai_key",
-                "api_base",
-                "deployment",
-                "mode"
-              ],
-              "description": "Use the Azure-hosted OpenAI API to embed text. This option is using the text-embedding-ada-002 model with 1536 embedding dimensions."
+              "openai_key": {
+                "title": "Azure OpenAI API key",
+                "description": "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                "airbyte_secret": true,
+                "type": "string"
+              },
+              "api_base": {
+                "title": "Resource base URL",
+                "description": "The base URL for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                "examples": ["https://your-resource-name.openai.azure.com"],
+                "type": "string"
+              },
+              "deployment": {
+                "title": "Deployment",
+                "description": "The deployment for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                "examples": ["your-resource-name"],
+                "type": "string"
+              }
             },
-            {
-              "title": "OpenAI-compatible",
-              "type": "object",
-              "properties": {
-                "mode": {
-                  "title": "Mode",
-                  "default": "openai_compatible",
-                  "const": "openai_compatible",
-                  "enum": [
-                    "openai_compatible"
-                  ],
-                  "type": "string"
-                },
-                "api_key": {
-                  "title": "API key",
-                  "default": "",
-                  "airbyte_secret": true,
-                  "type": "string"
-                },
-                "base_url": {
-                  "title": "Base URL",
-                  "description": "The base URL for your OpenAI-compatible service",
-                  "examples": [
-                    "https://your-service-name.com"
-                  ],
-                  "type": "string"
-                },
-                "model_name": {
-                  "title": "Model name",
-                  "description": "The name of the model to use for embedding",
-                  "default": "text-embedding-ada-002",
-                  "examples": [
-                    "text-embedding-ada-002"
-                  ],
-                  "type": "string"
-                },
-                "dimensions": {
-                  "title": "Embedding dimensions",
-                  "description": "The number of dimensions the embedding model is generating",
-                  "examples": [
-                    1536,
-                    384
-                  ],
-                  "type": "integer"
-                }
+            "required": ["openai_key", "api_base", "deployment", "mode"],
+            "description": "Use the Azure-hosted OpenAI API to embed text. This option is using the text-embedding-ada-002 model with 1536 embedding dimensions."
+          },
+          {
+            "title": "OpenAI-compatible",
+            "type": "object",
+            "properties": {
+              "mode": {
+                "title": "Mode",
+                "default": "openai_compatible",
+                "const": "openai_compatible",
+                "enum": ["openai_compatible"],
+                "type": "string"
               },
-              "required": [
-                "base_url",
-                "dimensions",
-                "mode"
-              ],
-              "description": "Use a service that's compatible with the OpenAI API to embed text."
+              "api_key": {
+                "title": "API key",
+                "default": "",
+                "airbyte_secret": true,
+                "type": "string"
+              },
+              "base_url": {
+                "title": "Base URL",
+                "description": "The base URL for your OpenAI-compatible service",
+                "examples": ["https://your-service-name.com"],
+                "type": "string"
+              },
+              "model_name": {
+                "title": "Model name",
+                "description": "The name of the model to use for embedding",
+                "default": "text-embedding-ada-002",
+                "examples": ["text-embedding-ada-002"],
+                "type": "string"
+              },
+              "dimensions": {
+                "title": "Embedding dimensions",
+                "description": "The number of dimensions the embedding model is generating",
+                "examples": [1536, 384],
+                "type": "integer"
+              }
+            },
+            "required": ["base_url", "dimensions", "mode"],
+            "description": "Use a service that's compatible with the OpenAI API to embed text."
+          }
+        ]
+      },
+      "processing": {
+        "title": "ProcessingConfigModel",
+        "type": "object",
+        "properties": {
+          "chunk_size": {
+            "title": "Chunk size",
+            "description": "Size of chunks in tokens to store in vector store (make sure it is not too big for the context if your LLM)",
+            "maximum": 8191,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "chunk_overlap": {
+            "title": "Chunk overlap",
+            "description": "Size of overlap between chunks in tokens to store in vector store to better capture relevant context",
+            "default": 0,
+            "type": "integer"
+          },
+          "text_fields": {
+            "title": "Text fields to embed",
+            "description": "List of fields in the record that should be used to calculate the embedding. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered text fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array.",
+            "default": [],
+            "always_show": true,
+            "examples": ["text", "user.name", "users.*.name"],
+            "type": "array",
+            "items": {
+              "type": "string"
             }
-          ]
-        },
-        "processing": {
-          "title": "ProcessingConfigModel",
-          "type": "object",
-          "properties": {
-            "chunk_size": {
-              "title": "Chunk size",
-              "description": "Size of chunks in tokens to store in vector store (make sure it is not too big for the context if your LLM)",
-              "maximum": 8191,
-              "minimum": 1,
-              "type": "integer"
-            },
-            "chunk_overlap": {
-              "title": "Chunk overlap",
-              "description": "Size of overlap between chunks in tokens to store in vector store to better capture relevant context",
-              "default": 0,
-              "type": "integer"
-            },
-            "text_fields": {
-              "title": "Text fields to embed",
-              "description": "List of fields in the record that should be used to calculate the embedding. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered text fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array.",
-              "default": [],
-              "always_show": true,
-              "examples": [
-                "text",
-                "user.name",
-                "users.*.name"
-              ],
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "metadata_fields": {
-              "title": "Fields to store as metadata",
-              "description": "List of fields in the record that should be stored as metadata. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered metadata fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array. When specifying nested paths, all matching values are flattened into an array set to a field named by the path.",
-              "default": [],
-              "always_show": true,
-              "examples": [
-                "age",
-                "user",
-                "user.name"
-              ],
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "text_splitter": {
-              "title": "Text splitter",
-              "description": "Split text fields into chunks based on the specified method.",
-              "type": "object",
-              "oneOf": [
-                {
-                  "title": "By Separator",
-                  "type": "object",
-                  "properties": {
-                    "mode": {
-                      "title": "Mode",
-                      "default": "separator",
-                      "const": "separator",
-                      "enum": [
-                        "separator"
-                      ],
-                      "type": "string"
-                    },
-                    "separators": {
-                      "title": "Separators",
-                      "description": "List of separator strings to split text fields by. The separator itself needs to be wrapped in double quotes, e.g. to split by the dot character, use \".\". To split by a newline, use \"\\n\".",
-                      "default": [
-                        "\"\\n\\n\"",
-                        "\"\\n\"",
-                        "\" \"",
-                        "\"\""
-                      ],
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "keep_separator": {
-                      "title": "Keep separator",
-                      "description": "Whether to keep the separator in the resulting chunks",
-                      "default": false,
-                      "type": "boolean"
-                    }
-                  },
-                  "description": "Split the text by the list of separators until the chunk size is reached, using the earlier mentioned separators where possible. This is useful for splitting text fields by paragraphs, sentences, words, etc.",
-                  "required": [
-                    "mode"
-                  ]
-                },
-                {
-                  "title": "By Markdown header",
-                  "type": "object",
-                  "properties": {
-                    "mode": {
-                      "title": "Mode",
-                      "default": "markdown",
-                      "const": "markdown",
-                      "enum": [
-                        "markdown"
-                      ],
-                      "type": "string"
-                    },
-                    "split_level": {
-                      "title": "Split level",
-                      "description": "Level of markdown headers to split text fields by. Headings down to the specified level will be used as split points",
-                      "default": 1,
-                      "minimum": 1,
-                      "maximum": 6,
-                      "type": "integer"
-                    }
-                  },
-                  "description": "Split the text by Markdown headers down to the specified header level. If the chunk size fits multiple sections, they will be combined into a single chunk.",
-                  "required": [
-                    "mode"
-                  ]
-                },
-                {
-                  "title": "By Programming Language",
-                  "type": "object",
-                  "properties": {
-                    "mode": {
-                      "title": "Mode",
-                      "default": "code",
-                      "const": "code",
-                      "enum": [
-                        "code"
-                      ],
-                      "type": "string"
-                    },
-                    "language": {
-                      "title": "Language",
-                      "description": "Split code in suitable places based on the programming language",
-                      "enum": [
-                        "cpp",
-                        "go",
-                        "java",
-                        "js",
-                        "php",
-                        "proto",
-                        "python",
-                        "rst",
-                        "ruby",
-                        "rust",
-                        "scala",
-                        "swift",
-                        "markdown",
-                        "latex",
-                        "html",
-                        "sol"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "language",
-                    "mode"
-                  ],
-                  "description": "Split the text by suitable delimiters based on the programming language. This is useful for splitting code into chunks."
-                }
-              ]
-            },
-            "field_name_mappings": {
-              "title": "Field name mappings",
-              "description": "List of fields to rename. Not applicable for nested fields, but can be used to rename fields already flattened via dot notation.",
-              "default": [],
-              "type": "array",
-              "items": {
-                "title": "FieldNameMappingConfigModel",
+          },
+          "metadata_fields": {
+            "title": "Fields to store as metadata",
+            "description": "List of fields in the record that should be stored as metadata. The field list is applied to all streams in the same way and non-existing fields are ignored. If none are defined, all fields are considered metadata fields. When specifying text fields, you can access nested fields in the record by using dot notation, e.g. `user.name` will access the `name` field in the `user` object. It's also possible to use wildcards to access all fields in an object, e.g. `users.*.name` will access all `names` fields in all entries of the `users` array. When specifying nested paths, all matching values are flattened into an array set to a field named by the path.",
+            "default": [],
+            "always_show": true,
+            "examples": ["age", "user", "user.name"],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "text_splitter": {
+            "title": "Text splitter",
+            "description": "Split text fields into chunks based on the specified method.",
+            "type": "object",
+            "oneOf": [
+              {
+                "title": "By Separator",
                 "type": "object",
                 "properties": {
-                  "from_field": {
-                    "title": "From field name",
-                    "description": "The field name in the source",
+                  "mode": {
+                    "title": "Mode",
+                    "default": "separator",
+                    "const": "separator",
+                    "enum": ["separator"],
                     "type": "string"
                   },
-                  "to_field": {
-                    "title": "To field name",
-                    "description": "The field name to use in the destination",
+                  "separators": {
+                    "title": "Separators",
+                    "description": "List of separator strings to split text fields by. The separator itself needs to be wrapped in double quotes, e.g. to split by the dot character, use \".\". To split by a newline, use \"\\n\".",
+                    "default": ["\"\\n\\n\"", "\"\\n\"", "\" \"", "\"\""],
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "keep_separator": {
+                    "title": "Keep separator",
+                    "description": "Whether to keep the separator in the resulting chunks",
+                    "default": false,
+                    "type": "boolean"
+                  }
+                },
+                "description": "Split the text by the list of separators until the chunk size is reached, using the earlier mentioned separators where possible. This is useful for splitting text fields by paragraphs, sentences, words, etc.",
+                "required": ["mode"]
+              },
+              {
+                "title": "By Markdown header",
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "title": "Mode",
+                    "default": "markdown",
+                    "const": "markdown",
+                    "enum": ["markdown"],
+                    "type": "string"
+                  },
+                  "split_level": {
+                    "title": "Split level",
+                    "description": "Level of markdown headers to split text fields by. Headings down to the specified level will be used as split points",
+                    "default": 1,
+                    "minimum": 1,
+                    "maximum": 6,
+                    "type": "integer"
+                  }
+                },
+                "description": "Split the text by Markdown headers down to the specified header level. If the chunk size fits multiple sections, they will be combined into a single chunk.",
+                "required": ["mode"]
+              },
+              {
+                "title": "By Programming Language",
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "title": "Mode",
+                    "default": "code",
+                    "const": "code",
+                    "enum": ["code"],
+                    "type": "string"
+                  },
+                  "language": {
+                    "title": "Language",
+                    "description": "Split code in suitable places based on the programming language",
+                    "enum": [
+                      "cpp",
+                      "go",
+                      "java",
+                      "js",
+                      "php",
+                      "proto",
+                      "python",
+                      "rst",
+                      "ruby",
+                      "rust",
+                      "scala",
+                      "swift",
+                      "markdown",
+                      "latex",
+                      "html",
+                      "sol"
+                    ],
                     "type": "string"
                   }
                 },
-                "required": [
-                  "from_field",
-                  "to_field"
-                ]
+                "required": ["language", "mode"],
+                "description": "Split the text by suitable delimiters based on the programming language. This is useful for splitting code into chunks."
               }
-            }
+            ]
           },
-          "required": [
-            "chunk_size"
-          ],
-          "group": "processing"
-        },
-        "omit_raw_text": {
-          "title": "Do not store raw text",
-          "description": "Do not store the text that gets embedded along with the vector and the metadata in the destination. If set to true, only the vector and the metadata will be stored - in this case raw text for LLM use cases needs to be retrieved from another source.",
-          "default": false,
-          "group": "advanced",
-          "type": "boolean"
-        },
-        "indexing": {
-          "title": "Indexing",
-          "type": "object",
-          "properties": {
-            "host": {
-              "title": "Host",
-              "description": "Enter the account name you want to use to access the database. This is usually the identifier before .snowflakecomputing.com",
-              "order": 1,
-              "examples": [
-                "AIRBYTE_ACCOUNT"
-              ],
-              "type": "string"
-            },
-            "role": {
-              "title": "Role",
-              "description": "Enter the role that you want to use to access Snowflake",
-              "order": 2,
-              "examples": [
-                "AIRBYTE_ROLE",
-                "ACCOUNTADMIN"
-              ],
-              "type": "string"
-            },
-            "warehouse": {
-              "title": "Warehouse",
-              "description": "Enter the name of the warehouse that you want to sync data into",
-              "order": 3,
-              "examples": [
-                "AIRBYTE_WAREHOUSE"
-              ],
-              "type": "string"
-            },
-            "database": {
-              "title": "Database",
-              "description": "Enter the name of the database that you want to sync data into",
-              "order": 4,
-              "examples": [
-                "AIRBYTE_DATABASE"
-              ],
-              "type": "string"
-            },
-            "default_schema": {
-              "title": "Default Schema",
-              "description": "Enter the name of the default schema",
-              "order": 5,
-              "examples": [
-                "AIRBYTE_SCHEMA"
-              ],
-              "type": "string"
-            },
-            "username": {
-              "title": "Username",
-              "description": "Enter the name of the user you want to use to access the database",
-              "order": 6,
-              "examples": [
-                "AIRBYTE_USER"
-              ],
-              "type": "string"
-            },
-            "credentials": {
-              "title": "Credentials",
+          "field_name_mappings": {
+            "title": "Field name mappings",
+            "description": "List of fields to rename. Not applicable for nested fields, but can be used to rename fields already flattened via dot notation.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "title": "FieldNameMappingConfigModel",
               "type": "object",
               "properties": {
-                "password": {
-                  "title": "Password",
-                  "description": "Enter the password you want to use to access the database",
-                  "airbyte_secret": true,
-                  "examples": [
-                    "AIRBYTE_PASSWORD"
-                  ],
-                  "order": 7,
+                "from_field": {
+                  "title": "From field name",
+                  "description": "The field name in the source",
+                  "type": "string"
+                },
+                "to_field": {
+                  "title": "To field name",
+                  "description": "The field name to use in the destination",
                   "type": "string"
                 }
               },
-              "required": [
-                "password"
-              ]
+              "required": ["from_field", "to_field"]
             }
-          },
-          "required": [
-            "host",
-            "role",
-            "warehouse",
-            "database",
-            "default_schema",
-            "username",
-            "credentials"
-          ],
-          "description": "Snowflake can be used to store vector data and retrieve embeddings.",
-          "group": "indexing"
-        }
+          }
+        },
+        "required": ["chunk_size"],
+        "group": "processing"
       },
-      "required": [
-        "embedding",
-        "processing",
-        "indexing"
-      ],
-      "groups": [
-        {
-          "id": "processing",
-          "title": "Processing"
+      "omit_raw_text": {
+        "title": "Do not store raw text",
+        "description": "Do not store the text that gets embedded along with the vector and the metadata in the destination. If set to true, only the vector and the metadata will be stored - in this case raw text for LLM use cases needs to be retrieved from another source.",
+        "default": false,
+        "group": "advanced",
+        "type": "boolean"
+      },
+      "indexing": {
+        "title": "Indexing",
+        "type": "object",
+        "properties": {
+          "host": {
+            "title": "Host",
+            "description": "Enter the account name you want to use to access the database. This is usually the identifier before .snowflakecomputing.com",
+            "order": 1,
+            "examples": ["AIRBYTE_ACCOUNT"],
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "description": "Enter the role that you want to use to access Snowflake",
+            "order": 2,
+            "examples": ["AIRBYTE_ROLE", "ACCOUNTADMIN"],
+            "type": "string"
+          },
+          "warehouse": {
+            "title": "Warehouse",
+            "description": "Enter the name of the warehouse that you want to sync data into",
+            "order": 3,
+            "examples": ["AIRBYTE_WAREHOUSE"],
+            "type": "string"
+          },
+          "database": {
+            "title": "Database",
+            "description": "Enter the name of the database that you want to sync data into",
+            "order": 4,
+            "examples": ["AIRBYTE_DATABASE"],
+            "type": "string"
+          },
+          "default_schema": {
+            "title": "Default Schema",
+            "description": "Enter the name of the default schema",
+            "order": 5,
+            "examples": ["AIRBYTE_SCHEMA"],
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "description": "Enter the name of the user you want to use to access the database",
+            "order": 6,
+            "examples": ["AIRBYTE_USER"],
+            "type": "string"
+          },
+          "credentials": {
+            "title": "Credentials",
+            "type": "object",
+            "properties": {
+              "password": {
+                "title": "Password",
+                "description": "Enter the password you want to use to access the database",
+                "airbyte_secret": true,
+                "examples": ["AIRBYTE_PASSWORD"],
+                "order": 7,
+                "type": "string"
+              }
+            },
+            "required": ["password"]
+          }
         },
-        {
-          "id": "embedding",
-          "title": "Embedding"
-        },
-        {
-          "id": "indexing",
-          "title": "Indexing"
-        },
-        {
-          "id": "advanced",
-          "title": "Advanced"
-        }
-      ]
+        "required": [
+          "host",
+          "role",
+          "warehouse",
+          "database",
+          "default_schema",
+          "username",
+          "credentials"
+        ],
+        "description": "Snowflake can be used to store vector data and retrieve embeddings.",
+        "group": "indexing"
+      }
     },
-    "supportsIncremental": true,
-    "supported_destination_sync_modes": [
-      "overwrite",
-      "append",
-      "append_dedup"
+    "required": ["embedding", "processing", "indexing"],
+    "groups": [
+      {
+        "id": "processing",
+        "title": "Processing"
+      },
+      {
+        "id": "embedding",
+        "title": "Embedding"
+      },
+      {
+        "id": "indexing",
+        "title": "Indexing"
+      },
+      {
+        "id": "advanced",
+        "title": "Advanced"
+      }
     ]
+  },
+  "supportsIncremental": true,
+  "supported_destination_sync_modes": ["overwrite", "append", "append_dedup"]
 }

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: vectorstore
   connectorType: destination
   definitionId: d9e5418d-f0f4-4d19-a8b1-5630543638e2
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/destination-snowflake-cortex
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake-cortex
   githubIssueLabel: destination-snowflake-cortex

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "airbyte-destination-snowflake-cortex"
-version = "0.1.0"
+version = "0.1.1"
 description = "Airbyte destination implementation for Snowflake cortex."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/unit_tests/destination_test.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/unit_tests/destination_test.py
@@ -81,5 +81,5 @@ class TestDestinationSnowflakeCortex(unittest.TestCase):
         destination = DestinationSnowflakeCortex()
         list(destination.write(self.config, configured_catalog, input_messages))
 
-        MockedWriter.assert_called_once_with(self.config_model.processing, mock_indexer, mock_embedder, batch_size=32, omit_raw_text=False)
+        MockedWriter.assert_called_once_with(self.config_model.processing, mock_indexer, mock_embedder, batch_size=150, omit_raw_text=False)
         mock_writer.write.assert_called_once_with(configured_catalog, input_messages)

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/unit_tests/indexer_test.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/unit_tests/indexer_test.py
@@ -184,6 +184,28 @@ def test_check():
     assert result == None
 
 
+def test_pre_sync_table_does_exist():
+    indexer = _create_snowflake_cortex_indexer(generate_catalog())
+    mock_processor = MagicMock()
+    indexer.default_processor = mock_processor
+    
+    mock_processor._get_tables_list.return_value = ["table1", "table2"]
+    mock_processor._execute_query.return_value = None
+    indexer.pre_sync(generate_catalog())
+    mock_processor._get_tables_list.assert_called_once()
+    mock_processor._execute_sql.assert_not_called()
+
+def test_pre_sync_table_exists():
+    indexer = _create_snowflake_cortex_indexer(generate_catalog())
+    mock_processor = MagicMock()
+    indexer.default_processor = mock_processor
+   
+    mock_processor._get_tables_list.return_value = ["example_stream2", "table2"]
+    mock_processor._execute_query.return_value = None
+    indexer.pre_sync(generate_catalog())
+    mock_processor._get_tables_list.assert_called_once()
+    mock_processor._execute_sql.assert_called_once()
+
 def generate_catalog():
     return ConfiguredAirbyteCatalog.parse_obj(
         {

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/unit_tests/indexer_test.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/unit_tests/indexer_test.py
@@ -135,7 +135,7 @@ def test_create_state_message():
 def test_get_write_strategy():
     indexer = _create_snowflake_cortex_indexer(generate_catalog())
     assert(indexer.get_write_strategy('example_stream') == WriteStrategy.MERGE)
-    assert(indexer.get_write_strategy('example_stream2') == WriteStrategy.REPLACE)
+    assert(indexer.get_write_strategy('example_stream2') == WriteStrategy.APPEND)
     assert(indexer.get_write_strategy('example_stream3') == WriteStrategy.APPEND)
 
 def test_get_document_id():

--- a/docs/integrations/destinations/snowflake-cortex.md
+++ b/docs/integrations/destinations/snowflake-cortex.md
@@ -81,4 +81,5 @@ To get started, sign up for [Snowflake](https://www.snowflake.com/en/). Ensure y
 
 | Version | Date       | Pull Request                                                  | Subject                                                                                                                                              |
 |:--------| :--------- |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.1.1 | 2024-05-15 | [#38206](https://github.com/airbytehq/airbyte/pull/38206) | Bug fixes.
 | 0.1.0 | 2024-05-13 | [#37333](https://github.com/airbytehq/airbyte/pull/36807) | Add support for Snowflake as a Vector destination.

--- a/docs/integrations/destinations/snowflake-cortex.md
+++ b/docs/integrations/destinations/snowflake-cortex.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This page guides you through the process of setting up the [Snowflake](https://pinecone.io/) as a vector destination.
+This page guides you through the process of setting up the [Snowflake](https://www.snowflake.com/en/) as a vector destination.
 
 There are three parts to this:
 * Processing - split up individual records in chunks so they will fit the context window and decide which fields to use as context and which are supplementary metadata.


### PR DESCRIPTION
This PR addresses the following: 

1. UI related fixes 
* Order params to match snowflake destination
* Remove secret field from params (which was hiding what was being typed)
* Updated doc link (was linked to Pinecone earlier) 
2. Update to write logic 
* For `destinationMode=Overwrite`, we first delete all records for the specified stream and then call cortexProcessor with `WriteStrategy.append` otherwise the batch size enforced by vector_db_based results in records getting overwritten every time batch size is met. We usually do this for all vector dbs, I missed it earlier. 

