### PR TITLE
skip-ci: fix format on master

### DIFF
--- a/airbyte-integrations/connectors/source-appsflyer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appsflyer/metadata.yaml
@@ -20,8 +20,8 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/appsflyer
   tags:
-  - language:python
-  - cdk:python
+    - language:python
+    - cdk:python
   ab_internal:
     sl: 100
     ql: 100


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/pull/38363 was merged with failing format.
Fix the formatting on this connector.
Skip CI to not run tests.
Tested that formatting passes locally.
