### PR TITLE
Increment the postgres-strict metadata version to match unstrict

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 2.0.12
+  dockerImageTag: 2.0.13
   dockerRepository: airbyte/destination-postgres-strict-encrypt
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres


### PR DESCRIPTION
Follow-up to the fix for [this](https://github.com/airbytehq/airbyte-internal-issues/issues/7990). I did not know to also bump the metadata.yaml for Postgres-strict.
