### PR TITLE
Live tests: pin requests library

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -275,6 +275,10 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.17.3
+
+Pin requests dependency.
+
 ### 0.17.2
 
 Fix duckdb dependency.

--- a/airbyte-ci/connectors/live-tests/poetry.lock
+++ b/airbyte-ci/connectors/live-tests/poetry.lock
@@ -2991,13 +2991,13 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.32.2"
+version = "2.31.0"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "requests-2.32.2-py3-none-any.whl", hash = "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c"},
-    {file = "requests-2.32.2.tar.gz", hash = "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289"},
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
 ]
 
 [package.dependencies]
@@ -3773,4 +3773,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10,<3.12"
-content-hash = "4571e53500c4578a1becaef89a7db95b01636039fba53d84e817a13c3bf3a6ff"
+content-hash = "409a21ec0ced14b78a136ff08a07efc9bac2eee3b7249f24ceb7cf16475ac624"

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -34,7 +34,7 @@ pytest-sugar = "^1.0.0"
 asyncer = "^0.0.5"
 rich = "^13.7.1"
 mitmproxy = "^10.2.4"
-requests = "^2.31.0"
+requests = "<=2.31.1"  # Pinned due to this issue https://github.com/docker/docker-py/issues/3256#issuecomment-2127688011
 pyyaml = "^6.0.1"
 dpath = "^2.1.6"
 genson = "^1.2.2"


### PR DESCRIPTION
Pinning `requests` due to this [issue](https://github.com/docker/docker-py/issues/3256#issuecomment-2127688011) that both @aldogonzalez8 and I had locally.