### PR TITLE
Live tests: GHA to run both validation & regression tests

### DIFF
--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -102,4 +102,4 @@ jobs:
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }} --connector_live_tests.test-evaluation-mode=diagnostic
+          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=all --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }} --connector_live_tests.test-evaluation-mode=diagnostic

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -73,8 +73,8 @@ jobs:
           if [ -z "${{ github.event.inputs.streams }}" ]; then
             echo "STREAM_PARAMS=" >> $GITHUB_ENV
           else
-            STREAMS=$(echo "${{ github.event.inputs.streams }}" | sed 's/,/ --connector_regression_tests.selected-streams=/g')
-            echo "STREAM_PARAMS=--connector_regression_tests.selected-streams=$STREAMS" >> $GITHUB_ENV
+            STREAMS=$(echo "${{ github.event.inputs.streams }}" | sed 's/,/ --connector_live_tests.selected-streams=/g')
+            echo "STREAM_PARAMS=--connector_live_tests.selected-streams=$STREAMS" >> $GITHUB_ENV
           fi
 
       - name: Setup Local CDK Flag
@@ -102,4 +102,4 @@ jobs:
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_regression_tests --connector_regression_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_regression_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }}
+          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=regression --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }}

--- a/.github/workflows/validation_tests.yml
+++ b/.github/workflows/validation_tests.yml
@@ -1,0 +1,105 @@
+name: Connector CI - Run Live Validation Tests
+
+concurrency:
+  # This is the name of the concurrency group. It is used to prevent concurrent runs of the same workflow.
+  #
+  # - github.head_ref is only defined on PR runs, it makes sure that the concurrency group is unique for pull requests
+  #  ensuring that only one run per pull request is active at a time.
+  #
+  # - github.run_id is defined on all runs, it makes sure that the concurrency group is unique for workflow dispatches.
+  # This allows us to run multiple workflow dispatches in parallel.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      connector_name:
+        description: Connector name (e.g. source-faker)
+        required: true
+      connection_id:
+        description: ID of the connection to test; use "auto" to let the connection retriever choose a connection
+        required: true
+      pr_url:
+        description: URL of the PR containing the code change
+        required: true
+      streams:
+        description: Streams to include in tests
+      use_local_cdk:
+        description: Use the local CDK when building the target connector
+        default: "false"
+        type: boolean
+
+jobs:
+  live_tests:
+    name: Live Tests
+    runs-on: connector-test-large
+    timeout-minutes: 360 # 6 hours
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v4
+      - name: Check PAT rate limits
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+      - name: Extract branch name [WORKFLOW DISPATCH]
+        shell: bash
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
+      - name: Install Poetry
+        id: install_poetry
+        uses: snok/install-poetry@v1
+
+      - name: Make poetry venv in project
+        id: poetry_venv
+        run: poetry config virtualenvs.in-project true
+
+      - name: Install Python packages
+        id: install_python_packages
+        working-directory: airbyte-ci/connectors/pipelines
+        run: poetry install
+
+      - name: Fetch last commit id from remote branch [WORKFLOW DISPATCH]
+        if: github.event_name == 'workflow_dispatch'
+        id: fetch_last_commit_id_wd
+        run: echo "commit_id=$(git rev-parse origin/${{ steps.extract_branch.outputs.branch }})" >> $GITHUB_OUTPUT
+
+      - name: Setup Stream Parameters
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ -z "${{ github.event.inputs.streams }}" ]; then
+            echo "STREAM_PARAMS=" >> $GITHUB_ENV
+          else
+            STREAMS=$(echo "${{ github.event.inputs.streams }}" | sed 's/,/ --connector_live_tests.selected-streams=/g')
+            echo "STREAM_PARAMS=--connector_live_tests.selected-streams=$STREAMS" >> $GITHUB_ENV
+          fi
+
+      - name: Setup Local CDK Flag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if ${{ github.event.inputs.use_local_cdk }}; then
+            echo "USE_LOCAL_CDK_FLAG=--use-local-cdk" >> $GITHUB_ENV
+          else
+            echo "USE_LOCAL_CDK_FLAG=" >> $GITHUB_ENV
+          fi
+
+      - name: Run Live Tests [WORKFLOW DISPATCH]
+        if: github.event_name == 'workflow_dispatch' # TODO: consider using the matrix strategy (https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs). See https://github.com/airbytehq/airbyte/pull/37659#discussion_r1583380234 for details.
+        uses: ./.github/actions/run-airbyte-ci
+        with:
+          context: "manual"
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_2 }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          gcp_integration_tester_credentials: ${{ secrets.GCLOUD_INTEGRATION_TESTER }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          git_branch: ${{ steps.extract_branch.outputs.branch }}
+          git_revision: ${{ steps.fetch_last_commit_id_pr.outputs.commit_id }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
+          s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }} --connector_live_tests.test-evaluation-mode=diagnostic

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/evaluation_modes.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/evaluation_modes.py
@@ -18,7 +18,7 @@ class TestEvaluationMode(Enum):
     tests only.
 
     The diagnostic mode can be made available to a test using the @pytest.mark.allow_diagnostic_mode decorator,
