### PR TITLE
feat(registry): Add Connector Metrics to final registry

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/README.md
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/README.md
@@ -186,3 +186,62 @@ You will need to add the following environment variables to your `.env` file:
 - `SLACK_TOKEN`: Set to an OAuth token for the [Connector Ops Dagster Bot](https://airbytehq-team.slack.com/apps/A05K845HBE0-connector-ops-dagster-bot?settings=1)
 - `PUBLISH_UPDATE_CHANNEL`: Set to `#test-ci-slack-intergrations`
 - `SLACK_NOTIFICATIONS_DISABLED`: Set to `False`
+
+### Resource Trees
+We use a concept of resource trees to organize our resources in the [orchestrator/__init__.py file](orchestrator/__init__.py).
+
+Each resource tree is a dictionary that contains the resources for a specific functionality or service. The resources are organized in a hierarchical structure that allows for easy access, management, and most importantly reuse.
+
+
+**RESOURCE TREE STRUCTURE EXAMPLE:**
+
+_💡 Note that we expand the `GCS_RESOURCE_TREE` inside the `METADATA_RESOURCE_TREE`. This is so that we can keep our primary resource trees independently usable in tests while preventing them from getting too verbose._
+
+```python
+GCS_RESOURCE_TREE = {
+    "gcp_gcs_client": gcp_gcs_client.configured(
+        {
+            "gcp_gcs_cred_string": {"env": "GCS_CREDENTIALS"},
+        }
+    ),
+    "registry_directory_manager": gcs_file_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": REGISTRIES_FOLDER}),
+    "registry_report_directory_manager": gcs_file_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": REPORT_FOLDER}),
+    "root_metadata_directory_manager": gcs_file_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": ""}),
+}
+
+METADATA_RESOURCE_TREE = {
+    **SLACK_RESOURCE_TREE,
+    **GCS_RESOURCE_TREE,
+    "all_metadata_file_blobs": gcs_directory_blobs.configured(
+        {"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": METADATA_FOLDER, "match_regex": f".*/{METADATA_FILE_NAME}$"}
+    ),
+    "latest_metadata_file_blobs": gcs_directory_blobs.configured(
+        {"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": METADATA_FOLDER, "match_regex": f".*latest/{METADATA_FILE_NAME}$"}
+    ),
+}
+
+# ...
+
+RESOURCES = {
+    **METADATA_RESOURCE_TREE,
+    **DATA_WAREHOUSE_RESOURCE_TREE,
+    **REGISTRY_RESOURCE_TREE,
+    **REGISTRY_ENTRY_RESOURCE_TREE,
+    **CONNECTOR_TEST_REPORT_RESOURCE_TREE,
+}
+```
+
+**RESOURCE TREES:**
+
+The resource tree is a hierarchical structure that defines the available resources for the orchestrator.
+Each resource represents a specific functionality or service that can be used by the jobs and assets.
+
+- SLACK_RESOURCE_TREE: Contains the Slack resource, which provides access to the Slack messaging platform.
+- GITHUB_RESOURCE_TREE: Contains the GitHub resources, including the GitHub client and various GitHub repositories.
+- GCS_RESOURCE_TREE: Contains the Google Cloud Storage (GCS) resources, including the GCS client and various GCS file managers.
+- METADATA_RESOURCE_TREE: Contains resources related to metadata management.
+- DATA_WAREHOUSE_RESOURCE_TREE: Contains resources for handling connector metrics.
+- REGISTRY_RESOURCE_TREE: Contains resources for managing registries.
+- REGISTRY_ENTRY_RESOURCE_TREE: Contains resources for managing registry entries.
+- CONNECTOR_TEST_REPORT_SENSOR_RESOURCE_TREE: Contains resources for handling connector test reports.
+- CONNECTOR_TEST_REPORT_RESOURCE_TREE: Contains resources for generating connector test reports.

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/connector_metrics.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/connector_metrics.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import json
+from collections import defaultdict
+from typing import Optional
+
+import sentry_sdk
+from dagster import OpExecutionContext, asset
+from google.cloud import storage
+from orchestrator.logging import sentry
+
+GROUP_NAME = "connector_metrics"
+
+
+@sentry_sdk.trace
+def _safe_read_gcs_file(gcs_blob: storage.Blob) -> Optional[str]:
+    """Read the connector metrics jsonl blob.
+
+    Args:
+        gcs_blob (storage.Blob): The blob.
+
+    Returns:
+        dict: The metrics.
+    """
+    if not gcs_blob.exists():
+        return None
+
+    return gcs_blob.download_as_string().decode("utf-8")
+
+
+def _convert_json_to_metrics_dict(jsonl_string: str) -> dict:
+    """Convert the jsonl string to a metrics dict."""
+    metrics_dict = defaultdict(dict)
+    jsonl_lines = jsonl_string.splitlines()
+    for line in jsonl_lines:
+        data = json.loads(line)
+        connector_data = data["_airbyte_data"]
+        connector_definition_id = connector_data["connector_definition_id"]
+        airbyte_platform = connector_data["airbyte_platform"]
+        metrics_dict[connector_definition_id][airbyte_platform] = connector_data
+
+    return metrics_dict
+
+
+# ASSETS
+
+
+@asset(required_resource_keys={"latest_metrics_gcs_blob"}, group_name=GROUP_NAME)
+@sentry.instrument_asset_op
+def latest_connnector_metrics(context: OpExecutionContext) -> dict:
+    latest_metrics_gcs_blob = context.resources.latest_metrics_gcs_blob
+
+    latest_metrics_jsonl = _safe_read_gcs_file(latest_metrics_gcs_blob)
+    if latest_metrics_jsonl is None:
+        context.log.warn(f"No metrics found for {latest_metrics_gcs_blob.name}")
+        return {}
+
+    try:
+        latest_metrics_dict = _convert_json_to_metrics_dict(latest_metrics_jsonl)
+    except Exception as e:
+        context.log.error(f"Error converting json to metrics dict: {str(e)}")
+        return {}
+
+    return latest_metrics_dict

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -6,6 +6,7 @@ import copy
 import json
 import os
 from datetime import datetime
+from enum import Enum
 from typing import List, Optional, Tuple, Union
 
 import orchestrator.hacks as HACKS
@@ -25,15 +26,27 @@ from orchestrator.logging import sentry
 from orchestrator.logging.publish_connector_lifecycle import PublishConnectorLifecycle, PublishConnectorLifecycleStage, StageStatus
 from orchestrator.models.metadata import LatestMetadataEntry, MetadataDefinition
 from orchestrator.utils.blob_helpers import yaml_blob_to_dict
-from orchestrator.utils.dagster_helpers import OutputDataFrame
-from orchestrator.utils.object_helpers import deep_copy_params, default_none_to_dict
+from orchestrator.utils.object_helpers import CaseInsensitveKeys, deep_copy_params, default_none_to_dict
 from pydantic import BaseModel, ValidationError
 from pydash.objects import get, set_with
 
-PolymorphicRegistryEntry = Union[ConnectorRegistrySourceDefinition, ConnectorRegistryDestinationDefinition]
-TaggedRegistryEntry = Tuple[str, PolymorphicRegistryEntry]
-
 GROUP_NAME = "registry_entry"
+
+# TYPES
+
+
+class ConnectorTypes(str, Enum, metaclass=CaseInsensitveKeys):
+    SOURCE = "source"
+    DESTINATION = "destination"
+
+
+class ConnectorTypePrimaryKey(str, Enum, metaclass=CaseInsensitveKeys):
+    SOURCE = "sourceDefinitionId"
+    DESTINATION = "destinationDefinitionId"
+
+
+PolymorphicRegistryEntry = Union[ConnectorRegistrySourceDefinition, ConnectorRegistryDestinationDefinition]
+TaggedRegistryEntry = Tuple[ConnectorTypes, PolymorphicRegistryEntry]
 
 metadata_partitions_def = DynamicPartitionsDefinition(name="metadata")
 
@@ -256,14 +269,14 @@ def read_registry_entry_blob(registry_entry_blob: storage.Blob) -> TaggedRegistr
     connector_type, ConnectorModel = get_connector_type_from_registry_entry(registry_entry_dict)
     registry_entry = ConnectorModel.parse_obj(registry_entry_dict)
 
-    return registry_entry, connector_type
+    return connector_type, registry_entry
 
 
 def get_connector_type_from_registry_entry(registry_entry: dict) -> TaggedRegistryEntry:
-    if registry_entry.get("sourceDefinitionId"):
-        return ("source", ConnectorRegistrySourceDefinition)
-    elif registry_entry.get("destinationDefinitionId"):
-        return ("destination", ConnectorRegistryDestinationDefinition)
+    if registry_entry.get(ConnectorTypePrimaryKey.SOURCE.value):
+        return (ConnectorTypes.SOURCE, ConnectorRegistrySourceDefinition)
+    elif registry_entry.get(ConnectorTypePrimaryKey.DESTINATION.value):
+        return (ConnectorTypes.DESTINATION, ConnectorRegistryDestinationDefinition)
     else:
         raise Exception("Could not determine connector type from registry entry")
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/config.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/config.py
@@ -17,6 +17,8 @@ NIGHTLY_INDIVIDUAL_TEST_REPORT_FILE_NAME = "output.json"
 NIGHTLY_GHA_WORKFLOW_ID = "connector_nightly_builds_dagger.yml"
 CI_TEST_REPORT_PREFIX = "airbyte-ci/connectors/test"
 CI_MASTER_TEST_OUTPUT_REGEX = f".*master.*output.json$"
+ANALYTICS_BUCKET = "ab-analytics-connector-metrics"
+ANALYTICS_FOLDER = "data/connector_quality_metrics"
 
 CONNECTOR_REPO_NAME = "airbytehq/airbyte"
 CONNECTORS_PATH = "airbyte-integrations/connectors"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
@@ -8,7 +8,7 @@ import uuid
 from typing import Optional
 
 import dagster._check as check
-from dagster import InitResourceContext, Noneable, StringSource, resource
+from dagster import BoolSource, Field, InitResourceContext, Noneable, StringSource, resource
 from dagster._core.storage.file_manager import check_file_like_obj
 from dagster_gcp.gcs.file_manager import GCSFileHandle, GCSFileManager
 from google.cloud import storage
@@ -156,15 +156,21 @@ def gcs_file_blob(resource_context: InitResourceContext) -> storage.Blob:
         "gcs_bucket": StringSource,
         "prefix": StringSource,
         "match_regex": StringSource,
+        "only_one": Field(config=bool, default_value=False),
+        "sort_key": Field(config=str, is_required=False),
+        "reverse_sort": Field(config=bool, default_value=False),
     },
 )
