### PR TITLE
airbyte-ci: fix extra steps running when selected commands are provided

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
@@ -318,5 +318,7 @@ class ConnectorContext(PipelineContext):
             RunStepOptions: Updated run step options.
         """
         run_step_options = deepcopy(run_step_options)
-        run_step_options.skip_steps += self._get_step_id_to_skip_according_to_metadata()
+        # If any `skip_steps` are present, we will run everything except the skipped steps, instead of just `keep_steps`.
+        if not run_step_options.keep_steps:
+            run_step_options.skip_steps += self._get_step_id_to_skip_according_to_metadata()
         return run_step_options


### PR DESCRIPTION
Fixes the issue discussed [here](https://airbytehq-team.slack.com/archives/C02UF50V9HA/p1716298177209659), where we were running all tests during the version increment check, instead of simply running the version increment check.

I think the logic around `skip_steps` and `keep_steps` is a little hard to follow so would be worth taking another look at some point, but this should fix the problem in the short term.