### PR TITLE
python-connector-base-image: upgrade to python 3.9.19 + update setuptools and pip

### DIFF
--- a/airbyte-ci/connectors/base_images/README.md
+++ b/airbyte-ci/connectors/base_images/README.md
@@ -6,21 +6,22 @@ Our connector build pipeline ([`airbyte-ci`](https://github.com/airbytehq/airbyt
 Our base images are declared in code, using the [Dagger Python SDK](https://dagger-io.readthedocs.io/en/sdk-python-v0.6.4/).
 
 - [Python base image code declaration](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/base_images/base_images/python/bases.py)
-- ~Java base image code declaration~ _TODO_
+- ~Java base image code declaration~ *TODO* 
+
 
 ## Where are the Dockerfiles?
-
 Our base images are not declared using Dockerfiles.
 They are declared in code using the [Dagger Python SDK](https://dagger-io.readthedocs.io/en/sdk-python-v0.6.4/).
 We prefer this approach because it allows us to interact with base images container as code: we can use python to declare the base images and use the full power of the language to build and test them.
 However, we do artificially generate Dockerfiles for debugging and documentation purposes.
 
-### Example for `airbyte/python-connector-base`:
 
+
+### Example for `airbyte/python-connector-base`:
 ```dockerfile
-FROM docker.io/python:3.9.18-slim-bookworm@sha256:44b7f161ed03f85e96d423b9916cdc8cb0509fb970fd643bdbc9896d49e1cad0
+FROM docker.io/python:3.9.19-slim-bookworm@sha256:b92e6f45b58d9cafacc38563e946f8d249d850db862cbbd8befcf7f49eef8209
 RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime
-RUN pip install --upgrade pip==23.2.1
+RUN pip install --upgrade pip==24.0 setuptools==70.0.0
 ENV POETRY_VIRTUALENVS_CREATE=false
 ENV POETRY_VIRTUALENVS_IN_PROJECT=false
 ENV POETRY_NO_INTERACTION=1
@@ -30,56 +31,57 @@ RUN sh -c apt-get update && apt-get install -y tesseract-ocr=5.3.0-2 poppler-uti
 RUN mkdir /usr/share/nltk_data
 ```
 
+
+
 ## Base images
+
 
 ### `airbyte/python-connector-base`
 
-| Version | Published | Docker Image Address                                                                                                  | Changelog                                                                                            |
-| ------- | --------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| 1.2.0   | ✅        | docker.io/airbyte/python-connector-base:1.2.0@sha256:c22a9d97464b69d6ef01898edf3f8612dc11614f05a84984451dde195f337db9 | Add CDK system dependencies: nltk data, tesseract, poppler.                                          |
-| 1.1.0   | ✅        | docker.io/airbyte/python-connector-base:1.1.0@sha256:bd98f6505c6764b1b5f99d3aedc23dfc9e9af631a62533f60eb32b1d3dbab20c | Install socat                                                                                        |
-| 1.0.0   | ✅        | docker.io/airbyte/python-connector-base:1.0.0@sha256:dd17e347fbda94f7c3abff539be298a65af2d7fc27a307d89297df1081a45c27 | Initial release: based on Python 3.9.18, on slim-bookworm system, with pip==23.2.1 and poetry==1.6.1 |
+| Version    | Published | Docker Image Address                                                                                                       | Changelog                                                                                            |
+| ---------- | --------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 1.2.1      | ✅        | docker.io/airbyte/python-connector-base:1.2.1@sha256:4a4255e2bccab71fa5912487e42d9755cdecffae77273fed8be01a081cd6e795      | Upgrade to Python 3.9.19 + update pip and setuptools                                                 |
+| 1.2.0      | ✅        | docker.io/airbyte/python-connector-base:1.2.0@sha256:c22a9d97464b69d6ef01898edf3f8612dc11614f05a84984451dde195f337db9      | Add CDK system dependencies: nltk data, tesseract, poppler.                                          |
+| 1.2.0-rc.1 | ✅        | docker.io/airbyte/python-connector-base:1.2.0-rc.1@sha256:f6467768b75fb09125f6e6b892b6b48c98d9fe085125f3ff4adc722afb1e5b30 |                                                                                                      |
+| 1.1.0      | ✅        | docker.io/airbyte/python-connector-base:1.1.0@sha256:bd98f6505c6764b1b5f99d3aedc23dfc9e9af631a62533f60eb32b1d3dbab20c      | Install socat                                                                                        |
+| 1.0.0      | ✅        | docker.io/airbyte/python-connector-base:1.0.0@sha256:dd17e347fbda94f7c3abff539be298a65af2d7fc27a307d89297df1081a45c27      | Initial release: based on Python 3.9.18, on slim-bookworm system, with pip==23.2.1 and poetry==1.6.1 |
+
 
 ## How to release a new base image version (example for Python)
 
 ### Requirements
-
-- [Docker](https://docs.docker.com/get-docker/)
-- [Poetry](https://python-poetry.org/docs/#installation)
-- Dockerhub logins
+* [Docker](https://docs.docker.com/get-docker/)
+* [Poetry](https://python-poetry.org/docs/#installation)
+* Dockerhub logins
 
 ### Steps
-
 1. `poetry install`
-2. Open `base_images/python/bases.py`.
+2. Open  `base_images/python/bases.py`.
 3. Make changes to the `AirbytePythonConnectorBaseImage`, you're likely going to change the `get_container` method to change the base image.
 4. Implement the `container` property which must return a `dagger.Container` object.
 5. **Recommended**: Add new sanity checks to `run_sanity_check` to confirm that the new version is working as expected.
 6. Cut a new base image version by running `poetry run generate-release`. You'll need your DockerHub credentials.
 
 It will:
-
-- Prompt you to pick which base image you'd like to publish.
-- Prompt you for a major/minor/patch/pre-release version bump.
-- Prompt you for a changelog message.
-- Run the sanity checks on the new version.
-- Optional: Publish the new version to DockerHub.
-- Regenerate the docs and the registry json file.
-
+  - Prompt you to pick which base image you'd like to publish.
+  - Prompt you for a major/minor/patch/pre-release version bump.
+  - Prompt you for  a changelog message.
+  - Run the sanity checks on the new version.
+  - Optional: Publish the new version to DockerHub.
+  - Regenerate the docs and the registry json file.
 7. Commit and push your changes.
 8. Create a PR and ask for a review from the Connector Operations team.
 
 **Please note that if you don't publish your image while cutting the new version you can publish it later with `poetry run publish <repository> <version>`.**
 No connector will use the new base image version until its metadata is updated to use it.
 If you're not fully confident with the new base image version please:
+  - please publish it as a pre-release version
+  - try out the new version on a couple of connectors
+  - cut a new version with a major/minor/patch bump and publish it
+  - This steps can happen in different PRs.
 
-- please publish it as a pre-release version
-- try out the new version on a couple of connectors
-- cut a new version with a major/minor/patch bump and publish it
-- This steps can happen in different PRs.
 
 ## Running tests locally
-
 ```bash
 poetry run pytest
 # Static typing checks

--- a/airbyte-ci/connectors/base_images/base_images/hacks.py
+++ b/airbyte-ci/connectors/base_images/base_images/hacks.py
@@ -20,9 +20,10 @@ def get_container_dockerfile(container) -> str:
     Returns:
         str: The Dockerfile of the base image container.
     """
-
     lineage = [
-        field for field in list(container._ctx.selections) if isinstance(field, dagger.api.base.Field) and field.type_name == "Container"
+        field
+        for field in list(container._ctx.selections)
+        if isinstance(field, dagger.client._core.Field) and field.type_name == "Container"
     ]
     dockerfile = []
 

--- a/airbyte-ci/connectors/base_images/base_images/python/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/python/bases.py
@@ -10,12 +10,12 @@ import dagger
 from base_images import bases, published_image
 from base_images import sanity_checks as base_sanity_checks
 from base_images.python import sanity_checks as python_sanity_checks
-from base_images.root_images import PYTHON_3_9_18
+from base_images.root_images import PYTHON_3_9_19
 
 
 class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
 
-    root_image: Final[published_image.PublishedImage] = PYTHON_3_9_18
+    root_image: Final[published_image.PublishedImage] = PYTHON_3_9_19
     repository: Final[str] = "airbyte/python-connector-base"
     pip_cache_name: Final[str] = "pip_cache"
     nltk_data_path: Final[str] = "/usr/share/nltk_data"
@@ -94,7 +94,7 @@ class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
             # Set the timezone to UTC
             .with_exec(["ln", "-snf", "/usr/share/zoneinfo/Etc/UTC", "/etc/localtime"])
             # Upgrade pip to the expected version
-            .with_exec(["pip", "install", "--upgrade", "pip==23.2.1"])
+            .with_exec(["pip", "install", "--upgrade", "pip==24.0", "setuptools==70.0.0"])
             # Declare poetry specific environment variables
             .with_env_variable("POETRY_VIRTUALENVS_CREATE", "false")
             .with_env_variable("POETRY_VIRTUALENVS_IN_PROJECT", "false")
@@ -117,8 +117,8 @@ class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
         container = self.get_container(platform)
         await base_sanity_checks.check_timezone_is_utc(container)
         await base_sanity_checks.check_a_command_is_available_using_version_option(container, "bash")
-        await python_sanity_checks.check_python_version(container, "3.9.18")
-        await python_sanity_checks.check_pip_version(container, "23.2.1")
+        await python_sanity_checks.check_python_version(container, "3.9.19")
+        await python_sanity_checks.check_pip_version(container, "24.0")
         await python_sanity_checks.check_poetry_version(container, "1.6.1")
         await python_sanity_checks.check_python_image_has_expected_env_vars(container)
         await base_sanity_checks.check_a_command_is_available_using_version_option(container, "socat", "-V")

--- a/airbyte-ci/connectors/base_images/base_images/root_images.py
+++ b/airbyte-ci/connectors/base_images/base_images/root_images.py
@@ -10,3 +10,10 @@ PYTHON_3_9_18 = PublishedImage(
     tag="3.9.18-slim-bookworm",
     sha="44b7f161ed03f85e96d423b9916cdc8cb0509fb970fd643bdbc9896d49e1cad0",
 )
+
+PYTHON_3_9_19 = PublishedImage(
+    registry="docker.io",
+    repository="python",
+    tag="3.9.19-slim-bookworm",
+    sha="b92e6f45b58d9cafacc38563e946f8d249d850db862cbbd8befcf7f49eef8209",
+)

--- a/airbyte-ci/connectors/base_images/generated/changelogs/airbyte_python_connector_base.json
+++ b/airbyte-ci/connectors/base_images/generated/changelogs/airbyte_python_connector_base.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "1.2.1",
+    "changelog_entry": "Upgrade to Python 3.9.19 + update pip and setuptools",
+    "dockerfile_example": "FROM docker.io/python:3.9.19-slim-bookworm@sha256:b92e6f45b58d9cafacc38563e946f8d249d850db862cbbd8befcf7f49eef8209\nRUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime\nRUN pip install --upgrade pip==24.0 setuptools==70.0.0\nENV POETRY_VIRTUALENVS_CREATE=false\nENV POETRY_VIRTUALENVS_IN_PROJECT=false\nENV POETRY_NO_INTERACTION=1\nRUN pip install poetry==1.6.1\nRUN sh -c apt update && apt-get install -y socat=1.7.4.4-2\nRUN sh -c apt-get update && apt-get install -y tesseract-ocr=5.3.0-2 poppler-utils=22.12.0-2+b1\nRUN mkdir /usr/share/nltk_data"
+  },
+  {
     "version": "1.2.0",
     "changelog_entry": "Add CDK system dependencies: nltk data, tesseract, poppler.",
     "dockerfile_example": "FROM docker.io/python:3.9.18-slim-bookworm@sha256:44b7f161ed03f85e96d423b9916cdc8cb0509fb970fd643bdbc9896d49e1cad0\nRUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime\nRUN pip install --upgrade pip==23.2.1\nENV POETRY_VIRTUALENVS_CREATE=false\nENV POETRY_VIRTUALENVS_IN_PROJECT=false\nENV POETRY_NO_INTERACTION=1\nRUN pip install poetry==1.6.1\nRUN sh -c apt update && apt-get install -y socat=1.7.4.4-2\nRUN sh -c apt-get update && apt-get install -y tesseract-ocr=5.3.0-2 poppler-utils=22.12.0-2+b1\nRUN mkdir /usr/share/nltk_data"

--- a/airbyte-ci/connectors/base_images/tests/test_python/test_bases.py
+++ b/airbyte-ci/connectors/base_images/tests/test_python/test_bases.py
@@ -19,7 +19,7 @@ class TestAirbytePythonConnectorBaseImage:
 
     def test_class_attributes(self):
         """Spot any regression in the class attributes."""
-        assert bases.AirbytePythonConnectorBaseImage.root_image == root_images.PYTHON_3_9_18
+        assert bases.AirbytePythonConnectorBaseImage.root_image == root_images.PYTHON_3_9_19
         assert bases.AirbytePythonConnectorBaseImage.repository == "airbyte/python-connector-base"
         assert bases.AirbytePythonConnectorBaseImage.pip_cache_name == "pip_cache"
 


### PR DESCRIPTION
## What
Relates to https://github.com/airbytehq/airbyte-internal-issues/issues/7166
We want to mitigate some vulnerabilities found on our base image.

Cut a new base image version for python connectors which:
* Upgrades Python version to 3.9.19
* Update pip and setuptools

The published image is available [here](https://hub.docker.com/layers/airbyte/python-connector-base/1.2.1/images/sha256-04ce17faf949ef4090d06a1a1f704eb4687fc3c5f750944149a400e2a9eaa0e1?context=explore).
It's adoption by connectors will be done in batch via the run of the `upgrade_base_image` airbyte-ci command.
