### PR TITLE
airbyte-ci: dynamic test step tree according to metadata

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -298,14 +298,14 @@ flowchart TD
 #### Options
 
 | Option                                                  | Multiple | Default value | Description                                                                                                                                                                                              |
-| ------------------------------------------------------- | -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| ------------------------------------------------------- | -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--skip-step/-x`                                        | True     |               | Skip steps by id e.g. `-x unit -x acceptance`                                                                                                                                                            |
 | `--only-step/-k`                                        | True     |               | Only run specific steps by id e.g. `-k unit -k acceptance`                                                                                                                                               |
 | `--fail-fast`                                           | False    | False         | Abort after any tests fail, rather than continuing to run additional tests. Use this setting to confirm a known bug is fixed (or not), or when you only require a pass/fail result.                      |
 | `--code-tests-only`                                     | True     | False         | Skip any tests not directly related to code updates. For instance, metadata checks, version bump checks, changelog verification, etc. Use this setting to help focus on code quality during development. |
 | `--concurrent-cat`                                      | False    | False         | Make CAT tests run concurrently using pytest-xdist. Be careful about source or destination API rate limits.                                                                                              |
 | `--<step-id>.<extra-parameter>=<extra-parameter-value>` | True     |               | You can pass extra parameters for specific test steps. More details in the extra parameters section below                                                                                                |
-| `--ci-requirements`                                     | False    |               |                                                                                                                                                                                                          | Output the CI requirements as a JSON payload. It is used to determine the CI runner to use. |
+| `--ci-requirements`                                     | False    |               |                                                                                                                                                                                                          | Output the CI requirements as a JSON payload. It is used to determine the CI runner to use. 
 
 Note:
 
@@ -745,6 +745,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 |---------|------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| 4.14.0  | [#38281](https://github.com/airbytehq/airbyte/pull/38281)  | Conditionally run test suites according to `connectorTestSuitesOptions` in metadata files.                                   |
 | 4.13.3  | [#38221](https://github.com/airbytehq/airbyte/pull/38221)  | Add dagster cloud dev deployment pipeline opitions                                                                           |
 | 4.13.2  | [#38246](https://github.com/airbytehq/airbyte/pull/38246)  | Remove invalid connector test step options.                                                                                  |
 | 4.13.1  | [#38020](https://github.com/airbytehq/airbyte/pull/38020)  | Add `auto_merge` as an internal package to test.                                                                             |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from types import TracebackType
@@ -15,6 +16,7 @@ import yaml  # type: ignore
 from asyncer import asyncify
 from dagger import Directory, Platform, Secret
 from github import PullRequest
+from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
 from pipelines.airbyte_ci.connectors.reports import ConnectorReport
 from pipelines.consts import BUILD_PLATFORMS
 from pipelines.dagger.actions import secrets
@@ -28,6 +30,13 @@ from pipelines.models.contexts.pipeline_context import PipelineContext
 if TYPE_CHECKING:
     from pathlib import Path as NativePath
     from typing import Dict, FrozenSet, List, Optional, Sequence
+
+# These test suite names are declared in metadata.yaml files
+TEST_SUITE_NAME_TO_STEP_ID = {
+    "unitTests": CONNECTOR_TEST_STEP_ID.UNIT,
+    "integrationTests": CONNECTOR_TEST_STEP_ID.INTEGRATION,
+    "acceptanceTests": CONNECTOR_TEST_STEP_ID.ACCEPTANCE,
+}
 
 
 class ConnectorContext(PipelineContext):
@@ -140,7 +149,7 @@ class ConnectorContext(PipelineContext):
             ci_gcs_credentials=ci_gcs_credentials,
             ci_git_user=ci_git_user,
             ci_github_access_token=ci_github_access_token,
-            run_step_options=run_step_options,
+            run_step_options=self._get_updated_run_step_options(run_step_options),
             enable_report_auto_open=enable_report_auto_open,
         )
 
@@ -286,3 +295,12 @@ class ConnectorContext(PipelineContext):
 
     def create_slack_message(self) -> str:
         raise NotImplementedError
+
+    def _get_step_id_to_skip_according_to_metadata(self) -> List[CONNECTOR_TEST_STEP_ID]:
+        enabled_test_suites = [option["suite"] for option in self.metadata.get("connectorTestSuitesOptions", [])]
+        return [step_id for test_suite_name, step_id in TEST_SUITE_NAME_TO_STEP_ID.items() if test_suite_name not in enabled_test_suites]
+
+    def _get_updated_run_step_options(self, run_step_options: RunStepOptions) -> RunStepOptions:
+        run_step_options = deepcopy(run_step_options)
+        run_step_options.skip_steps += self._get_step_id_to_skip_according_to_metadata()
+        return run_step_options

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.13.3"
+version = "4.14.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_actions/test_environments.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_actions/test_environments.py
@@ -2,10 +2,10 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-import asyncclick as click
 import pytest
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.dagger.actions.python import common
+from pipelines.helpers.connectors.modifed import ConnectorWithModifiedFiles
 
 pytestmark = [
     pytest.mark.anyio,
@@ -16,7 +16,7 @@ pytestmark = [
 def connector_context(dagger_client):
     context = ConnectorContext(
         pipeline_name="test",
-        connector="source-faker",
+        connector=ConnectorWithModifiedFiles("source-faker", modified_files={}),
         git_branch="test",
         git_revision="test",
         diffed_branch="test",


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/7552

Make `airbyte-ci` consume the `connectorTestSuitesOptions` from connector metadata to conditionally run test suites declared in there.

## How
* Implement a `get_test_suites_to_run_according_to_metadata` function taking the metadata and the optional steps to run
* Call it at test step tree creation for python and java connectors


## User Impact
After merging this we should ask all connector developers to update their branch so that they get the freshest connector metadata introduced in https://github.com/airbytehq/airbyte/pull/38188 . Critical tests would be skipped otherwise...
