### PR TITLE
fix(source-google-analytics-data-api): enforce unique property IDs

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.4.2
+  dockerImageTag: 2.4.3
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.4.2"
+version = "2.4.3"
 name = "source-google-analytics-data-api"
 description = "Source implementation for Google Analytics Data Api."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/spec.json
@@ -85,7 +85,8 @@
           "type": "string",
           "pattern": "^[0-9]*$"
         },
-        "examples": [["1738294", "5729978930"]]
+        "examples": [["1738294", "5729978930"]],
+        "uniqueItems": true
       },
       "date_ranges_start_date": {
         "type": "string",

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -263,7 +263,8 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                                |
-| :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------- |
+|:--------|:-----------| :------------------------------------------------------- |:---------------------------------------------------------------------------------------|
+| 2.4.3   | 2024-06-03 | [38865](https://github.com/airbytehq/airbyte/pull/38865) | Enforce unique property IDs                                                            |
 | 2.4.2   | 2024-03-20 | [36302](https://github.com/airbytehq/airbyte/pull/36302) | Don't extract state from the latest record if stream doesn't have a cursor_field       |
 | 2.4.1   | 2024-02-09 | [35073](https://github.com/airbytehq/airbyte/pull/35073) | Manage dependencies with Poetry.                                                       |
 | 2.4.0   | 2024-02-07 | [34951](https://github.com/airbytehq/airbyte/pull/34951) | Replace the spec parameter from previous version to convert all `conversions:*` fields |


### PR DESCRIPTION
## What
Add constraint for unique property IDs. Resolves: https://github.com/airbytehq/oncall/issues/5495
## How
Add `"uniqueItems": true` to the spec.
![Screenshot from 2024-06-04 13-59-37](https://github.com/airbytehq/airbyte/assets/35109939/1a0e1f30-dec7-419a-80f6-32592e08c1a0)


## User Impact
This fix will help to avoid unclear errors on discovery when the user has duplicate IDs in the config.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
