### PR TITLE
CATs: add connector code to setup container

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.1
+
+Provide the ability for users to perform setup/teardown by building and running a container before each test.
+
 ## 3.8.0
 
 Add `TestDiscovery.test_primary_keys_data_type`, which validates that primary keys are not of type `array` or `object` in discovered catalog.

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py
@@ -212,6 +212,7 @@ async def setup_and_teardown(
         logging.info("Running setup")
         setup_teardown_container = await setup_and_teardown_runner.do_setup(
             dagger_client,
+            base_path,
             base_path / setup_teardown_dockerfile_config.setup_teardown_dockerfile_path,
             setup_teardown_dockerfile_config.setup_command,
             connector_config,

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/setup_and_teardown_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/setup_and_teardown_runner.py
@@ -24,7 +24,7 @@ async def _build_container(dagger_client: dagger.Client, dockerfile_path: Path) 
     return await dagger_client.container().build(context=workspace, dockerfile="Dockerfile.cat_setup_teardown")
 
 
-async def _build_setup_container(dagger_client: dagger.Client, connector_path: Path, dockerfile_path: Path) -> dagger.Container:
+async def _build_client_container(dagger_client: dagger.Client, connector_path: Path, dockerfile_path: Path) -> dagger.Container:
     container = await _build_container(dagger_client, dockerfile_path)
     return container.with_mounted_directory(
         "/connector", dagger_client.host().directory(str(connector_path), exclude=get_default_excluded_files())
@@ -59,7 +59,7 @@ async def _run(container: dagger.Container, command: List[str]) -> dagger.Contai
 async def do_setup(
     dagger_client: dagger.Client, connector_path: Path, dockerfile_path: Path, command: List[str], connector_config: SecretDict
 ):
-    return await _run_with_config(await _build_setup_container(dagger_client, connector_path, dockerfile_path), command, connector_config)
+    return await _run_with_config(await _build_client_container(dagger_client, connector_path, dockerfile_path), command, connector_config)
 
 
 async def do_teardown(container: dagger.Container, command: List[str]):

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "3.7.0"
+version = "3.8.1"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
As a follow up to https://github.com/airbytehq/airbyte/pull/40551, add the connector code to the setup container for use when e.g. seeding the database.