### PR TITLE
Edits for clarifying process, visual presentation, and removal of ina…

### DIFF
--- a/docs/connector-development/README.md
+++ b/docs/connector-development/README.md
@@ -12,7 +12,7 @@ The first step in creating a new connector is to choose the tools you’ll use t
 
 After building and testing your connector, you’ll need to publish it. This makes it available in your workspace. At that point, you can use the connector you’ve built to move some data! 
 
-If you want to contribute what you’ve built to the catalog of publicly available connectors, follow the steps provided in the [contribution guide for submitting new connectors](../contributing-to-airbyte/submit-new-connector.md). 
+If you want to contribute what you’ve built to the Airbyte Cloud and OSS connector catalog, follow the steps provided in the [contribution guide for submitting new connectors](../contributing-to-airbyte/submit-new-connector.md). 
 
 ### Connector development options
 | Tool                   | Description                                                                                                                                                                                                      |

--- a/docs/connector-development/README.md
+++ b/docs/connector-development/README.md
@@ -14,7 +14,7 @@ After building and testing your connector, you’ll need to publish it. This mak
 
 If you want to contribute what you’ve built to the catalog of publicly available connectors, follow the steps provided in the [contribution guide for submitting new connectors](../contributing-to-airbyte/submit-new-connector.md). 
 
-### Connector Development Options
+### Connector development options
 | Tool                   | Description                                                                                                                                                                                                      |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Connector Builder](./connector-builder-ui/overview.md)           | We recommend Connector Builder for developing a connector for an API source. If you’re using Airbyte Cloud, no local developer environment is required to create a new connection with the Connector Builder because you configure it directly in the Airbyte web UI. This tool guides you through creating and testing a connection. Refer to our [tutorial](./connector-builder-ui/tutorial.mdx) on the Connector Builder to guide you through the basics.  |

--- a/docs/connector-development/README.md
+++ b/docs/connector-development/README.md
@@ -1,158 +1,33 @@
 # Connector Development
 
