### PR TITLE
[airbyte-cdk]: add condition to check type retriever

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -671,7 +671,11 @@ class ModelToComponentFactory:
 
     def _merge_stream_slicers(self, model: DeclarativeStreamModel, config: Config) -> Optional[StreamSlicer]:
         stream_slicer = None
-        if hasattr(model.retriever, "partition_router") and model.retriever.partition_router:
+        if (
+            hasattr(model.retriever, "partition_router")
+            and isinstance(model.retriever, SimpleRetrieverModel)
+            and model.retriever.partition_router
+        ):
             stream_slicer_model = model.retriever.partition_router
             if isinstance(stream_slicer_model, list):
                 stream_slicer = CartesianProductStreamSlicer(


### PR DESCRIPTION
## What
During a stream with a custom retriever and partition router creation, we encountered a type error. The partition router is being mapped as a dictionary during the parsing of the stream model. This issue arises because the partition router is not described as an object in the model.

## How
Updated the condition to also check the type of retriever 

## User Impact
No

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
