### PR TITLE
Destination CDK: Skip flush of zero byte records. 

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -174,6 +174,7 @@ corresponds to that version.
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.36.6  | 2024-06-05 | [\#39106](https://github.com/airbytehq/airbyte/pull/39106) | Skip write to storage with 0 byte file                                                                                                                         |
 | 0.36.5  | 2024-06-01 | [\#38792](https://github.com/airbytehq/airbyte/pull/38792) | Throw config exception if no selectable table exists in user provided schemas                                                                                  |
 | 0.36.4  | 2024-05-31 | [\#38824](https://github.com/airbytehq/airbyte/pull/38824) | Param marked as non-null to nullable in JdbcDestinationHandler for NPE fix                                                                                     |
 | 0.36.2  | 2024-05-29 | [\#38538](https://github.com/airbytehq/airbyte/pull/38357) | Exit connector when encountering a config error.                                                                                                               |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.36.5
+version=0.36.6

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/staging/operation/StagingStreamOperations.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/staging/operation/StagingStreamOperations.kt
@@ -50,7 +50,11 @@ class StagingStreamOperations<DestinationState : MinimumDestinationState>(
             log.info {
                 "Buffer flush complete for stream ${streamConfig.id.originalName} (${FileUtils.byteCountToDisplaySize(it.byteCount)}) to staging"
             }
-            storageOperation.writeToStage(streamConfig, writeBuffer)
+            if (it.byteCount != 0L) {
+                storageOperation.writeToStage(streamConfig, writeBuffer)
+            } else {
+                log.info { "Skipping writing to storage since there are no bytes to write" }
+            }
         }
     }
 }


### PR DESCRIPTION
## What
Related: https://github.com/airbytehq/airbyte/issues/31425
Fixes: https://github.com/airbytehq/airbyte-internal-issues/issues/6728

In the old code, the below trace was the culprit in `AsyncFlush.kt`, fixing it for good in new flow. 
```
2024-03-18 23:37:22 destination > WARN pool-4-thread-1 i.a.c.i.d.s.c.CsvSerializedBuffer(flushWriter):85 Trying to flush but no printer is initialized.
2024-03-18 23:37:22 destination > WARN pool-4-thread-1 i.a.c.i.d.s.c.CsvSerializedBuffer(closeWriter):95 Trying to close but no printer is initialized.
2024-03-18 23:37:22 destination > INFO pool-4-thread-1 i.a.c.i.d.r.BaseSerializedBuffer(flush):172 Finished writing data to c062ec97-5fca-4b9c-815e-dd35430f525b6128245000758765392.csv.gz (0 bytes)
```

This seems to happen when sources are slow and Async framework issues a flush irrespective of the number of records, leading to the Flush function just initializing empty buffer and doing UPLOAD/COPY with 0 byte files. 

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
