### PR TITLE
Exclude airbyte-cdk modules from schema discovery

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/json_file_schema_loader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/json_file_schema_loader.py
@@ -18,7 +18,7 @@ def _default_file_path() -> str:
     # Schema files are always in "source_<connector_name>/schemas/<stream_name>.json
     # The connector's module name can be inferred by looking at the modules loaded and look for the one starting with source_
     source_modules = [
-        k for k, v in sys.modules.items() if "source_" in k
+        k for k, v in sys.modules.items() if "source_" in k and "airbyte_cdk" not in k
     ]  # example: ['source_exchange_rates', 'source_exchange_rates.source']
     if source_modules:
         module = source_modules[0].split(".")[0]

--- a/airbyte-cdk/python/unit_tests/sources/declarative/schema/test_json_file_schema_loader.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/schema/test_json_file_schema_loader.py
@@ -1,9 +1,10 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
+from unittest.mock import patch
 
 import pytest
-from airbyte_cdk.sources.declarative.schema import JsonFileSchemaLoader
+from airbyte_cdk.sources.declarative.schema.json_file_schema_loader import JsonFileSchemaLoader, _default_file_path
 
 
 @pytest.mark.parametrize(
@@ -24,3 +25,13 @@ def test_extract_resource_and_schema_path(test_name, input_path, expected_resour
 
     assert actual_resource == expected_resource
     assert actual_path == expected_path
+
+
+@patch("airbyte_cdk.sources.declarative.schema.json_file_schema_loader.sys")
+def test_exclude_cdk_packages(mocked_sys):
+    keys = ["airbyte_cdk.sources.concurrent_source.concurrent_source_adapter", "source_gitlab.utils"]
+    mocked_sys.modules = {key: "" for key in keys}
+
+    default_file_path = _default_file_path()
+
+    assert "source_gitlab" in default_file_path


### PR DESCRIPTION
## What
With the addition of package `airbyte_cdk.sources.concurrent_source.concurrent_source_adapter`, it is often not possible to load schemas from files

## How
Exclude airbyte_cdk module from package discovery


## User Impact
Will fix schema loading. I'm not sure what has changed because the file was introduced on version 0.55.0 but I got the issue in source-gitlab by upgrading from version "0.80.0" to version = "1.5.3". Hence the issue was probably introduced [here](https://github.com/airbytehq/airbyte/commit/0ceb76920ac7eaa15a0d8c27957d33e4701a16de#diff-47714054f8c46d0ecfa2a50b9d4b823d473a3dca5b835f61690fa6d56c617185R18-R19) during the major bump version.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
