### PR TITLE
disable version increment check workflow on forks

### DIFF
--- a/.github/workflows/connectors_version_increment_check.yml
+++ b/.github/workflows/connectors_version_increment_check.yml
@@ -22,6 +22,7 @@ jobs:
   connectors_ci:
     name: Connectors Version Increment Check
     runs-on: connector-test-large
+    if: github.event.pull_request.head.repo.fork != true
     timeout-minutes: 10
     steps:
       - name: Checkout Airbyte


### PR DESCRIPTION
## What
This workflow can't run on forks because it requires secret access. We should skip it to avoid red CI on forks.
The version increment check already runs for forks in the community CI worfklow.

⚠️ Auto merge is enabled on this PR.