### PR TITLE
Live tests: cache calls to `get_message_count_per_type`, which is called frequently

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -280,6 +280,10 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.17.5
+
+Performance improvements using caching.
+
 ### 0.17.4
 
 Fix control image when running tests in CI.

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.17.4"
+version = "0.17.5"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/models.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/models.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Iterator, MutableMapping
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -348,6 +349,7 @@ class ExecutionResult:
                 statuses[message.trace.stream_status.stream_descriptor.name].append(message.trace.stream_status)
         return statuses
 
+    @cache
     def get_message_count_per_type(self) -> dict[AirbyteMessageType, int]:
         message_count: dict[AirbyteMessageType, int] = defaultdict(int)
         for message in self.airbyte_messages:
@@ -439,6 +441,9 @@ class ExecutionResult:
             self.logger.error(f"Failed to update {self.connector_under_test.name} configuration on actor {self.actor_id}: {e}")
             self.logger.error(f"Response: {response.text}")
         self.logger.info(f"Updated configuration for {self.connector_under_test.name}, actor {self.actor_id}")
+
+    def __hash__(self):
+        return hash(self.connector_under_test.version)
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
I noticed a pretty major performance issue when I started running validation tests with regression tests.

A profile showed an unusual amount of time being spent in `ExecutionResult.get_message_count_per_type` and `Report.get_record_count_per_stream`. When called, these methods parse all Airbyte messages from the command execution output, so it can be time consuming. These were being called many times, from `Report.render`.

This information is cacheable because it's just a mapping of message type: int, so this PR caches it. With the cache, the time spent in `render` was reduced from ~73% of the total time to ~17% for my test runs.

There are some other performance improvements that we can look into but this is the lowest-hanging fruit. The others will require larger reorgs of the code and/or consideration of memory issues.

Snippet of the profile data before the refactor:
<img width="789" alt="image" src="https://github.com/airbytehq/airbyte/assets/5257313/9f627e35-309a-4054-8006-b6e81d21dba6">



After:

<img width="794" alt="image" src="https://github.com/airbytehq/airbyte/assets/5257313/ddbeaa6b-58f6-4e35-bf17-07e2bd4b1df9">
