### PR TITLE
source-nytimes: update base image to 1.2.2

### DIFF
--- a/airbyte-integrations/connectors/source-nytimes/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nytimes/metadata.yaml
@@ -3,11 +3,11 @@ data:
     ql: 100
     sl: 100
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/python-connector-base:1.2.1@sha256:4a4255e2bccab71fa5912487e42d9755cdecffae77273fed8be01a081cd6e795
+    baseImage: docker.io/airbyte/python-connector-base:1.2.2@sha256:57703de3b4c4204bd68a7b13c9300f8e03c0189bffddaffc796f1da25d2dbea0
   connectorSubtype: api
   connectorType: source
   definitionId: 0fae6a9a-04eb-44d4-96e1-e02d3dbc1d83
-  dockerImageTag: 0.1.5
+  dockerImageTag: 0.1.6
   dockerRepository: airbyte/source-nytimes
   documentationUrl: https://docs.airbyte.com/integrations/sources/nytimes
   githubIssueLabel: source-nytimes

--- a/airbyte-integrations/connectors/source-nytimes/pyproject.toml
+++ b/airbyte-integrations/connectors/source-nytimes/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.5"
+version = "0.1.6"
 name = "source-nytimes"
 description = "Source implementation for Nytimes."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/nytimes.md
+++ b/docs/integrations/sources/nytimes.md
@@ -45,11 +45,12 @@ The New York Times connector should not run into limitations under normal usage.
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 0.1.6   | 2024-06-5  | [39119](https://github.com/airbytehq/airbyte/pull/39119)     | Upgrade base image to 1.2.2                                                     |
 | 0.1.5   | 2024-04-19 | [37204](https://github.com/airbytehq/airbyte/pull/37204) | Updating to 0.80.0 CDK                                                          |
 | 0.1.4   | 2024-04-18 | [37204](https://github.com/airbytehq/airbyte/pull/37204) | Manage dependencies with Poetry.                                                |
 | 0.1.3   | 2024-04-15 | [37204](https://github.com/airbytehq/airbyte/pull/37204) | Base image migration: remove Dockerfile and use the python-connector-base image |
 | 0.1.2   | 2024-04-12 | [37204](https://github.com/airbytehq/airbyte/pull/37204) | schema descriptions                                                             |
 | 0.1.1   | 2023-02-13 | [22925](https://github.com/airbytehq/airbyte/pull/22925) | Specified date formatting in specification                                      |
-| 0.1.0   | 2022-11-01 | [18746](https://github.com/airbytehq/airbyte/pull/18746) | 🎉 New Source: New York Times                                                   |
+| 0.1.0   | 2022-11-01 | [18746](https://github.com/airbytehq/airbyte/pull/18746) | 🎉 New Source: New York Times                                                  |
 
 </details>


### PR DESCRIPTION
## What
Missing version bump in https://github.com/airbytehq/airbyte/pull/39101
