### PR TITLE
Source File: Add transport params for SSH/SCP/SFTP

### DIFF
--- a/airbyte-integrations/connectors/source-file/poetry.lock
+++ b/airbyte-integrations/connectors/source-file/poetry.lock
@@ -1622,6 +1622,17 @@ files = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+description = "A deep merge function for 🐍."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
+    {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
+]
+
+[[package]]
 name = "multidict"
 version = "6.0.5"
 description = "multidict implementation"
@@ -2978,4 +2989,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.12"
-content-hash = "029441ef128251a0f9995bb4c3bb4e0af2ca581bf5a9420d227ca0b819a7b7c5"
+content-hash = "52ef99acda88a15392618c4b62e2bf751a118092866f751211fd34a6a81ec3ba"

--- a/airbyte-integrations/connectors/source-file/pyproject.toml
+++ b/airbyte-integrations/connectors/source-file/pyproject.toml
@@ -33,6 +33,7 @@ gcsfs = "==2022.7.1"
 pyxlsb = "==1.0.10"
 genson = "==1.2.2"
 fastparquet = "^2024.2.0"
+mergedeep = "^1.3.4"
 
 [tool.poetry.scripts]
 source-file = "source_file.run:run"

--- a/airbyte-integrations/connectors/source-file/source_file/spec.json
+++ b/airbyte-integrations/connectors/source-file/source_file/spec.json
@@ -168,6 +168,16 @@
                 "title": "Port",
                 "default": "22",
                 "description": ""
+              },
+              "transport_params": {
+                "type": "string",
+                "title": "Transport Params",
+                "description": "This should be a string in JSON format. See <a href=\"https://github.com/piskvorky/smart_open\">smart_open documentation</a> for more details.",
+                "examples": [
+                  "{}",
+                  "{\"timeout\": 120}",
+                  "{\"timeout\": 120, \"buffer_size\": 1024}"
+                ]
               }
             }
           },
@@ -201,6 +211,16 @@
                 "title": "Port",
                 "default": "22",
                 "description": ""
+              },
+              "transport_params": {
+                "type": "string",
+                "title": "Transport Params",
+                "description": "This should be a string in JSON format. See <a href=\"https://github.com/piskvorky/smart_open\">smart_open documentation</a> for more details.",
+                "examples": [
+                  "{}",
+                  "{\"timeout\": 120}",
+                  "{\"timeout\": 120, \"buffer_size\": 1024}"
+                ]
               }
             }
           },
@@ -234,6 +254,16 @@
                 "title": "Port",
                 "default": "22",
                 "description": ""
+              },
+              "transport_params": {
+                "type": "string",
+                "title": "Transport Params",
+                "description": "This should be a string in JSON format. See <a href=\"https://github.com/piskvorky/smart_open\">smart_open documentation</a> for more details.",
+                "examples": [
+                  "{}",
+                  "{\"timeout\": 120}",
+                  "{\"timeout\": 120, \"buffer_size\": 1024}"
+                ]
               }
             }
           },


### PR DESCRIPTION
## What
Introduce new configuration parameter for SSH/SCP/SFTP connections, allowing users to override transport parameters applied to smart_open.

## How
- A new `transport_params` optional JSON string property to SSH/SCP/SFTP configuration spec.
- Added function for parsing the configuration and merging it into the default configuration.
- If the this option is not set, existing default configuration will be used.
- Added documentation to the file-source README.

## Review guide
1. airbyte-integrations/connectors/source-file/source_file/spec.json
2. airbyte-integrations/connectors/source-file/source_file/client.json
3. airbyte-integrations/connectors/source-file/README.md
## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
New optional entry `Transport Params` is added to the supported providers' configuration UI.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
