### PR TITLE
feat(python cdk): Allow regex_search in jinja interpolations

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1046,11 +1046,7 @@ definitions:
         items:
           type: string
         examples:
-          - [
-              "crm.list.read",
-              "crm.objects.contacts.read",
-              "crm.schema.contacts.read",
-            ]
+          - ["crm.list.read", "crm.objects.contacts.read", "crm.schema.contacts.read"]
       token_expiry_date:
         title: Token Expiry Date
         description: The access token expiry date.
@@ -2600,3 +2596,10 @@ interpolation:
       examples:
         - '{{ 1 | string }} -> "1"'
         - '{{ ["hello", "world" | string }} -> "["hello", "world"]"'
+    - title: Regex Search
+      description: Match the input string against a regular expression and return the first match.
+      arguments:
+        regex: The regular expression to search for. It must include a capture group.
+      return_type: str
+      examples:
+        - '{{ "goodbye, cruel world" | regex_search("goodbye,\s(.*)$") }} -> "cruel world"'

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1046,7 +1046,11 @@ definitions:
         items:
           type: string
         examples:
-          - ["crm.list.read", "crm.objects.contacts.read", "crm.schema.contacts.read"]
+          - [
+              "crm.list.read",
+              "crm.objects.contacts.read",
+              "crm.schema.contacts.read",
+            ]
       token_expiry_date:
         title: Token Expiry Date
         description: The access token expiry date.

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/filters.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/filters.py
@@ -4,8 +4,8 @@
 import base64
 import hashlib
 import json
+import re
 from typing import Any, Optional
-
 
 def hash(value: Any, hash_type: str = "md5", salt: Optional[str] = None) -> str:
     """
@@ -104,6 +104,15 @@ def string(value: Any) -> str:
     ret = f'"""{json.dumps(value)}"""'
     return ret
 
+def regex_search(value: str, regex: str) -> str:
+    """
+    Match a regular expression against a string and return the first match group if it exists.
+    """
+    match = re.search(regex, value)
+    if match and len(match.groups()) > 0:
+        return match.group(1)
+    return ""
 
-_filters_list = [hash, base64encode, base64decode, string]
+
+_filters_list = [hash, base64encode, base64decode, string, regex_search]
 filters = {f.__name__: f for f in _filters_list}

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/filters.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/filters.py
@@ -7,6 +7,7 @@ import json
 import re
 from typing import Any, Optional
 
+
 def hash(value: Any, hash_type: str = "md5", salt: Optional[str] = None) -> str:
     """
       Implementation of a custom Jinja2 hash filter
@@ -103,6 +104,7 @@ def string(value: Any) -> str:
         return value
     ret = f'"""{json.dumps(value)}"""'
     return ret
