### PR TITLE
bug(docs): Fix font weight 500 omission being a style rule

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -4,7 +4,7 @@
  * work well for content-centric websites.
  */
 
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;600;700&display=swap");
 
 /* You can override the default Infima variables here. */
 :root {
@@ -105,6 +105,7 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
 
 .navbar .navbar__link {
   color: var(--ifm-menu-color);
+  font-weight: var(--ifm-font-weight-normal);
 }
 
 .navbar .navbar__link:hover {
@@ -192,6 +193,10 @@ img {
 .iconExternalLink_I5OW {
   margin-left: 0.3rem;
   display: none;
+}
+
+.menu__link {
+  font-weight: var(--ifm-font-weight-normal);
 }
 
 .menu__link--sublist-caret:after {


### PR DESCRIPTION
## Problem
1. We have new designs that need font weight 500
2. We did not import that font weight for inter in our docs site
3. After importing, our navigation titles went from 400 to 500 font weight
4. This is because our styling was relying on the omission!

## Solution
1. Import font weight 500
2. Find areas that were using 500 and downgrade them to 400 (because thats the visual equivalent of where we are today)er