### PR TITLE
Issue 7990: postgres destination throws config error when drop fails due to dependency and cascadeDrop=false

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 2.0.12
+  dockerImageTag: 2.0.13
   dockerRepository: airbyte/destination-postgres
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresDestinationHandler.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresDestinationHandler.kt
@@ -6,9 +6,11 @@ package io.airbyte.integrations.destination.postgres.typing_deduping
 import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.cdk.db.jdbc.JdbcDatabase
 import io.airbyte.cdk.integrations.destination.jdbc.typing_deduping.JdbcDestinationHandler
+import io.airbyte.commons.exceptions.ConfigErrorException
 import io.airbyte.integrations.base.destination.typing_deduping.AirbyteProtocolType
 import io.airbyte.integrations.base.destination.typing_deduping.AirbyteType
 import io.airbyte.integrations.base.destination.typing_deduping.Array
+import io.airbyte.integrations.base.destination.typing_deduping.Sql
 import io.airbyte.integrations.base.destination.typing_deduping.Struct
 import io.airbyte.integrations.base.destination.typing_deduping.Union
 import io.airbyte.integrations.base.destination.typing_deduping.UnsupportedOneOf
@@ -63,6 +65,25 @@ class PostgresDestinationHandler(
             AirbyteProtocolType.TIME_WITHOUT_TIMEZONE -> "time"
             AirbyteProtocolType.DATE -> "date"
             AirbyteProtocolType.UNKNOWN -> "jsonb"
+        }
+    }
+
+    override fun execute(sql: Sql) {
+        try {
+            super.execute(sql)
+        } catch (e: Exception) {
+            // executing the
+            // DROP TABLE command.
+            if (
+                e.message!!.contains("ERROR: cannot drop table") &&
+                    e.message!!.contains("because other objects depend on it")
+            ) {
+                throw ConfigErrorException(
+                    "Failed to drop table without the CASCADE option. Consider changing the drop_cascade configuration parameter",
+                    e
+                )
+            }
+            throw e
         }
     }
 }

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresSqlGeneratorIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresSqlGeneratorIntegrationTest.java
@@ -134,8 +134,8 @@ public class PostgresSqlGeneratorIntegrationTest extends JdbcSqlGeneratorIntegra
   }
 
   /**
-   * Verify that * when cascadeDrop is disabled * an error caused by dropping a table with
-   * dependencies * results in a configuration error with the correct message
+   * Verify that when cascadeDrop is disabled, an error caused by dropping a table with
+   * dependencies results in a configuration error with the correct message.
    */
   @Test
   public void testCascadeDropDisabled() throws Exception {

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresSqlGeneratorIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresSqlGeneratorIntegrationTest.java
@@ -134,8 +134,8 @@ public class PostgresSqlGeneratorIntegrationTest extends JdbcSqlGeneratorIntegra
   }
 
   /**
-   * Verify that when cascadeDrop is disabled, an error caused by dropping a table with
-   * dependencies results in a configuration error with the correct message.
+   * Verify that when cascadeDrop is disabled, an error caused by dropping a table with dependencies
+   * results in a configuration error with the correct message.
    */
   @Test
   public void testCascadeDropDisabled() throws Exception {

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -267,6 +267,7 @@ _where_ it is deployed.
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                  |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------|
+| 2.0.13  | 2024-06-13 | [\#40159](https://github.com/airbytehq/airbyte/pull/40159) | Config error on drop failure when cascade is disabled                                                    |
 | 2.0.12  | 2024-06-12 | [\#39388](https://github.com/airbytehq/airbyte/pull/39388) | Sources auto-conversion to Kotlin                                                                        |
 | 2.0.11  | 2024-06-10 | [\#39372](https://github.com/airbytehq/airbyte/pull/39372) | Fixed function already exists error                                                                      |
 | 2.0.10  | 2024-05-07 | [\#37660](https://github.com/airbytehq/airbyte/pull/37660) | Adopt CDK 0.33.2                                                                                         |


### PR DESCRIPTION
## What

Resolves [this issue](https://app.zenhub.com/workspaces/destinations-6332532d6893ce001c7a56a7/issues/gh/airbytehq/airbyte-internal-issues/7990): when a Postgres table cannot be dropped due to a client-created dependency, and the client has not enabled "cascadeDrop=true", the failure should be surfaced as a configuration error.

## How
The postgres destination handler overrides the execute method and wraps the superclass behavior in a try/catch that detects the specific failure and rethrows it as a configuration error.

Note that this could become problematic if error handling is also implemented in the parent. (However, it shouldn't be, since JDBC is a connection protocol, and errors are database-specific.)

The test case fails on master with

@
<img width="1384" alt="Screenshot 2024-06-21 at 9 51 35 AM" src="https://github.com/airbytehq/airbyte/assets/173103728/4bd0080d-64b6-4f64-8b52-7aa75cade0e8">


## User Impact
The user will know that the error is the result of their configuration or downstream usage and take the appropriate action (either remove the dependency or enable cascadeDrop=true).

## Can this PR be safely reverted and rolled back?

- [ ] YES 💚
- [ X] I think so. (I'm new :) )
- [ ] NO ❌
