### PR TITLE
CATs: handling for global state messages

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.3
+
+Add handling for global state messages.
+
 ## 3.8.2
 
 Allow tests to access the setup/teardown container.

--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.8.3
 
-Add handling for global state messages.
+Add handling for global state messages (for use by DB sources).
 
 ## 3.8.2
 

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
@@ -164,8 +164,7 @@ class TestIncremental(BaseTest):
 
         # For legacy state format, the final state message contains the final state of all streams. For per-stream state format,
         # the complete final state of streams must be assembled by going through all prior state messages received
-        is_per_stream = is_per_stream_state(states_1[-1])
-        if is_per_stream:
+        if is_per_stream_state(states_1[-1]):
             latest_state = construct_latest_state_from_messages(states_1)
             state_input = []
             for stream_name, stream_state in latest_state.items():

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "3.8.2"
+version = "3.8.3"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
Our CATs make some assumptions that the state message format is either legacy or per-stream, but DB sources use a global state message. This PR adds control flow so they can provide logic for testing with global state.