### PR TITLE
[airbyte-cdk] Use `jinja.sandbox.SandboxEnvironment` to restrict `InterpolatedString`

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -11,7 +11,7 @@ from airbyte_cdk.sources.declarative.interpolation.macros import macros
 from airbyte_cdk.sources.types import Config
 from jinja2 import meta
 from jinja2.exceptions import UndefinedError
-from jinja2.sandbox import Environment
+from jinja2.sandbox import SandboxedEnvironment
 
 
 class JinjaInterpolation(Interpolation):
@@ -49,7 +49,7 @@ class JinjaInterpolation(Interpolation):
     RESTRICTED_BUILTIN_FUNCTIONS = ["range"]  # The range function can cause very expensive computations
 
     def __init__(self) -> None:
-        self._environment = Environment()
+        self._environment = SandboxedEnvironment()
         self._environment.filters.update(**filters)
         self._environment.globals.update(**macros)
 


### PR DESCRIPTION
## What
Use Jinja SandboxEnvironment to restrict trying to pry into Python env from the jinja interpolated strings.

## Review guide
1. Grab the PR locally
2. Start Builder using local CDK
3. Try to break out of an interpolated string

The thing I'm slightly worried about is whether we have strong unit test coverage that makes sure that all macros and functions that we _think_ will work will still work.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
