### PR TITLE
Fix bash location for run-ab-platform.sh

### DIFF
--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERSION=0.60.1
 # Run away from anything even a little scary


### PR DESCRIPTION

## What
Finds the default bash of the current environment, as some systems don't have `bash` in `/bin/bash.`

## How
It changes the first line that specifies the interpreter to use `/usr/bin/env`

## Review guide
Execute `run-ab-platform.sh` and verify it works.

## User Impact
Users of systems not havin bash in `/bin/bash` will be able to run `run-ab-platform.sh`.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
