### PR TITLE
airbyte-ci: ignore CAT results when running on community connectors

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -24,11 +24,10 @@ from pipelines.airbyte_ci.steps.docker import SimpleDockerStep
 from pipelines.consts import INTERNAL_TOOL_PATHS, CIContext
 from pipelines.dagger.actions import secrets
 from pipelines.dagger.actions.python.poetry import with_poetry
-from pipelines.helpers.utils import METADATA_FILE_NAME, get_exec_result
+from pipelines.helpers.utils import METADATA_FILE_NAME, get_exec_result, slugify
 from pipelines.models.artifacts import Artifact
 from pipelines.models.secrets import Secret
 from pipelines.models.steps import STEP_PARAMS, MountPath, Step, StepResult, StepStatus
-from slugify import slugify
 
 
 class VersionCheck(Step, ABC):
@@ -288,7 +287,6 @@ class AcceptanceTests(Step):
             cat_container = self.dagger_client.container().from_(self.context.connector_acceptance_test_image)
 
         connector_container_id = await connector_under_test_container.id()
-
         cat_container = (
             cat_container.with_env_variable("RUN_IN_AIRBYTE_CI", "1")
             .with_exec(["mkdir", "/dagger_share"], skip_entrypoint=True)
@@ -308,6 +306,17 @@ class AcceptanceTests(Step):
 
         return cat_container.with_unix_socket("/var/run/docker.sock", self.context.dagger_client.host().unix_socket("/var/run/docker.sock"))
 
+    def get_is_hard_failure(self) -> bool:
+        """When a connector is not certified or the CI context is master, we consider the acceptance tests as hard failures:
+        The overall status of the pipeline will be FAILURE if the acceptance tests fail.
+        For marketplace connectors we defer to the IncrementalAcceptanceTests step to determine if the acceptance tests are hard failures:
+        If a new test is failing compared to the released version of the connector.
+
+        Returns:
+            bool: Whether a failure of acceptance tests should be considered a hard failures.
+        """
+        return self.context.connector.metadata.get("supportLevel") == "certified" or self.context.ci_context == CIContext.MASTER
+
     async def get_step_result(self, container: Container) -> StepResult:
         """Retrieve stdout, stderr and exit code from the executed CAT container.
         Pull the report logs from the container and create an Artifact object from it.
@@ -326,6 +335,10 @@ class AcceptanceTests(Step):
             content=container.file(self.REPORT_LOG_PATH),
             to_upload=True,
         )
+        status = self.get_step_status_from_exit_code(exit_code)
+
+        is_hard_failure = status is StepStatus.FAILURE and self.get_is_hard_failure()
+
         return StepResult(
             step=self,
             status=self.get_step_status_from_exit_code(exit_code),
@@ -333,6 +346,7 @@ class AcceptanceTests(Step):
             stdout=stdout,
             output=container,
             artifacts=[report_log_artifact],
+            consider_in_overall_status=is_hard_failure,
         )
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/templates/test_report.html.j2
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/templates/test_report.html.j2
@@ -162,7 +162,11 @@ function copyToClipBoard(htmlElement) {
     {% if step_result.status == StepStatus.SUCCESS %}
       <label for="{{ step_result.step.title }}" class="lbl-toggle success">{{ step_result.step.title }} | {{ format_duration(step_result.step.run_duration) }}</label>
     {% elif step_result.status == StepStatus.FAILURE %}
+      {% if not step_result.consider_in_overall_status %}
+      <label for="{{ step_result.step.title }}" class="lbl-toggle failure">{{ step_result.step.title }} | Ignored (Failed) | {{ format_duration(step_result.step.run_duration) }}</label>
+      {% else %}
       <label for="{{ step_result.step.title }}" class="lbl-toggle failure">{{ step_result.step.title }} | {{ format_duration(step_result.step.run_duration) }}</label>
+      {% endif %}
     {% else %}
       <label for="{{ step_result.step.title }}" class="lbl-toggle">{{ step_result.step.title }} | {{ format_duration(step_result.step.run_duration) }}</label>
     {% endif %}

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
@@ -295,7 +295,7 @@ class PipelineContext:
         """
         if exception_value is not None or report is None:
             return ContextState.ERROR
-        if report is not None and report.failed_steps:
+        if report is not None and report.considered_failed_steps:
             return ContextState.FAILURE
         if report is not None and report.success:
             return ContextState.SUCCESSFUL

--- a/airbyte-ci/connectors/pipelines/pipelines/models/reports.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/reports.py
@@ -61,6 +61,10 @@ class Report:
         return [step_result for step_result in self.steps_results if step_result.status is StepStatus.FAILURE]
 
     @property
+    def considered_failed_steps(self) -> List[StepResult]:
+        return [step_result for step_result in self.failed_steps if step_result.consider_in_overall_status]
+
+    @property
     def successful_steps(self) -> List[StepResult]:
         return [step_result for step_result in self.steps_results if step_result.status is StepStatus.SUCCESS]
 
@@ -70,7 +74,7 @@ class Report:
 
     @property
     def success(self) -> bool:
-        return len(self.failed_steps) == 0 and (len(self.skipped_steps) > 0 or len(self.successful_steps) > 0)
+        return len(self.considered_failed_steps) == 0 and (len(self.skipped_steps) > 0 or len(self.successful_steps) > 0)
 
     @property
     def run_duration(self) -> timedelta:

--- a/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
@@ -88,6 +88,7 @@ class StepResult(Result):
     """A dataclass to capture the result of a step."""
 
     step: Step
+    consider_in_overall_status: bool = True
 
     def __repr__(self) -> str:  # noqa D105
         return f"{self.step.title}: {self.status.value}"


### PR DESCRIPTION
## What
We decided that it was fine to make CI pass on community connectors if their acceptance tests results are not made worse than what they are on `master`.

**Detection of "not made worse" is implemented in https://github.com/airbytehq/airbyte/pull/39363**


To do so we have to change the CI logic slightly to allow CAT to fail on community connector while still emitting a 🟢 CI status.

It'll allow keeping the original CAT results for debugging but not fail CI if they are not passing.

## How
1. Introduce a `consider_result_in_overall_status` flag at the `StepResult` level.
It allows `Step` to emit `StepResult` which won't be considered in the overall computation of success / failure for a pipeline.

2. Update the HTML report to show when a step was ignored from overall results.
3. Change the definition of `success` at the `Report` level to integrate this new `consider_result_in_overall_status` flag.

