### PR TITLE
Snowflake Cortex : Update icon name in metadata file.

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
@@ -17,7 +17,7 @@ data:
   dockerRepository: airbyte/destination-snowflake-cortex
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake-cortex
   githubIssueLabel: destination-snowflake-cortex
-  icon: snowflake.svg
+  icon: snowflake-cortex.svg
   license: MIT
   name: Snowflake Cortex
   remoteRegistries:


### PR DESCRIPTION
Updated name from "snowflake.svg" to "snowflake-cortex.svg". This should hopefully fix the issue with snowflake logo not showing up on platform.