### PR TITLE
Update metadata sensor to 2 min polling interval

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -169,7 +169,7 @@ SENSORS = [
 ]
 
 SCHEDULES = [
-    ScheduleDefinition(job=add_new_metadata_partitions, cron_schedule="*/5 * * * *", tags={"dagster/priority": HIGH_QUEUE_PRIORITY}),
+    ScheduleDefinition(job=add_new_metadata_partitions, cron_schedule="*/2 * * * *", tags={"dagster/priority": HIGH_QUEUE_PRIORITY}),
     ScheduleDefinition(job=generate_connector_test_summary_reports, cron_schedule="@hourly"),
     ScheduleDefinition(
         cron_schedule="0 8 * * *",  # Daily at 8am US/Pacific


### PR DESCRIPTION
## What
Decrease the polling interval from 5min to 2min

## Why
We can now tighten up this interval as the job runs much faster.

The logic now takes < 10s

However the full run from resource spin up to spin down is 1.5 minutes.

Which is why I chose every 2 minutes and not every minute

---
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/7820