### PR TITLE
🐛 Source Shopify: Have comma separated tags for products stream

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9da77001-af33-4bcd-be46-6252bf9342b9
-  dockerImageTag: 2.2.0
+  dockerImageTag: 2.2.1
   dockerRepository: airbyte/source-shopify
   documentationUrl: https://docs.airbyte.com/integrations/sources/shopify
   githubIssueLabel: source-shopify

--- a/airbyte-integrations/connectors/source-shopify/pyproject.toml
+++ b/airbyte-integrations/connectors/source-shopify/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.2.0"
+version = "2.2.1"
 name = "source-shopify"
 description = "Source CDK implementation for Shopify."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/shopify_graphql/bulk/query.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/shopify_graphql/bulk/query.py
@@ -1672,11 +1672,11 @@ class Product(ShopifyBulkQuery):
             option["product_id"] = product_id if product_id else None
         return options
 
-    def _unnest_tags(self, record: MutableMapping[str, Any]) -> str:
+    def _unnest_tags(self, record: MutableMapping[str, Any]) -> Optional[str]:
         # we keep supporting 1 tag only, as it was for the REST stream,
         # to avoid breaking change.
         tags = record.get("tags", [])
-        return tags[0] if len(tags) > 0 else None
+        return ", ".join(tags) if tags else None
 
     def record_process_components(self, record: MutableMapping[str, Any]) -> Iterable[MutableMapping[str, Any]]:
         """

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -208,6 +208,7 @@ For all `Shopify GraphQL BULK` api requests these limitations are applied: https
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                                                                                                                   |
 | :------ |:-----------| :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.2.1   | 2024-05-30 | [38769](https://github.com/airbytehq/airbyte/pull/38769) | Have products stream return all the tags comma separated |
 | 2.2.0   | 2024-05-29 | [38746](https://github.com/airbytehq/airbyte/pull/38746) | Updated countries schema |
 | 2.1.4   | 2024-05-24 | [38610](https://github.com/airbytehq/airbyte/pull/38610) | Updated the source `API Version` to `2024-04` |
 | 2.1.3   | 2024-05-23 | [38464](https://github.com/airbytehq/airbyte/pull/38464) | Added missing fields to `Products` stream |


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/38671

Since the migration of the product stream to bulk, the tags have changed. Instead of having a string that is comma separated with all the tags, we only have the first returned by the API. 

Repro steps:
* Have a product with multiple tags. In our test account, I used https://admin.shopify.com/store/airbyte-integration-test/products/6796217909437
* Run the sync with a version earlier than 2.1.0
```
docker run -v $(pwd)/secrets:/secrets airbyte/source-shopify:2.0.8 read --config /secrets/config.json --catalog /secrets/configured_catalog.json
<...>
{"type": "RECORD", "record": {"stream": "products", "data": {"id": 6796217909437, <...> "tags": "another tag, developer-tools-generator"<...> }, "emitted_at": 1717009835101}}
```
* Run the sync with the most recent version (i.e. 2.2.0):
```
docker run -v $(pwd)/secrets:/secrets airbyte/source-shopify:2.0.8 read --config /secrets/config.json --catalog /secrets/configured_catalog.json
<...>
{"type": "RECORD", "record": {"stream": "products", "data": {"id": 6796217909437, <...> "tags": "another tag",<...>}, "emitted_at": 1717010445667}}
```

## How
By joining the tags using `, `, we will get the same result as the previous versions

```
python main.py read --config secrets/config.json --catalog integration_tests/configured_catalog.json --debug
<...>
{"type": "RECORD", "record": {"stream": "products", "data": {"id": 6796217909437, <...> "tags": "another tag, developer-tools-generator" <...>}, "emitted_at": 1717010558707}}
```

## User Impact
The tags will now be as they were before the Bulk API migration.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
