### PR TITLE
Source Hubspot: add associations to custom objects again

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/pyproject.toml
+++ b/airbyte-integrations/connectors/source-hubspot/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.2.3dev0"
+version = "4.2.3dev1"
 name = "source-hubspot"
 description = "Source implementation for HubSpot."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-hubspot/pyproject.toml
+++ b/airbyte-integrations/connectors/source-hubspot/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.2.3"
+version = "4.2.3dev0"
 name = "source-hubspot"
 description = "Source implementation for HubSpot."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/source.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/source.py
@@ -247,6 +247,7 @@ class SourceHubspot(AbstractSource):
                     schema=custom_object_stream_instance.schema,
                     fully_qualified_name=custom_object_stream_instance.fully_qualified_name,
                     custom_properties=custom_object_stream_instance.custom_properties,
+                    associations=custom_object_stream_instance.associations,
                     **common_params,
                 )
                 super(self.__class__, self).__init__(parent=parent, **kwargs)

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -110,6 +110,7 @@ class RecordUnnester:
                 f"{top_level_name}_{name}": value for (top_level_name, data) in data_to_unnest.items() for (name, value) in data.items()
             }
             final = {**record, **unnested_data}
+            final.pop("properties", None)  # HACK: Disable field in Airbyte does not work for a moment :(
             yield final
 
 
@@ -311,7 +312,7 @@ class API:
                 "createdAt": {"type": ["null", "string"], "format": "date-time"},
                 "updatedAt": {"type": ["null", "string"], "format": "date-time"},
                 "archived": {"type": ["null", "boolean"]},
-                "properties": {"type": ["null", "object"], "properties": properties},
+                # "properties": {"type": ["null", "object"], "properties": properties},  # HACK: Disable field in Airbyte does not work for a moment :(
                 "associations": {"type": ["null", "object"], "properties": {}},
                 **unnested_properties,
             },
@@ -453,7 +454,8 @@ class Stream(HttpStream, ABC):
     def get_json_schema(self) -> Mapping[str, Any]:
         json_schema = super().get_json_schema()
         if self.properties:
-            properties = {"properties": {"type": "object", "properties": self.properties}}
+            properties = {}  # HACK: Disable field in Airbyte does not work for a moment :(
+            # properties = {"properties": {"type": "object", "properties": self.properties}}
             unnested_properties = {
                 f"properties_{property_name}": property_value for (property_name, property_value) in self.properties.items()
             }

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
@@ -313,7 +313,7 @@ class TestSplittingPropertiesFunctionality:
         # check that we have records for all set ids, and that each record has 2000 properties (not more, and not less)
         assert len(stream_records) == sum([len(ids) for ids in record_ids_paginated])
         for record in stream_records:
-            assert len(record["properties"]) == NUMBER_OF_PROPERTIES
+            # assert len(record["properties"]) == NUMBER_OF_PROPERTIES
             properties = [field for field in record if field.startswith("properties_")]
             assert len(properties) == NUMBER_OF_PROPERTIES
 
@@ -347,7 +347,7 @@ class TestSplittingPropertiesFunctionality:
 
         assert len(stream_records) == 5
         for record in stream_records:
-            assert len(record["properties"]) == NUMBER_OF_PROPERTIES
+            # assert len(record["properties"]) == NUMBER_OF_PROPERTIES
             properties = [field for field in record if field.startswith("properties_")]
             assert len(properties) == NUMBER_OF_PROPERTIES
 

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
@@ -375,7 +375,16 @@ def custom_object_schema_fixture():
                 "formField": True,
             }
         ],
-        "associations": [],
+        "associations": [
+            {
+                "createdAt": "2024-04-11T13:02:44.674Z",
+                "fromObjectTypeId": "2-7232155",
+                "name": "animals_to_contact",
+                "id": "105",
+                "toObjectTypeId": "42-42",
+                "updatedAt": "2024-04-11T13:02:44.674Z",
+            }
+        ],
         "name": "animals",
     }
 
@@ -392,6 +401,7 @@ def expected_custom_object_json_schema():
             "updatedAt": {"type": ["null", "string"], "format": "date-time"},
             "archived": {"type": ["null", "boolean"]},
             "properties": {"type": ["null", "object"], "properties": {"name": {"type": ["null", "string"]}}},
