### PR TITLE
low-code CDK: Add partition router to custom retriever model

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -185,6 +185,18 @@ class CustomRetriever(BaseModel):
         examples=['source_railz.components.MyCustomRetriever'],
         title='Class Name',
     )
+    partition_router: Optional[
+        Union[
+            CustomPartitionRouter,
+            ListPartitionRouter,
+            SubstreamPartitionRouter,
+            List[Union[CustomPartitionRouter, ListPartitionRouter, SubstreamPartitionRouter]],
+        ]
+    ] = Field(
+        [],
+        description='PartitionRouter component that describes how to partition the stream, enabling incremental syncs and checkpointing.',
+        title='Partition Router',
+    )
     parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
 
 


### PR DESCRIPTION
## What
During a stream with a custom retriever and partition router creation, we encountered a type error. The partition router is being mapped as a dictionary during the parsing of the stream model. This issue arises because the partition router is not described as an object in the model.

Fixed https://github.com/airbytehq/airbyte-internal-issues/issues/8096

## How
Partition router described as object in custom retriever model. 

## User Impact
No

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [ ] NO ❌
