### PR TITLE
[destination-oracle]  Update oracle.md to update requirements #37400

### DIFF
--- a/docs/integrations/destinations/oracle.md
+++ b/docs/integrations/destinations/oracle.md
@@ -32,8 +32,7 @@ The Oracle connector is currently in Alpha on Airbyte Cloud. Only TLS encrypted 
 
 To use the Oracle destination, you'll need:
 
-- An Oracle server version 18 or above
-- It's possible to use Oracle 12+ but you need to configure the table name length to 120 chars.
+- An Oracle server version 21 or above
 
 #### Network Access
 


### PR DESCRIPTION
Cannot create destination after upgrading connector version to 1.0.0 failed with ORA-00902: invalid datatype

JSON types appeared version 21 of the database, and version 23 is current.

## What
https://github.com/airbytehq/airbyte/issues/37400

## How
Updated the document

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
