### PR TITLE
Airbyte CI: fix repo_dir access before assignment

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -747,7 +747,8 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 ## Changelog
 
 | Version | PR                                                         | Description                                                                                                                  |
-| ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+|---------|------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| 4.15.6  | [#38783](https://github.com/airbytehq/airbyte/pull/38783)  | Fix a variable access error with `repo_dir` in the `bump_version` command.                                                   |
 | 4.15.5  | [#38732](https://github.com/airbytehq/airbyte/pull/38732)  | Update metadata deploy pipeline to 3.10                                                                                      |
 | 4.15.4  | [#38646](https://github.com/airbytehq/airbyte/pull/38646)  | Make airbyte-ci able to test external repos.                                                                                 |
 | 4.15.3  | [#38645](https://github.com/airbytehq/airbyte/pull/38645)  | Fix typo preventing correct secret mounting on Python connectors integration tests.                                          |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/pipeline.py
@@ -153,9 +153,10 @@ class SetConnectorVersion(Step):
 
     async def get_repo_dir(self) -> Directory:
         if not self.repo_dir:
-            repo_dir = await self.context.get_repo_dir()
-            self.repo_dir = repo_dir
-        return repo_dir
+            self.repo_dir = await self.context.get_repo_dir()
+            if self.repo_dir is None:
+                raise ValueError("Failed to set the repo directory from the ConnectorContext.")
+        return self.repo_dir
 
     async def _run(self) -> StepResult:
         result = await self.update_metadata()

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/pipeline.py
@@ -152,10 +152,8 @@ class SetConnectorVersion(Step):
         self.export = export
 
     async def get_repo_dir(self) -> Directory:
-        if not self.repo_dir:
+        if self.repo_dir is None:
             self.repo_dir = await self.context.get_repo_dir()
-            if self.repo_dir is None:
-                raise ValueError("Failed to set the repo directory from the ConnectorContext.")
         return self.repo_dir
 
     async def _run(self) -> StepResult:

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.15.5"
+version = "4.15.6"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Unblock the python CDK publish pipeline

## How
<!--
* Describe how code changes achieve the solution.
-->
Fix `UnboundLocalError: local variable 'repo_dir' referenced before assignment` by returning `self.repo_dir` and _explicitly_ none-checking instead of `if not` because apparently mypy doesn't know how that works.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
