### PR TITLE
re-enable destination-firebolt on Airbyte OSS and Cloud

### DIFF
--- a/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
@@ -12,9 +12,9 @@ data:
   name: Firebolt
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
-      enabled: false
+      enabled: true
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/firebolt
   supportsDbt: true


### PR DESCRIPTION
After https://github.com/airbytehq/airbyte/pull/35359 and https://github.com/airbytehq/airbyte/pull/35838 it looks like destination-firebolt was not re-enabled in the connector registries. 