### PR TITLE
Add FirstRecordSchemaLoader to Airbyte CDK

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/__init__.py
@@ -6,5 +6,6 @@ from airbyte_cdk.sources.declarative.schema.default_schema_loader import Default
 from airbyte_cdk.sources.declarative.schema.inline_schema_loader import InlineSchemaLoader
 from airbyte_cdk.sources.declarative.schema.json_file_schema_loader import JsonFileSchemaLoader
 from airbyte_cdk.sources.declarative.schema.schema_loader import SchemaLoader
+from airbyte_cdk.sources.declarative.schema.first_record_schema_loader import FirstRecordSchemaLoader
 
-__all__ = ["JsonFileSchemaLoader", "DefaultSchemaLoader", "SchemaLoader", "InlineSchemaLoader"]
+__all__ = ["JsonFileSchemaLoader", "DefaultSchemaLoader", "SchemaLoader", "InlineSchemaLoader", "FirstRecordSchemaLoader"]

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/first_record_schema_loader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/first_record_schema_loader.py
@@ -46,7 +46,7 @@ def is_date(string: str) -> bool:
         return False
 
 
-def map_value_to_schema_dtype(value: Any) -> Dict[str, Union[Dict[str, Any], str, List]]:
+def map_value_to_schema_dtype(value: Any) -> Dict[str, Union[Dict[str, Any], str, List[Any]]]:
     if isinstance(value, bool):
         return {"type": ["boolean", "null"]}
     elif isinstance(value, int) or isinstance(value, float):
