### PR TITLE
airbyte-ci: run internal package tests on external repos

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -748,6 +748,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.15.4  | [#TBD](https://github.com/airbytehq/airbyte/pull/TBD)      | Make airbyte-ci able to test external repos.                                                                                 |
 | 4.15.3  | [#38645](https://github.com/airbytehq/airbyte/pull/38645)  | Fix typo preventing correct secret mounting on Python connectors integration tests.                                          |
 | 4.15.2  | [#38628](https://github.com/airbytehq/airbyte/pull/38628)  | Introduce ConnectorTestContext to avoid trying fetching connector secret in the PublishContext.                              |
 | 4.15.1  | [#38615](https://github.com/airbytehq/airbyte/pull/38615)  | Do not eagerly fetch connector secrets.                                                                                      |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/commands.py
@@ -35,6 +35,7 @@ async def find_modified_internal_packages(pipeline_context: ClickPipelineContext
             pipeline_context.params["diffed_branch"],
             pipeline_context.params["is_local"],
             pipeline_context.params["ci_context"],
+            git_repo_url=pipeline_context.params["git_repo_url"],
         )
     )
     modified_packages = set()

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.15.3"
+version = "4.15.4"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
We want to run internal packages test on forks. The current logic to detect modified internal packages did not customize the git repo url.