-There are two types of connectors in Airbyte: Sources and Destinations. Connectors can be built in
-any programming language, as long as they're built into docker images that implement the
-[Airbyte specification](../understanding-airbyte/airbyte-protocol.md).
+### Before you start
+
+Before building a new connector, review [Airbyte's data protocol specification](../understanding-airbyte/airbyte-protocol.md). As you begin, you should also familiarize yourself with our guide to [Best Practices for Connector Development](./best-practices.md).
+
+If you need support along the way, visit the [Slack channel](https://airbytehq.slack.com/archives/C027KKE4BCZ) we have dedicated to helping users with connector development where you can search previous discussions or ask a question of your own. 
+
+### Process overview
+
+The first step in creating a new connector is to choose the tools you’ll use to build it. There are three basic approaches Airbyte provides to start developing a connector. To understand which approach you should take, review the [compatibility guide](./connector-builder-ui/connector-builder-compatibility.md).  [The Airbyte community also maintains some CDKs](#community-maintained-cdks) suitable for certain use cases.
+
+After building and testing your connector, you’ll need to publish it. This makes it available in your workspace. At that point, you can use the connector you’ve built to move some data! 
+
+If you want to contribute what you’ve built to the catalog of publicly available connectors, follow the steps provided in the [contribution guide for submitting new connectors](../contributing-to-airbyte/submit-new-connector.md). 
+
+### Connector Development Options
+| Tool                   | Description                                                                                                                                                                                                      |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Connector Builder](./connector-builder-ui/overview.md)           | We recommend Connector Builder for developing a connector for an API source. If you’re using Airbyte Cloud, no local developer environment is required to create a new connection with the Connector Builder because you configure it directly in the Airbyte web UI. This tool guides you through creating and testing a connection. Refer to our [tutorial](./connector-builder-ui/tutorial.mdx) on the Connector Builder to guide you through the basics.  |
+| [Low Code Connector Development Kit (CDK)](./config-based/low-code-cdk-overview.md)           | This framework lets you build source connectors for HTTP API sources. The Low-code CDK is a declarative framework that allows you to describe the connector using a YAML schema(link) without writing Python code. It’s flexible enough to include [custom Python components](./config-based/advanced-topics.md#custom-components) in conjunction with this method if necessary.                                                                                                                        |
+| [Python Connector Development Kit (CDK)](./cdk-python/basic-concepts.md)       | While this method provides the most flexibility to developers, it also requires the most code and maintenance. This library provides classes that work out-of-the-box for most scenarios you’ll encounter along with the generators to make the connector scaffolds for you. We maintain an [in-depth guide](./tutorials/custom-python-connector/0-getting-started.md) to building a connector using the Python CDK.                                                                                                                                           |
+
 
 Most database sources and destinations are written in Java. API sources and destinations are written
 in Python using the [Low-code CDK](config-based/low-code-cdk-overview.md) or
 [Python CDK](cdk-python/).
 
-If you need to build a connector for an API Source, start with Connector Builder. It'll be enough
-for most use cases. If you need help with connector development, we offer premium support to our
-open-source users, [talk to our team](https://airbyte.com/talk-to-sales-premium-support) to get
-access to it.
-
-### Connector Builder
-
-The [connector builder UI](connector-builder-ui/overview.md) is based on the low-code development
-framework below and allows to develop and use connectors without leaving the Airbyte web UI. No
-local developer environment required.
-
-### Low-code Connector-Development Framework
-
-You can use the [low-code framework](config-based/low-code-cdk-overview.md) to build source
-connectors for HTTP API sources. Low-code CDK is a declarative framework that provides a YAML schema
-to describe your connector without writing any Python code, but allowing you to use custom Python
-components if required.
-
-### Python Connector-Development Kit \(CDK\)
-
-You can build a connector in Python with the [Airbyte CDK](cdk-python/). Compared to the low-code
-CDK, the Python CDK is more flexible, but building the connector will be more involved. It provides
-classes that work out of the box for most scenarios, and Airbyte provides generators that make the
-connector scaffolds for you. Here's a guide for
-[building a connector in Python CDK](tutorials/custom-python-connector/0-getting-started.md).
-
 ### Community maintained CDKs
-
-The Airbyte community also maintains some CDKs:
 
 - The [Typescript CDK](https://github.com/faros-ai/airbyte-connectors) is actively maintained by
   Faros.ai for use in their product.
 - The [Airbyte Dotnet CDK](https://github.com/mrhamburg/airbyte.cdk.dotnet) in C#.
-
-:::note
-Before building a new connector, review
-[Airbyte's data protocol specification](../understanding-airbyte/airbyte-protocol.md).
-:::
-
-## Adding a new connector
-
-The easiest way to make and start using a connector in your workspace is by using the
-[Connector Builder](connector-builder-ui/overview.md).
-
-If you're writing your connector in Python or low-code CDK, use the generator to get the project
-started:
-
-```bash
-cd airbyte-integrations/connector-templates/generator
-./generate.sh
-```
-
-and choose the relevant template by using the arrow keys. This will generate a new connector in the
-`airbyte-integrations/connectors/<your-connector>` directory.
-
-Search the generated directory for "TODO"s and follow them to implement your connector. For more
-detailed walkthroughs and instructions, follow the relevant tutorial:
-
-- [Building a HTTP source with the CDK](tutorials/custom-python-connector/0-getting-started.md)
-- [Building a Java destination](tutorials/building-a-java-destination.md)
-
-As you implement your connector, make sure to review the
-[Best Practices for Connector Development](best-practices.md) guide.
-
-## Updating an existing connector
-
-The steps for updating an existing connector are the same as for building a new connector minus the
-need to use the autogenerator to create a new connector. Therefore the steps are:
-
-1. Iterate on the connector to make the needed changes
-2. Run tests
-3. Add any needed docs updates
-4. Create a PR and get it reviewed and merged.
-
-The new version of the connector will automatically be published in Cloud and OSS registries when
-the PR is merged.
-
-## Publishing a connector
-
-Once you've finished iterating on the changes to a connector as specified in its `README.md`, follow
-these instructions to ship the new version of the connector with Airbyte out of the box.
-
-1. Bump the docker image version in the [metadata.yaml](connector-metadata-file.md) of the
-   connector.
-2. Submit a PR containing the changes you made.
-3. One of Airbyte maintainers will review the change in the new version and make sure the tests are
-   passing.
-4. You our an Airbyte maintainer can merge the PR once it is approved and all the required CI checks
-   are passing you.
-5. Once the PR is merged the new connector version will be published to DockerHub and the connector
-   should now be available for everyone who uses it. Thank you!
-
-### Updating Connector Metadata
-
-When a new (or updated version) of a connector is ready, our automations will check your branch for
-a few things:
-
-- Does the connector have an icon?
-- Does the connector have documentation and is it in the proper format?
-- Does the connector have a changelog entry for this version?
-- The [metadata.yaml](connector-metadata-file.md) file is valid.
-
-If any of the above are failing, you won't be able to merge your PR or publish your connector.
-
-Connector icons should be square SVGs and be located in
-[this directory](https://github.com/airbytehq/airbyte/tree/master/airbyte-config-oss/init-oss/src/main/resources/icons).
-
-Connector documentation and changelogs are markdown files living either
-[here for sources](https://github.com/airbytehq/airbyte/tree/master/docs/integrations/sources), or
-[here for destinations](https://github.com/airbytehq/airbyte/tree/master/docs/integrations/destinations).
-
-## Using credentials in CI
-
-In order to run integration tests in CI, you'll often need to inject credentials into CI. There are
-a few steps for doing this:
-
-1. **Place the credentials into Google Secret Manager(GSM)**: Airbyte uses a project 'Google Secret
-   Manager' service as the source of truth for all CI secrets. Place the credentials **exactly as
-   they should be used by the connector** into a GSM secret
-   [here](https://console.cloud.google.com/security/secret-manager?referrer=search&orgonly=true&project=dataline-integration-testing&supportedpurview=organizationId)
-   i.e.: it should basically be a copy paste of the `config.json` passed into a connector via the
-   `--config` flag. We use the following naming pattern:
-   `SECRET_<capital source OR destination name>_CREDS` e.g: `SECRET_SOURCE-S3_CREDS` or
-   `SECRET_DESTINATION-SNOWFLAKE_CREDS`.
-2. **Add the GSM secret's labels**:
-   - `connector` (required) -- unique connector's name or set of connectors' names with '\_' as
-     delimiter i.e.: `connector=source-s3`, `connector=destination-snowflake`
-   - `filename` (optional) -- custom target secret file. Unfortunately Google doesn't use '.' into
-     labels' values and so Airbyte CI scripts will add '.json' to the end automatically. By default
-     secrets will be saved to `./secrets/config.json` i.e: `filename=config_auth` =>
-     `secrets/config_auth.json`
-3. **Save a necessary JSON value**
-   [Example](https://user-images.githubusercontent.com/11213273/146040653-4a76c371-a00e-41fe-8300-cbd411f10b2e.png).
-4. That should be it.
-
-#### Access CI secrets on GSM
-
-Access to GSM storage is limited to Airbyte employees. To give an employee permissions to the
-project:
-
-1. Go to the permissions'
-   [page](https://console.cloud.google.com/iam-admin/iam?project=dataline-integration-testing)
-2. Add a new principal to `dataline-integration-testing`:
-
-- input their login email
-- select the role `Development_CI_Secrets`
-
-3. Save

--- a/docs/connector-development/README.md
+++ b/docs/connector-development/README.md
@@ -8,7 +8,7 @@ If you need support along the way, visit the [Slack channel](https://airbytehq.s
 
 ### Process overview
 
-The first step in creating a new connector is to choose the tools you’ll use to build it. There are three basic approaches Airbyte provides to start developing a connector. To understand which approach you should take, review the [compatibility guide](./connector-builder-ui/connector-builder-compatibility.md).  [The Airbyte community also maintains some CDKs](#community-maintained-cdks) suitable for certain use cases.
+The first step in creating a new connector is to choose the tools you’ll use to build it. There are three basic approaches Airbyte provides to start developing a connector. To understand which approach you should take, review the [compatibility guide](./connector-builder-ui/connector-builder-compatibility.md).
 
 After building and testing your connector, you’ll need to publish it. This makes it available in your workspace. At that point, you can use the connector you’ve built to move some data! 
 


### PR DESCRIPTION
…ccuracies as well as the removal of sections that will be inserted elsewhere in documentation

## What
These edits improve the introduction to the overview of building new connectors. 
I've removed material that is no longer accurate. 
I've removed instructions specifically addressing the process for contributions, instead directing readers to the documents on contributing newly built connectors. 
I've reorganized some of the content into a table to enhance clarity. 

## How
Docs Update

## Review guide
Please keep in mind that I'll be finding a more user-friendly location in the docs for deleted information on "Updating existing connectors" and "Using credentials in UI"

## User Impact
Removes ambiguity of text relating to user intent. Previously, this doc was addressing two different audiences with different needs.
1) Those who want to contribute a connector to the catalog. 
2) Those who want to build a connector specifically for use in their own workspace, with no need to read instructions that only apply to contributors.

This doc is now more clearly applicable to anyone looking to build a connector and guides those with more specific needs to the next applicable piece of documentation. 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