+
 
 def regex_search(value: str, regex: str) -> str:
     """

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -97,7 +97,7 @@ class JinjaInterpolation(Interpolation):
                     return self._literal_eval(result, valid_types)
             else:
                 # If input is not a string, return it as is
-                raise Exception(f"Expected a string. got {input_str}")
+                raise Exception(f"Expected a string, got {input_str}")
         except UndefinedError:
             pass
         # If result is empty or resulted in an undefined error, evaluate and return the default string

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_filters.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_filters.py
@@ -78,3 +78,24 @@ def test_base64decode(input_string: str, expected_string: str):
     filter_base64decode = interpolation.eval(s, config={})
 
     assert filter_base64decode == expected_string
+
+
+def test_regex_search_valid():
+    expression_with_regex = "{{ '<https://this-is-test-link.com/?page=2>; rel=\"next\"' | regex_search('<(.*)>; rel=.*') }}"
+
+    val = interpolation.eval(expression_with_regex, {})
+    assert val == "https://this-is-test-link.com/?page=2"
+
+def test_regex_search_no_match_group():
+    # If no group is set in the regular expression, the result will be an empty string
+    expression_with_regex = "{{ '<https://this-is-test-link.com/?page=2>; rel=\"next\"' | regex_search('<.*>; rel=.*') }}"
+
+    val = interpolation.eval(expression_with_regex, {})
+    assert val == None
+
+def test_regex_search_no_match():
+    # If no group is set in the regular expression, the result will be an empty string
+    expression_with_regex = "{{ '<https://this-is-test-link.com/?page=2>; rel=\"next\"' | regex_search('WATWATWAT') }}"
+
+    val = interpolation.eval(expression_with_regex, {})
+    assert val == None

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_filters.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_filters.py
@@ -10,7 +10,7 @@ from airbyte_cdk.sources.declarative.interpolation.jinja import JinjaInterpolati
 interpolation = JinjaInterpolation()
 
 
-def test_hash_md5_no_salt():
+def test_hash_md5_no_salt() -> None:
     input_string = "abcd"
     s = "{{ '%s' | hash('md5') }}" % input_string
     filter_hash = interpolation.eval(s, config={})
@@ -23,7 +23,7 @@ def test_hash_md5_no_salt():
     assert filter_hash == hashlib_computed_hash
 
 
-def test_hash_md5_on_numeric_value():
+def test_hash_md5_on_numeric_value() -> None:
     input_value = 123.456
     s = "{{ %f | hash('md5') }}" % input_value
     filter_hash = interpolation.eval(s, config={})
@@ -36,7 +36,7 @@ def test_hash_md5_on_numeric_value():
     assert filter_hash == hashlib_computed_hash
 
 
-def test_hash_md5_with_salt():
+def test_hash_md5_with_salt() -> None:
     input_string = "test_input_string"
     input_salt = "test_input_salt"
 
@@ -55,7 +55,7 @@ def test_hash_md5_with_salt():
     "input_string",
     ["test_input_client_id", "some_client_secret_1", "12345", "775.78"],
 )
-def test_base64encode(input_string: str):
+def test_base64encode(input_string: str) -> None:
     s = "{{ '%s' | base64encode }}" % input_string
     filter_base64encode = interpolation.eval(s, config={})
 
@@ -73,7 +73,7 @@ def test_base64encode(input_string: str):
         ("cGFzc3dvcmQ=", "password"),
     ],
 )
-def test_base64decode(input_string: str, expected_string: str):
+def test_base64decode(input_string: str, expected_string: str) -> None:
     s = "{{ '%s' | base64decode }}" % input_string
     filter_base64decode = interpolation.eval(s, config={})
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_filters.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_filters.py
@@ -80,22 +80,25 @@ def test_base64decode(input_string: str, expected_string: str) -> None:
     assert filter_base64decode == expected_string
 
 
-def test_regex_search_valid():
+def test_regex_search_valid() -> None:
     expression_with_regex = "{{ '<https://this-is-test-link.com/?page=2>; rel=\"next\"' | regex_search('<(.*)>; rel=.*') }}"
 
     val = interpolation.eval(expression_with_regex, {})
     assert val == "https://this-is-test-link.com/?page=2"
 
-def test_regex_search_no_match_group():
+
+def test_regex_search_no_match_group() -> None:
     # If no group is set in the regular expression, the result will be an empty string
     expression_with_regex = "{{ '<https://this-is-test-link.com/?page=2>; rel=\"next\"' | regex_search('<.*>; rel=.*') }}"
 
     val = interpolation.eval(expression_with_regex, {})
-    assert val == None
+    assert val is None
 
-def test_regex_search_no_match():
+
+def test_regex_search_no_match() -> None:
     # If no group is set in the regular expression, the result will be an empty string
     expression_with_regex = "{{ '<https://this-is-test-link.com/?page=2>; rel=\"next\"' | regex_search('WATWATWAT') }}"
 
     val = interpolation.eval(expression_with_regex, {})
-    assert val == None
+
+    assert val is None


### PR DESCRIPTION
## What

Adds `regex_search` Jinja filter to interpolations. In cases when an API returns a string in a header or json path that contains what you need, but with some decoration, you can use this to grab just the substring that you want. 

## How
Implemented a new custom `regex_search` filter that is heavily inspired by [Ansible one](https://github.com/ansible/ansible/blob/6c0f4c8a2df78e0863723bffa06f6594b9bdd540/lib/ansible/plugins/filter/core.py#L155).

## User Impact
Once merged, users can use `regex_search` in their low-code manifests.

## How this works
https://www.loom.com/share/80a8a6ad1cd84e42b92a6ae756afe4d8

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
