### PR TITLE
🐛 Source Shopify: fix failed CAT test with `future_state.abnormal_values`

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-shopify/acceptance-test-config.yml
@@ -59,10 +59,6 @@ acceptance_tests:
         future_state:
           future_state_path: "integration_tests/abnormal_state.json"
         timeout_seconds: 8400
-        # some of the streams are not passing the `test_read_sequential_slices`
-        # due to the inability to deal with `frozen` data in sandbox
-        # TODO: remove this, once the CAT's `test_read_sequential_slices` is fixed.
-        skip_comprehensive_incremental_tests: true
   full_refresh:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/abnormal_state.json
@@ -285,7 +285,9 @@
   {
     "type": "STREAM",
     "stream": {
-      "stream_state": {},
+      "stream_state": {
+        "id": 99999999999999
+      },
       "stream_descriptor": {
         "name": "balance_transactions"
       }
@@ -562,7 +564,9 @@
   {
     "type": "STREAM",
     "stream": {
-      "stream_state": {},
+      "stream_state": {
+        "id": 99999999999999
+      },
       "stream_descriptor": {
         "name": "disputes"
       }
@@ -571,7 +575,9 @@
   {
     "type": "STREAM",
     "stream": {
-      "stream_state": {},
+      "stream_state": {
+        "updated_at": "2027-07-11T13:07:45-07:00"
+      },
       "stream_descriptor": {
         "name": "customer_saved_search"
       }

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/configured_catalog.json
@@ -6,10 +6,10 @@
         "json_schema": {},
         "supported_sync_modes": ["incremental", "full_refresh"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["updated_at"]
+        "default_cursor_field": ["id"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"],
+      "cursor_field": ["id"],
       "destination_sync_mode": "append"
     },
     {
@@ -42,10 +42,10 @@
         "json_schema": {},
         "supported_sync_modes": ["incremental", "full_refresh"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["updated_at"]
+        "default_cursor_field": ["id"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"],
+      "cursor_field": ["id"],
       "destination_sync_mode": "append"
     },
     {
@@ -472,10 +472,10 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["id"]
+        "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["id"],
+      "cursor_field": ["updated_at"],
       "destination_sync_mode": "append"
     },
     {


### PR DESCRIPTION
## What
Based on this [test report](https://storage.cloud.google.com/airbyte-ci-reports-multi/airbyte-ci/connectors/test/nightly_builds/master/1717977926/3b3392317f166fecb8723531054c0c745865142b/source-shopify/2.2.3/output.html) and [this discovered issue](https://github.com/airbytehq/airbyte/pull/39136#issuecomment-2158006606), the `incremental.future_state` test should use the right `future_state.abnormal_state` values to pass the test

## How
- updated the `integration_tests/configured_catalog.json` with the correct `cursor_field` values
- updated the `integration_tests/abnormal_state.json` with the correct `cursor_field` and `value`