### PR TITLE
destination-postgres: fix PostgresDestinationTest to use isDestinationV2=true

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.kt
@@ -29,16 +29,18 @@ import java.sql.Connection
 import java.sql.ResultSet
 import java.time.Instant
 import java.util.*
-import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 import java.util.stream.Collectors
 import java.util.stream.IntStream
 import javax.sql.DataSource
 import org.junit.jupiter.api.*
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.MountableFile
 
-@Timeout(value = 10, unit = TimeUnit.MINUTES)
+@Execution(ExecutionMode.CONCURRENT)
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class PostgresDestinationTest {
     private var config: JsonNode? = null
 
@@ -247,7 +249,7 @@ class PostgresDestinationTest {
     fun sanityTest() {
         val destination: Destination = PostgresDestination()
         val config = this.config!!
-        DestinationConfig.initialize(config)
+        DestinationConfig.initialize(config, true)
         val consumer =
             destination.getSerializedMessageConsumer(
                 config,
@@ -286,7 +288,9 @@ class PostgresDestinationTest {
                 { connection: Connection ->
                     connection
                         .createStatement()
-                        .executeQuery("SELECT * FROM public._airbyte_raw_id_and_name;")
+                        .executeQuery(
+                            "SELECT * FROM airbyte_internal.public_raw__stream_id_and_name;"
+                        )
                 },
                 { queryResult: ResultSet -> defaultSourceOperations.rowToJson(queryResult) }
             )


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
