### PR TITLE
fix: update automatic cloud PR creator to adhere to conventional title requirement

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -313,8 +313,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          commit-message: Updating CDK version following release
-          title: Updating CDK version following release
+          commit-message: 'chore: update CDK version following release'
+          title: 'chore: update CDK version following release'
           body: This is an automatically generated PR triggered by a CDK release
           branch: automatic-cdk-release
           base: master

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -313,8 +313,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          commit-message: 'chore: update CDK version following release'
-          title: 'chore: update CDK version following release'
+          commit-message: "chore: update CDK version following release"
+          title: "chore: update CDK version following release"
           body: This is an automatically generated PR triggered by a CDK release
           branch: automatic-cdk-release
           base: master


### PR DESCRIPTION
use `chore` and decapitalize the description so that our automatically-opened PRs pass the title checks in platform

⚠️ This PR is set to auto-merge and will merge when approved