### PR TITLE
feat(registry): Run remove stale partitions nightly

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -170,6 +170,11 @@ SENSORS = [
 
 SCHEDULES = [
     ScheduleDefinition(job=add_new_metadata_partitions, cron_schedule="*/2 * * * *", tags={"dagster/priority": HIGH_QUEUE_PRIORITY}),
+    ScheduleDefinition(
+        cron_schedule="0 1 * * *",  # Daily at 1am US/Pacific
+        execution_timezone="US/Pacific",
+        job=remove_stale_metadata_partitions,
+    ),
     ScheduleDefinition(job=generate_connector_test_summary_reports, cron_schedule="@hourly"),
     ScheduleDefinition(
         cron_schedule="0 8 * * *",  # Daily at 8am US/Pacific

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
### TL;DR

This PR adds a new schedule in the orchestrator for removing stale metadata partitions nightly.

### What changed?

A new line was added to schedule this existing job daily at 1am US/Pacific time.

