### PR TITLE
chore(source-azure-blob-storage): fix abnormal state for `parquet` stream

### DIFF
--- a/airbyte-integrations/connectors/source-azure-blob-storage/integration_tests/abnormal_states/parquet.json
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/integration_tests/abnormal_states/parquet.json
@@ -3,16 +3,18 @@
     "type": "STREAM",
     "stream": {
       "stream_state": {
-        "_ab_source_file_last_modified": "2999-01-01T00:00:00.000000Z_simple_test.csv",
+        "_ab_source_file_last_modified": "2999-01-02T00:00:00.000000Z_test_payroll/Fiscal_Year=2022/Leave_Status_as_of_June_30=ACTIVE/Pay_Basis=per%20Annum/4e0ea65c5a074c0592e43f7b950f3ce8-0.parquet",
         "history": {
-          "test_payroll/Fiscal_Year=2021/Leave_Status_as_of_June_30=ACTIVE/Pay_Basis=per%20Annum/4e0ea65c5a074c0592e43f7b950f3ce8-0.parquet": "2999-01-01T00:00:00.000000Z",
-          "test_payroll/Fiscal_Year=2021/Leave_Status_as_of_June_30=ACTIVE/Pay_Basis=per%20Hour/4e0ea65c5a074c0592e43f7b950f3ce8-0.parquet": "2999-01-01T00:00:00.000000Z",
           "test_payroll/Fiscal_Year=2021/Leave_Status_as_of_June_30=ON%20LEAVE/Pay_Basis=per%20Annum/4e0ea65c5a074c0592e43f7b950f3ce8-0.parquet": "2999-01-01T00:00:00.000000Z",
-          "test_payroll/Fiscal_Year=2022/Leave_Status_as_of_June_30=ACTIVE/Pay_Basis=per%20Annum/4e0ea65c5a074c0592e43f7b950f3ce8-0.parquet": "2999-01-01T00:00:00.000000Z",
-          "test_payroll/Fiscal_Year=2022/Leave_Status_as_of_June_30=ON%20LEAVE/Pay_Basis=per%20Annum/4e0ea65c5a074c0592e43f7b950f3ce8-0.parquet": "2999-01-01T00:00:00.000000Z"
+          "test_payroll/Fiscal_Year=2021/Leave_Status_as_of_June_30=ACTIVE/Pay_Basis=per%20Hour/4e0ea65c5a074c0592e43f7b950f3ce8-0.parquet": "2999-01-01T00:00:00.000000Z",
+          "test_payroll/Fiscal_Year=2021/Leave_Status_as_of_June_30=ACTIVE/Pay_Basis=per%20Annum/4e0ea65c5a074c0592e43f7b950f3ce8-0.parquet": "2999-01-02T00:00:00.000000Z",
+          "test_payroll/Fiscal_Year=2022/Leave_Status_as_of_June_30=ON%20LEAVE/Pay_Basis=per%20Annum/4e0ea65c5a074c0592e43f7b950f3ce8-0.parquet": "2999-01-01T00:00:00.000000Z",
+          "test_payroll/Fiscal_Year=2022/Leave_Status_as_of_June_30=ACTIVE/Pay_Basis=per%20Annum/4e0ea65c5a074c0592e43f7b950f3ce8-0.parquet": "2999-01-01T00:00:00.000000Z"
         }
       },
-      "stream_descriptor": { "name": "airbyte-source-azure-blob-storage-test" }
+      "stream_descriptor": {
+        "name": "airbyte-source-azure-blob-storage-test"
+      }
     }
   }
 ]


### PR DESCRIPTION
## What
Fix the state format of the `parquet` stream due to the error in the nightly tests after the latest incremental tests update that added cursor type validation.

## User Impact
No user impact

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
