### PR TITLE
connectors-insights: retrieve python cdk version whatever the cdk metadata

### DIFF
--- a/airbyte-ci/connectors/connectors_insights/README.md
+++ b/airbyte-ci/connectors/connectors_insights/README.md
@@ -56,5 +56,8 @@ This CLI is currently running nightly in GitHub Actions. The workflow can be fou
 
 ## Changelog
 
+### 0.1.1
+- Fix missing CDK version on some connectors
+
 ### 0.1.0
 - Initial release

--- a/airbyte-ci/connectors/connectors_insights/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_insights/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-insights"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/insights.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/insights.py
@@ -65,8 +65,7 @@ def get_sbom_inferred_insights(raw_sbom: str | None, connector: Connector) -> Di
         dependency = {"type": artifact["type"], "version": artifact["version"], "package_name": artifact["name"]}
         if isinstance(sbom_inferred_insights["dependencies"], list) and dependency not in sbom_inferred_insights["dependencies"]:
             sbom_inferred_insights["dependencies"].append(dependency)
-    if connector.cdk_name == "python" or connector.cdk_name == "low-code":
-        sbom_inferred_insights["cdk_version"] = python_artifacts.get("airbyte-cdk", {}).get("version")
+    sbom_inferred_insights["cdk_version"] = python_artifacts.get("airbyte-cdk", {}).get("version")
     return sbom_inferred_insights
 
 


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/8409

The CDK version was missing on some connectors because I conditioned the retrieval of the CDK version on the `cdk_name` metadata. Because of missing metadata field the cdk version was not declare, but it's pointless.


