### PR TITLE
Fail without enqueueing iff the airbyte message type is unrecognized

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -173,7 +173,8 @@ corresponds to that version.
 ### Java CDK
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                        |
-|:--------| :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:--------| :--------- | :--------------------------------------------------------- |:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.40.4  | 2024-06-18 | [\#40254](https://github.com/airbytehq/airbyte/pull/40254) | Destinations: Do not throw on unrecognized airbyte message type (ignore message instead)                                                                       |
 | 0.40.3  | 2024-06-18 | [\#39526](https://github.com/airbytehq/airbyte/pull/39526) | Destinations: INCOMPLETE stream status is a TRANSIENT error rather than SYSTEM                                                                                 |
 | 0.40.2  | 2024-06-18 | [\#39552](https://github.com/airbytehq/airbyte/pull/39552) | Destinations: Throw error if the ConfiguredCatalog has no streams                                                                                              |
 | 0.40.1  | 2024-06-14 | [\#39349](https://github.com/airbytehq/airbyte/pull/39349) | Source stats for full refresh streams                                                                                                                          |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumer.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumer.kt
@@ -103,15 +103,14 @@ constructor(
          * do it without touching buffer manager.
          */
         val partialAirbyteMessage =
-            airbyteMessageDeserializer.deserializeAirbyteMessage(
-                message,
-            )
-
-        // The message had an unrecognized type, presumably because
-        // upstream is head. Just skip it.
-        if (partialAirbyteMessage == null) {
-            return
-        }
+            try {
+                airbyteMessageDeserializer.deserializeAirbyteMessage(
+                    message,
+                )
+            } catch (e: AirbyteMessageDeserializer.UnrecognizedAirbyteMessageTypeException) {
+                logger.warn { "Ignoring unrecognized message type: ${e.message}" }
+                return
+            }
 
         when (partialAirbyteMessage.type) {
             AirbyteMessage.Type.RECORD -> {

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumer.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumer.kt
@@ -106,6 +106,13 @@ constructor(
             airbyteMessageDeserializer.deserializeAirbyteMessage(
                 message,
             )
+
+        // The message had an unrecognized type, presumably because
+        // upstream is head. Just skip it.
+        if (partialAirbyteMessage == null) {
+            return
+        }
+
         when (partialAirbyteMessage.type) {
             AirbyteMessage.Type.RECORD -> {
                 validateRecord(partialAirbyteMessage)

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/deser/AirbyteMessageDeserializer.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/deser/AirbyteMessageDeserializer.kt
@@ -8,7 +8,6 @@ import io.airbyte.cdk.integrations.destination.async.model.PartialAirbyteMessage
 import io.airbyte.commons.json.Jsons
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.github.oshai.kotlinlogging.KotlinLogging
-import java.util.*
 
 private val logger = KotlinLogging.logger {}
 
@@ -27,15 +26,15 @@ class AirbyteMessageDeserializer(
      * Message.
      *
      * Throws on deserialization errors, obfuscating the error message to avoid data leakage. In
-     * recoverable cases (currently only when the top-level message type is unrecognized), returns
-     * null, logging a warning.
+     * recoverable cases (currently only when the top-level message type is unrecognized), throws
+     * a dedicated exception.
      *
      * PartialAirbyteMessage holds either:
      * * entire serialized message string when message is a valid State Message
      * * serialized AirbyteRecordMessage when message is a valid Record Message
      *
      * @param message the string to deserialize
-     * @return PartialAirbyteMessage if the message is valid, null if there was a recoverable error
+     * @return PartialAirbyteMessage if the message is valid
      */
     fun deserializeAirbyteMessage(
         message: String?,
@@ -60,13 +59,13 @@ class AirbyteMessageDeserializer(
                     logger.warn { "Unrecognized message type: $unrecognized" }
                     throw UnrecognizedAirbyteMessageTypeException(unrecognized!!)
                 } else {
-                    val obfuscated = Jsons.obfuscate(e)
+                    val obfuscated = Jsons.obfuscateDeserializationException(e)
                     throw RuntimeException(
                         "ValueInstantiationException when deserializing PartialAirbyteMessage: $obfuscated"
                     )
                 }
             } catch (e: Exception) {
-                val obfuscated = Jsons.obfuscate(e)
+                val obfuscated = Jsons.obfuscateDeserializationException(e)
                 throw RuntimeException("Could not deserialize PartialAirbyteMessage: $obfuscated")
             }
 

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/deser/AirbyteMessageDeserializer.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/deser/AirbyteMessageDeserializer.kt
@@ -26,8 +26,8 @@ class AirbyteMessageDeserializer(
      * Message.
      *
      * Throws on deserialization errors, obfuscating the error message to avoid data leakage. In
-     * recoverable cases (currently only when the top-level message type is unrecognized), throws
-     * a dedicated exception.
+     * recoverable cases (currently only when the top-level message type is unrecognized), throws a
+     * dedicated exception.
      *
      * PartialAirbyteMessage holds either:
      * * entire serialized message string when message is a valid State Message

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.40.3
+version=0.40.4

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/base/AirbyteTraceMessageUtilityTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/base/AirbyteTraceMessageUtilityTest.kt
@@ -48,6 +48,7 @@ class AirbyteTraceMessageUtilityTest {
             Mockito.mock(RuntimeException::class.java),
             "this is a config error"
         )
+        System.out.println("HERE:" + outContent.toString(StandardCharsets.UTF_8))
         val outJson = Jsons.deserialize(outContent.toString(StandardCharsets.UTF_8))
         assertJsonNodeIsTraceMessage(outJson)
         Assertions.assertEquals("config_error", outJson["trace"]["error"]["failure_type"].asText())

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/base/AirbyteTraceMessageUtilityTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/base/AirbyteTraceMessageUtilityTest.kt
@@ -48,7 +48,6 @@ class AirbyteTraceMessageUtilityTest {
             Mockito.mock(RuntimeException::class.java),
             "this is a config error"
         )
-        System.out.println("HERE:" + outContent.toString(StandardCharsets.UTF_8))
         val outJson = Jsons.deserialize(outContent.toString(StandardCharsets.UTF_8))
         assertJsonNodeIsTraceMessage(outJson)
         Assertions.assertEquals("config_error", outJson["trace"]["error"]["failure_type"].asText())

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumerTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/destination/async/AsyncStreamConsumerTest.kt
@@ -457,7 +457,7 @@ class AsyncStreamConsumerTest {
             airbyteMessageDeserializer.deserializeAirbyteMessage(
                 serializedAirbyteMessage,
             )
-        assertEquals(airbyteRecordString, partial!!.serialized)
+        assertEquals(airbyteRecordString, partial.serialized)
     }
 
     @Test
@@ -483,7 +483,7 @@ class AsyncStreamConsumerTest {
             airbyteMessageDeserializer.deserializeAirbyteMessage(
                 serializedAirbyteMessage,
             )
-        assertEquals(airbyteRecordString, partial!!.serialized)
+        assertEquals(airbyteRecordString, partial.serialized)
     }
 
     @Test
@@ -503,7 +503,7 @@ class AsyncStreamConsumerTest {
             airbyteMessageDeserializer.deserializeAirbyteMessage(
                 serializedAirbyteMessage,
             )
-        assertEquals(emptyMap.toString(), partial!!.serialized)
+        assertEquals(emptyMap.toString(), partial.serialized)
     }
 
     @Test
@@ -513,7 +513,7 @@ class AsyncStreamConsumerTest {
             airbyteMessageDeserializer.deserializeAirbyteMessage(
                 serializedAirbyteMessage,
             )
-        assertEquals(serializedAirbyteMessage, partial!!.serialized)
+        assertEquals(serializedAirbyteMessage, partial.serialized)
     }
 
     @Test
@@ -742,7 +742,8 @@ class AsyncStreamConsumerTest {
         val retyped =
             serialized.replace(AirbyteMessage.Type.RECORD.toString(), "__UNKNOWN_TYPE_OF_MESSAGE__")
         // Assert that this doesn't throw an exception
-        assertDoesNotThrow { airbyteMessageDeserializer.deserializeAirbyteMessage(retyped) }
+        consumer.start()
+        assertDoesNotThrow { consumer.accept(retyped, retyped.length) }
     }
 
     @Test
@@ -757,13 +758,12 @@ class AsyncStreamConsumerTest {
                 )
         val serialized = Jsons.serialize(airbyteMessage)
         // Fake an upstream protocol change
-        val offender = "__UNKNOWN_NONTTYPE_ENUM__"
+        val offender = "__UNKNOWN_NONTYPE_ENUM__"
         val retyped = serialized.replace("STREAM", offender)
         // Assert that this doesn't throw an exception
+        consumer.start()
         val throwable =
-            assertThrows(RuntimeException::class.java) {
-                airbyteMessageDeserializer.deserializeAirbyteMessage(retyped)
-            }
+            assertThrows(RuntimeException::class.java) { consumer.accept(retyped, retyped.length) }
         // Ensure that the offending data has been scrubbed from the error message
         assertFalse(throwable.message!!.contains(offender))
     }

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/Jsons.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/Jsons.kt
@@ -430,7 +430,7 @@ object Jsons {
      * potentially-sensitive information. </snip...>
      */
     private fun <T : Any> handleDeserThrowable(throwable: Throwable): Optional<T> {
-        val obfuscated = obfuscate(throwable)
+        val obfuscated = obfuscateDeserializationException(throwable)
         LOGGER.warn { "Failed to deserialize json due to $obfuscated" }
         return Optional.empty()
     }
@@ -440,7 +440,7 @@ object Jsons {
      * sensitive information in the exception message (which would be exposed with eg,
      * ExceptionUtils.getStackTrace(t).)
      */
-    fun obfuscate(throwable: Throwable): String {
+    fun obfuscateDeserializationException(throwable: Throwable): String {
         var t: Throwable = throwable
         val sb = StringBuilder()
         sb.append(t.javaClass)

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/Jsons.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/Jsons.kt
@@ -140,6 +140,11 @@ object Jsons {
     }
 
     @JvmStatic
+    fun <T : Any> deserializeExactUnchecked(jsonString: String?, klass: Class<T>?): T {
+        return OBJECT_MAPPER_EXACT.readValue(jsonString, klass)
+    }
+
+    @JvmStatic
     fun <T : Any> tryDeserialize(jsonString: String, klass: Class<T>): Optional<T> {
         return try {
             Optional.of(OBJECT_MAPPER.readValue(jsonString, klass))
@@ -425,9 +430,17 @@ object Jsons {
      * potentially-sensitive information. </snip...>
      */
     private fun <T : Any> handleDeserThrowable(throwable: Throwable): Optional<T> {
-        // Manually build the stacktrace, excluding the top-level exception object
-        // so that we don't accidentally include the exception message.
-        // Otherwise we could just do ExceptionUtils.getStackTrace(t).
+        val obfuscated = obfuscate(throwable)
+        LOGGER.warn { "Failed to deserialize json due to $obfuscated" }
+        return Optional.empty()
+    }
+
+    /**
+     * Build a stacktrace from the given throwable, enabling us to log or rethrow without leaking
+     * sensitive information in the exception message (which would be exposed with eg,
+     * ExceptionUtils.getStackTrace(t).)
+     */
+    fun obfuscate(throwable: Throwable): String {
         var t: Throwable = throwable
         val sb = StringBuilder()
         sb.append(t.javaClass)
@@ -444,8 +457,7 @@ object Jsons {
                 sb.append(traceElement.toString())
             }
         }
-        LOGGER.warn { "Failed to deserialize json due to $sb" }
-        return Optional.empty()
+        return sb.toString()
     }
 
     /**

--- a/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/Jsons.kt
+++ b/airbyte-cdk/java/airbyte-cdk/dependencies/src/main/kotlin/io/airbyte/commons/json/Jsons.kt
@@ -139,6 +139,9 @@ object Jsons {
         }
     }
 
+    // WARNING: This message throws bare exceptions on parse failure which might
+    // leak sensitive data. Use obfuscateDeserializationException() to strip
+    // the sensitive data before logging.
     @JvmStatic
     fun <T : Any> deserializeExactUnchecked(jsonString: String?, klass: Class<T>?): T {
         return OBJECT_MAPPER_EXACT.readValue(jsonString, klass)


### PR DESCRIPTION
## What
Addresses [this Zenhub issue](https://app.zenhub.com/workspaces/destinations-6332532d6893ce001c7a56a7/issues/gh/airbytehq/airbyte-internal-issues/8064): when the airbyte message type is unrecognized, log an error instead of throwing the exception.

## How
1. Error handling/obfuscation is lifted out of the json deserializer (which is type-agnostic) into the caller (AirbyteMessageDeserializer)
2. The caller's return value is made nullable
3. The caller detects the specific failure (top-level enum type only), logs the unrecognized type only (no other client data context) and returns null
4. The caller's caller skips enqueuing on null

NOTE: This means that we will never call enqueue with the byte size passed into accept. However, @stephane-airbyte noticed that we do nothing with this when the type is unrecognized anyway (which may be a mistake if something's relying on that matching the calls to accept).

cc @edgao 

## User Impact
User should notice very little. In the rare event we add a new message type, it will not be a breaking change.

## Can this PR be safely reverted and rolled back?
- [ X] YES 💚
- [ ] NO ❌
Yes, as long as we are not in the middle of the process of releasing a new message type. :)
