### PR TITLE
destination-s3: role_arn only for Airbyte Cloud

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 0.6.2
+  dockerImageTag: 0.6.3
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
@@ -35,7 +35,7 @@
       },
       "role_arn": {
         "type": "string",
-        "description": "The Role ARN",
+        "description": "The Role ARN (only available on Airbyte Cloud)",
         "title": "Role ARN",
         "examples": ["arn:aws:iam::123456789:role/ExternalIdIsYourWorkspaceId"],
         "order": 2

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -10,7 +10,7 @@ List of required fields:
 - **S3 Bucket Path**
 - **S3 Bucket Region**
 
-If you are using STS Assume Role, you must provide the following:
+If you are using STS Assume Role (only available on Airbyte Cloud), you must provide the following:
 
 - **Role ARN**
 
@@ -87,7 +87,7 @@ At this time, object-level permissions alone are not sufficient to successfully 
 <!-- env:cloud -->
 
 :::note
-S3 authentication using an IAM role member must be enabled by a member of the Airbyte team. If you'd like to use this feature, please [contact the Sales team](https://airbyte.com/company/talk-to-sales) for more information.
+S3 authentication using an IAM role member must be enabled by a member of the Airbyte team, and is only available on Airbyte Cloud. If you'd like to use this feature, please [contact the Sales team](https://airbyte.com/company/talk-to-sales) for more information.
 :::
 
 <!-- /env:cloud -->
@@ -514,7 +514,8 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                              |
 | :------ | :--------- | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.6.2   | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204)   | add assume role auth                                                                                                                                 |
+| 0.6.3   | 2024-04-15 | [xxx](https://github.com/airbytehq/airbyte/pull/xxx)       | Clarify that assume-role is only for Airbyte Cloud auth                                                                                              |
+| 0.6.2   | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204)   | Add assume-role auth                                                                                                                                 |
 | 0.6.1   | 2024-04-08 | [37546](https://github.com/airbytehq/airbyte/pull/37546)   | Adapt to CDK 0.30.8;                                                                                                                                 |
 | 0.6.0   | 2024-04-08 | [36869](https://github.com/airbytehq/airbyte/pull/36869)   | Adapt to CDK 0.29.8; Kotlin converted code.                                                                                                          |
 | 0.5.9   | 2024-02-22 | [35569](https://github.com/airbytehq/airbyte/pull/35569)   | Fix logging bug.                                                                                                                                     |


### PR DESCRIPTION
Clarify that assume-role is only available on Airbyte Cloud 

Closes: https://github.com/airbytehq/airbyte/issues/33039