### PR TITLE
Increase Timeout Limit for Connectors Version Increment Check

### DIFF
--- a/.github/workflows/connectors_version_increment_check.yml
+++ b/.github/workflows/connectors_version_increment_check.yml
@@ -23,7 +23,7 @@ jobs:
     name: Connectors Version Increment Check
     runs-on: connector-test-large
     if: github.event.pull_request.head.repo.fork != true
-    timeout-minutes: 10
+    timeout-minutes: 12
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v4


### PR DESCRIPTION
## What
The `Connectors Version Increment Check` Github workflow has a habit of intermittently failing due to hitting the job's 10 minute timeout limit, despite the actual version check passing successfully. This leads to a slightly confusing scenario where the report shows a ✅ and no errors, but the job itself fails:

```
The job running on runner connector-test-large_1ef8ca9dac40 has exceeded the maximum execution time of 10 minutes.
```

This can block PRs that are otherwise good to merge, and sometimes requires multiple retries to succeed. 

The longest reported job I have personally seen reporting a failure was [11 minutes and 7 seconds](https://github.com/airbytehq/airbyte/actions/runs/9604398110), so I naively set the timeout to 12 minutes in the hopes that it will solve the issue in the short term until we can determine the feasibility of slimming the time taken to complete this workflow.

[Issue to track this](https://github.com/airbytehq/airbyte-internal-issues/issues/8419)

## User Impact
Hopefully no more failing jobs when the actual check is ✅

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
