### PR TITLE
Audrey/airflow airbyte operator

### DIFF
--- a/docs/operator-guides/using-the-airflow-airbyte-operator.md
+++ b/docs/operator-guides/using-the-airflow-airbyte-operator.md
@@ -15,7 +15,7 @@ For [historic reasons](https://github.com/airbytehq/airbyte/issues/836), the Air
 
 :::caution
 
-Due to some difficulties in setting up Airflow, we recommend first trying out the deployment using the local example [here](https://github.com/airbytehq/airbyte/tree/master/resources/examples/airflow), as it contains accurate configuration required to get the Airbyte operator up and running.
+Due to some difficulties in setting up Airflow, we recommend first trying out the deployment using the local example [here](https://github.com/airbytehq/airbyte/blob/master/docs/operator-guides/using-the-airflow-airbyte-operator.md), as it contains accurate configuration required to get the Airbyte operator up and running.
 
 :::
 

--- a/docs/operator-guides/using-the-airflow-airbyte-operator.md
+++ b/docs/operator-guides/using-the-airflow-airbyte-operator.md
@@ -13,11 +13,6 @@ For [historic reasons](https://github.com/airbytehq/airbyte/issues/836), the Air
 
 :::
 
-:::caution
-
-Due to some difficulties in setting up Airflow, we recommend first trying out the deployment using the local example [here](https://github.com/airbytehq/airbyte/blob/master/docs/operator-guides/using-the-airflow-airbyte-operator.md), as it contains accurate configuration required to get the Airbyte operator up and running.
-
-:::
 
 The Airbyte Provider documentation on Airflow project can be found [here](https://airflow.apache.org/docs/apache-airflow-providers-airbyte/stable/index.html).
 


### PR DESCRIPTION
## What
Removes a note from the following doc: "Using the Airbyte Operator to orchestrate AirbyteOSS"
This note contained a broken link
https://airbytehq-team.slack.com/archives/C032Y32T065/p1715890717234299
![image](https://github.com/airbytehq/airbyte/assets/23410478/e3a09cb3-c7b0-43bf-aef5-a544bb882580)

## How
Removed the caution note on this page. This may require follow-up to determine if users need an alternate resource. For now, this assures the docs aren't sharing outdated information with a broken link. 

## Review guide


## User Impact


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
