### PR TITLE
🐛 Source Stripe: fix the `invoices` stream, incremental sync, after the PR #39393

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e094cb9a-26de-4645-8761-65c0c425d1de
-  dockerImageTag: 5.4.1
+  dockerImageTag: 5.4.2
   dockerRepository: airbyte/source-stripe
   documentationUrl: https://docs.airbyte.com/integrations/sources/stripe
   githubIssueLabel: source-stripe

--- a/airbyte-integrations/connectors/source-stripe/pyproject.toml
+++ b/airbyte-integrations/connectors/source-stripe/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "5.4.1"
+version = "5.4.2"
 name = "source-stripe"
 description = "Source implementation for Stripe."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -242,10 +242,12 @@ class SourceStripe(ConcurrentSourceAdapter):
                 "invoice.payment_failed",
                 "invoice.payment_succeeded",
                 "invoice.sent",
-                "invoice.upcoming",
                 "invoice.updated",
                 "invoice.voided",
                 "invoice.will_be_due",
+                # the event type = "invoice.upcoming" doesn't contain the `primary_key = `id` field,
+                # thus isn't used, see the doc: https://docs.stripe.com/api/invoices/object#invoice_object-id
+                # reference issue: https://github.com/airbytehq/oncall/issues/5560
             ],
             **args,
         )

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -225,6 +225,7 @@ Each record is marked with `is_deleted` flag when the appropriate event happens 
 
 | Version | Date       | Pull Request                                              | Subject                                                                                                                                                                                                                       |
 | :------ | :--------- | :-------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 5.4.2   | 2024-06-11 | [39412](https://github.com/airbytehq/airbyte/pull/39412)  | Removed `invoice.upcomming` event type from (incremental sync) for `Invoices` stream              |
 | 5.4.1   | 2024-06-11 | [39393](https://github.com/airbytehq/airbyte/pull/39393)  | Added missing `event types` (incremental sync) for `Invoices` stream                                                              |
 | 5.4.0   | 2024-06-05 | [39138](https://github.com/airbytehq/airbyte/pull/39138)  | Fixed the `Refunds` stream missing data for the `incremental` sync                                                             |
 | 5.3.9   | 2024-05-22 | [38550](https://github.com/airbytehq/airbyte/pull/38550)  | Update authenticator package                                                             |


### PR DESCRIPTION
## What
Resolving:
- https://github.com/airbytehq/oncall/issues/5560

## How
- removed the `invoice. upcoming` event type from the request, because it doesn't provide the `id`, since there is no `invoice` created/updated.././etc yet. 

For more, see this doc: 
 - https://docs.stripe.com/api/invoices/object#invoice_object-id

## User Impact
No impact is expected, not a breaking change.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
