### PR TITLE
chore(source-declarative-manifest) Update breaking change notice

### DIFF
--- a/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
@@ -28,6 +28,11 @@ data:
       enabled: true
       packageName: airbyte-source-declarative-manifest
   supportLevel: community
+  releases:
+    breakingChanges:
+      1.0.0:
+        message: Version 1.0.0 deletes a few deprecated classes. See the [cdk-migrations.md doc](https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/cdk-migrations.md#upgrading-to-100) for more details on how to upgrade.
+        upgradeDeadline: "2024-05-20"
   tags:
     - language:python
   connectorTestSuitesOptions:

--- a/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
@@ -32,7 +32,7 @@ data:
     breakingChanges:
       1.0.0:
         message: Version 1.0.0 deletes a few deprecated classes. See the [cdk-migrations.md doc](https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/cdk-migrations.md#upgrading-to-100) for more details on how to upgrade.
-        upgradeDeadline: "2024-05-20"
+        upgradeDeadline: "2024-05-30"
   tags:
     - language:python
   connectorTestSuitesOptions:


### PR DESCRIPTION
## What
The latest version of the connector failed to publish because it did not have a breaking change notice.
This PR adds a notice pointing to the migration guide.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
