### PR TITLE
chore(source-monday): fix abnormal state for `items` stream

### DIFF
--- a/airbyte-integrations/connectors/source-monday/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-monday/integration_tests/abnormal_state.json
@@ -6,7 +6,7 @@
         "name": "items"
       },
       "stream_state": {
-        "updated_at": 1699041749,
+        "updated_at_int": 1699041749,
         "activity_logs": {
           "created_at_int": 1699041749
         }


### PR DESCRIPTION
## What
Fix the cursor field name in an abnormal state due to an error in the nightly tests. The cursor field in the abnormal state has been fixed from `updated_at` to `updated_at_int` for the `items` stream.


## User Impact
No user impact.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
