### PR TITLE
✨ Source Google Analytics (Universal Analytics): disable connectors

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/main.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/main.py
@@ -24,4 +24,3 @@ if __name__ == "__main__":
             internal_message=error_message,
             failure_type=FailureType.config_error,
         )
-

--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/main.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/main.py
@@ -2,12 +2,18 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-
-import sys
-
-from airbyte_cdk.entrypoint import launch
-from source_google_analytics_v4_service_account_only import SourceGoogleAnalyticsV4ServiceAccountOnly
+from airbyte_cdk.exception_handler import init_uncaught_exception_handler
+from airbyte_cdk.logger import init_logger
+from airbyte_cdk.models import FailureType
+from airbyte_cdk.utils import AirbyteTracedException
 
 if __name__ == "__main__":
-    source = SourceGoogleAnalyticsV4ServiceAccountOnly()
-    launch(source, sys.argv[1:])
+    logger = init_logger("airbyte")
+    init_uncaught_exception_handler(logger)
+
+    error_message = "Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google’s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data."
+    raise AirbyteTracedException(
+        message=error_message,
+        internal_message=error_message,
+        failure_type=FailureType.config_error,
+    )

--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/main.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/main.py
@@ -2,18 +2,26 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import sys
+
+from airbyte_cdk.entrypoint import AirbyteEntrypoint
 from airbyte_cdk.exception_handler import init_uncaught_exception_handler
 from airbyte_cdk.logger import init_logger
-from airbyte_cdk.models import FailureType
+from airbyte_cdk.models import AirbyteMessage, ConnectorSpecification, FailureType, Type
 from airbyte_cdk.utils import AirbyteTracedException
 
 if __name__ == "__main__":
     logger = init_logger("airbyte")
     init_uncaught_exception_handler(logger)
 
-    error_message = "Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google’s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data."
-    raise AirbyteTracedException(
-        message=error_message,
-        internal_message=error_message,
-        failure_type=FailureType.config_error,
-    )
+    if AirbyteEntrypoint.parse_args(sys.argv[1:]).command == "spec":
+        message = AirbyteMessage(type=Type.SPEC, spec=ConnectorSpecification.parse_obj({"connectionSpecification": {}}))
+        print(message.json(exclude_unset=True))
+    else:
+        error_message = "Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google’s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data."
+        raise AirbyteTracedException(
+            message=error_message,
+            internal_message=error_message,
+            failure_type=FailureType.config_error,
+        )
+

--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
@@ -26,7 +26,7 @@ data:
     oss:
       enabled: false
   releaseStage: generally_available
-  supportLevel: community
+  supportLevel: archived
   tags:
     - language:python
     - cdk:python

--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9e28a926-8f3c-4911-982d-a2e1c378b59c
-  dockerImageTag: 0.0.2
+  dockerImageTag: 0.1.0
   dockerRepository: airbyte/source-google-analytics-v4-service-account-only
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-v4-service-account-only
   githubIssueLabel: source-google-analytics-v4-service-account-only

--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
@@ -22,9 +22,9 @@ data:
   name: Google Analytics (Universal Analytics)
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
-      enabled: true
+      enabled: false
   releaseStage: generally_available
   supportLevel: community
   tags:

--- a/airbyte-integrations/connectors/source-google-analytics-v4/main.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/main.py
@@ -2,18 +2,25 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import sys
+
+from airbyte_cdk.entrypoint import AirbyteEntrypoint
 from airbyte_cdk.exception_handler import init_uncaught_exception_handler
 from airbyte_cdk.logger import init_logger
-from airbyte_cdk.models import FailureType
+from airbyte_cdk.models import AirbyteMessage, ConnectorSpecification, FailureType, Type
 from airbyte_cdk.utils import AirbyteTracedException
 
 if __name__ == "__main__":
     logger = init_logger("airbyte")
     init_uncaught_exception_handler(logger)
 
-    error_message = "Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google’s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data."
-    raise AirbyteTracedException(
-        message=error_message,
-        internal_message=error_message,
-        failure_type=FailureType.config_error,
-    )
+    if AirbyteEntrypoint.parse_args(sys.argv[1:]).command == "spec":
+        message = AirbyteMessage(type=Type.SPEC, spec=ConnectorSpecification.parse_obj({"connectionSpecification": {}}))
+        print(message.json(exclude_unset=True))
+    else:
+        error_message = "Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google’s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data."
+        raise AirbyteTracedException(
+            message=error_message,
+            internal_message=error_message,
+            failure_type=FailureType.config_error,
+        )