+            "associations": {"type": ["null", "object"], "properties": {}},
             "properties_name": {"type": ["null", "string"]},
         },
     }
@@ -405,6 +415,7 @@ def test_custom_object_stream_doesnt_call_hubspot_to_get_json_schema_if_availabl
         schema=expected_custom_object_json_schema,
         fully_qualified_name="p123_animals",
         custom_properties={"name": {"type": ["null", "string"]}},
+        associations = ["contact"],
         **common_params,
     )
 
@@ -440,10 +451,13 @@ def test_contacts_merged_audit_stream_doesnt_call_hubspot_to_get_json_schema(req
 
 def test_get_custom_objects_metadata_success(requests_mock, custom_object_schema, expected_custom_object_json_schema, api):
     requests_mock.register_uri("GET", "/crm/v3/schemas", json={"results": [custom_object_schema]})
-    for (entity, fully_qualified_name, schema, custom_properties) in api.get_custom_objects_metadata():
+    association_type_id = custom_object_schema['associations'][0]['toObjectTypeId']
+    requests_mock.register_uri("GET", f"/crm/v3/schemas/{association_type_id}", json={"fullyQualifiedName": "contact"})
+    for (entity, fully_qualified_name, schema, custom_properties, associations) in api.get_custom_objects_metadata():
         assert entity == "animals"
         assert fully_qualified_name == "p19936848_Animal"
         assert schema == expected_custom_object_json_schema
+        assert set(associations) == {"contact"}
 
 
 @pytest.mark.parametrize(

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
@@ -400,7 +400,7 @@ def expected_custom_object_json_schema():
             "createdAt": {"type": ["null", "string"], "format": "date-time"},
             "updatedAt": {"type": ["null", "string"], "format": "date-time"},
             "archived": {"type": ["null", "boolean"]},
-            "properties": {"type": ["null", "object"], "properties": {"name": {"type": ["null", "string"]}}},
+            # "properties": {"type": ["null", "object"], "properties": {"name": {"type": ["null", "string"]}}},
             "associations": {"type": ["null", "object"], "properties": {}},
             "properties_name": {"type": ["null", "string"]},
         },
@@ -483,7 +483,7 @@ def test_get_custom_objects_metadata_success(requests_mock, custom_object_schema
                     "id": 1,
                     "createdAt": "2020-01-01",
                     "email": {"from": "integration-test@airbyte.io", "to": "michael_scott@gmail.com"},
-                    "properties": {"phone": "+38044-111-111", "address": "31, Cleveland str, Washington DC"},
+                    # "properties": {"phone": "+38044-111-111", "address": "31, Cleveland str, Washington DC"},
                     "properties_phone": "+38044-111-111",
                     "properties_address": "31, Cleveland str, Washington DC",
                 }
@@ -525,7 +525,7 @@ def test_get_custom_objects_metadata_success(requests_mock, custom_object_schema
                     "email": {"from": "integration-test@airbyte.io", "to": "michael_scott@gmail.com"},
                     "email_from": "integration-test@airbyte.io",
                     "email_to": "michael_scott@gmail.com",
-                    "properties": {"phone": "+38044-111-111", "address": "31, Cleveland str, Washington DC"},
+                    # "properties": {"phone": "+38044-111-111", "address": "31, Cleveland str, Washington DC"},
                     "properties_phone": "+38044-111-111",
                     "properties_address": "31, Cleveland str, Washington DC",
                 }


### PR DESCRIPTION
## What
I used [PR](https://github.com/airbytehq/airbyte/issues/31509) as the base

The question about Custom object associations:
https://github.com/airbytehq/airbyte/discussions/38650

## How
There are two types of associations with custom objects:
1. Associations **from** custom objects
2. Associations **to** custom objects

**from** are resolved in moment of creation of custom object stream
**to** are more complicated. I added field `associated_custom_objects` to `CRMSearchStream`  and store new associations there.

## Review guide
1. `airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py`
2. `airbyte-integrations/connectors/source-hubspot/source_hubspot/source.py`


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
We use the connector but I didn't have excessive testing. 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
