### PR TITLE
Revert "Enable source-google-analytics-v4 on Cloud, but leave it as archived"

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
@@ -22,7 +22,7 @@ data:
   name: Google Analytics (Universal Analytics)
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: false
   releaseStage: generally_available


### PR DESCRIPTION
Reverts airbytehq/airbyte#40662 to remove the connector from the registry