### PR TITLE
🐛 Source Hubspot: add `TypeTransformer` to `Tickets` stream

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 4.1.3
+  dockerImageTag: 4.1.4
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   githubIssueLabel: source-hubspot

--- a/airbyte-integrations/connectors/source-hubspot/pyproject.toml
+++ b/airbyte-integrations/connectors/source-hubspot/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.1.3"
+version = "4.1.4"
 name = "source-hubspot"
 description = "Source implementation for HubSpot."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -2244,6 +2244,10 @@ class Tickets(CRMSearchStream):
     primary_key = "id"
     scopes = {"tickets"}
     last_modified_field = "hs_lastmodifieddate"
+    # the `contacts` property started to send the `array of string`,
+    # but the schema declares it to be `array of integer`,
+    # applying the default schema type normalization fixes the issue.
+    transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
 
 
 class CustomObject(CRMSearchStream, ABC):

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -1084,6 +1084,9 @@ class CRMSearchStream(IncrementalStream, ABC):
     associations: List[str] = None
     fully_qualified_name: str = None
 
+    # added to guarantee the data types, declared for the stream's schema
+    transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
+
     @property
     def url(self):
         object_type_id = self.fully_qualified_name or self.entity
@@ -2244,10 +2247,6 @@ class Tickets(CRMSearchStream):
     primary_key = "id"
     scopes = {"tickets"}
     last_modified_field = "hs_lastmodifieddate"
-    # the `contacts` property started to send the `array of string`,
-    # but the schema declares it to be `array of integer`,
-    # applying the default schema type normalization fixes the issue.
-    transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
 
 
 class CustomObject(CRMSearchStream, ABC):

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -334,6 +334,7 @@ The connector is restricted by normal HubSpot [rate limitations](https://legacyd
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                          |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4.1.4   | 2024-05-16 | [38286](https://github.com/airbytehq/airbyte/pull/38286) | Added default schema normalization for the  `Tickets` stream, to ensure the data types |
 | 4.1.3   | 2024-05-13 | [38128](https://github.com/airbytehq/airbyte/pull/38128) | contacts_list_memberships as semi-incremental stream                                                                                                                             |
 | 4.1.2   | 2024-04-24 | [36642](https://github.com/airbytehq/airbyte/pull/36642) | Schema descriptions and CDK 0.80.0                                                                                                                                               |
 | 4.1.1   | 2024-04-11 | [35945](https://github.com/airbytehq/airbyte/pull/35945) | Add integration tests                                                                                                                                                            |


### PR DESCRIPTION
## What
Having this issue: 
- https://airbyte-globallogic.slack.com/archives/C06QMBS52NR/p1715864071876399 
- 
There is an issue with the Hubspot source. [The nightly tests failed](https://connectors.airbyte.com/files/generated_reports/test_summary/source-hubspot/index.html) because the contacts in the tickets stream are of the wrong type. The expected type is an integer, but we are getting a string for our test account.

## How
- added `TypeTransformer` with default schema normalization to ensure the declared data types, declared in stream schema

## User Impact
No impact is expected.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
