### PR TITLE
Fix link to storybook

### DIFF
--- a/docs/connector-development/connector-specification-reference.md
+++ b/docs/connector-development/connector-specification-reference.md
@@ -6,7 +6,7 @@ The [connector specification](../understanding-airbyte/airbyte-protocol.md#spec)
 
 While iterating on your specification, you can preview what it will look like in the UI in realtime by following the instructions below.
 
-1. Open the `ConnectorForm` preview component in our deployed Storybook at: https://components.airbyte.dev/?path=/story/connector-connectorform--preview
+1. Open the `ConnectorForm` preview component in our deployed Storybook at: https://storybook.airbyte.dev/?path=/story/connector-connectorform--preview
 2. Press `raw` on the `connectionSpecification` property, so you will be able to paste a JSON structured string
 3. Set the string you want to preview the UI for
 4. When submitting the form you can see a preview of the values in the "Actions" tab


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/38566

Fixes the doc link to our hosted storybook to point to the new one. Note: the story we link to is still broken, but that need to be fixed in the platform repository.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
