### PR TITLE
Enable source-google-analytics-v4 on Cloud, but leave it as archived

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
@@ -22,7 +22,7 @@ data:
   name: Google Analytics (Universal Analytics)
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: false
   releaseStage: generally_available


### PR DESCRIPTION
## What
Enable source-google-analytics-v4 on cloud so the platform picks up the new support level 

## User Impact
- The Cloud platform will see the connector as archived

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