-def gcs_directory_blobs(resource_context: InitResourceContext) -> storage.Blob:
+def gcs_directory_blobs(resource_context: InitResourceContext) -> list[storage.Blob] | storage.Blob:
     """
     List all blobs in a bucket that match the prefix.
     """
     gcs_bucket = resource_context.resource_config["gcs_bucket"]
     prefix = resource_context.resource_config["prefix"]
     match_regex = resource_context.resource_config["match_regex"]
+    only_one = resource_context.resource_config["only_one"]
+    sort_key = resource_context.resource_config.get("sort_key")
+    reverse_sort = resource_context.resource_config["reverse_sort"]
 
     storage_client = resource_context.resources.gcp_gcs_client
     bucket = storage_client.get_bucket(gcs_bucket)
@@ -174,5 +180,11 @@ def gcs_directory_blobs(resource_context: InitResourceContext) -> storage.Blob:
     gcs_file_blobs = bucket.list_blobs(prefix=prefix)
     if match_regex:
         gcs_file_blobs = [blob for blob in gcs_file_blobs if re.match(match_regex, blob.name)]
+
+    if sort_key:
+        gcs_file_blobs = sorted(gcs_file_blobs, key=lambda x: getattr(x, sort_key), reverse=reverse_sort)
+
+    if only_one:
+        return gcs_file_blobs[0] if gcs_file_blobs else None
 
     return gcs_file_blobs

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/object_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/object_helpers.py
@@ -3,7 +3,7 @@
 #
 
 import copy
