### PR TITLE
Update heartbeats.md

### DIFF
--- a/docs/understanding-airbyte/heartbeats.md
+++ b/docs/understanding-airbyte/heartbeats.md
@@ -53,7 +53,9 @@ The heartbeat can be configured using the file flags.yaml through 2 entries:
 - `hseartbeat-max-seconds-between-messages`: this configures the maximum time allowed between 2 messages.
   The default is 3 hours.
 - `heartbeat.failSync`: Setting this to true will make the syncs to fail if a missed heartbeat is detected.
-  If false no sync will be failed because of a missed heartbeat. The default value is true.
+  If false no sync will be failed because of a missed heartbeat. The default value is false.
+
+**Note:** modifications to flags.yaml will currently only be respected in non-OSS editions of Airbyte.
 
 ### Destination
 


### PR DESCRIPTION

## What
-the default value of heartbeat.failSync is now false (https://github.com/airbytehq/airbyte-platform/blob/main/flags.yml#L5)

-added note to communicate that modifications to flags.yaml may not currently be respected in OSS editions. This may be subject to change in the future.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
