### PR TITLE
bug(registry): coerse null strings

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.1.3"
+version = "0.1.4"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
## What
The metrics data from metabase writes 

This causes the platform to also ingest a null string

## How
The raw Metrics is outside our immediate control.

So I simply updated the decoder to coerce `"null"` to `null` 

