### PR TITLE
airbyte-ci: fix IncrementalAcceptanceTests behavior: skip them when AcceptanceTests succeed

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -792,6 +792,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.18.2  | [#39483](https://github.com/airbytehq/airbyte/pull/39483)      | Skip IncrementalAcceptanceTests when AcceptanceTests succeed.   |
 | 4.18.1  | [#39457](https://github.com/airbytehq/airbyte/pull/39457)      | Make slugify consistent with live-test   |
 | 4.18.0  | [#39366](https://github.com/airbytehq/airbyte/pull/39366)      | Implement IncrementalAcceptance tests to only fail CI on community connectors when there's an Acceptance tests regression.   |
 | 4.17.0  | [#39321](https://github.com/airbytehq/airbyte/pull/39321)  | Bust the java connector build cache flow to get fresh yum packages on a daily basis.                                         |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -351,7 +351,7 @@ class AcceptanceTests(Step):
             stdout=stdout,
             output={"report_log": report_log_artifact},
             artifacts=[report_log_artifact],
-            consider_in_overall_status=is_hard_failure,
+            consider_in_overall_status=status is StepStatus.SUCCESS or is_hard_failure,
         )
 
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.18.1"
+version = "4.18.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
When AcceptanceTests succeed we don't want to run IncrementalAcceptanceTests.

