### PR TITLE
airbyte-ci: fix use of GH token

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -761,6 +761,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.20.2  | [#40709](https://github.com/airbytehq/airbyte/pull/40709)  | Fix use of GH token.                                                                                                                           |
 | 4.20.1  | [#40698](https://github.com/airbytehq/airbyte/pull/40698)  | Add live tests evaluation mode options.                                                                                      |
 | 4.20.0  | [#38816](https://github.com/airbytehq/airbyte/pull/38816)  | Add command for running all live tests (validation + regression).                                                            |
 | 4.19.0  | [#39600](https://github.com/airbytehq/airbyte/pull/39600)  | Productionize the `up-to-date` command                                                                                       |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -659,7 +659,7 @@ class LiveTests(Step):
                 .with_secret_variable(
                     "CI_GITHUB_ACCESS_TOKEN",
                     self.context.dagger_client.set_secret(
-                        self.context.ci_github_access_token.value if self.context.ci_github_access_token else ""
+                        "CI_GITHUB_ACCESS_TOKEN", self.context.ci_github_access_token.value if self.context.ci_github_access_token else ""
                     ),
                 )
                 .with_exec(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, ClassVar, Dict, List, Optional, Set
 
+import dagger
 import requests  # type: ignore
 import semver
 import yaml  # type: ignore
@@ -655,13 +656,15 @@ class LiveTests(Step):
                         "https://github.com/airbytehq/airbyte-platform-internal.git",
                     ]
                 )
+                .with_secret_variable(
+                    "CI_GITHUB_ACCESS_TOKEN",
+                    dagger.Secret(self.context.ci_github_access_token.value if self.context.ci_github_access_token else "")
+                )
                 .with_exec(
                     [
-                        "poetry",
-                        "config",
-                        "http-basic.airbyte-platform-internal-source",
-                        self.github_user,
-                        self.context.ci_github_access_token.value if self.context.ci_github_access_token else "",
+                        "/bin/sh",
+                        "-c",
+                        f"poetry config http-basic.airbyte-platform-internal-source {self.github_user} $CI_GITHUB_ACCESS_TOKEN",
                     ]
                 )
                 # Add GCP credentials from the environment and point google to their location (also required for connection-retriever)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -658,7 +658,7 @@ class LiveTests(Step):
                 )
                 .with_secret_variable(
                     "CI_GITHUB_ACCESS_TOKEN",
-                    dagger.Secret(self.context.ci_github_access_token.value if self.context.ci_github_access_token else "")
+                    dagger.Secret(dagger.Doc(self.context.ci_github_access_token.value if self.context.ci_github_access_token else "")),
                 )
                 .with_exec(
                     [

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -658,7 +658,9 @@ class LiveTests(Step):
                 )
                 .with_secret_variable(
                     "CI_GITHUB_ACCESS_TOKEN",
-                    dagger.Secret(dagger.Doc(self.context.ci_github_access_token.value if self.context.ci_github_access_token else "")),
+                    self.context.dagger_client.set_secret(
+                        self.context.ci_github_access_token.value if self.context.ci_github_access_token else ""
+                    ),
                 )
                 .with_exec(
                     [

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
@@ -215,13 +215,12 @@ def prepare_container_for_poe_tasks(
                     "https://github.com/airbytehq/airbyte-platform-internal.git",
                 ]
             )
+            .with_secret_variable("CI_GITHUB_ACCESS_TOKEN", dagger.Secret(pipeline_context_params["ci_github_access_token"].value))
             .with_exec(
                 [
-                    "poetry",
-                    "config",
-                    "http-basic.airbyte-platform-internal-source",
-                    "octavia-squidington-iii",
-                    pipeline_context_params["ci_github_access_token"].value,
+                    "/bin/sh",
+                    "-c",
+                    "poetry config http-basic.airbyte-platform-internal-source octavia-squidington-iii $CI_GITHUB_ACCESS_TOKEN",
                 ]
             )
             .with_exec(["poetry", "lock", "--no-update"])

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
@@ -216,7 +216,7 @@ def prepare_container_for_poe_tasks(
                 ]
             )
             .with_secret_variable(
-                "CI_GITHUB_ACCESS_TOKEN", dagger.Doc(dagger.Secret(pipeline_context_params["ci_github_access_token"].value))
+                "CI_GITHUB_ACCESS_TOKEN", dagger_client.set_secret(pipeline_context_params["ci_github_access_token"].value)
             )
             .with_exec(
                 [

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
@@ -216,7 +216,8 @@ def prepare_container_for_poe_tasks(
                 ]
             )
             .with_secret_variable(
-                "CI_GITHUB_ACCESS_TOKEN", dagger_client.set_secret(pipeline_context_params["ci_github_access_token"].value)
+                "CI_GITHUB_ACCESS_TOKEN",
+                dagger_client.set_secret("CI_GITHUB_ACCESS_TOKEN", pipeline_context_params["ci_github_access_token"].value),
             )
             .with_exec(
                 [

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
@@ -215,7 +215,9 @@ def prepare_container_for_poe_tasks(
                     "https://github.com/airbytehq/airbyte-platform-internal.git",
                 ]
             )
-            .with_secret_variable("CI_GITHUB_ACCESS_TOKEN", dagger.Secret(pipeline_context_params["ci_github_access_token"].value))
+            .with_secret_variable(
+                "CI_GITHUB_ACCESS_TOKEN", dagger.Doc(dagger.Secret(pipeline_context_params["ci_github_access_token"].value))
+            )
             .with_exec(
                 [
                     "/bin/sh",

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.20.1"
+version = "4.20.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
For the GH token, use `with_secret_env_variable`.