### PR TITLE
✨ Source Mixpanel: make engage stream really incremental

### DIFF
--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
-  dockerImageTag: 3.1.5
+  dockerImageTag: 3.2.0
   dockerRepository: airbyte/source-mixpanel
   documentationUrl: https://docs.airbyte.com/integrations/sources/mixpanel
   githubIssueLabel: source-mixpanel

--- a/airbyte-integrations/connectors/source-mixpanel/pyproject.toml
+++ b/airbyte-integrations/connectors/source-mixpanel/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.1.5"
+version = "3.2.0"
 name = "source-mixpanel"
 description = "Source implementation for Mixpanel."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/components.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/components.py
@@ -102,6 +102,22 @@ class FunnelsHttpRequester(MixpanelHttpRequester):
         return params
 
 
+class EngagesHttpRequester(MixpanelHttpRequester):
+    def get_request_params(
+        self,
+        *,
+        stream_state: Optional[StreamState] = None,
+        stream_slice: Optional[StreamSlice] = None,
+        next_page_token: Optional[Mapping[str, Any]] = None,
+    ) -> MutableMapping[str, Any]:
+        params = super().get_request_params(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
+        if "start_time" in stream_slice:
+            params["where"] = f'properties["$last_seen"] > "{stream_slice["start_time"]}"'
+        elif "start_date" in self.config:
+            params["where"] = f'properties["$last_seen"] > "{self.config["start_date"]}"'
+        return params
+
+
 class CohortMembersSubstreamPartitionRouter(SubstreamPartitionRouter):
     def get_request_body_json(
         self,

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/components.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/components.py
@@ -112,9 +112,9 @@ class EngagesHttpRequester(MixpanelHttpRequester):
     ) -> MutableMapping[str, Any]:
         params = super().get_request_params(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
         if "start_time" in stream_slice:
-            params["where"] = f'properties["$last_seen"] > "{stream_slice["start_time"]}"'
+            params["where"] = f'properties["$last_seen"] >= "{stream_slice["start_time"]}"'
         elif "start_date" in self.config:
-            params["where"] = f'properties["$last_seen"] > "{self.config["start_date"]}"'
+            params["where"] = f'properties["$last_seen"] >= "{self.config["start_date"]}"'
         return params
 
 

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/manifest.yaml
@@ -166,10 +166,17 @@ definitions:
     primary_key: distinct_id
     $parameters:
       name: engage
-      path: 2.0/engage
       field_path: results
     retriever:
-      $ref: "#/definitions/retriever"
+      type: SimpleRetriever
+      requester:
+        type: CustomRequester
+        class_name: "source_mixpanel.components.EngagesHttpRequester"
+        url_base: "https://{{ '' if config.region == 'US' else config.region+'.' }}mixpanel.com/api/"
+        path: 2.0/engage
+        authenticator: "#/definitions/authenticator"
+        error_handler:
+          $ref: "#/definitions/default_error_handler"
       paginator:
         $ref: "#/definitions/paginator"
       record_selector:

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -58,6 +58,7 @@ Syncing huge date windows may take longer due to Mixpanel's low API rate-limits 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                                                                                                                                                            |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.2.0 | 2024-06-26 | [40607](https://github.com/airbytehq/airbyte/pull/40607) | Make engage stream really incremental |
 | 3.1.5 | 2024-06-26 | [40549](https://github.com/airbytehq/airbyte/pull/40549) | Migrate off deprecated auth package |
 | 3.1.4 | 2024-06-25 | [40376](https://github.com/airbytehq/airbyte/pull/40376) | Update dependencies |
 | 3.1.3 | 2024-06-22 | [40138](https://github.com/airbytehq/airbyte/pull/40138) | Update dependencies |


### PR DESCRIPTION
## What

Fix https://github.com/airbytehq/airbyte/issues/40583

## How

This PR add a where parameters for the engage stream to be able to retrieve only records according to the start_date or the incremental start_time. This improves greatly the sync time because it does not retrieve all the data and then filter on the start_date.

## Review guide

1. `airbyte-integrations/connectors/source-mixpanel/source_mixpanel/components.py` : Add EngagesHttpRequester with the clause where
2. `airbyte-integrations/connectors/source-mixpanel/source_mixpanel/manifest.yaml`: Update the manifest to use EngagesHttpRequester for the engage stream

## User Impact
Improved performance for the engage stream

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
