### PR TITLE
Change docs based on CLI prompt

### DIFF
--- a/docs/connector-development/config-based/tutorial/1-create-source.md
+++ b/docs/connector-development/config-based/tutorial/1-create-source.md
@@ -14,7 +14,7 @@ cd airbyte-integrations/connector-templates/generator
 ./generate.sh
 ```
 
-This will bring up an interactive helper application. Use the arrow keys to pick a template from the list. Select the `Configuration Based Source` template and then input the name of your connector. The application will create a new directory in `airbyte/airbyte-integrations/connectors/` with the name of your new connector.
+This will bring up an interactive helper application. Use the arrow keys to pick a template from the list. Select the `Low-code Source` template and then input the name of your connector. The application will create a new directory in `airbyte/airbyte-integrations/connectors/` with the name of your new connector.
 The generator will create a new module for your connector with the name `source-<connector-name>`.
 
 ```


### PR DESCRIPTION
Command line output changed

## What
The documentation does not reflect the action option to choose from the Interactive Helper (CLI)

### The options to choose from are
```shell
? [PLOP] Please choose a generator. (Use arrow keys)
❯ Python CDK Destination - Generate a destination connector based on Python CDK.
  Python CDK Source - Generate a source connector based on Python CDK.
  Low-code Source - Generate a source based on the low-code CDK.
```

## How
N.A.

## Review guide
N.A.

## User Impact
* What is the end result perceived by the user?
- Better documentation
* If there are negative side effects, please list them. 
N.A.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
