### PR TITLE
Use `GITHUB_TOKEN` in version increment checks for community PRs

### DIFF
--- a/.github/workflows/connectors_version_increment_check.yml
+++ b/.github/workflows/connectors_version_increment_check.yml
@@ -30,7 +30,9 @@ jobs:
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
             ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }} \
+            ${{ GITHUB_TOKEN }}
+
       - name: Fetch last commit id from remote branch [PULL REQUESTS]
         if: github.event_name == 'pull_request'
         id: fetch_last_commit_id_pr


### PR DESCRIPTION
## What

Attempting to fix a CI failure where `find_non_rate_limited_pat` would fail because non of the secret PATS are available in `connectors_version_increment_check`. 

Not entirely sure if that's the way we want to solve this, or if this will work at all, so cc @stephane-airbyte.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
