### PR TITLE
Revert "Updating terminology Community Connector > Marketplace Connec…

### DIFF
--- a/docs/contributing-to-airbyte/README.md
+++ b/docs/contributing-to-airbyte/README.md
@@ -13,8 +13,9 @@ Before getting started, please review Airbyte's Code of Conduct. Everyone intera
 ## Code Contributions
 
 Most of the issues that are open for contributions are tagged with [`good-first-issue`](https://github.com/airbytehq/airbyte/issues?q=is%3Aopen+is%3Aissue+label%3Agood-first-issue) or [`help-welcome`](https://github.com/airbytehq/airbyte/labels/help-welcome).
+A great place to start looking will be our GitHub projects for [**Community Connector Issues**](https://github.com/orgs/airbytehq/projects/50)
 
-Please include documentation when contributing a new connector. Refer to the [guidelines on updating documentation](writing-docs.md) which includes a template to use while documenting a new connector.
+Contributions for new connectors should come with documentation. Refer to the [guidelines on updateing documentation](writing-docs.md) which include a template to use while documentiong a new connector. 
 
 Proposed updates to a connector should include updates to the connector's documentation. 
 

--- a/docs/enterprise-setup/upgrading-from-community.md
+++ b/docs/enterprise-setup/upgrading-from-community.md
@@ -16,10 +16,10 @@ These instructions are for you if:
 
 ### Step 1: Update Airbyte Open Source
 
-You must first update to the latest Open Source Community release. We assume you are running the following steps from the root of the `airbytehq/airbyte-platform` cloned repo.
+You must first update to the latest Open Source community release. We assume you are running the following steps from the root of the `airbytehq/airbyte-platform` cloned repo.
 
 1. Determine your current helm release name by running `helm list`. This will now be referred to as `[RELEASE_NAME]` for the rest of this guide.
-2. Upgrade to the latest Open Source Community release. The output will now be refered to as `[RELEASE_VERSION]` for the rest of this guide:
+2. Upgrade to the latest Open Source community release. The output will now be refered to as `[RELEASE_VERSION]` for the rest of this guide:
 
 ```sh
 helm upgrade [RELEASE_NAME] airbyte/airbyte

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -14,7 +14,7 @@ Learn more about contributing to Airbyte [here](/contributing-to-airbyte/).
 
 ## Connector Support Levels
 
-Airbyte uses a tiered system for connectors to help you understand what to expect from a connector. In short, there are three tiers: Integrations, Marketplace Connectors, and Custom Connectors. Review the documentation on [connector support levels](./connector-support-levels.md) for details on each tier.
+Airbyte uses a tiered system for connectors to help you understand what to expect from a connector. In short, there are three tiers: Certified Connectors, Community Connectors, and Custom Connectors. Review the documentation on [connector support levels](./connector-support-levels.md) for details on each tier.
 
 _[View the connector registries in full](https://connectors.airbyte.com/files/generated_reports/connector_registry_report.html)_
 

--- a/docs/integrations/connector-support-levels.md
+++ b/docs/integrations/connector-support-levels.md
@@ -6,10 +6,10 @@ products: all
 
 The following table describes the support levels of Airbyte connectors.
 
-|                                      | Integration                                 | Marketplace                                                                                              | Custom                                                                                                                                                                                                                                                             |
+|                                      | Certified                                 | Community                                                                                              | Custom                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Availability**                     | Available to all users                    | Available to all users                                                                                 | Available to all users                                                                                                                                                                                                                                             |
-| **Who builds them?**                 | Either the community or the Airbyte team. | Typically they are built by the community. The Airbyte team may upgrade them to become an Integration at any time. | Anyone can build custom connectors. We recommend using our [Connector Builder](https://docs.airbyte.com/connector-development/connector-builder-ui/overview) or [Low-code CDK](https://docs.airbyte.com/connector-development/config-based/low-code-cdk-overview). |
+| **Who builds them?**                 | Either the community or the Airbyte team. | Typically they are built by the community. The Airbyte team may upgrade them to Certified at any time. | Anyone can build custom connectors. We recommend using our [Connector Builder](https://docs.airbyte.com/connector-development/connector-builder-ui/overview) or [Low-code CDK](https://docs.airbyte.com/connector-development/config-based/low-code-cdk-overview). |
 | **Who maintains them?**              | The Airbyte team                          | Users                                                                                                  | Users                                                                                                                                                                                                                                                              |
 | **Production Readiness**             | Guaranteed by Airbyte                     | Not guaranteed                                                                                         | Not guaranteed                                                                                                                                                                                                                                                     |
 | **Support: Cloud**                   | Supported\*                               | No Support                                                                                             | Supported\*\*                                                                                                                                                                                                                                                      |
@@ -17,7 +17,7 @@ The following table describes the support levels of Airbyte connectors.
 | **Support: Self-Managed Enterprise** | Supported\*                               | No Support                                                                                             | Supported\*\*                                                                                                                                                                                                                                                      |
 | **Support: Community (OSS)**         | Slack Support only                        | No Support                                                                                             | Slack Support only                                                                                                                                                                                                                                                 |
 
-\*For Integrations, Official Support SLAs are only available to customers with Premium
+\*For Certified connectors, Official Support SLAs are only available to customers with Premium
 Support included in their contract. Otherwise, please use our support portal and we will address
 your issues as soon as possible.
 
@@ -25,36 +25,35 @@ your issues as soon as possible.
 Support included in their contract. This support is provided with best efforts, and
 maintenance/upgrades are owned by the customer.
 
-## Integrations
+## Certified
 
-An **Integration** type connector is actively maintained and supported by the Airbyte team and maintains a
+A **Certified** connector is actively maintained and supported by the Airbyte team and maintains a
 high quality bar. It is production ready.
 
-### What you should know about Integrations:
+### What you should know about Certified connectors:
 
-- Integrations are official Airbyte connectors that are available to all users.
-- These connectors have been tested and vetted. They are production ready.
-- Integrations should go through minimal breaking change but in the event an upgrade is
+- Certified connectors are available to all users.
+- These connectors have been tested and vetted in order to be certified and are production ready.
+- Certified connectors should go through minimal breaking change but in the event an upgrade is
   needed users will be given an adequate upgrade window.
 
-## Marketplace
+## Community
 
-A **Marketplace** connector is maintained by the community members until it becomes an official Integration. Airbyte
+A **Community** connector is maintained by the Airbyte community until it becomes Certified. Airbyte
 has over 800 code contributors and 15,000 people in the Slack community to help. The Airbyte team is
-continually reviewing Marketplace connectors as usage grows to determine when a Marketplace connector should become an Airbyte Integration. Marketplace connectors are not maintained
-by Airbyte and  we do not offer support SLAs around them. We encourage caution when using them in
+continually certifying Community connectors as usage grows. As these connectors are not maintained
+by Airbyte, we do not offer support SLAs around them, and we encourage caution when using them in
 production.
 
-### What you should know about Marketplace connectors:
+### What you should know about Community connectors:
 
-- Marketplace connectors are available to all users.
-- Marketplace connectors may be upgraded to an official Integration at any time, and we will notify users of these
+- Community connectors are available to all users.
+- Community connectors may be upgraded to Certified at any time, and we will notify users of these
   upgrades via our Slack Community and in our Connector Catalog.
-- Marketplace connectors might not be feature-complete (features planned for release are under
+- Community connectors might not be feature-complete (features planned for release are under
   development or not prioritized) and may include backward-incompatible/breaking API changes with no
   or short notice.
-- Marketplace connectors have no Support SLAs.
-- You're very welcome to contribute new features and streams to an existing Marketplace integration. Airbyte Contributor Experience team is happy to review PRs when we have capacity.
+- Community connectors have no Support SLAs.
 
 ## Archived
 

--- a/docs/understanding-airbyte/database-data-catalog.md
+++ b/docs/understanding-airbyte/database-data-catalog.md
@@ -8,9 +8,7 @@
   - Each record represents a connector that Airbyte supports, e.g. Postgres. This table represents all the connectors that is supported by the current running platform.
   - The `actor_type` column tells us whether the record represents a Source or a Destination.
   - The `spec` column is a JSON blob. The schema of this JSON blob matches the [spec](airbyte-protocol.md#actor-specification) model in the Airbyte Protocol. Because the protocol object is JSON, this has to be a JSON blob.
-  - The `support_level` describes the support level of the connector (e.g. `community`, `certified`, or `archived`).
-    - In the product UI, Marketplace contains connectors with `community` support level, and Integrations tab contains `certified` connectors.
-    - `support_level: archived` signals that this connector is no longer supported, and it's not available to install for any new connections. 
+  - The `support_level` describes the support level of the connector (e.g. community, certified).
   - The `docker_repository` field is the name of the docker image associated with the connector definition. `docker_image_tag` is the tag of the docker image and the version of the connector definition.
   - The `source_type` field is only used for Sources, and represents the category of the connector definition (e.g. API, Database).
   - The `resource_requirements` field sets a default resource requirement for any connector of this type. This overrides the default we set for all connector definitions, and it can be overridden by a connection-specific resource requirement. The column is a JSON blob with the schema defined in [ActorDefinitionResourceRequirements.yaml](https://github.com/airbytehq/airbyte/blob/master/airbyte-config-oss/config-models-oss/src/main/resources/types/ActorDefinitionResourceRequirements.yaml)

--- a/docs/using-airbyte/getting-started/add-a-destination.md
+++ b/docs/using-airbyte/getting-started/add-a-destination.md
@@ -16,7 +16,7 @@ Once you've signed up for Airbyte Cloud or logged in to your Airbyte Open Source
 You can use the provided search bar at the top of the page, or scroll down the list to find the destination you want to replicate data from.
 
 :::tip
-You can filter the list of destinations by support level. Airbyte connectors are categorized in two support levels, Integrations and Marketplace Connectors. See our [Connector Support Levels](/integrations/connector-support-levels.md) page for more information on this topic.
+You can filter the list of destinations by support level. Airbyte connectors are categorized in two support levels, Certified and Community. See our [Connector Support Levels](/integrations/connector-support-levels.md) page for more information on this topic.
 :::
 
 <Tabs groupId="cloud-hosted">


### PR DESCRIPTION
…tor, Certified Connector > Integration (#40678)"

This reverts commit 53c5dd6ce2b3a9d78aafe7dfa9302fd5e33def9e.

We have not yet merged the change to rename these support levels in the platform UI, and the exact terminology is still being debated on slack [here](https://airbytehq-team.slack.com/archives/C06NM9DV7QU/p1719969778646849).

This docs change should be merged alongside the platform change at the same time, so we should revert this change for now to keep docs consistent with the platform, and re-open and adjust the terminology once we are ready to release the platform change. 