### PR TITLE
airbyte-ci: add live tests evaluation mode options

### DIFF
--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -29,6 +29,13 @@ on:
         description: Use the local CDK when building the target connector
         default: "false"
         type: boolean
+      test_evaluation_mode:
+        type: choice
+        description: Whether to run tests in diagnostic mode, for eligible tests; select "dynamic" to use the connector's certification status to determine the test mode
+        options:
+        - strict
+        - diagnostic
+        - dynamic
 
 jobs:
   live_tests:
@@ -102,4 +109,4 @@ jobs:
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=all --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }} --connector_live_tests.test-evaluation-mode=diagnostic
+          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=all --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }} --connector_live_tests.test-evaluation-mode=${{ github.event.inputs.test_evaluation_mode }}

--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -90,7 +90,8 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         working-directory: airbyte-integrations/connectors/${{ github.event.inputs.connector_name }}
         run: |
-          if [[ $(awk '/supportLevel:/ {print $2}' metadata.yaml) == "certified" ]]; then
+          support_level=$(awk '/supportLevel:/ {print $2}' metadata.yaml)
+          if [[ "$support_level" == "certified" ]]; then
             echo "TEST_EVALUATION_MODE=--connector_live_tests.test-evaluation-mode=strict" >> $GITHUB_ENV
           else
             echo "TEST_EVALUATION_MODE=--connector_live_tests.test-evaluation-mode=diagnostic" >> $GITHUB_ENV
@@ -112,4 +113,4 @@ jobs:
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=all --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }} ${{ github.event.inputs.test_evaluation_mode }}
+          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=all --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }} ${{ env.TEST_EVALUATION_MODE }}

--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -86,17 +86,6 @@ jobs:
             echo "USE_LOCAL_CDK_FLAG=" >> $GITHUB_ENV
           fi
 
-      - name: Setup Test Evaluation Mode using Support Level
-        if: github.event_name == 'workflow_dispatch'
-        working-directory: airbyte-integrations/connectors/${{ github.event.inputs.connector_name }}
-        run: |
-          support_level=$(awk '/supportLevel:/ {print $2}' metadata.yaml)
-          if [[ "$support_level" == "certified" ]]; then
-            echo "TEST_EVALUATION_MODE=--connector_live_tests.test-evaluation-mode=strict" >> $GITHUB_ENV
-          else
-            echo "TEST_EVALUATION_MODE=--connector_live_tests.test-evaluation-mode=diagnostic" >> $GITHUB_ENV
-          fi
-
       - name: Run Live Tests [WORKFLOW DISPATCH]
         if: github.event_name == 'workflow_dispatch' # TODO: consider using the matrix strategy (https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs). See https://github.com/airbytehq/airbyte/pull/37659#discussion_r1583380234 for details.
         uses: ./.github/actions/run-airbyte-ci
@@ -113,4 +102,4 @@ jobs:
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=all --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }} ${{ env.TEST_EVALUATION_MODE }}
+          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=all --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }}

--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -29,13 +29,6 @@ on:
         description: Use the local CDK when building the target connector
         default: "false"
         type: boolean
-      test_evaluation_mode:
-        type: choice
-        description: Whether to run tests in diagnostic mode, for eligible tests; select "dynamic" to use the connector's certification status to determine the test mode
-        options:
-        - strict
-        - diagnostic
-        - dynamic
 
 jobs:
   live_tests:
@@ -93,6 +86,16 @@ jobs:
             echo "USE_LOCAL_CDK_FLAG=" >> $GITHUB_ENV
           fi
 
+      - name: Setup Test Evaluation Mode using Support Level
+        if: github.event_name == 'workflow_dispatch'
+        working-directory: airbyte-integrations/connectors/${{ github.event.inputs.connector_name }}
+        run: |
+          if [[ $(awk '/supportLevel:/ {print $2}' metadata.yaml) == "certified" ]]; then
+            echo "TEST_EVALUATION_MODE=--connector_live_tests.test-evaluation-mode=strict" >> $GITHUB_ENV
+          else
+            echo "TEST_EVALUATION_MODE=--connector_live_tests.test-evaluation-mode=diagnostic" >> $GITHUB_ENV
+          fi
+
       - name: Run Live Tests [WORKFLOW DISPATCH]
         if: github.event_name == 'workflow_dispatch' # TODO: consider using the matrix strategy (https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs). See https://github.com/airbytehq/airbyte/pull/37659#discussion_r1583380234 for details.
         uses: ./.github/actions/run-airbyte-ci
@@ -109,4 +112,4 @@ jobs:
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=all --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }} --connector_live_tests.test-evaluation-mode=${{ github.event.inputs.test_evaluation_mode }}
+          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=all --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.STREAM_PARAMS }} ${{ github.event.inputs.test_evaluation_mode }}

