### PR TITLE
auto-merge: consider skipped test runs as successful

### DIFF
--- a/airbyte-ci/connectors/auto_merge/README.md
+++ b/airbyte-ci/connectors/auto_merge/README.md
@@ -47,3 +47,11 @@ poetry run auto-merge
 
 The execution will set the `GITHUB_STEP_SUMMARY` env var with a markdown summary of the PRs that
 have been merged.
+
+## Changelog
+
+### 0.1.1
+Consider skipped check runs as successful.
+
+### 0.1.0
+Initial release

--- a/airbyte-ci/connectors/auto_merge/pyproject.toml
+++ b/airbyte-ci/connectors/auto_merge/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-merge"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -120,6 +120,6 @@ def auto_merge() -> None:
             back_off_if_rate_limited(gh_client)
             if merged_pr := process_pr(repo, pr, required_passing_contexts, dry_run):
                 merged_prs.append(merged_pr)
-        if os.environ["GITHUB_STEP_SUMMARY"]:
+        if "GITHUB_STEP_SUMMARY" in os.environ:
             job_summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text(generate_job_summary_as_markdown(merged_prs))
             logger.info(f"Job summary written to {job_summary_path}")

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
@@ -36,7 +36,12 @@ def head_commit_passes_all_required_checks(
     head_commit: GithubCommit, pr: PullRequest, required_checks: set[str]
 ) -> Tuple[bool, Optional[str]]:
     successful_status_contexts = [commit_status.context for commit_status in head_commit.get_statuses() if commit_status.state == "success"]
-    successful_check_runs = [check_run.name for check_run in head_commit.get_check_runs() if check_run.conclusion == "success"]
+    successful_check_runs = [
+        check_run.name
+        for check_run in head_commit.get_check_runs()
+        # Github considers a required check as passing if it has a conclusion of "success" or "skipped"
+        if check_run.conclusion == "success" or check_run.conclusion == "skipped"
+    ]
     successful_contexts = set(successful_status_contexts + successful_check_runs)
     if not required_checks.issubset(successful_contexts):
         return False, "not all required checks passed"


### PR DESCRIPTION
## What
Github considers a required check as passing if it has a conclusion of "success" or "skipped".

But the auto-merge tool checked that all required checks were successful. 
It's incorrect as, for instance, the required Gradle Check is skipped on python connectors.

## How
Consider a check as successful if its completion status is `success` or `skipped`
