### PR TITLE
Docs typo: wrong month in refreshes section

### DIFF
--- a/docs/operator-guides/refreshes.md
+++ b/docs/operator-guides/refreshes.md
@@ -85,7 +85,7 @@ With the advent of Refresh and Retain History Syncs, Airbyte has provided a way 
 
 ### Example: Understanding and Recovering from a Flaky Source
 
-Consider the following example. You are extracting data into your data warehouse and notice that data for April, 2024 is missing. You are using an append sync mode.
+Consider the following example. You are extracting data into your data warehouse and notice that data for March, 2024 is missing. You are using an append sync mode.
 
 | year_month (pk) | total_sales | \_airbyte_extracted_at | \_airbyte_generation_id | \_airbyte_meta                 | \_airbyte_raw_id |
 | --------------- | ----------- | ---------------------- | ----------------------- | ------------------------------ | ---------------- |


### PR DESCRIPTION
## What
Just reading through this new docs page and I noticed a small typo!

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
