### PR TITLE
docs(snowflake): fix description of snowflake warehouse

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/cloud_registry.json
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/cloud_registry.json
@@ -5534,7 +5534,7 @@
               "order": 1
             },
             "warehouse": {
-              "description": "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\">warehouse</a> that you want to sync data into",
+              "description": "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\">warehouse</a> that you want to use as a compute cluster",
               "examples": ["AIRBYTE_WAREHOUSE"],
               "type": "string",
               "title": "Warehouse",

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/oss_registry.json
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/oss_registry.json
@@ -6936,7 +6936,7 @@
               "order": 1
             },
             "warehouse": {
-              "description": "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\">warehouse</a> that you want to sync data into",
+              "description": "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\">warehouse</a> that you want to use as a compute cluster",
               "examples": ["AIRBYTE_WAREHOUSE"],
               "type": "string",
               "title": "Warehouse",

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/config.py
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/destination_snowflake_cortex/config.py
@@ -41,7 +41,7 @@ class SnowflakeCortexIndexingModel(BaseModel):
         ...,
         title="Warehouse",
         order=3,
-        description="Enter the name of the warehouse that you want to sync data into",
+        description="Enter the name of the warehouse that you want to use as a compute cluster",
         examples=["AIRBYTE_WAREHOUSE"],
     )
     database: str = Field(

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/integration_tests/spec.json
@@ -332,7 +332,7 @@
           },
           "warehouse": {
             "title": "Warehouse",
-            "description": "Enter the name of the warehouse that you want to sync data into",
+            "description": "Enter the name of the warehouse that you want to use as a compute cluster",
             "order": 3,
             "examples": ["AIRBYTE_WAREHOUSE"],
             "type": "string"

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
@@ -31,7 +31,7 @@
         "order": 1
       },
       "warehouse": {
-        "description": "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\">warehouse</a> that you want to sync data into",
+        "description": "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\">warehouse</a> that you want to use as a compute cluster",
         "examples": ["AIRBYTE_WAREHOUSE"],
         "type": "string",
         "title": "Warehouse",


### PR DESCRIPTION
## What

In Snowflake, warehouse is a compute cluster instead of a place to save data. Yeah, I know the term is misleading.

Here are docs:

- https://docs.snowflake.com/en/user-guide/warehouses
- https://www.reddit.com/r/snowflake/comments/16758sn/trivia_why_did_snowflake_choose_name_warehouse/

I opened another related pull request at https://github.com/airbytehq/terraform-provider-airbyte/pull/120

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
