### PR TITLE
fix: pass `AIRBYTE_INSTALLATION_ID` env-var to `docker compose` command

### DIFF
--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -378,7 +378,7 @@ if [ -z "$dockerDetachedMode" ]; then
   TelemetryDockerUp &
 fi
 
-docker compose up $dockerDetachedMode
+AIRBYTE_INSTALLATION_ID="${telemetryUserUUID}" docker compose up $dockerDetachedMode
 
 # $? is the exit code of the last command. So here: docker compose up
 if test $? -ne 0; then


### PR DESCRIPTION
## What
- fix airbytehq/airbyte-internal-issues#8162
- builds on the changes made in [airbyte/airbyte-platform-internal#12702](https://github.com/airbytehq/airbyte-platform-internal/pull/12702)

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
