### PR TITLE
:bug: Source Shopify: skip `comprehensive incremental` tests

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-shopify/acceptance-test-config.yml
@@ -59,6 +59,10 @@ acceptance_tests:
         future_state:
           future_state_path: "integration_tests/abnormal_state.json"
         timeout_seconds: 8400
+        # some of the streams are not passing the `test_read_sequential_slices`
+        # due to the inability to deal with `frozen` data in sandbox
+        # TODO: remove this, once the CAT's `test_read_sequential_slices` is fixed.
+        skip_comprehensive_incremental_tests: true
   full_refresh:
     tests:
       - config_path: "secrets/config.json"


### PR DESCRIPTION
## What
Due to the fact the `test_read_senquential_slices()` CAT tests cannot work with the frozen data, this test is skipped until it's fixed on the CAT side or other workaround is applied.

Case:
- STATE value has the same date pattern as the `start_date` config value because the data is frozen, the first read outputs 2 records, with the STATE of `2021-01-01`, then the subsequent read uses this STATE value and reads the same amount of data (duplicates the data) because the records are updated with the same `cursor` value.
