### PR TITLE
refactor(source-s3): Replace AirbyteLogger with logging.Logger

### DIFF
--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
-  dockerImageTag: 4.5.14
+  dockerImageTag: 4.5.15
   dockerRepository: airbyte/source-s3
   documentationUrl: https://docs.airbyte.com/integrations/sources/s3
   githubIssueLabel: source-s3

--- a/airbyte-integrations/connectors/source-s3/pyproject.toml
+++ b/airbyte-integrations/connectors/source-s3/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.5.14"
+version = "4.5.15"
 name = "source-s3"
 description = "Source implementation for S3."
 authors = [ "Airbyte <contact@airbyte.io>",]
@@ -30,11 +30,11 @@ source-s3 = "source_s3.run:run"
 
 [tool.poetry.dependencies.airbyte-cdk]
 extras = [ "file-based",]
-version = "^0.88.1"
+version = "4.5.15"
 
 [tool.poetry.dependencies.smart-open]
 extras = [ "s3",]
-version = "==5.1.0"
+version = "4.5.15"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.1"

--- a/airbyte-integrations/connectors/source-s3/pyproject.toml
+++ b/airbyte-integrations/connectors/source-s3/pyproject.toml
@@ -30,11 +30,11 @@ source-s3 = "source_s3.run:run"
 
 [tool.poetry.dependencies.airbyte-cdk]
 extras = [ "file-based",]
-version = "4.5.15"
+version = "^0.88.1"
 
 [tool.poetry.dependencies.smart-open]
 extras = [ "s3",]
-version = "4.5.15"
+version = "==5.1.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.1"

--- a/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/source.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/source.py
@@ -2,11 +2,11 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import logging
 from abc import ABC, abstractmethod
 from traceback import format_exc
 from typing import Any, List, Mapping, Optional, Tuple
 
-from airbyte_cdk.logger import AirbyteLogger
 from airbyte_cdk.models import ConnectorSpecification, SyncMode
 from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode
 from airbyte_cdk.sources import AbstractSource
@@ -43,7 +43,7 @@ class SourceFilesAbstract(AbstractSource, ABC):
         :return: link to docs page for this source e.g. "https://docs.airbyte.com/integrations/sources/s3"
         """
 
-    def check_connection(self, logger: AirbyteLogger, config: Mapping[str, Any]) -> Tuple[bool, Optional[Any]]:
+    def check_connection(self, logger: logging.Logger, config: Mapping[str, Any]) -> Tuple[bool, Optional[Any]]:
         """
         This method checks two things:
             - That the credentials provided in config are valid for access.

--- a/airbyte-integrations/connectors/source-s3/source_s3/utils.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/utils.py
@@ -2,16 +2,16 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import logging
 import multiprocessing as mp
 import traceback
 from multiprocessing import Queue
 from typing import Any, Callable, List, Mapping
 
 import dill