--- a/airbyte-integrations/connectors/source-google-analytics-v4/main.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/main.py
@@ -2,7 +2,18 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from source_google_analytics_v4.run import run
+from airbyte_cdk.exception_handler import init_uncaught_exception_handler
+from airbyte_cdk.logger import init_logger
+from airbyte_cdk.models import FailureType
+from airbyte_cdk.utils import AirbyteTracedException
 
 if __name__ == "__main__":
-    run()
+    logger = init_logger("airbyte")
+    init_uncaught_exception_handler(logger)
+
+    error_message = "Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google’s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data."
+    raise AirbyteTracedException(
+        message=error_message,
+        internal_message=error_message,
+        failure_type=FailureType.config_error,
+    )

--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -29,7 +29,7 @@ data:
     cloud:
       enabled: false
     oss:
-      enabled: true
+      enabled: false
   releaseStage: generally_available
   supportLevel: certified
   tags:

--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -31,7 +31,7 @@ data:
     oss:
       enabled: false
   releaseStage: generally_available
-  supportLevel: community
+  supportLevel: archived
   tags:
     - language:python
     - cdk:python

--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: eff3616a-f9c3-11eb-9a03-0242ac130003
-  dockerImageTag: 0.3.3
+  dockerImageTag: 0.4.0
   dockerRepository: airbyte/source-google-analytics-v4
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-v4
   githubIssueLabel: source-google-analytics-v4

--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -31,7 +31,7 @@ data:
     oss:
       enabled: false
   releaseStage: generally_available
-  supportLevel: certified
+  supportLevel: community
   tags:
     - language:python
     - cdk:python

--- a/airbyte-integrations/connectors/source-google-analytics-v4/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.3.3"
+version = "0.4.0"
 name = "source-google-analytics-v4"
 description = "Source implementation for Google Analytics V4."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/google-analytics-v4-service-account-only.md