@@ -64,14 +64,16 @@ def map_value_to_schema_dtype(value: Any) -> Dict[str, Union[Dict[str, Any], str
     elif isinstance(value, str):
         return {"type": ["string", "null"]}
     elif isinstance(value, dict):
-        nested_schema = {"properties": {}, "type": ["object", "null"]}
+        nested_schema: Dict[str, Union[Dict[str, Any], str, List[Any]]] = {"properties": {}, "type": ["object", "null"]}
         for k, v in value.items():
             nested_schema["properties"][k] = map_value_to_schema_dtype(v)
         return nested_schema
+    else:
+        raise TypeError(f"Unsupported value type: {type(value)}")
 
 
 def convert_record_to_schema(record: Dict[str, Any]) -> Dict[str, Any]:
-    generated_schema = {
+    generated_schema: Dict[str, Any] = {
         "$schema": "http://json-schema.org/schema#",
         "additionalProperties": True,
         "properties": {},

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/first_record_schema_loader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/first_record_schema_loader.py
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+from dataclasses import InitVar, dataclass
+from typing import Any, Mapping, Union, Dict, List
+import dateutil.parser
+
+from airbyte_cdk.sources.declarative.schema.schema_loader import SchemaLoader
+from airbyte_cdk.sources.declarative.retrievers.retriever import Retriever
+
+
+def is_valid_date_or_datetime_or_time(string: str) -> bool:
+    try:
+        dateutil.parser.parse(string)
+        return True
+    except ValueError:
+        return False
+
+
+def is_datetime(string: str) -> bool:
+    try:
+        dt = dateutil.parser.parse(string)
+        dt.time()
+        dt.date()
+        return True
+    except ValueError:
+        return False
+
+
+def is_time(string: str) -> bool:
+    try:
+        dt = dateutil.parser.parse(string)
+        dt.time()
+        return True
+    except ValueError:
+        return False
+
+
+def is_date(string: str) -> bool:
+    try:
+        dt = dateutil.parser.parse(string)
+        dt.date()
+        return True
+    except ValueError:
+        return False
+
+
+def map_value_to_schema_dtype(value: Any) -> Dict[str, Union[Dict[str, Any], str, List]]:
+    if isinstance(value, bool):
+        return {"type": ["boolean", "null"]}
+    elif isinstance(value, int) or isinstance(value, float):
+        return {"type": ["number", "null"]}
+    elif isinstance(value, list):
+        return {"type": ["array", "null"]}
+    elif isinstance(value, str) and is_valid_date_or_datetime_or_time(value):
+        if is_datetime(value):
+            return {"type": ["string", "null"], "format": "date-time"}
+        if is_date(value):
+            return {"type": ["string", "null"], "format": "date"}
+        if is_time(value):
+            return {"type": ["string", "null"], "format": "time"}
+        return {"type": ["string", "null"]}
+    elif isinstance(value, str):
+        return {"type": ["string", "null"]}
+    elif isinstance(value, dict):
+        nested_schema = {"properties": {}, "type": ["object", "null"]}
+        for k, v in value.items():
+            nested_schema["properties"][k] = map_value_to_schema_dtype(v)
+        return nested_schema
+
+
+def convert_record_to_schema(record: Dict[str, Any]) -> Dict[str, Any]:
+    generated_schema = {
+        "$schema": "http://json-schema.org/schema#",
+        "additionalProperties": True,
+        "properties": {},
+        "type": "object"
+    }
+    for key, value in record.items():
+        generated_schema["properties"][key] = map_value_to_schema_dtype(value)
+    return generated_schema
+
+
+@dataclass
+class FirstRecordSchemaLoader(SchemaLoader):
+    """Uses the first record to build a schema dynamically"""
+
+    retriever: Retriever
+    parameters: InitVar[Mapping[str, Any]]
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        first_record = next(self.retriever.read_records(record_schema={}))
+        generated_schema = convert_record_to_schema(first_record)
+        return generated_schema

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/first_record_schema_loader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/first_record_schema_loader.py
@@ -90,6 +90,6 @@ class FirstRecordSchemaLoader(SchemaLoader):
     parameters: InitVar[Mapping[str, Any]]
 
     def get_json_schema(self) -> Mapping[str, Any]:
-        first_record = next(self.retriever.read_records(record_schema={}))
-        generated_schema = convert_record_to_schema(first_record)
+        first_record = next(iter(self.retriever.read_records(records_schema={})))
+        generated_schema = convert_record_to_schema(dict(first_record))
         return generated_schema

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/first_record_schema_loader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/first_record_schema_loader.py
@@ -64,7 +64,7 @@ def map_value_to_schema_dtype(value: Any) -> Dict[str, Union[Dict[str, Any], str
     elif isinstance(value, str):
         return {"type": ["string", "null"]}
     elif isinstance(value, dict):
-        nested_schema: Dict[str, Union[Dict[str, Any], str, List[Any]]] = {"properties": {}, "type": ["object", "null"]}
+        nested_schema: Dict[str, Any] = {"properties": {}, "type": ["object", "null"]}
         for k, v in value.items():
             nested_schema["properties"][k] = map_value_to_schema_dtype(v)
         return nested_schema

--- a/airbyte-cdk/python/unit_tests/sources/declarative/schema/test_first_record_schema_loader.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/schema/test_first_record_schema_loader.py
@@ -1,0 +1,15 @@
+from unittest.mock import MagicMock
+from airbyte_cdk.sources.declarative.schema import FirstRecordSchemaLoader
+
+FIRST_RECORD = {'id': 'abcd1234', 'label': 'user-viewer-role', 'description': 'user-viewer-role', 'created': '2023-06-28T17:39:34.000Z', 'lastUpdated': '2023-06-28T17:39:34.000Z', '_links': {'permissions': {'href': 'https://abcd-admin.okta.com/api/v1/iam/roles/role12345/permissions'}, 'self': {'href': 'https://abcd-admin.okta.com/api/v1/iam/roles/role12345'}}}
+EXPECTED_SCHEMA = {'$schema': 'http://json-schema.org/schema#', 'additionalProperties': True, 'properties': {'id': {'type': ['string', 'null']}, 'label': {'type': ['string', 'null']}, 'description': {'type': ['string', 'null']}, 'created': {'type': ['string', 'null'], 'format': 'date-time'}, 'lastUpdated': {'type': ['string', 'null'], 'format': 'date-time'}, '_links': {'properties': {'permissions': {'properties': {'href': {'type': ['string', 'null']}}, 'type': ['object', 'null']}, 'self': {'properties': {'href': {'type': ['string', 'null']}}, 'type': ['object', 'null']}}, 'type': ['object', 'null']}}, 'type': 'object'}
+
+def test_first_record_schema_loader():
+    iterator = MagicMock()
+    iterator.__next__.return_value = FIRST_RECORD
+
+    retriever = MagicMock()
+    retriever.read_records.return_value = iterator
+
+    first_record_schema_loader = FirstRecordSchemaLoader(retriever=retriever)
+    assert first_record_schema_loader.get_json_schema() == EXPECTED_SCHEMA


### PR DESCRIPTION
## What
Adds a new schema loader to Airbyte CDK (`FirstRecordSchemaLoader`) that is useful when the schema is not predefined and needs to be dynamically generated based on the first record in the response.

## How
Adds a new schema loader in the declarative folder

## User Impact
No breaking changes.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