-from airbyte_cdk.logger import AirbyteLogger
 
 
-def run_in_external_process(fn: Callable, timeout: int, max_timeout: int, logger: AirbyteLogger, args: List[Any]) -> Mapping[str, Any]:
+def run_in_external_process(fn: Callable, timeout: int, max_timeout: int, logger: logging.Logger, args: List[Any]) -> Mapping[str, Any]:
     """
     fn passed in must return a tuple of (desired return value, Exception OR None)
     This allows propagating any errors from the process up and raising accordingly

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -336,7 +336,7 @@ This connector utilizes the open source [Unstructured](https://unstructured-io.g
 
 | Version | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
 | :------ | :--------- | :-------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------- |
-| 4.5.15 | 2024-05-15 | [0](https://github.com/airbytehq/airbyte/pull/0) | Replace AirbyteLogger with logging.Logger |
+| 4.5.15 | 2024-05-20 | [38252](https://github.com/airbytehq/airbyte/pull/38252) | Replace AirbyteLogger with logging.Logger |
 | 4.5.14 | 2024-05-09 | [38090](https://github.com/airbytehq/airbyte/pull/38090) | Bump python-cdk version to include CSV field length fix |
 | 4.5.13 | 2024-05-03 | [37776](https://github.com/airbytehq/airbyte/pull/37776) | Update `airbyte-cdk` to fix the `discovery` command issue |
 | 4.5.12 | 2024-04-11 | [37001](https://github.com/airbytehq/airbyte/pull/37001) | Update airbyte-cdk to flush print buffer for every message |

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -336,96 +336,97 @@ This connector utilizes the open source [Unstructured](https://unstructured-io.g
 
 | Version | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
 | :------ | :--------- | :-------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------- |
+| 4.5.15 | 2024-05-15 | [0](https://github.com/airbytehq/airbyte/pull/0) | Replace AirbyteLogger with logging.Logger |
 | 4.5.14 | 2024-05-09 | [38090](https://github.com/airbytehq/airbyte/pull/38090) | Bump python-cdk version to include CSV field length fix |
-| 4.5.13  | 2024-05-03 | [37776](https://github.com/airbytehq/airbyte/pull/37776)                                                        | Update `airbyte-cdk` to fix the `discovery` command issue                                                            |
-| 4.5.12  | 2024-04-11 | [37001](https://github.com/airbytehq/airbyte/pull/37001)                                                        | Update airbyte-cdk to flush print buffer for every message                                                           |
-| 4.5.11  | 2024-03-14 | [36160](https://github.com/airbytehq/airbyte/pull/36160)                                                        | Bump python-cdk version to include CSV tab delimiter fix                                                             |
-| 4.5.10  | 2024-03-11 | [35955](https://github.com/airbytehq/airbyte/pull/35955)                                                        | Pin `transformers` transitive dependency                                                                             |
-| 4.5.9   | 2024-03-06 | [35857](https://github.com/airbytehq/airbyte/pull/35857)                                                        | Bump poetry.lock to upgrade transitive dependency                                                                    |
-| 4.5.8   | 2024-03-04 | [35808](https://github.com/airbytehq/airbyte/pull/35808)                                                        | Use cached AWS client                                                                                                |
-| 4.5.7   | 2024-02-23 | [34895](https://github.com/airbytehq/airbyte/pull/34895)                                                        | Run incremental syncs with concurrency                                                                               |
-| 4.5.6   | 2024-02-21 | [35246](https://github.com/airbytehq/airbyte/pull/35246)                                                        | Fixes bug that occurred when creating CSV streams with tab delimiter.                                                |
-| 4.5.5   | 2024-02-18 | [35392](https://github.com/airbytehq/airbyte/pull/35392)                                                        | Add support filtering by start date                                                                                  |
-| 4.5.4   | 2024-02-15 | [35055](https://github.com/airbytehq/airbyte/pull/35055)                                                        | Temporarily revert concurrency                                                                                       |
-| 4.5.3   | 2024-02-12 | [35164](https://github.com/airbytehq/airbyte/pull/35164)                                                        | Manage dependencies with Poetry.                                                                                     |
-| 4.5.2   | 2024-02-06 | [34930](https://github.com/airbytehq/airbyte/pull/34930)                                                        | Bump CDK version to fix issue when SyncMode is missing from catalog                                                  |
-| 4.5.1   | 2024-02-02 | [31701](https://github.com/airbytehq/airbyte/pull/31701)                                                        | Add `region` support                                                                                                 |
-| 4.5.0   | 2024-02-01 | [34591](https://github.com/airbytehq/airbyte/pull/34591)                                                        | Run full refresh syncs concurrently                                                                                  |
-| 4.4.1   | 2024-01-30 | [34665](https://github.com/airbytehq/airbyte/pull/34665)                                                        | Pin moto & CDK version                                                                                               |
-| 4.4.0   | 2024-01-12 | [33818](https://github.com/airbytehq/airbyte/pull/33818)                                                        | Add IAM Role Authentication                                                                                          |
-| 4.3.1   | 2024-01-04 | [33937](https://github.com/airbytehq/airbyte/pull/33937)                                                        | Prepare for airbyte-lib                                                                                              |
-| 4.3.0   | 2023-12-14 | [33411](https://github.com/airbytehq/airbyte/pull/33411)                                                        | Bump CDK version to auto-set primary key for document file streams and support raw txt files                         |
-| 4.2.4   | 2023-12-06 | [33187](https://github.com/airbytehq/airbyte/pull/33187)                                                        | Bump CDK version to hide source-defined primary key                                                                  |
-| 4.2.3   | 2023-11-16 | [32608](https://github.com/airbytehq/airbyte/pull/32608)                                                        | Improve document file type parser                                                                                    |
-| 4.2.2   | 2023-11-20 | [32677](https://github.com/airbytehq/airbyte/pull/32677)                                                        | Only read files with ".zip" extension as zipped files                                                                |
-| 4.2.1   | 2023-11-13 | [32357](https://github.com/airbytehq/airbyte/pull/32357)                                                        | Improve spec schema                                                                                                  |
-| 4.2.0   | 2023-11-02 | [32109](https://github.com/airbytehq/airbyte/pull/32109)                                                        | Fix docs; add HTTPS validation for S3 endpoint; fix coverage                                                         |
-| 4.1.4   | 2023-10-30 | [31904](https://github.com/airbytehq/airbyte/pull/31904)                                                        | Update CDK                                                                                                           |
-| 4.1.3   | 2023-10-25 | [31654](https://github.com/airbytehq/airbyte/pull/31654)                                                        | Reduce image size                                                                                                    |
-| 4.1.2   | 2023-10-23 | [31383](https://github.com/airbytehq/airbyte/pull/31383)                                                        | Add handling NoSuchBucket error                                                                                      |
-| 4.1.1   | 2023-10-19 | [31601](https://github.com/airbytehq/airbyte/pull/31601)                                                        | Base image migration: remove Dockerfile and use the python-connector-base image                                      |
-| 4.1.0   | 2023-10-17 | [31340](https://github.com/airbytehq/airbyte/pull/31340)                                                        | Add reading files inside zip archive                                                                                 |
-| 4.0.5   | 2023-10-16 | [31209](https://github.com/airbytehq/airbyte/pull/31209)                                                        | Add experimental Markdown/PDF/Docx file format                                                                       |
-| 4.0.4   | 2023-09-18 | [30476](https://github.com/airbytehq/airbyte/pull/30476)                                                        | Remove streams.\*.file_type from source-s3 configuration                                                             |
-| 4.0.3   | 2023-09-13 | [30387](https://github.com/airbytehq/airbyte/pull/30387)                                                        | Bump Airbyte-CDK version to improve messages for record parse errors                                                 |
-| 4.0.2   | 2023-09-07 | [28639](https://github.com/airbytehq/airbyte/pull/28639)                                                        | Always show S3 Key fields                                                                                            |
-| 4.0.1   | 2023-09-06 | [30217](https://github.com/airbytehq/airbyte/pull/30217)                                                        | Migrate inference error to config errors and avoir sentry alerts                                                     |
-| 4.0.0   | 2023-09-05 | [29757](https://github.com/airbytehq/airbyte/pull/29757)                                                        | New version using file-based CDK                                                                                     |
-| 3.1.11  | 2023-08-30 | [29986](https://github.com/airbytehq/airbyte/pull/29986)                                                        | Add config error for conversion error                                                                                |
-| 3.1.10  | 2023-08-29 | [29943](https://github.com/airbytehq/airbyte/pull/29943)                                                        | Add config error for arrow invalid error                                                                             |
-| 3.1.9   | 2023-08-23 | [29753](https://github.com/airbytehq/airbyte/pull/29753)                                                        | Feature parity update for V4 release                                                                                 |
-| 3.1.8   | 2023-08-17 | [29520](https://github.com/airbytehq/airbyte/pull/29520)                                                        | Update legacy state and error handling                                                                               |
-| 3.1.7   | 2023-08-17 | [29505](https://github.com/airbytehq/airbyte/pull/29505)                                                        | v4 StreamReader and Cursor fixes                                                                                     |
-| 3.1.6   | 2023-08-16 | [29480](https://github.com/airbytehq/airbyte/pull/29480)                                                        | update Pyarrow to version 12.0.1                                                                                     |
-| 3.1.5   | 2023-08-15 | [29418](https://github.com/airbytehq/airbyte/pull/29418)                                                        | Avoid duplicate syncs when migrating from v3 to v4                                                                   |
-| 3.1.4   | 2023-08-15 | [29382](https://github.com/airbytehq/airbyte/pull/29382)                                                        | Handle legacy path prefix & path pattern                                                                             |
-| 3.1.3   | 2023-08-05 | [29028](https://github.com/airbytehq/airbyte/pull/29028)                                                        | Update v3 & v4 connector to handle either state message                                                              |
-| 3.1.2   | 2023-07-29 | [28786](https://github.com/airbytehq/airbyte/pull/28786)                                                        | Add a codepath for using the file-based CDK                                                                          |
-| 3.1.1   | 2023-07-26 | [28730](https://github.com/airbytehq/airbyte/pull/28730)                                                        | Add human readable error message and improve validation for encoding field when it empty                             |
-| 3.1.0   | 2023-06-26 | [27725](https://github.com/airbytehq/airbyte/pull/27725)                                                        | License Update: Elv2                                                                                                 |
-| 3.0.3   | 2023-06-23 | [27651](https://github.com/airbytehq/airbyte/pull/27651)                                                        | Handle Bucket Access Errors                                                                                          |
-| 3.0.2   | 2023-06-22 | [27611](https://github.com/airbytehq/airbyte/pull/27611)                                                        | Fix start date                                                                                                       |
-| 3.0.1   | 2023-06-22 | [27604](https://github.com/airbytehq/airbyte/pull/27604)                                                        | Add logging for file reading                                                                                         |
-| 3.0.0   | 2023-05-02 | [25127](https://github.com/airbytehq/airbyte/pull/25127)                                                        | Remove ab_additional column; Use platform-handled schema evolution                                                   |
-| 2.2.0   | 2023-05-10 | [25937](https://github.com/airbytehq/airbyte/pull/25937)                                                        | Add support for Parquet Dataset                                                                                      |
-| 2.1.4   | 2023-05-01 | [25361](https://github.com/airbytehq/airbyte/pull/25361)                                                        | Parse nested avro schemas                                                                                            |
-| 2.1.3   | 2023-05-01 | [25706](https://github.com/airbytehq/airbyte/pull/25706)                                                        | Remove minimum block size for CSV check                                                                              |
-| 2.1.2   | 2023-04-18 | [25067](https://github.com/airbytehq/airbyte/pull/25067)                                                        | Handle block size related errors; fix config validator                                                               |
-| 2.1.1   | 2023-04-18 | [25010](https://github.com/airbytehq/airbyte/pull/25010)                                                        | Refactor filter logic                                                                                                |
-| 2.1.0   | 2023-04-10 | [25010](https://github.com/airbytehq/airbyte/pull/25010)                                                        | Add `start_date` field to filter files based on `LastModified` option                                                |
-| 2.0.4   | 2023-03-23 | [24429](https://github.com/airbytehq/airbyte/pull/24429)                                                        | Call `check` with a little block size to save time and memory.                                                       |
-| 2.0.3   | 2023-03-17 | [24178](https://github.com/airbytehq/airbyte/pull/24178)                                                        | Support legacy datetime format for the period of migration, fix time-zone conversion.                                |
-| 2.0.2   | 2023-03-16 | [24157](https://github.com/airbytehq/airbyte/pull/24157)                                                        | Return empty schema if `discover` finds no files; Do not infer extra data types when user defined schema is applied. |
-| 2.0.1   | 2023-03-06 | [23195](https://github.com/airbytehq/airbyte/pull/23195)                                                        | Fix datetime format string                                                                                           |
-| 2.0.0   | 2023-03-14 | [23189](https://github.com/airbytehq/airbyte/pull/23189)                                                        | Infer schema based on one file instead of all the files                                                              |
-| 1.0.2   | 2023-03-02 | [23669](https://github.com/airbytehq/airbyte/pull/23669)                                                        | Made `Advanced Reader Options` and `Advanced Options` truly `optional` for `CSV` format                              |
-| 1.0.1   | 2023-02-27 | [23502](https://github.com/airbytehq/airbyte/pull/23502)                                                        | Fix error handling                                                                                                   |
-| 1.0.0   | 2023-02-17 | [23198](https://github.com/airbytehq/airbyte/pull/23198)                                                        | Fix Avro schema discovery                                                                                            |
-| 0.1.32  | 2023-02-07 | [22500](https://github.com/airbytehq/airbyte/pull/22500)                                                        | Speed up discovery                                                                                                   |
-| 0.1.31  | 2023-02-08 | [22550](https://github.com/airbytehq/airbyte/pull/22550)                                                        | Validate CSV read options and convert options                                                                        |
-| 0.1.30  | 2023-01-25 | [21587](https://github.com/airbytehq/airbyte/pull/21587)                                                        | Make sure spec works as expected in UI                                                                               |
-| 0.1.29  | 2023-01-19 | [21604](https://github.com/airbytehq/airbyte/pull/21604)                                                        | Handle OSError: skip unreachable keys and keep working on accessible ones. Warn a customer                           |
-| 0.1.28  | 2023-01-10 | [21210](https://github.com/airbytehq/airbyte/pull/21210)                                                        | Update block size for json file format                                                                               |
-| 0.1.27  | 2022-12-08 | [20262](https://github.com/airbytehq/airbyte/pull/20262)                                                        | Check config settings for CSV file format                                                                            |
-| 0.1.26  | 2022-11-08 | [19006](https://github.com/airbytehq/airbyte/pull/19006)                                                        | Add virtual-hosted-style option                                                                                      |
-| 0.1.24  | 2022-10-28 | [18602](https://github.com/airbytehq/airbyte/pull/18602)                                                        | Wrap errors into AirbyteTracedException pointing to a problem file                                                   |
-| 0.1.23  | 2022-10-10 | [17991](https://github.com/airbytehq/airbyte/pull/17991)                                                        | Fix pyarrow to JSON schema type conversion for arrays                                                                |
-| 0.1.23  | 2022-10-10 | [17800](https://github.com/airbytehq/airbyte/pull/17800)                                                        | Deleted `use_ssl` and `verify_ssl_cert` flags and hardcoded to `True`                                                |
-| 0.1.22  | 2022-09-28 | [17304](https://github.com/airbytehq/airbyte/pull/17304)                                                        | Migrate to per-stream state                                                                                          |
-| 0.1.21  | 2022-09-20 | [16921](https://github.com/airbytehq/airbyte/pull/16921)                                                        | Upgrade pyarrow                                                                                                      |
-| 0.1.20  | 2022-09-12 | [16607](https://github.com/airbytehq/airbyte/pull/16607)                                                        | Fix for reading jsonl files containing nested structures                                                             |
-| 0.1.19  | 2022-09-13 | [16631](https://github.com/airbytehq/airbyte/pull/16631)                                                        | Adjust column type to a broadest one when merging two or more json schemas                                           |
-| 0.1.18  | 2022-08-01 | [14213](https://github.com/airbytehq/airbyte/pull/14213)                                                        | Add support for jsonl format files.                                                                                  |
-| 0.1.17  | 2022-07-21 | [14911](https://github.com/airbytehq/airbyte/pull/14911)                                                        | "decimal" type added for parquet                                                                                     |
-| 0.1.16  | 2022-07-13 | [14669](https://github.com/airbytehq/airbyte/pull/14669)                                                        | Fixed bug when extra columns apeared to be non-present in master schema                                              |
-| 0.1.15  | 2022-05-31 | [12568](https://github.com/airbytehq/airbyte/pull/12568)                                                        | Fixed possible case of files being missed during incremental syncs                                                   |
-| 0.1.14  | 2022-05-23 | [11967](https://github.com/airbytehq/airbyte/pull/11967)                                                        | Increase unit test coverage up to 90%                                                                                |
-| 0.1.13  | 2022-05-11 | [12730](https://github.com/airbytehq/airbyte/pull/12730)                                                        | Fixed empty options issue                                                                                            |
-| 0.1.12  | 2022-05-11 | [12602](https://github.com/airbytehq/airbyte/pull/12602)                                                        | Added support for Avro file format                                                                                   |
-| 0.1.11  | 2022-04-30 | [12500](https://github.com/airbytehq/airbyte/pull/12500)                                                        | Improve input configuration copy                                                                                     |
-| 0.1.10  | 2022-01-28 | [8252](https://github.com/airbytehq/airbyte/pull/8252)                                                          | Refactoring of files' metadata                                                                                       |
-| 0.1.9   | 2022-01-06 | [9163](https://github.com/airbytehq/airbyte/pull/9163)                                                          | Work-around for web-UI, `backslash - t` converts to `tab` for `format.delimiter` field.                              |
-| 0.1.7   | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)                                                          | Remove base-python dependencies                                                                                      |
+| 4.5.13 | 2024-05-03 | [37776](https://github.com/airbytehq/airbyte/pull/37776) | Update `airbyte-cdk` to fix the `discovery` command issue |
+| 4.5.12 | 2024-04-11 | [37001](https://github.com/airbytehq/airbyte/pull/37001) | Update airbyte-cdk to flush print buffer for every message |
+| 4.5.11 | 2024-03-14 | [36160](https://github.com/airbytehq/airbyte/pull/36160) | Bump python-cdk version to include CSV tab delimiter fix |
+| 4.5.10 | 2024-03-11 | [35955](https://github.com/airbytehq/airbyte/pull/35955) | Pin `transformers` transitive dependency |
+| 4.5.9 | 2024-03-06 | [35857](https://github.com/airbytehq/airbyte/pull/35857) | Bump poetry.lock to upgrade transitive dependency |
+| 4.5.8 | 2024-03-04 | [35808](https://github.com/airbytehq/airbyte/pull/35808) | Use cached AWS client |
+| 4.5.7 | 2024-02-23 | [34895](https://github.com/airbytehq/airbyte/pull/34895) | Run incremental syncs with concurrency |
+| 4.5.6 | 2024-02-21 | [35246](https://github.com/airbytehq/airbyte/pull/35246) | Fixes bug that occurred when creating CSV streams with tab delimiter. |
+| 4.5.5 | 2024-02-18 | [35392](https://github.com/airbytehq/airbyte/pull/35392) | Add support filtering by start date |
+| 4.5.4 | 2024-02-15 | [35055](https://github.com/airbytehq/airbyte/pull/35055) | Temporarily revert concurrency |
+| 4.5.3 | 2024-02-12 | [35164](https://github.com/airbytehq/airbyte/pull/35164) | Manage dependencies with Poetry. |
+| 4.5.2 | 2024-02-06 | [34930](https://github.com/airbytehq/airbyte/pull/34930) | Bump CDK version to fix issue when SyncMode is missing from catalog |
+| 4.5.1 | 2024-02-02 | [31701](https://github.com/airbytehq/airbyte/pull/31701) | Add `region` support |
+| 4.5.0 | 2024-02-01 | [34591](https://github.com/airbytehq/airbyte/pull/34591) | Run full refresh syncs concurrently |
+| 4.4.1 | 2024-01-30 | [34665](https://github.com/airbytehq/airbyte/pull/34665) | Pin moto & CDK version |
+| 4.4.0 | 2024-01-12 | [33818](https://github.com/airbytehq/airbyte/pull/33818) | Add IAM Role Authentication |
+| 4.3.1 | 2024-01-04 | [33937](https://github.com/airbytehq/airbyte/pull/33937) | Prepare for airbyte-lib |
+| 4.3.0 | 2023-12-14 | [33411](https://github.com/airbytehq/airbyte/pull/33411) | Bump CDK version to auto-set primary key for document file streams and support raw txt files |
+| 4.2.4 | 2023-12-06 | [33187](https://github.com/airbytehq/airbyte/pull/33187) | Bump CDK version to hide source-defined primary key |
+| 4.2.3 | 2023-11-16 | [32608](https://github.com/airbytehq/airbyte/pull/32608) | Improve document file type parser |
+| 4.2.2 | 2023-11-20 | [32677](https://github.com/airbytehq/airbyte/pull/32677) | Only read files with ".zip" extension as zipped files |
+| 4.2.1 | 2023-11-13 | [32357](https://github.com/airbytehq/airbyte/pull/32357) | Improve spec schema |
+| 4.2.0 | 2023-11-02 | [32109](https://github.com/airbytehq/airbyte/pull/32109) | Fix docs; add HTTPS validation for S3 endpoint; fix coverage |
+| 4.1.4 | 2023-10-30 | [31904](https://github.com/airbytehq/airbyte/pull/31904) | Update CDK |
+| 4.1.3 | 2023-10-25 | [31654](https://github.com/airbytehq/airbyte/pull/31654) | Reduce image size |
+| 4.1.2 | 2023-10-23 | [31383](https://github.com/airbytehq/airbyte/pull/31383) | Add handling NoSuchBucket error |
+| 4.1.1 | 2023-10-19 | [31601](https://github.com/airbytehq/airbyte/pull/31601) | Base image migration: remove Dockerfile and use the python-connector-base image |
+| 4.1.0 | 2023-10-17 | [31340](https://github.com/airbytehq/airbyte/pull/31340) | Add reading files inside zip archive |
+| 4.0.5 | 2023-10-16 | [31209](https://github.com/airbytehq/airbyte/pull/31209) | Add experimental Markdown/PDF/Docx file format |
+| 4.0.4 | 2023-09-18 | [30476](https://github.com/airbytehq/airbyte/pull/30476) | Remove streams.\*.file_type from source-s3 configuration |
+| 4.0.3 | 2023-09-13 | [30387](https://github.com/airbytehq/airbyte/pull/30387) | Bump Airbyte-CDK version to improve messages for record parse errors |
+| 4.0.2 | 2023-09-07 | [28639](https://github.com/airbytehq/airbyte/pull/28639) | Always show S3 Key fields |
+| 4.0.1 | 2023-09-06 | [30217](https://github.com/airbytehq/airbyte/pull/30217) | Migrate inference error to config errors and avoir sentry alerts |
+| 4.0.0 | 2023-09-05 | [29757](https://github.com/airbytehq/airbyte/pull/29757) | New version using file-based CDK |
+| 3.1.11 | 2023-08-30 | [29986](https://github.com/airbytehq/airbyte/pull/29986) | Add config error for conversion error |
+| 3.1.10 | 2023-08-29 | [29943](https://github.com/airbytehq/airbyte/pull/29943) | Add config error for arrow invalid error |
+| 3.1.9 | 2023-08-23 | [29753](https://github.com/airbytehq/airbyte/pull/29753) | Feature parity update for V4 release |
+| 3.1.8 | 2023-08-17 | [29520](https://github.com/airbytehq/airbyte/pull/29520) | Update legacy state and error handling |
+| 3.1.7 | 2023-08-17 | [29505](https://github.com/airbytehq/airbyte/pull/29505) | v4 StreamReader and Cursor fixes |
+| 3.1.6 | 2023-08-16 | [29480](https://github.com/airbytehq/airbyte/pull/29480) | update Pyarrow to version 12.0.1 |
+| 3.1.5 | 2023-08-15 | [29418](https://github.com/airbytehq/airbyte/pull/29418) | Avoid duplicate syncs when migrating from v3 to v4 |
+| 3.1.4 | 2023-08-15 | [29382](https://github.com/airbytehq/airbyte/pull/29382) | Handle legacy path prefix & path pattern |
+| 3.1.3 | 2023-08-05 | [29028](https://github.com/airbytehq/airbyte/pull/29028) | Update v3 & v4 connector to handle either state message |
+| 3.1.2 | 2023-07-29 | [28786](https://github.com/airbytehq/airbyte/pull/28786) | Add a codepath for using the file-based CDK |
+| 3.1.1 | 2023-07-26 | [28730](https://github.com/airbytehq/airbyte/pull/28730) | Add human readable error message and improve validation for encoding field when it empty |
+| 3.1.0 | 2023-06-26 | [27725](https://github.com/airbytehq/airbyte/pull/27725) | License Update: Elv2 |
+| 3.0.3 | 2023-06-23 | [27651](https://github.com/airbytehq/airbyte/pull/27651) | Handle Bucket Access Errors |
+| 3.0.2 | 2023-06-22 | [27611](https://github.com/airbytehq/airbyte/pull/27611) | Fix start date |
+| 3.0.1 | 2023-06-22 | [27604](https://github.com/airbytehq/airbyte/pull/27604) | Add logging for file reading |
+| 3.0.0 | 2023-05-02 | [25127](https://github.com/airbytehq/airbyte/pull/25127) | Remove ab_additional column; Use platform-handled schema evolution |
+| 2.2.0 | 2023-05-10 | [25937](https://github.com/airbytehq/airbyte/pull/25937) | Add support for Parquet Dataset |
+| 2.1.4 | 2023-05-01 | [25361](https://github.com/airbytehq/airbyte/pull/25361) | Parse nested avro schemas |
+| 2.1.3 | 2023-05-01 | [25706](https://github.com/airbytehq/airbyte/pull/25706) | Remove minimum block size for CSV check |
+| 2.1.2 | 2023-04-18 | [25067](https://github.com/airbytehq/airbyte/pull/25067) | Handle block size related errors; fix config validator |
+| 2.1.1 | 2023-04-18 | [25010](https://github.com/airbytehq/airbyte/pull/25010) | Refactor filter logic |
+| 2.1.0 | 2023-04-10 | [25010](https://github.com/airbytehq/airbyte/pull/25010) | Add `start_date` field to filter files based on `LastModified` option |
+| 2.0.4 | 2023-03-23 | [24429](https://github.com/airbytehq/airbyte/pull/24429) | Call `check` with a little block size to save time and memory. |
+| 2.0.3 | 2023-03-17 | [24178](https://github.com/airbytehq/airbyte/pull/24178) | Support legacy datetime format for the period of migration, fix time-zone conversion. |
+| 2.0.2 | 2023-03-16 | [24157](https://github.com/airbytehq/airbyte/pull/24157) | Return empty schema if `discover` finds no files; Do not infer extra data types when user defined schema is applied. |
+| 2.0.1 | 2023-03-06 | [23195](https://github.com/airbytehq/airbyte/pull/23195) | Fix datetime format string |
+| 2.0.0 | 2023-03-14 | [23189](https://github.com/airbytehq/airbyte/pull/23189) | Infer schema based on one file instead of all the files |
+| 1.0.2 | 2023-03-02 | [23669](https://github.com/airbytehq/airbyte/pull/23669) | Made `Advanced Reader Options` and `Advanced Options` truly `optional` for `CSV` format |
+| 1.0.1 | 2023-02-27 | [23502](https://github.com/airbytehq/airbyte/pull/23502) | Fix error handling |
+| 1.0.0 | 2023-02-17 | [23198](https://github.com/airbytehq/airbyte/pull/23198) | Fix Avro schema discovery |
+| 0.1.32 | 2023-02-07 | [22500](https://github.com/airbytehq/airbyte/pull/22500) | Speed up discovery |
+| 0.1.31 | 2023-02-08 | [22550](https://github.com/airbytehq/airbyte/pull/22550) | Validate CSV read options and convert options |
+| 0.1.30 | 2023-01-25 | [21587](https://github.com/airbytehq/airbyte/pull/21587) | Make sure spec works as expected in UI |
+| 0.1.29 | 2023-01-19 | [21604](https://github.com/airbytehq/airbyte/pull/21604) | Handle OSError: skip unreachable keys and keep working on accessible ones. Warn a customer |
+| 0.1.28 | 2023-01-10 | [21210](https://github.com/airbytehq/airbyte/pull/21210) | Update block size for json file format |
+| 0.1.27 | 2022-12-08 | [20262](https://github.com/airbytehq/airbyte/pull/20262) | Check config settings for CSV file format |
+| 0.1.26 | 2022-11-08 | [19006](https://github.com/airbytehq/airbyte/pull/19006) | Add virtual-hosted-style option |
+| 0.1.24 | 2022-10-28 | [18602](https://github.com/airbytehq/airbyte/pull/18602) | Wrap errors into AirbyteTracedException pointing to a problem file |
+| 0.1.23 | 2022-10-10 | [17991](https://github.com/airbytehq/airbyte/pull/17991) | Fix pyarrow to JSON schema type conversion for arrays |
+| 0.1.23 | 2022-10-10 | [17800](https://github.com/airbytehq/airbyte/pull/17800) | Deleted `use_ssl` and `verify_ssl_cert` flags and hardcoded to `True` |
+| 0.1.22 | 2022-09-28 | [17304](https://github.com/airbytehq/airbyte/pull/17304) | Migrate to per-stream state |
+| 0.1.21 | 2022-09-20 | [16921](https://github.com/airbytehq/airbyte/pull/16921) | Upgrade pyarrow |
+| 0.1.20 | 2022-09-12 | [16607](https://github.com/airbytehq/airbyte/pull/16607) | Fix for reading jsonl files containing nested structures |
+| 0.1.19 | 2022-09-13 | [16631](https://github.com/airbytehq/airbyte/pull/16631) | Adjust column type to a broadest one when merging two or more json schemas |
+| 0.1.18 | 2022-08-01 | [14213](https://github.com/airbytehq/airbyte/pull/14213) | Add support for jsonl format files. |
+| 0.1.17 | 2022-07-21 | [14911](https://github.com/airbytehq/airbyte/pull/14911) | "decimal" type added for parquet |
+| 0.1.16 | 2022-07-13 | [14669](https://github.com/airbytehq/airbyte/pull/14669) | Fixed bug when extra columns apeared to be non-present in master schema |
+| 0.1.15 | 2022-05-31 | [12568](https://github.com/airbytehq/airbyte/pull/12568) | Fixed possible case of files being missed during incremental syncs |
+| 0.1.14 | 2022-05-23 | [11967](https://github.com/airbytehq/airbyte/pull/11967) | Increase unit test coverage up to 90% |
+| 0.1.13 | 2022-05-11 | [12730](https://github.com/airbytehq/airbyte/pull/12730) | Fixed empty options issue |
+| 0.1.12 | 2022-05-11 | [12602](https://github.com/airbytehq/airbyte/pull/12602) | Added support for Avro file format |
+| 0.1.11 | 2022-04-30 | [12500](https://github.com/airbytehq/airbyte/pull/12500) | Improve input configuration copy |
+| 0.1.10 | 2022-01-28 | [8252](https://github.com/airbytehq/airbyte/pull/8252) | Refactoring of files' metadata |
+| 0.1.9 | 2022-01-06 | [9163](https://github.com/airbytehq/airbyte/pull/9163) | Work-around for web-UI, `backslash - t` converts to `tab` for `format.delimiter` field. |
+| 0.1.7 | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499) | Remove base-python dependencies |
 | 0.1.6   | 2021-10-15 | [6615](https://github.com/airbytehq/airbyte/pull/6615) & [7058](https://github.com/airbytehq/airbyte/pull/7058) | Memory and performance optimisation. Advanced options for CSV parsing.                                               |
 | 0.1.5   | 2021-09-24 | [6398](https://github.com/airbytehq/airbyte/pull/6398)                                                          | Support custom non Amazon S3 services                                                                                |
 | 0.1.4   | 2021-08-13 | [5305](https://github.com/airbytehq/airbyte/pull/5305)                                                          | Support of Parquet format                                                                                            |


### PR DESCRIPTION
## What
Replace usage of deprecated AirbyteLogger with logging.Logger

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
