### PR TITLE
airbyte-ci: bust java build cache to fix vulnerabilities

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -792,6 +792,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 |---------|------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| 4.17.0  | [#39321](https://github.com/airbytehq/airbyte/pull/39321)      | Bust the java connector build cache flow to get fresh yum packages on a daily basis.                                                                               |
 | 4.16.0  | [#38772](https://github.com/airbytehq/airbyte/pull/38232)      | Add pipeline to replace usage of AirbyteLogger.                                                                               |
 | 4.15.7  | [#38772](https://github.com/airbytehq/airbyte/pull/38772)      | Fix regression test connector image retrieval.                                                                               |
 | 4.15.6  | [#38783](https://github.com/airbytehq/airbyte/pull/38783)  | Fix a variable access error with `repo_dir` in the `bump_version` command.                                                   |

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.16.0"
+version = "4.17.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
The `yum update` command occuring the java connector build pipeline is cached by dagger.
This prevents benefittng from updated system packages which might get fixed vulnerabilities.

## How
Bust the `yum update` layer on a daily basis.

[Pre-release `source-postgres`](https://github.com/airbytehq/airbyte/actions/runs/9403713858/job/25900901795) to check if less vulnerabilities are in a version with a fresh `yum update` 
## Results
`grype airbyte/source-postgres:latest`
> `1 critical, 12 high, 16 medium, 6 low, 0 negligible`

`grype airbyte/source-postgres:3.4.13-dev.fcd46868de`
> `1 critical, 5 high, 6 medium, 0 low, 0 negligible`

Sounds like a win 🎉 