--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -280,6 +280,10 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.17.6
+
+Display diagnostic test with warning.
+
 ### 0.17.5
 
 Performance improvements using caching.

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.17.5"
+version = "0.17.6"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/templates/report.html.j2
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/templates/report.html.j2
@@ -487,7 +487,11 @@
             {% for test in test_results %}
                 <div class="test-result">
                     {% if test["result"] == "passed" %}
+                    {% if test["output"] %}
+                    <h3 class="test-name" style="color: yellow;">{{ test["name"] }} [{{ test["result"] + " with errors" }}]</h3>
+                    {% else %}
                     <h3 class="test-name" style="color: #7ee787;">{{ test["name"] }} [{{ test["result"] }}]</h3>
+                    {% endif %}
                     {% elif  test["result"] == "failed" %}
                     <h3 class="test-name" style="color: crimson;">{{ test["name"] }} [{{ test["result"] }}]</h3>
                     {% else %}

--- a/airbyte-ci/connectors/live-tests/src/live_tests/validation_tests/test_read.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/validation_tests/test_read.py
@@ -43,6 +43,7 @@ async def test_read(
     - Appropriate stream status messages are emitted for each stream
     - If a primary key exists for the stream, it is present in the records emitted
     """
+    raise ValueError("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     has_records = False
     errors = []
     warnings = []

--- a/airbyte-ci/connectors/live-tests/src/live_tests/validation_tests/test_read.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/validation_tests/test_read.py
@@ -43,7 +43,6 @@ async def test_read(
     - Appropriate stream status messages are emitted for each stream
     - If a primary key exists for the stream, it is present in the records emitted
     """
-    raise ValueError("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     has_records = False
     errors = []
     warnings = []

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -761,6 +761,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.20.1  | [#40698](https://github.com/airbytehq/airbyte/pull/40698)  | Add live tests evaluation mode options.                                                                                      |
 | 4.20.0  | [#38816](https://github.com/airbytehq/airbyte/pull/38816)  | Add command for running all live tests (validation + regression).                                                            |
 | 4.19.0  | [#39600](https://github.com/airbytehq/airbyte/pull/39600)  | Productionize the `up-to-date` command                                                                                       |
 | 4.18.3  | [#39341](https://github.com/airbytehq/airbyte/pull/39341)  | Fix `--use-local-cdk` option: change `no-deps` to `force-reinstall`                                                          |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -568,14 +568,8 @@ class LiveTests(Step):
         self.target_version = self.context.run_step_options.get_item_or_default(options, "target-version", "dev")
         self.should_read_with_state = self.context.run_step_options.get_item_or_default(options, "should-read-with-state", "1")
         self.selected_streams = self.context.run_step_options.get_item_or_default(options, "selected-streams", None)
-        self.test_evaluation_mode = self._get_test_evaluation_mode_from_options(options)
+        self.test_evaluation_mode = "strict" if self.context.connector.metadata.get("supportLevel") == "certified" else "diagnostic"
         self.run_id = os.getenv("GITHUB_RUN_ID") or str(int(time.time()))
-
-    def _get_test_evaluation_mode_from_options(self, options: Dict[str, List[Any]]) -> str:
-        mode = self.context.run_step_options.get_item_or_default(options, "test-evaluation-mode", "strict")
-        if self.context.connector.metadata.get("supportLevel") == "certified" and mode != "strict":
-            raise ValueError("Certified connectors must run live tests in `strict` mode.")
-        return mode
 
     async def _run(self, connector_under_test_container: Container) -> StepResult:
         """Run the regression test suite.

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -566,15 +566,13 @@ class LiveTests(Step):
         self.target_version = self.context.run_step_options.get_item_or_default(options, "target-version", "dev")
         self.should_read_with_state = self.context.run_step_options.get_item_or_default(options, "should-read-with-state", "1")
         self.selected_streams = self.context.run_step_options.get_item_or_default(options, "selected-streams", None)
-        self.test_evaluation_mode = self.context.run_step_options.get_item_or_default(options, "test-evaluation-mode", "strict")
+        self.test_evaluation_mode = self._get_test_evaluation_mode_from_options(options)
         self.run_id = os.getenv("GITHUB_RUN_ID") or str(int(time.time()))
 
     def _get_test_evaluation_mode_from_options(self, options):
         mode = self.context.run_step_options.get_item_or_default(options, "test-evaluation-mode", "strict")
-        if mode == "dynamic":
-            mode = "strict" if self.context.connector.metadata.get("supportLevel") == "certified" else "diagnostic"
         if self.context.connector.metadata.get("supportLevel") == "certified" and mode != "strict":
-            raise ValueError("Certified connectors must be run in `strict` mode.")
+            raise ValueError("Certified connectors must run live tests in `strict` mode.")
         return mode
 
     async def _run(self, connector_under_test_container: Container) -> StepResult:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -587,7 +587,6 @@ class LiveTests(Step):
             StepResult: Failure or success of the regression tests with stdout and stderr.
         """
         container = await self._build_test_container(await connector_under_test_container.id())
-        main_logger.info(f">>>>>>>>>>>>>>>>>>>>>>>> Built test container, running command = {self._test_command()}")
         container = container.with_(hacks.never_fail_exec(self._run_command_with_proxy(" ".join(self._test_command()))))
         tests_artifacts_dir = str(self.local_tests_artifacts_dir)
         path_to_report = f"{tests_artifacts_dir}/session_{self.run_id}/report.html"
@@ -600,12 +599,9 @@ class LiveTests(Step):
             )
             regression_test_report = None
         else:
-            try:
-                await container.file(path_to_report).export(path_to_report)
-                with open(path_to_report, "r") as fp:
-                    regression_test_report = fp.read()
-            except Exception as exc:
-                main_logger.exception(f"EXCEPTION READING REPORT >>>>>>>>>>>>>>>>>>. {exc}")
+            await container.file(path_to_report).export(path_to_report)
+            with open(path_to_report, "r") as fp:
+                regression_test_report = fp.read()
 
         return StepResult(
             step=self,

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -585,6 +585,7 @@ class LiveTests(Step):
             StepResult: Failure or success of the regression tests with stdout and stderr.
         """
         container = await self._build_test_container(await connector_under_test_container.id())
+        main_logger.info(f">>>>>>>>>>>>>>>>>>>>>>>> Built test container, running command = {self._test_command()}")
         container = container.with_(hacks.never_fail_exec(self._run_command_with_proxy(" ".join(self._test_command()))))
         tests_artifacts_dir = str(self.local_tests_artifacts_dir)
         path_to_report = f"{tests_artifacts_dir}/session_{self.run_id}/report.html"
@@ -597,9 +598,12 @@ class LiveTests(Step):
             )
             regression_test_report = None
         else:
-            await container.file(path_to_report).export(path_to_report)
-            with open(path_to_report, "r") as fp:
-                regression_test_report = fp.read()
+            try:
+                await container.file(path_to_report).export(path_to_report)
+                with open(path_to_report, "r") as fp:
+                    regression_test_report = fp.read()
+            except Exception as exc:
+                main_logger.exception(f"EXCEPTION READING REPORT >>>>>>>>>>>>>>>>>>. {exc}")
 
         return StepResult(
             step=self,

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -569,6 +569,14 @@ class LiveTests(Step):
         self.test_evaluation_mode = self.context.run_step_options.get_item_or_default(options, "test-evaluation-mode", "strict")
         self.run_id = os.getenv("GITHUB_RUN_ID") or str(int(time.time()))
 
+    def _get_test_evaluation_mode_from_options(self, options):
+        mode = self.context.run_step_options.get_item_or_default(options, "test-evaluation-mode", "strict")
+        if mode == "dynamic":
+            mode = "strict" if self.context.connector.metadata.get("supportLevel") == "certified" else "diagnostic"
+        if self.context.connector.metadata.get("supportLevel") == "certified" and mode != "strict":
+            raise ValueError("Certified connectors must be run in `strict` mode.")
+        return mode
+
     async def _run(self, connector_under_test_container: Container) -> StepResult:
         """Run the regression test suite.
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -13,7 +13,7 @@ from enum import Enum
 from functools import cached_property
 from pathlib import Path
 from textwrap import dedent
-from typing import ClassVar, List, Optional, Set
+from typing import Any, ClassVar, Dict, List, Optional, Set
 
 import requests  # type: ignore
 import semver
@@ -513,7 +513,9 @@ class LiveTests(Step):
             command_options += ["--should-read-with-state", self.should_read_with_state]
         if self.test_evaluation_mode:
             command_options += ["--test-evaluation-mode", self.test_evaluation_mode]
-        return command_options + ["--stream", self.selected_streams] if self.selected_streams else []
+        if self.selected_streams:
+            command_options += ["--stream", self.selected_streams]
+        return command_options
 
     def _run_command_with_proxy(self, command: str) -> List[str]:
         """
@@ -569,7 +571,7 @@ class LiveTests(Step):
         self.test_evaluation_mode = self._get_test_evaluation_mode_from_options(options)
         self.run_id = os.getenv("GITHUB_RUN_ID") or str(int(time.time()))
 
-    def _get_test_evaluation_mode_from_options(self, options):
+    def _get_test_evaluation_mode_from_options(self, options: Dict[str, List[Any]]) -> str:
         mode = self.context.run_step_options.get_item_or_default(options, "test-evaluation-mode", "strict")
         if self.context.connector.metadata.get("supportLevel") == "certified" and mode != "strict":
             raise ValueError("Certified connectors must run live tests in `strict` mode.")

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.20.0"
+version = "4.20.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
Surface the option for live tests to be run in `strict` or `diagnostic` mode.

Users can also choose `dynamic`, in which case certified connectors will be run in `strict` mode and non-certified will be run in `diagnostic` mode.

In `diagnostic` mode, a subset of tests may emit a warning and relevant info but will always pass as long as there was not an unhandled exception in the test itself.

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/8510.