### PR TITLE
bug(docs): Fix icon width on safari

### DIFF
--- a/docusaurus/src/components/HeaderDecoration.module.css
+++ b/docusaurus/src/components/HeaderDecoration.module.css
@@ -82,5 +82,5 @@ div.connectorMetadataCallout  {
 
 .metricIcon svg {
   height: 12px;
-  width: fit-content;
+  width: auto;
 }


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Safari hates `width: fit-content`

chrome:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/PTsI7qAmiIMkhFQg04QF/17a32864-21db-44bd-8e84-53fad49d1938.png)


safari:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/PTsI7qAmiIMkhFQg04QF/dfda4dfb-0071-47ba-ac42-2ed01c39d8b1.png)


## How
use `width:auto` instead
## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
