### PR TITLE
Airbyte CDK: remove unreleased version

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -6,9 +6,6 @@
 ## 0.88.4
 HttpMocker, Adding the delete method.
 
-## 0.88.3
-Add Delete method to HttpMocker
-
 ## 0.88.2
 Fix dependency for pytz
 


### PR DESCRIPTION
## What
I'm amending my misunderstanding of the release process. For CDK, there is a [GHA](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml) that generates new versions, so there is no need to bump up manually.

## How
I just removed the release version text 88.3 The change was released in 88.4.


## User Impact
There is no impact, the 88.3 version was not released

![image](https://github.com/airbytehq/airbyte/assets/168454423/6d3bc686-cc66-4af6-bdc1-a2f98d76a10e)

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
