### PR TITLE
fix(source-intercom): add step granularity for activity logs stream 

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.6.5
+  dockerImageTag: 0.6.6
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   githubIssueLabel: source-intercom

--- a/airbyte-integrations/connectors/source-intercom/pyproject.toml
+++ b/airbyte-integrations/connectors/source-intercom/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.6.5"
+version = "0.6.6"
 name = "source-intercom"
 description = "Source implementation for Intercom Yaml."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -2308,7 +2308,7 @@ definitions:
         - "%s"
       datetime_format: "%s"
       cursor_granularity: "PT1S"
-      step: "P30D"
+      step: "P{{ config.get('activity_logs_time_step', 30) }}D"
       start_datetime:
         datetime: "{{ config['start_date'] }}"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/spec.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/spec.json
@@ -19,19 +19,32 @@
         "title": "Access token",
         "type": "string",
         "description": "Access token for making authenticated requests. See the <a href=\"https://developers.intercom.com/building-apps/docs/authentication-types#how-to-get-your-access-token\">Intercom docs</a> for more information.",
-        "airbyte_secret": true
+        "airbyte_secret": true,
+        "order": 0
       },
       "client_id": {
         "title": "Client Id",
         "type": "string",
         "description": "Client Id for your Intercom application.",
-        "airbyte_secret": true
+        "airbyte_secret": true,
+        "order": 1
       },
       "client_secret": {
         "title": "Client Secret",
         "type": "string",
         "description": "Client Secret for your Intercom application.",
-        "airbyte_secret": true
+        "airbyte_secret": true,
+        "order": 2
+      },
+      "activity_logs_time_step": {
+        "type": "integer",
+        "default": 30,
+        "minimum": 1,
+        "maximum": 91,
+        "title": "Activity logs stream slice step size (in days)",
+        "description": "Set lower value in case of failing long running sync of Activity Logs stream.",
+        "examples": [30, 10, 5],
+        "order": 3
       }
     }
   },

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -75,6 +75,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                          |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------|
+| 0.6.6   | 2024-05-24 | [38626](https://github.com/airbytehq/airbyte/pull/38626) | Add step granularity for activity logs stream                                                                                    |
 | 0.6.5   | 2024-04-19 | [36644](https://github.com/airbytehq/airbyte/pull/36644) | Updating to 0.80.0 CDK                                                                                                           |
 | 0.6.4   | 2024-04-12 | [36644](https://github.com/airbytehq/airbyte/pull/36644) | Schema descriptions                                                                                                              |
 | 0.6.3   | 2024-03-23 | [36414](https://github.com/airbytehq/airbyte/pull/36414) | Fixed `pagination` regression bug for `conversations` stream                                                                     |


### PR DESCRIPTION
## What

Resolving https://github.com/airbytehq/oncall/issues/5397

## How

- add step granularity for activity logs stream
reason:
500 error likely raised due to too big interval, experimentally got stable response with step == 5 days

## Review guide

1. `airbyte-integrations/connectors/source-intercom/source_intercom/spec.json`
2. `airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml`


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
