### PR TITLE
🐛 Postgres Destination fails when the connection is persisted across steps

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 2.0.10
+  dockerImageTag: 2.0.11
   dockerRepository: airbyte/destination-postgres-strict-encrypt
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 2.0.10
+  dockerImageTag: 2.0.11
   dockerRepository: airbyte/destination-postgres
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
@@ -73,7 +73,7 @@ public class PostgresDestination extends AbstractJdbcDestination<PostgresState> 
     // Adding 60 seconds to connection timeout, for ssl connections, default 10 seconds is not enough
     return builder.withConnectionTimeout(Duration.ofSeconds(60))
         .withConnectionInitSql("""
-                               CREATE FUNCTION pg_temp.airbyte_safe_cast(_in text, INOUT _out ANYELEMENT)
+                               CREATE OR REPLACE FUNCTION pg_temp.airbyte_safe_cast(_in text, INOUT _out ANYELEMENT)
                                  LANGUAGE plpgsql AS
                                $func$
                                BEGIN

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -267,6 +267,7 @@ _where_ it is deployed.
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                  |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------- |
+| 2.0.11  | 2024-06-10 | [\#39372](https://github.com/airbytehq/airbyte/pull/39372) | Fixed function already exists error                                                                      |
 | 2.0.10  | 2024-05-07 | [\#37660](https://github.com/airbytehq/airbyte/pull/37660) | Adopt CDK 0.33.2                                                                                         |
 | 2.0.9   | 2024-04-11 | [\#36974](https://github.com/airbytehq/airbyte/pull/36974) | Add option to drop with `CASCADE`                                                                        |
 | 2.0.8   | 2024-04-10 | [\#36805](https://github.com/airbytehq/airbyte/pull/36805) | Adopt CDK 0.29.10 to improve long column name handling                                                   |


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/39364
When using PostgreSQL as a destination, we the connector tries to recreate a postgreSQL function (airbyte_safe_cast) while on the same connection which leads to an SQL error which crashes the sync process.

## How
We've modified the SQL query to either create or replace the function, not only create which would lead to an error if the function already existed

## Review guide
Try to use PostgreSQL as a destination with any source

## User Impact
The function may re-created the function when it's not needed, but this shouldn't happen anyway as it's only on the session, in case other errors happen related to re-using the session, this would not crash the connector

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