### PR TITLE
connectors-insights: write sbom to file in container

### DIFF
--- a/airbyte-ci/connectors/connectors_insights/README.md
+++ b/airbyte-ci/connectors/connectors_insights/README.md
@@ -56,6 +56,9 @@ This CLI is currently running nightly in GitHub Actions. The workflow can be fou
 
 ## Changelog
 
+### 0.2.2
+- Write the sbom output to a file and not to stdout to avoid issues with large outputs.
+
 ### 0.2.1
 - Implement a high-level error handling to not fail the entire process if a connector fails to generate insights.
 

--- a/airbyte-ci/connectors/connectors_insights/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_insights/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-insights"
-version = "0.2.1"
+version = "0.2.2"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/pylint.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/pylint.py
@@ -41,10 +41,12 @@ async def get_pylint_output(dagger_client: dagger.Client, connector: Connector) 
     if connector.language not in [ConnectorLanguage.PYTHON, ConnectorLanguage.LOW_CODE]:
         return None
     cdk_deprecation_checker_path = Path(os.path.abspath(__file__)).parent / "pylint_plugins/cdk_deprecation_checkers.py"
+    pip_cache_volume: dagger.CacheVolume = dagger_client.cache_volume("pip_cache")
 
     return await (
         dagger_client.container()
         .from_(connector.image_address)
+        .with_mounted_cache("/root/.cache/pip", pip_cache_volume)
         .with_new_file("__init__.py", contents="")
         .with_exec(["pip", "install", "pylint"], skip_entrypoint=True)
         .with_workdir(connector.technical_name.replace("-", "_"))

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/sbom.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/sbom.py
@@ -46,4 +46,4 @@ async def get_json_sbom(dagger_client: dagger.Client, connector: Connector) -> s
         str: The SBOM in JSON format.
     """
     syft_container = get_syft_container(dagger_client)
-    return await syft_container.with_exec([connector.image_address, "-o", "syft-json"]).stdout()
+    return await syft_container.with_exec([connector.image_address, "-o", "syft-json=/sbom.json"]).file("/sbom.json").contents()


### PR DESCRIPTION
## What
This change helps reducing the volume of data written to stdout to improve workflow log readability and workaround dagger's stdout limit.