+++ b/docs/integrations/sources/google-analytics-v4-service-account-only.md
@@ -8,6 +8,12 @@ This connector supports Universal Analytics properties through the [Reporting AP
 
 </HideInUI>
 
+:::danger
+
+Google Analytics (Universal Analytics) will deprecate its API on July 1. At that point, this connector will stop working. For more information, please see https://support.google.com/analytics/answer/11583528.
+
+:::
+
 :::caution
 
 **The Google Analytics (Universal Analytics) connector will be deprecated soon.**

--- a/docs/integrations/sources/google-analytics-v4-service-account-only.md
+++ b/docs/integrations/sources/google-analytics-v4-service-account-only.md
@@ -10,7 +10,7 @@ This connector supports Universal Analytics properties through the [Reporting AP
 
 :::danger
 
-Google Analytics (Universal Analytics) will deprecate its API on July 1. At that point, this connector will stop working. For more information, please see https://support.google.com/analytics/answer/11583528.
+Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google's Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data.
 
 :::
 

--- a/docs/integrations/sources/google-analytics-v4-service-account-only.md
+++ b/docs/integrations/sources/google-analytics-v4-service-account-only.md
@@ -267,7 +267,8 @@ The Google Analytics connector should not run into the "requests per 100 seconds
   <summary>Expand to review</summary>
 
 | Version | Date       | Pull Request                                             | Subject                                  |
-| :------ | :--------- | :------------------------------------------------------- | :--------------------------------------- |
+|:--------|:-----------| :------------------------------------------------------- |:-----------------------------------------|
+| 0.1.0   | 2024-07-01 | [40244](https://github.com/airbytehq/airbyte/pull/40244) | Deprecate the connector                  |
 | 0.0.2   | 2024-04-19 | [37432](https://github.com/airbytehq/airbyte/pull/36267) | Fix empty response error for test stream |
 | 0.0.1   | 2024-01-29 | [34323](https://github.com/airbytehq/airbyte/pull/34323) | Initial Release                          |
 

--- a/docs/integrations/sources/google-analytics-v4.md
+++ b/docs/integrations/sources/google-analytics-v4.md
@@ -8,6 +8,12 @@ This connector supports Universal Analytics properties through the [Reporting AP
 
 </HideInUI>
 
+:::danger
+
+Google Analytics (Universal Analytics) will deprecate its API on July 1. At that point, this connector will stop working. For more information, please see https://support.google.com/analytics/answer/11583528.
+
+:::
+
 :::caution
 
 **The Google Analytics (Universal Analytics) connector will be deprecated soon.**

--- a/docs/integrations/sources/google-analytics-v4.md
+++ b/docs/integrations/sources/google-analytics-v4.md
@@ -10,7 +10,7 @@ This connector supports Universal Analytics properties through the [Reporting AP
 
 :::danger
 
-Google Analytics (Universal Analytics) will deprecate its API on July 1. At that point, this connector will stop working. For more information, please see https://support.google.com/analytics/answer/11583528.
+Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google's Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data.
 
 :::
 

--- a/docs/integrations/sources/google-analytics-v4.md
+++ b/docs/integrations/sources/google-analytics-v4.md
@@ -269,9 +269,10 @@ The Google Analytics connector should not run into the "requests per 100 seconds
   <summary>Expand to review</summary>
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
-| :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------- |
-| 0.3.3 | 2024-06-21 | [39940](https://github.com/airbytehq/airbyte/pull/39940) | Update dependencies |
-| 0.3.2 | 2024-06-04 | [38934](https://github.com/airbytehq/airbyte/pull/38934) | [autopull] Upgrade base image to v1.2.1 |
+|:--------| :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------- |
+| 0.4.0   | 2024-07-01 | [40244](https://github.com/airbytehq/airbyte/pull/40244) | Deprecate the connector                  |
+| 0.3.3   | 2024-06-21 | [39940](https://github.com/airbytehq/airbyte/pull/39940) | Update dependencies |
+| 0.3.2   | 2024-06-04 | [38934](https://github.com/airbytehq/airbyte/pull/38934) | [autopull] Upgrade base image to v1.2.1 |
 | 0.3.1   | 2024-04-19 | [37432](https://github.com/airbytehq/airbyte/pull/36267) | Fix empty response error for test stream                                                     |
 | 0.3.0   | 2024-03-19 | [36267](https://github.com/airbytehq/airbyte/pull/36267) | Pin airbyte-cdk version to `^0`                                                              |
 | 0.2.5   | 2024-02-09 | [35101](https://github.com/airbytehq/airbyte/pull/35101) | Manage dependencies with Poetry.                                                             |


### PR DESCRIPTION
## What
The API will be deprecated on July 1st. We need to:
* Deprecate the connector
* Prevent the connector from sending alerts

## How
* Setting the registries.x.enabled to false
* Have the main.py just break with a config error
    * Note that I did not remove the code which could be confusing for future dev. We can do that if we see value in it. Else, I would wait for us to `rm -rf source-google-analytics-v4`

The outcome looks likes this:
```
(.venv) source-google-analytics-v4% python main.py spec
{"type": "SPEC", "spec": {"connectionSpecification": {}}}

(.venv) source-google-analytics-v4% python main.py check --config secrets/config.json
{"type": "LOG", "log": {"level": "FATAL", "message": "Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google\u2019s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data.\nTraceback (most recent call last):\n  File \"/Users/maxime/devel/code/airbyte/airbyte-integrations/connectors/source-google-analytics-v4/main.py\", line 22, in <module>\n    raise AirbyteTracedException(\nairbyte_cdk.utils.traced_exception.AirbyteTracedException: Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google\u2019s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data."}}
{"type": "TRACE", "trace": {"type": "ERROR", "emitted_at": 1719341396169.7432, "error": {"message": "Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google\u2019s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data.", "internal_message": "Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google\u2019s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data.", "stack_trace": "Traceback (most recent call last):\n  File \"/Users/maxime/devel/code/airbyte/airbyte-integrations/connectors/source-google-analytics-v4/main.py\", line 22, in <module>\n    raise AirbyteTracedException(\nairbyte_cdk.utils.traced_exception.AirbyteTracedException: Google Analytics Universal Analytics Source Connector will be deprecated due to the deprecation of the Google Analytics Universal Analytics API by Google. This deprecation is scheduled by Google on July 1, 2024 (see Google\u2019s Documentation for more details). Transition to the Google Analytics 4 (GA4) Source Connector by July 1, 2024, to continue accessing your analytics data.\n", "failure_type": "config_error", "stream_descriptor": null}}}
```

## User Impact
We intend to merge this late on Sunday. At that point:
* The users won't be able to configure new `Google Analytics (Universal Analytics)` sources
* Cloud users will be updated to the newest versions which will just raise the config error so no data will be synced
* OSS users will still be able to run the syncs but this will most likely raise system_errors

## Can this PR be safely reverted and rolled back?
- [X] YES 💚 (but we expect that the API Connectors oncall person will receive pager alerts)
- [ ] NO ❌
