### PR TITLE
Allow access to _partition for source-jira

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -14,6 +14,19 @@ from jinja2.exceptions import UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 
 
+class StreamPartitionAccessEnvironment(SandboxedEnvironment):
+    """
+    Currently, source-jira is setting an attribute to StreamSlice specific to its use case which because of the PerPartitionCursor is set to
+    StreamSlice._partition but not exposed through StreamSlice.partition. This is a patch to still allow source-jira to have access to this
+    parameter
+    """
+
+    def is_safe_attribute(self, obj: Any, attr: str, value: Any) -> bool:
+        if attr in ["_partition"]:
+            return True
+        return super().is_safe_attribute(obj, attr, value)
+
+
 class JinjaInterpolation(Interpolation):
     """
     Interpolation strategy using the Jinja2 template engine.
@@ -49,7 +62,7 @@ class JinjaInterpolation(Interpolation):
     RESTRICTED_BUILTIN_FUNCTIONS = ["range"]  # The range function can cause very expensive computations
 
     def __init__(self) -> None:
-        self._environment = SandboxedEnvironment()
+        self._environment = StreamPartitionAccessEnvironment()
         self._environment.filters.update(**filters)
         self._environment.globals.update(**macros)
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -24,7 +24,7 @@ class StreamPartitionAccessEnvironment(SandboxedEnvironment):
     def is_safe_attribute(self, obj: Any, attr: str, value: Any) -> bool:
         if attr in ["_partition"]:
             return True
-        return super().is_safe_attribute(obj, attr, value)
+        return super().is_safe_attribute(obj, attr, value)  # type: ignore  # for some reason, mypy says 'Returning Any from function declared to return "bool"'
 
 
 class JinjaInterpolation(Interpolation):

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
@@ -5,6 +5,7 @@
 import datetime
 
 import pytest
+from airbyte_cdk import StreamSlice
 from airbyte_cdk.sources.declarative.interpolation.jinja import JinjaInterpolation
 from freezegun import freeze_time
 from jinja2.exceptions import TemplateSyntaxError
@@ -261,3 +262,15 @@ def test_macros_examples(template_string, expected_value):
     # If you change the expected output, you must also change the expected output in declarative_component_schema.yaml
     now_utc = interpolation.eval(template_string, {})
     assert now_utc == expected_value
+
+
+def test_interpolation_private_partition_attribute():
+    inner_partition = StreamSlice(partition={}, cursor_slice={})
+    expected_output = "value"
+    setattr(inner_partition, "parent_stream_fields", expected_output)
+    stream_slice = StreamSlice(partition=inner_partition, cursor_slice={})
+    template = "{{ stream_slice._partition.parent_stream_fields }}"
+
+    actual_output = JinjaInterpolation().eval(template, {}, **{"stream_slice": stream_slice})
+
+    assert actual_output == expected_output


### PR DESCRIPTION
## What
source-jira use internal attributes `_partition` but since [this change](https://github.com/airbytehq/airbyte/commit/5c9115b0b7205df58aa275ff823989c723f94b9f), internal attributes are not available anymore. In order to patch that, we will make this attribute available through the interpolation. Note that it's not just `StreamSlice._partition` that will be available but any `x._partition`

## How
Re-implementing SandboxedEnvironment

## User Impact
We will maintain backward compatibility for source-jira at least

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
