### PR TITLE
feat(low-code): add new format float_s

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
@@ -27,6 +27,8 @@ class DatetimeParser:
         # See https://stackoverflow.com/a/4974930
         if format == "%s":
             return datetime.datetime.fromtimestamp(int(date), tz=datetime.timezone.utc)
+        elif format == "%float_s":
+            return datetime.datetime.fromtimestamp(float(date), tz=datetime.timezone.utc)
         elif format == "%ms":
             return self._UNIX_EPOCH + datetime.timedelta(milliseconds=int(date))
 
@@ -41,6 +43,8 @@ class DatetimeParser:
         # See https://stackoverflow.com/a/4974930
         if format == "%s":
             return str(int(dt.timestamp()))
+        if format == "%float_s":
+            return str(float(dt.timestamp()))
         if format == "%ms":
             # timstamp() returns a float representing the number of seconds since the unix epoch
             return str(int(dt.timestamp() * 1000))

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
@@ -27,7 +27,7 @@ class DatetimeParser:
         # See https://stackoverflow.com/a/4974930
         if format == "%s":
             return datetime.datetime.fromtimestamp(int(date), tz=datetime.timezone.utc)
-        elif format == "%float_s":
+        elif format == "%s_as_float":
             return datetime.datetime.fromtimestamp(float(date), tz=datetime.timezone.utc)
         elif format == "%ms":
             return self._UNIX_EPOCH + datetime.timedelta(milliseconds=int(date))
@@ -43,7 +43,7 @@ class DatetimeParser:
         # See https://stackoverflow.com/a/4974930
         if format == "%s":
             return str(int(dt.timestamp()))
-        if format == "%float_s":
+        if format == "%s_as_float":
             return str(float(dt.timestamp()))
         if format == "%ms":
             # timstamp() returns a float representing the number of seconds since the unix epoch

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -719,7 +719,7 @@ definitions:
         description: |
           The datetime format used to format the datetime values that are sent in outgoing requests to the API. Use placeholders starting with "%" to describe the format the API is using. The following placeholders are available:
             * **%s**: Epoch unix timestamp - `1686218963`
-            * **%s_as_float**: Epoch unix timestamp in seconds as float - `1686218963.123456`
+            * **%s_as_float**: Epoch unix timestamp in seconds as float with microsecond precision - `1686218963.123456`
             * **%ms**: Epoch unix timestamp (milliseconds) - `1686218963123`
             * **%a**: Weekday (abbreviated) - `Sun`
             * **%A**: Weekday (full) - `Sunday`
@@ -1715,7 +1715,7 @@ definitions:
         description: |
           Format of the datetime value. Defaults to "%Y-%m-%dT%H:%M:%S.%f%z" if left empty. Use placeholders starting with "%" to describe the format the API is using. The following placeholders are available:
             * **%s**: Epoch unix timestamp - `1686218963`
-            * **%s_as_float**: Epoch unix timestamp in seconds as float - `1686218963.123456`
+            * **%s_as_float**: Epoch unix timestamp in seconds as float with microsecond precision - `1686218963.123456`
             * **%ms**: Epoch unix timestamp - `1686218963123`
             * **%a**: Weekday (abbreviated) - `Sun`
             * **%A**: Weekday (full) - `Sunday`

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -719,6 +719,7 @@ definitions:
         description: |
           The datetime format used to format the datetime values that are sent in outgoing requests to the API. Use placeholders starting with "%" to describe the format the API is using. The following placeholders are available:
             * **%s**: Epoch unix timestamp - `1686218963`
+            * **%s_as_float**: Epoch unix timestamp in seconds as float - `1686218963.123456`
             * **%ms**: Epoch unix timestamp (milliseconds) - `1686218963123`
             * **%a**: Weekday (abbreviated) - `Sun`
             * **%A**: Weekday (full) - `Sunday`
@@ -752,6 +753,7 @@ definitions:
           - "%Y-%m-%d"
           - "%s"
           - "%ms"
+          - "%s_as_float"
       start_datetime:
         title: Start Datetime
         description: The datetime that determines the earliest record that should be synced.
@@ -1713,6 +1715,7 @@ definitions:
         description: |
           Format of the datetime value. Defaults to "%Y-%m-%dT%H:%M:%S.%f%z" if left empty. Use placeholders starting with "%" to describe the format the API is using. The following placeholders are available:
             * **%s**: Epoch unix timestamp - `1686218963`
+            * **%s_as_float**: Epoch unix timestamp in seconds as float - `1686218963.123456`
             * **%ms**: Epoch unix timestamp - `1686218963123`
             * **%a**: Weekday (abbreviated) - `Sun`
             * **%A**: Weekday (full) - `Sunday`

--- a/airbyte-cdk/python/unit_tests/sources/declarative/datetime/test_datetime_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/datetime/test_datetime_parser.py
@@ -30,13 +30,13 @@ from airbyte_cdk.sources.declarative.datetime.datetime_parser import DatetimePar
             datetime.datetime(2021, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
         ),
         (
-                "test_parse_timestamp",
-                "1675092508.873709",
-                "%float_s",
-                datetime.datetime(2023, 1, 30, 15, 28, 28, 873709, tzinfo=datetime.timezone.utc),
+            "test_parse_timestamp_as_float",
+            "1675092508.873709",
+            "%s_as_float",
+            datetime.datetime(2023, 1, 30, 15, 28, 28, 873709, tzinfo=datetime.timezone.utc),
         ),
         (
-            "test_parse_timestamp",
+            "test_parse_ms_timestamp",
             "1609459200001",
             "%ms",
             datetime.datetime(2021, 1, 1, 0, 0, 0, 1000, tzinfo=datetime.timezone.utc),
@@ -55,6 +55,7 @@ def test_parse_date(test_name, input_date, date_format, expected_output_date):
     [
         ("test_format_timestamp", datetime.datetime(2021, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), "%s", "1609459200"),
         ("test_format_timestamp_ms", datetime.datetime(2021, 1, 1, 0, 0, 0, 1000, tzinfo=datetime.timezone.utc), "%ms", "1609459200001"),
+        ("test_format_timestamp_as_float", datetime.datetime(2023, 1, 30, 15, 28, 28, 873709, tzinfo=datetime.timezone.utc), "%s_as_float", "1675092508.873709"),
         ("test_format_string", datetime.datetime(2021, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), "%Y-%m-%d", "2021-01-01"),
         ("test_format_to_number", datetime.datetime(2021, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), "%Y%m%d", "20210101"),
     ],

--- a/airbyte-cdk/python/unit_tests/sources/declarative/datetime/test_datetime_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/datetime/test_datetime_parser.py
@@ -30,6 +30,12 @@ from airbyte_cdk.sources.declarative.datetime.datetime_parser import DatetimePar
             datetime.datetime(2021, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
         ),
         (
+                "test_parse_timestamp",
+                "1675092508.873709",
+                "%float_s",
+                datetime.datetime(2023, 1, 30, 15, 28, 28, 873709, tzinfo=datetime.timezone.utc),
+        ),
+        (
             "test_parse_timestamp",
             "1609459200001",
             "%ms",


### PR DESCRIPTION
## What
Add a new format - `%s_as_float` which represents time since the Unix epoch in seconds as a float, including microseconds. This format will be used in the Slack `channel_messages` stream.


## How
The **DatetimeParser** class is updated to handle the `%s_as_float` format for parsing and formatting datetime objects. This ensures that timestamps with microsecond precision are correctly interpreted and formatted.


## User Impact
Users will be able to accurately parse and format timestamps with microsecond precision. There are no negative side effects expected.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
