### PR TITLE
`up-to-date`: run weekly

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -5,8 +5,8 @@ concurrency:
 
 on:
   schedule:
-    # Runs everyday at 12:00 UTC
-    - cron: "0 12 * * *"
+    # Runs everyday Saturday at 12:00 UTC
+    - cron: "0 12 * * 6"
   workflow_dispatch:
     inputs:
       connectors-options:


### PR DESCRIPTION
## What
I actually think it's saner to run up-to-date on a weekly basis.
It works on a daily basis, but if a very common transitive dependency  like setuptools  is updated it means we're basically republishing our full catalog.
This is what happenned today (feel free to look at #connector-publish-updates, I get a notification for every message there and it's :exploding_head: ) 
It can be a bit annoying as it'll create a significant CI queue which can prevent quick connector OC fixes. 
So I suggest running up-to-date on saturday, it gives auto-merge the opportunity to merge updates on Sunday, and it won't get in the way of our working hours.
