### PR TITLE
:sparkles: Source Slack: Fix cursor granularity for the `channel_messages` stream

### DIFF
--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c2281cee-86f9-4a86-bb48-d23286b4c7bd
-  dockerImageTag: 1.1.1
+  dockerImageTag: 1.1.2
   dockerRepository: airbyte/source-slack
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   githubIssueLabel: source-slack

--- a/airbyte-integrations/connectors/source-slack/pyproject.toml
+++ b/airbyte-integrations/connectors/source-slack/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.1.1"
+version = "1.1.2"
 name = "source-slack"
 description = "Source implementation for Slack."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-slack/source_slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/source_slack/manifest.yaml
@@ -219,7 +219,7 @@ definitions:
       cursor_datetime_formats:
         - "%s"
       step: P100D
-      cursor_granularity: P10D
+      cursor_granularity: PT1S
       lookback_window: "P{{ config.get('lookback_window', 0) }}D"
       datetime_format: "%s"
       start_datetime:

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -167,7 +167,8 @@ Slack has [rate limit restrictions](https://api.slack.com/docs/rate-limits).
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                              |
-| :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------------- |
+|:--------| :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------------- |
+| 1.1.2   | 2024-05-23 | [38619](https://github.com/airbytehq/airbyte/pull/38619) | Fix cursor granularity for the `channel_messages` stream                             |
 | 1.1.1   | 2024-05-02 | [36661](https://github.com/airbytehq/airbyte/pull/36661) | Schema descriptions                                                                  |
 | 1.1.0   | 2024-04-18 | [37332](https://github.com/airbytehq/airbyte/pull/37332) | Add the capability to sync from private channels                                     |
 | 1.0.0   | 2024-04-02 | [35477](https://github.com/airbytehq/airbyte/pull/35477) | Migration to low-code CDK                                                            |


### PR DESCRIPTION
## What
Fix cursor granularity for the `Channel Messages` stream.

## How
In the previous version, the cursor granularity (the step between slices) was 10 days, which could result in some records being missed. This update changes the granularity to 1 second, as the cursor value used in the request is in seconds.


## User Impact
The change ensures that no records are missed by improving the precision of the cursor. 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [x] NO ❌