-    and passing in the --validation-test-mode=diagnostic flag.
+    and passing in the --test-evaluation-mode=diagnostic flag.
     """
 
     DIAGNOSTIC = "diagnostic"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
@@ -43,8 +43,8 @@ if TYPE_CHECKING:
     from pytest_sugar import SugarTerminalReporter  # type: ignore
 
 # CONSTS
-LOGGER = logging.getLogger("regression")
-MAIN_OUTPUT_DIRECTORY = Path("/tmp/regression_tests_artifacts")
+LOGGER = logging.getLogger("live-tests")
+MAIN_OUTPUT_DIRECTORY = Path("/tmp/live_tests_artifacts")
 
 # It's used by Dagger and its very verbose
 logging.getLogger("httpx").setLevel(logging.ERROR)
@@ -54,7 +54,7 @@ logging.getLogger("httpx").setLevel(logging.ERROR)
 def pytest_addoption(parser: Parser) -> None:
     parser.addoption(
         "--connector-image",
-        help="The connector image name on which the regressions tests will run: e.g. airbyte/source-faker",
+        help="The connector image name on which the tests will run: e.g. airbyte/source-faker",
     )
     parser.addoption(
         "--control-version",
@@ -63,7 +63,7 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addoption(
         "--target-version",
         default="dev",
-        help="The target version used for regression testing. Defaults to dev.",
+        help="The target version used for regression and validation testing. Defaults to dev.",
     )
     parser.addoption("--config-path")
     parser.addoption("--catalog-path")
@@ -140,7 +140,7 @@ def pytest_configure(config: Config) -> None:
     else:
         config.stash[stash_keys.SHOULD_READ_WITH_STATE] = prompt_for_read_with_or_without_state()
 
-    retrieval_reason = f"Running regression tests on connection for connector {config.stash[stash_keys.CONNECTOR_IMAGE]} on target versions ({config.stash[stash_keys.TARGET_VERSION]})."
+    retrieval_reason = f"Running live tests on connection for connector {config.stash[stash_keys.CONNECTOR_IMAGE]} on target versions ({config.stash[stash_keys.TARGET_VERSION]})."
 
     try:
         config.stash[stash_keys.CONNECTION_OBJECTS] = get_connection_objects(

--- a/airbyte-ci/connectors/live-tests/src/live_tests/validation_tests/test_read.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/validation_tests/test_read.py
@@ -7,7 +7,6 @@ from functools import reduce
 from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Optional, Tuple
 
 import pytest
-from airbyte_cdk.sources.file_based.schema_helpers import conforms_to_schema
 from airbyte_protocol.models import (
     AirbyteStateMessage,
     AirbyteStateStats,
@@ -16,6 +15,7 @@ from airbyte_protocol.models import (
     AirbyteStreamStatusTraceMessage,
     ConfiguredAirbyteCatalog,
 )
+from live_tests.commons.json_schema_helper import conforms_to_schema
 from live_tests.commons.models import ExecutionResult
 from live_tests.utils import fail_test_on_failing_execution_results, get_test_logger
 

--- a/airbyte-ci/connectors/live-tests/tests/test_json_schema_helper.py
+++ b/airbyte-ci/connectors/live-tests/tests/test_json_schema_helper.py
@@ -16,7 +16,13 @@ from airbyte_protocol.models import (
     SyncMode,
     Type,
 )
-from live_tests.commons.json_schema_helper import ComparableType, JsonSchemaHelper, conforms_to_schema, get_expected_schema_structure, get_object_structure
+from live_tests.commons.json_schema_helper import (
+    ComparableType,
+    JsonSchemaHelper,
+    conforms_to_schema,
+    get_expected_schema_structure,
+    get_object_structure,
+)
 from pydantic import BaseModel
 
 

--- a/airbyte-ci/connectors/live-tests/tests/test_json_schema_helper.py
+++ b/airbyte-ci/connectors/live-tests/tests/test_json_schema_helper.py
@@ -3,7 +3,7 @@
 #
 
 from enum import Enum
-from typing import Any, Iterable, List, Text, Tuple, Union
+from typing import Any, Iterable, List, Mapping, Text, Tuple, Union
 
 import pendulum
 import pytest
@@ -16,7 +16,7 @@ from airbyte_protocol.models import (
     SyncMode,
     Type,
 )
-from live_tests.commons.json_schema_helper import JsonSchemaHelper, get_expected_schema_structure, get_object_structure
+from live_tests.commons.json_schema_helper import ComparableType, JsonSchemaHelper, conforms_to_schema, get_expected_schema_structure, get_object_structure
 from pydantic import BaseModel
 
 
@@ -280,3 +280,194 @@ def test_find_and_get_nodes(keys: List[Text], num_paths: int, last_value: Any):
         for path in variant_paths:
             values_at_nodes.append(schema_helper.get_node(path))
         assert last_value in values_at_nodes
+
+
+COMPLETE_CONFORMING_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "val1",
+    "array_field": [1.1, 2.2],
+    "object_field": {"col": "val"},
+}
+
+
+NONCONFORMING_EXTRA_COLUMN_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "val1",
+    "array_field": [1.1, 2.2],
+    "object_field": {"col": "val"},
+    "column_x": "extra",
+}
+
+CONFORMING_WITH_MISSING_COLUMN_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "val1",
+    "array_field": [1.1, 2.2],
+}
+
+CONFORMING_WITH_NARROWER_TYPE_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": True,
+    "number_field": True,
+    "string_field": True,
+    "array_field": [1.1, 2.2],
+    "object_field": {"col": "val"},
+}
+
+NONCONFORMING_WIDER_TYPE_RECORD = {
+    "null_field": "not None",
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "val1",
+    "array_field": [1.1, 2.2],
+    "object_field": {"col": "val"},
+}
+
+NONCONFORMING_NON_OBJECT_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "val1",
+    "array_field": [1.1, 2.2],
+    "object_field": "not an object",
+}
+
+NONCONFORMING_NON_ARRAY_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "val1",
+    "array_field": "not an array",
+    "object_field": {"col": "val"},
+}
+
+CONFORMING_MIXED_TYPE_NARROWER_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "val1",
+    "array_field": [1.1, 2.2],
+    "object_field": {"col": "val"},
+}
+
+NONCONFORMING_MIXED_TYPE_WIDER_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "val1",
+    "array_field": [1.1, 2.2],
+    "object_field": {"col": "val"},
+}
+
+CONFORMING_MIXED_TYPE_WITHIN_TYPE_RANGE_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "val1",
+    "array_field": [1.1, 2.2],
+    "object_field": {"col": "val"},
+}
+
+NONCONFORMING_INVALID_ARRAY_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": ["this should not be an array"],
+    "array_field": [1.1, 2.2],
+    "object_field": {"col": "val"},
+}
+
+NONCONFORMING_TOO_WIDE_ARRAY_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "okay",
+    "array_field": ["val1", "val2"],
+    "object_field": {"col": "val"},
+}
+
+
+CONFORMING_NARROWER_ARRAY_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": "okay",
+    "array_field": [1, 2],
+    "object_field": {"col": "val"},
+}
+
+
+NONCONFORMING_INVALID_OBJECT_RECORD = {
+    "null_field": None,
+    "boolean_field": True,
+    "integer_field": 1,
+    "number_field": 1.5,
+    "string_field": {"this": "should not be an object"},
+    "array_field": [1.1, 2.2],
+    "object_field": {"col": "val"},
+}
+
+
+SCHEMA = {
+    "type": "object",
+    "properties": {
+        "null_field": {"type": "null"},
+        "boolean_field": {"type": "boolean"},
+        "integer_field": {"type": "integer"},
+        "number_field": {"type": "number"},
+        "string_field": {"type": "string"},
+        "array_field": {
+            "type": "array",
+            "items": {
+                "type": "number",
+            },
+        },
+        "object_field": {"type": "object"},
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "record,schema,expected_result",
+    [
+        pytest.param(COMPLETE_CONFORMING_RECORD, SCHEMA, True, id="record-conforms"),
+        pytest.param(NONCONFORMING_EXTRA_COLUMN_RECORD, SCHEMA, False, id="nonconforming-extra-column"),
+        pytest.param(CONFORMING_WITH_MISSING_COLUMN_RECORD, SCHEMA, True, id="record-conforms-with-missing-column"),
+        pytest.param(CONFORMING_WITH_NARROWER_TYPE_RECORD, SCHEMA, True, id="record-conforms-with-narrower-type"),
+        pytest.param(NONCONFORMING_WIDER_TYPE_RECORD, SCHEMA, False, id="nonconforming-wider-type"),
+        pytest.param(NONCONFORMING_NON_OBJECT_RECORD, SCHEMA, False, id="nonconforming-string-is-not-an-object"),
+        pytest.param(NONCONFORMING_NON_ARRAY_RECORD, SCHEMA, False, id="nonconforming-string-is-not-an-array"),
+        pytest.param(NONCONFORMING_TOO_WIDE_ARRAY_RECORD, SCHEMA, False, id="nonconforming-array-values-too-wide"),
+        pytest.param(CONFORMING_NARROWER_ARRAY_RECORD, SCHEMA, True, id="conforming-array-values-narrower-than-schema"),
+        pytest.param(NONCONFORMING_INVALID_ARRAY_RECORD, SCHEMA, False, id="nonconforming-array-is-not-a-string"),
+        pytest.param(NONCONFORMING_INVALID_OBJECT_RECORD, SCHEMA, False, id="nonconforming-object-is-not-a-string"),
+    ],
+)
+def test_conforms_to_schema(record: Mapping[str, Any], schema: Mapping[str, Any], expected_result: bool) -> None:
+    assert conforms_to_schema(record, schema) == expected_result
+
+
+def test_comparable_types() -> None:
+    assert ComparableType.OBJECT > ComparableType.STRING
+    assert ComparableType.STRING > ComparableType.NUMBER
+    assert ComparableType.NUMBER > ComparableType.INTEGER
+    assert ComparableType.INTEGER > ComparableType.BOOLEAN
+    assert ComparableType["OBJECT"] == ComparableType.OBJECT

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -792,6 +792,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 |---------|------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| 4.19.0  | [#38816](https://github.com/airbytehq/airbyte/pull/38816)      | Add command for running all live tests (validation + regression).                                                            |
 | 4.18.3  | [#39341](https://github.com/airbytehq/airbyte/pull/39341)  | Fix `--use-local-cdk` option: change `no-deps` to `force-reinstall`                                                          |
 | 4.18.2  | [#39483](https://github.com/airbytehq/airbyte/pull/39483)  | Skip IncrementalAcceptanceTests when AcceptanceTests succeed.                                                                |
 | 4.18.1  | [#39457](https://github.com/airbytehq/airbyte/pull/39457)  | Make slugify consistent with live-test                                                                                       |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
@@ -26,8 +26,6 @@ class CONNECTOR_TEST_STEP_ID(str, Enum):
     MIGRATE_POETRY_DELETE_SETUP_PY = "migrate_to_poetry.delete_setup_py"
     MIGRATE_POETRY_REGRESSION_TEST = "migrate_to_poetry.regression"
     CONNECTOR_LIVE_TESTS = "connector_live_tests"
-    CONNECTOR_REGRESSION_TESTS = "connector_regression_tests"
-    CONNECTOR_VALIDATION_TESTS = "connector_validation_tests"
     REGRESSION_TEST = "common.regression_test"
     ADD_CHANGELOG_ENTRY = "bump_version.changelog"
     SET_CONNECTOR_VERSION = "bump_version.set"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
@@ -27,6 +27,7 @@ class CONNECTOR_TEST_STEP_ID(str, Enum):
     MIGRATE_POETRY_REGRESSION_TEST = "migrate_to_poetry.regression"
     CONNECTOR_LIVE_TESTS = "connector_live_tests"
     CONNECTOR_REGRESSION_TESTS = "connector_regression_tests"
+    CONNECTOR_VALIDATION_TESTS = "connector_validation_tests"
     REGRESSION_TEST = "common.regression_test"
     ADD_CHANGELOG_ENTRY = "bump_version.changelog"
     SET_CONNECTOR_VERSION = "bump_version.set"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
@@ -25,6 +25,7 @@ class CONNECTOR_TEST_STEP_ID(str, Enum):
     MIGRATE_POETRY_POETRY_INIT = "migrate_to_poetry.poetry_init"
     MIGRATE_POETRY_DELETE_SETUP_PY = "migrate_to_poetry.delete_setup_py"
     MIGRATE_POETRY_REGRESSION_TEST = "migrate_to_poetry.regression"
+    CONNECTOR_LIVE_TESTS = "connector_live_tests"
     CONNECTOR_REGRESSION_TESTS = "connector_regression_tests"
     REGRESSION_TEST = "common.regression_test"
     ADD_CHANGELOG_ENTRY = "bump_version.changelog"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
@@ -11,7 +11,7 @@ from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
 from pipelines.airbyte_ci.connectors.pipeline import run_connectors_pipelines
 from pipelines.airbyte_ci.connectors.test.context import ConnectorTestContext
 from pipelines.airbyte_ci.connectors.test.pipeline import run_connector_test_pipeline
-from pipelines.airbyte_ci.connectors.test.steps.common import RegressionTests
+from pipelines.airbyte_ci.connectors.test.steps.common import LiveTests
 from pipelines.cli.click_decorators import click_ci_requirements_option
 from pipelines.cli.dagger_pipeline_command import DaggerPipelineCommand
 from pipelines.consts import LOCAL_BUILD_PLATFORM, MAIN_CONNECTOR_TESTING_SECRET_STORE_ALIAS, ContextState
@@ -25,8 +25,6 @@ from pipelines.models.steps import STEP_PARAMS
 GITHUB_GLOBAL_CONTEXT_FOR_TESTS = "Connectors CI tests"
 GITHUB_GLOBAL_DESCRIPTION_FOR_TESTS = "Running connectors tests"
 TESTS_SKIPPED_BY_DEFAULT = [
-    CONNECTOR_TEST_STEP_ID.CONNECTOR_REGRESSION_TESTS,
-    CONNECTOR_TEST_STEP_ID.CONNECTOR_VALIDATION_TESTS,
     CONNECTOR_TEST_STEP_ID.CONNECTOR_LIVE_TESTS,
 ]
 
@@ -186,9 +184,9 @@ async def test(
         return False
 
     finally:
-        if RegressionTests.regression_tests_artifacts_dir.exists():
-            shutil.rmtree(RegressionTests.regression_tests_artifacts_dir)
-            main_logger.info(f"  Test artifacts cleaned up from {RegressionTests.regression_tests_artifacts_dir}")
+        if LiveTests.local_tests_artifacts_dir.exists():
+            shutil.rmtree(LiveTests.local_tests_artifacts_dir)
+            main_logger.info(f"  Test artifacts cleaned up from {LiveTests.local_tests_artifacts_dir}")
 
     @ctx.call_on_close
     def send_commit_status_check() -> None:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
@@ -115,7 +115,7 @@ async def test(
         raise click.UsageError("Cannot use both --only-step and --skip-step at the same time.")
     if not only_steps:
         skip_steps = list(skip_steps)
-        skip_steps += [CONNECTOR_TEST_STEP_ID.CONNECTOR_REGRESSION_TESTS]
+        skip_steps += [CONNECTOR_TEST_STEP_ID.CONNECTOR_REGRESSION_TESTS, CONNECTOR_TEST_STEP_ID.CONNECTOR_LIVE_TESTS]
     if ctx.obj["is_ci"]:
         fail_if_missing_docker_hub_creds(ctx)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
@@ -115,7 +115,7 @@ async def test(
         raise click.UsageError("Cannot use both --only-step and --skip-step at the same time.")
     if not only_steps:
         skip_steps = list(skip_steps)
-        skip_steps += [CONNECTOR_TEST_STEP_ID.CONNECTOR_REGRESSION_TESTS, CONNECTOR_TEST_STEP_ID.CONNECTOR_LIVE_TESTS]
+        skip_steps += [CONNECTOR_TEST_STEP_ID.CONNECTOR_REGRESSION_TESTS, CONNECTOR_TEST_STEP_ID.CONNECTOR_VALIDATION_TESTS, CONNECTOR_TEST_STEP_ID.CONNECTOR_LIVE_TESTS]
     if ctx.obj["is_ci"]:
         fail_if_missing_docker_hub_creds(ctx)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
@@ -24,6 +24,11 @@ from pipelines.models.steps import STEP_PARAMS
 
 GITHUB_GLOBAL_CONTEXT_FOR_TESTS = "Connectors CI tests"
 GITHUB_GLOBAL_DESCRIPTION_FOR_TESTS = "Running connectors tests"
+TESTS_SKIPPED_BY_DEFAULT = [
+    CONNECTOR_TEST_STEP_ID.CONNECTOR_REGRESSION_TESTS,
+    CONNECTOR_TEST_STEP_ID.CONNECTOR_VALIDATION_TESTS,
+    CONNECTOR_TEST_STEP_ID.CONNECTOR_LIVE_TESTS,
+]
 
 
 @click.command(
@@ -115,7 +120,7 @@ async def test(
         raise click.UsageError("Cannot use both --only-step and --skip-step at the same time.")
     if not only_steps:
         skip_steps = list(skip_steps)
-        skip_steps += [CONNECTOR_TEST_STEP_ID.CONNECTOR_REGRESSION_TESTS, CONNECTOR_TEST_STEP_ID.CONNECTOR_VALIDATION_TESTS, CONNECTOR_TEST_STEP_ID.CONNECTOR_LIVE_TESTS]
+        skip_steps += TESTS_SKIPPED_BY_DEFAULT
     if ctx.obj["is_ci"]:
         fail_if_missing_docker_hub_creds(ctx)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -475,7 +475,7 @@ class LiveTests(Step):
                 "poetry",
                 "run",
                 "pytest",
-                "src/live_tests/regression_tests",
+                "src/live_tests",
                 "--connector-image",
                 self.connector_image,
                 "--connection-id",

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -467,13 +467,6 @@ class AbstractLiveTests(Step):
             "--durations": ["3"],  # Show the 3 slowest tests in the report
         }
 
-    @property
-    @abstractmethod
-    def title(self):
-        """
-        The title of the tests, for report display purposes.
-        """
-        ...
 
     @abstractmethod
     def _test_command(self):

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
@@ -292,6 +292,12 @@ def get_test_steps(context: ConnectorTestContext) -> STEP_TREE:
                 args=lambda results: {"connector_under_test_container": results[CONNECTOR_TEST_STEP_ID.BUILD].output[LOCAL_BUILD_PLATFORM]},
                 depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
             ),
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.CONNECTOR_LIVE_TESTS,
+                step=LiveTests(context),
+                args=lambda results: {"connector_under_test_container": results[CONNECTOR_TEST_STEP_ID.BUILD].output[LOCAL_BUILD_PLATFORM]},
+                depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
+            ),
         ],
         [
             StepToRun(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
@@ -15,7 +15,7 @@ from pipelines import hacks
 from pipelines.airbyte_ci.connectors.build_image.steps.python_connectors import BuildConnectorImages
 from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
 from pipelines.airbyte_ci.connectors.test.context import ConnectorTestContext
-from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests, IncrementalAcceptanceTests, RegressionTests
+from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests, IncrementalAcceptanceTests, LiveTests, RegressionTests, ValidationTests
 from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.dagger.actions import secrets
 from pipelines.dagger.actions.python.poetry import with_poetry
@@ -289,6 +289,12 @@ def get_test_steps(context: ConnectorTestContext) -> STEP_TREE:
             StepToRun(
                 id=CONNECTOR_TEST_STEP_ID.CONNECTOR_REGRESSION_TESTS,
                 step=RegressionTests(context),
+                args=lambda results: {"connector_under_test_container": results[CONNECTOR_TEST_STEP_ID.BUILD].output[LOCAL_BUILD_PLATFORM]},
+                depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
+            ),
+            StepToRun(
+                id=CONNECTOR_TEST_STEP_ID.CONNECTOR_VALIDATION_TESTS,
+                step=ValidationTests(context),
                 args=lambda results: {"connector_under_test_container": results[CONNECTOR_TEST_STEP_ID.BUILD].output[LOCAL_BUILD_PLATFORM]},
                 depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
             ),

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
@@ -15,7 +15,7 @@ from pipelines import hacks
 from pipelines.airbyte_ci.connectors.build_image.steps.python_connectors import BuildConnectorImages
 from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
 from pipelines.airbyte_ci.connectors.test.context import ConnectorTestContext
-from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests, IncrementalAcceptanceTests, LiveTests, RegressionTests, ValidationTests
+from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests, IncrementalAcceptanceTests, LiveTests
 from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.dagger.actions import secrets
 from pipelines.dagger.actions.python.poetry import with_poetry
@@ -283,18 +283,6 @@ def get_test_steps(context: ConnectorTestContext) -> STEP_TREE:
                     concurrent_test_run=context.concurrent_cat,
                     secrets=context.get_secrets_for_step_id(CONNECTOR_TEST_STEP_ID.ACCEPTANCE),
                 ),
-                args=lambda results: {"connector_under_test_container": results[CONNECTOR_TEST_STEP_ID.BUILD].output[LOCAL_BUILD_PLATFORM]},
-                depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
-            ),
-            StepToRun(
-                id=CONNECTOR_TEST_STEP_ID.CONNECTOR_REGRESSION_TESTS,
-                step=RegressionTests(context),
-                args=lambda results: {"connector_under_test_container": results[CONNECTOR_TEST_STEP_ID.BUILD].output[LOCAL_BUILD_PLATFORM]},
-                depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
-            ),
-            StepToRun(
-                id=CONNECTOR_TEST_STEP_ID.CONNECTOR_VALIDATION_TESTS,
-                step=ValidationTests(context),
                 args=lambda results: {"connector_under_test_container": results[CONNECTOR_TEST_STEP_ID.BUILD].output[LOCAL_BUILD_PLATFORM]},
                 depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
             ),

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.18.3"
+version = "4.19.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
Add the ability to run all live tests in CI.

## How
Updates `airbyte-ci` to have a new command for running all validation + regression tests. Ultimately we may want to remove the regression tests altogether.

Also adds a GHA for running validation + regression tests.

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/7854.
