### PR TITLE
fix(connector-builder): hide secrets in errors 

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
@@ -13,6 +13,7 @@ from airbyte_cdk.models import Type as MessageType
 from airbyte_cdk.sources.declarative.declarative_source import DeclarativeSource
 from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
 from airbyte_cdk.sources.declarative.parsers.model_to_component_factory import ModelToComponentFactory
+from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 
 DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE = 5
@@ -70,7 +71,7 @@ def read_stream(
         )
     except Exception as exc:
         error = AirbyteTracedException.from_exception(
-            exc, message=f"Error reading stream with config={config} and catalog={configured_catalog}: {str(exc)}"
+            exc, message=filter_secrets(f"Error reading stream with config={config} and catalog={configured_catalog}: {str(exc)}")
         )
         return error.as_airbyte_message()
 


### PR DESCRIPTION
## What
Add hiding secrets from connector builder errors. Resolves: https://github.com/airbytehq/airbyte-internal-issues/issues/7263

## How
Use the `filter_secrets` method to hide secrets from builder errors.

## User Impact
User secrets will no longer be exposed after encountering errors.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
