### PR TITLE
docs: increase the max partial failure attempt to 20.

### DIFF
--- a/docs/understanding-airbyte/jobs.md
+++ b/docs/understanding-airbyte/jobs.md
@@ -72,7 +72,7 @@ Based on the outcome of previous attempts, the number of permitted attempts per 
 
 - 5 subsequent attempts where no data was synchronized
 - 10 total attempts where no data was synchronized
-- 10 total attempts where some data was synchronized
+- 20 total attempts where some data was synchronized
 
 For oss users, these values are configurable. See [Configuring Airbyte](../operator-guides/configuring-airbyte.md#jobs) for more details.
 


### PR DESCRIPTION
## What
We are increasing the max partial failure attempt to 20 to accommodate the new CDC load algorithmn.

This may result in longer jobs. However all jobs that are longer will be moving data, so we'll also increase the chance a job succeeds in the event of transient errors.

Change was made in airbyte-platform. This is the docs update.

## How
Update the docs.

## Review guide
None.

## User Impact
None.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
