### PR TITLE
airbyte-ci: make uploaded artifacts path deterministic

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -28,7 +28,7 @@ from pipelines.helpers.utils import METADATA_FILE_NAME, get_exec_result
 from pipelines.models.artifacts import Artifact
 from pipelines.models.secrets import Secret
 from pipelines.models.steps import STEP_PARAMS, MountPath, Step, StepResult, StepStatus
-from slugify import slugify
+from pipelines.helpers.utils import slugify
 
 
 class VersionCheck(Step, ABC):

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -24,11 +24,10 @@ from pipelines.airbyte_ci.steps.docker import SimpleDockerStep
 from pipelines.consts import INTERNAL_TOOL_PATHS, CIContext
 from pipelines.dagger.actions import secrets
 from pipelines.dagger.actions.python.poetry import with_poetry
-from pipelines.helpers.utils import METADATA_FILE_NAME, get_exec_result
+from pipelines.helpers.utils import METADATA_FILE_NAME, get_exec_result, slugify
 from pipelines.models.artifacts import Artifact
 from pipelines.models.secrets import Secret
 from pipelines.models.steps import STEP_PARAMS, MountPath, Step, StepResult, StepStatus
-from pipelines.helpers.utils import slugify
 
 
 class VersionCheck(Step, ABC):

--- a/airbyte-ci/connectors/pipelines/pipelines/cli/dagger_pipeline_command.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/cli/dagger_pipeline_command.py
@@ -76,7 +76,6 @@ class DaggerPipelineCommand(click.Command):
 
         git_branch = ctx.obj["git_branch"]
         git_revision = ctx.obj["git_revision"]
-        pipeline_start_timestamp = ctx.obj["pipeline_start_timestamp"]
         ci_context = ctx.obj["ci_context"]
         ci_job_key = ctx.obj["ci_job_key"] if ctx.obj.get("ci_job_key") else ci_context
 
@@ -94,7 +93,6 @@ class DaggerPipelineCommand(click.Command):
             cmd,
             ci_job_key,
             sanitized_branch,
-            pipeline_start_timestamp,
             git_revision,
         ]
 

--- a/airbyte-ci/connectors/pipelines/pipelines/models/reports.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/reports.py
@@ -124,7 +124,7 @@ class Report:
                     gcs_url = await artifact.upload_to_gcs(
                         dagger_client=self.pipeline_context.dagger_client,
                         bucket=self.pipeline_context.ci_report_bucket,  # type: ignore
-                        key=f"{self.report_output_prefix}/artifacts/{slugify(step_result.step.title)}/{upload_time}_{artifact.name}",
+                        key=f"{self.report_output_prefix}/artifacts/{slugify(step_result.step.title)}/{artifact.name}",
                         gcs_credentials=self.pipeline_context.ci_gcp_credentials,  # type: ignore
                     )
                     self.pipeline_context.logger.info(f"Artifact {artifact.name} for {step_result.step.title} uploaded to {gcs_url}")

--- a/airbyte-ci/connectors/pipelines/tests/test_helpers/test_utils.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_helpers/test_utils.py
@@ -30,7 +30,7 @@ from tests.utils import pick_a_random_connector
                     "ci_job_key": None,
                 },
             ),
-            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_context/my_branch/my_pipeline_start_timestamp/my_git_revision",
+            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_context/my_branch/my_git_revision",
         ),
         (
             mock.MagicMock(
@@ -43,7 +43,7 @@ from tests.utils import pick_a_random_connector
                     "ci_job_key": "my_ci_job_key",
                 },
             ),
-            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch/my_pipeline_start_timestamp/my_git_revision",
+            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch/my_git_revision",
         ),
         (
             mock.MagicMock(
@@ -56,7 +56,7 @@ from tests.utils import pick_a_random_connector
                     "ci_job_key": "my_ci_job_key",
                 },
             ),
-            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch/my_pipeline_start_timestamp/my_git_revision",
+            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch/my_git_revision",
         ),
         (
             mock.MagicMock(
@@ -69,7 +69,7 @@ from tests.utils import pick_a_random_connector
                     "ci_job_key": "my_ci_job_key",
                 },
             ),
-            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch/my_pipeline_start_timestamp/my_git_revision",
+            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch/my_git_revision",
         ),
         (
             mock.MagicMock(
@@ -82,7 +82,7 @@ from tests.utils import pick_a_random_connector
                     "ci_job_key": "my_ci_job_key",
                 },
             ),
-            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch_with_slashes/my_pipeline_start_timestamp/my_git_revision",
+            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch_with_slashes/my_git_revision",
         ),
         (
             mock.MagicMock(
@@ -95,7 +95,7 @@ from tests.utils import pick_a_random_connector
                     "ci_job_key": "my_ci_job_key",
                 },
             ),
-            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch_with_slashesandspecialcharacters/my_pipeline_start_timestamp/my_git_revision",
+            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch_with_slashesandspecialcharacters/my_git_revision",
         ),
         (
             mock.MagicMock(
@@ -108,7 +108,7 @@ from tests.utils import pick_a_random_connector
                     "ci_job_key": "my_ci_job_key",
                 },
             ),
-            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch_with_slashesandspecialcharacters/my_pipeline_start_timestamp/my_git_revision",
+            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch_with_slashesandspecialcharacters/my_git_revision",
         ),
         (
             mock.MagicMock(
@@ -121,7 +121,7 @@ from tests.utils import pick_a_random_connector
                     "ci_job_key": "my_ci_job_key",
                 },
             ),
-            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch_with_slashesandspecialcharacters/my_pipeline_start_timestamp/my_git_revision",
+            f"{consts.STATIC_REPORT_PREFIX}/command/path/my_ci_job_key/my_branch_with_slashesandspecialcharacters/my_git_revision",
         ),
     ],
 )


### PR DESCRIPTION
## What
Our current report / artifact path on GCS have their timestamp generation in it.
I don't think it's useful and it prevents us from having deterministic path which would help us fetch reports from previous execution on different branches.

Here's an example of a CAT json report uploaded to a deterministic path:
https://storage.cloud.google.com/airbyte-ci-reports-multi/airbyte-ci/connectors/test/manual/augustin_06-07-airbyte-ci_make_uploaded_artifacts_path_deterministic/1951884e59f44b3c23609d213c9f31621e5531a6/source-faker/6.1.3/artifacts/acceptance-tests/cat_report_log.jsonl