### PR TITLE
auto-merge: set merge method to squash

### DIFF
--- a/airbyte-ci/connectors/auto_merge/README.md
+++ b/airbyte-ci/connectors/auto_merge/README.md
@@ -50,8 +50,11 @@ have been merged.
 
 ## Changelog
 
+### 0.1.2
+Set merge method to `squash`.
+
 ### 0.1.1
 Consider skipped check runs as successful.
 
 ### 0.1.0
-Initial release
+Initial release.

--- a/airbyte-ci/connectors/auto_merge/pyproject.toml
+++ b/airbyte-ci/connectors/auto_merge/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-merge"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/consts.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/consts.py
@@ -10,3 +10,4 @@ CONNECTOR_PATH_PREFIXES = {
     "docs/integrations/sources",
     "docs/integrations/destinations",
 }
+MERGE_METHOD = "squash"

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -8,11 +8,11 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from github import Auth, Github
 
-from .consts import AIRBYTE_REPO, AUTO_MERGE_LABEL, BASE_BRANCH, CONNECTOR_PATH_PREFIXES
+from .consts import AIRBYTE_REPO, AUTO_MERGE_LABEL, BASE_BRANCH, MERGE_METHOD
 from .env import GITHUB_TOKEN, PRODUCTION
 from .helpers import generate_job_summary_as_markdown
 from .pr_validators import ENABLED_VALIDATORS
@@ -58,6 +58,29 @@ def check_if_pr_is_auto_mergeable(head_commit: GithubCommit, pr: PullRequest, re
     return True
 
 
+def merge_with_retries(pr: PullRequest, max_retries: int = 3, wait_time: int = 60) -> Optional[PullRequest]:
+    """Merge a PR with retries
+
+    Args:
+        pr (PullRequest): The PR to merge
+        max_retries (int, optional): The maximum number of retries. Defaults to 3.
+        wait_time (int, optional): The time to wait between retries in seconds. Defaults to 60.
+    """
+    for i in range(max_retries):
+        try:
+            pr.merge(merge_method=MERGE_METHOD)
+            logger.info(f"PR #{pr.number} was auto-merged")
+            return pr
+        except Exception as e:
+            logger.error(f"Failed to merge PR #{pr.number} - {e}")
+            if i < max_retries - 1:
+                logger.info(f"Retrying to merge PR #{pr.number}")
+                time.sleep(wait_time)
+            else:
+                logger.error(f"Failed to merge PR #{pr.number} after {max_retries} retries")
+    return None
+
+
 def process_pr(repo: GithubRepo, pr: PullRequest, required_passing_contexts: set[str], dry_run: bool) -> None | PullRequest:
     """Process a PR to see if it is auto-mergeable and merge it if it is.
 
@@ -74,8 +97,7 @@ def process_pr(repo: GithubRepo, pr: PullRequest, required_passing_contexts: set
     head_commit = repo.get_commit(sha=pr.head.sha)
     if check_if_pr_is_auto_mergeable(head_commit, pr, required_passing_contexts):
         if not dry_run:
-            pr.merge()
-            logger.info(f"PR #{pr.number} was auto-merged")
+            merge_with_retries(pr)
             return pr
         else:
             logger.info(f"PR #{pr.number} is auto-mergeable but dry-run is enabled")


### PR DESCRIPTION
## What
The default merge method in Github API is `merge`. But our repository forces the `squash` method. This leads to 405 errors when trying to auto merge a PR.

## How
Set the `merge_method` to `squash` on PR merge