-import json
+from enum import EnumMeta
 from typing import TypeVar
 
 import mergedeep
@@ -55,3 +55,15 @@ def default_none_to_dict(value, key, obj):
 
     if value is None:
         obj[key] = {}
+
+
+class CaseInsensitveKeys(EnumMeta):
+    """A metaclass for creating enums with case-insensitive keys."""
+
+    def __getitem__(cls, item):
+        try:
+            return super().__getitem__(item)
+        except:
+            for key in cls._member_map_:
+                if key.casefold() == item.casefold():
+                    return super().__getitem__(key)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_connector_metrics.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_connector_metrics.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from orchestrator.assets.connector_metrics import _convert_json_to_metrics_dict
+
+
+def test_convert_json_to_metrics_dict():
+    jsonl_string = (
+        '{"_airbyte_ab_id":"4043ed5a-2fea-4edd-8e42-5fafb5521bae","_airbyte_emitted_at":1716765524746,"_airbyte_data":{"connector_type":"destination","connector_definition_id":"0b75218b-f702-4a28-85ac-34d3d84c0fc2","connector_name":"Chroma","docker_repository":"airbyte/destination-chroma","airbyte_platform":"all","connector_version":"all","sync_success_rate":"low","usage":"medium"}}\n'
+        '{"_airbyte_ab_id":"b99b6003-551a-4732-8ef5-dab626745977","_airbyte_emitted_at":1716765524746,"_airbyte_data":{"connector_type":"destination","connector_definition_id":"0b75218b-f702-4a28-85ac-34d3d84c0fc2","connector_name":"Chroma","docker_repository":"airbyte/destination-chroma","airbyte_platform":"oss","connector_version":"0.0.10","sync_success_rate":"low","usage":"medium"}}\n'
+        '{"_airbyte_ab_id":"753037c6-80d8-408b-93b6-135b94e75361","_airbyte_emitted_at":1716765524746,"_airbyte_data":{"connector_type":"source","connector_definition_id":"28ce1fbd-1e15-453f-aa9f-da6c4d928e92","connector_name":"Vantage","docker_repository":"airbyte/source-vantage","airbyte_platform":"oss","connector_version":"0.1.0","sync_success_rate":"low","usage":"medium"}}\n'
+        '{"_airbyte_ab_id":"a5d8989c-5944-48ea-b80b-8a69baef6f15","_airbyte_emitted_at":1716765524746,"_airbyte_data":{"connector_type":"source","connector_definition_id":"28ce1fbd-1e15-453f-aa9f-da6c4d928e92","connector_name":"Vantage","docker_repository":"airbyte/source-vantage","airbyte_platform":"cloud","connector_version":"0.1.0","sync_success_rate":"low","usage":"medium"}}\n'
+        '{"_airbyte_ab_id":"4204f086-b8f9-4b74-94bb-13d418d4724d","_airbyte_emitted_at":1716765524746,"_airbyte_data":{"connector_type":"source","connector_definition_id":"28ce1fbd-1e15-453f-aa9f-da6c4d928e92","connector_name":"Vantage","docker_repository":"airbyte/source-vantage","airbyte_platform":"all","connector_version":"all","sync_success_rate":"low","usage":"medium"}}\n'
+    )
+
+    expected_metrics_dict = {
+        "0b75218b-f702-4a28-85ac-34d3d84c0fc2": {
+            "all": {
+                "connector_type": "destination",
+                "connector_definition_id": "0b75218b-f702-4a28-85ac-34d3d84c0fc2",
+                "connector_name": "Chroma",
+                "docker_repository": "airbyte/destination-chroma",
+                "airbyte_platform": "all",
+                "connector_version": "all",
+                "sync_success_rate": "low",
+                "usage": "medium",
+            },
+            "oss": {
+                "connector_type": "destination",
+                "connector_definition_id": "0b75218b-f702-4a28-85ac-34d3d84c0fc2",
+                "connector_name": "Chroma",
+                "docker_repository": "airbyte/destination-chroma",
+                "airbyte_platform": "oss",
+                "connector_version": "0.0.10",
+                "sync_success_rate": "low",
+                "usage": "medium",
+            },
+        },
+        "28ce1fbd-1e15-453f-aa9f-da6c4d928e92": {
+            "oss": {
+                "connector_type": "source",
+                "connector_definition_id": "28ce1fbd-1e15-453f-aa9f-da6c4d928e92",
+                "connector_name": "Vantage",
+                "docker_repository": "airbyte/source-vantage",
+                "airbyte_platform": "oss",
+                "connector_version": "0.1.0",
+                "sync_success_rate": "low",
+                "usage": "medium",
+            },
+            "cloud": {
+                "connector_type": "source",
+                "connector_definition_id": "28ce1fbd-1e15-453f-aa9f-da6c4d928e92",
+                "connector_name": "Vantage",
+                "docker_repository": "airbyte/source-vantage",
+                "airbyte_platform": "cloud",
+                "connector_version": "0.1.0",
+                "sync_success_rate": "low",
+                "usage": "medium",
+            },
+            "all": {
+                "connector_type": "source",
+                "connector_definition_id": "28ce1fbd-1e15-453f-aa9f-da6c4d928e92",
+                "connector_name": "Vantage",
+                "docker_repository": "airbyte/source-vantage",
+                "airbyte_platform": "all",
+                "connector_version": "all",
+                "sync_success_rate": "low",
+                "usage": "medium",
+            },
+        },
+    }
+
+    metrics_dict = _convert_json_to_metrics_dict(jsonl_string)
+
+    assert metrics_dict == expected_metrics_dict


### PR DESCRIPTION
## What
Adds dynamic metrics from an internal metabase dashboard to the registry

![Screenshot 2024-05-27 at 11.49.58 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/PTsI7qAmiIMkhFQg04QF/6dd1a71e-5466-47c6-aa42-7cb7274eb94e.png)

![Screenshot 2024-05-27 at 11.49.52 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/PTsI7qAmiIMkhFQg04QF/59d7550e-603a-45e6-a2e7-e3c95e3ada37.png)




closes https://github.com/airbytehq/airbyte-internal-issues/issues/7465

## How
1. Adds connector metrics to our dagster graph
2. Uses these connector metrics to fill out `generated.metrics` on each RegistryEntry
3. Publishes the updated registry
