### PR TITLE
CDK: Add jinja macro format_datetime_string

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2565,11 +2565,20 @@ interpolation:
       description: Converts a datetime or a datetime-string to the specified format.
       arguments:
         datetime: The datetime object or a string to convert. If datetime is a string, it must be formatted as ISO8601.
-        format: The datetime format
+        format: The datetime format.
       return_type: str
       examples:
         - "{{ format_datetime(config['start_time'], '%Y-%m-%d') }}"
         - "{{ format_datetime(config['start_date'], '%Y-%m-%dT%H:%M:%S.%fZ') }}"
+    - title: Format Datetime String
+      description: Converts a datetime-string from the specified format to datetime.
+      arguments:
+        datetime: The datetime string to convert.
+        format: The datetime format.
+      return_type: datetime
+      examples:
+        - "{{ format_datetime_string(config['start_time'], '%Y-%m-%d') }}"
+        - "{{ format_datetime_string(config['start_date'], '%a, %d %b %Y %H:%M:%S %z') }}"
   filters:
     - title: Hash
       description: Convert the specified value to a hashed string.

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/macros.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/macros.py
@@ -126,5 +126,15 @@ def format_datetime(dt: Union[str, datetime.datetime], format: str) -> str:
     return dt_datetime.strftime(format)
 
 
-_macros_list = [now_utc, today_utc, timestamp, max, day_delta, duration, format_datetime]
+def format_datetime_string(dt: str, format: str) -> datetime.datetime:
+    """
+    Converts string to datetime based on input format
+
+    Usage:
+    `"{{ format_datetime_string(config.start_date, '%a, %d %b %Y %H:%M:%S %z') }}"`
+    """
+    return datetime.datetime.strptime(dt, format)
+
+
+_macros_list = [now_utc, today_utc, timestamp, max, day_delta, duration, format_datetime, format_datetime_string]
 macros = {f.__name__: f for f in _macros_list}

--- a/airbyte-cdk/python/pyproject.toml
+++ b/airbyte-cdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "airbyte-cdk"
-version = "2.0.0"
+version = "2.0.1"
 description = "A framework for writing Airbyte Connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_macros.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_macros.py
@@ -16,6 +16,7 @@ from airbyte_cdk.sources.declarative.interpolation.macros import macros
         ("test_max", "max", True),
         ("test_day_delta", "day_delta", True),
         ("test_format_datetime", "format_datetime", True),
+        ("test_format_datetime_string", "format_datetime_string", True),
         ("test_duration", "duration", True),
         ("test_not_a_macro", "thisisnotavalidmacro", False),
     ],
@@ -43,6 +44,18 @@ def test_macros_export(test_name, fn_name, found_in_macros):
 def test_format_datetime(test_name, input_value, format, expected_output):
     format_datetime = macros["format_datetime"]
     assert format_datetime(input_value, format) == expected_output
+
+
+@pytest.mark.parametrize(
+    "test_name, input_value, format, expected_output",
+    [
+        ("test_datetime_iso", "2022-01-01T01:01:01Z", "%Y-%m-%dT%H:%M:%SZ", datetime.datetime(2022, 1, 1, 1, 1, 1)),
+        ("test_datetime_iso", "Sat, 01 Jan 2022 01:01:01 +0000", "%a, %d %b %Y %H:%M:%S %z", datetime.datetime(2022, 1, 1, 1, 1, 1, tzinfo=datetime.timezone.utc)),
+    ],
+)
+def test_format_datetime_string(test_name, input_value, format, expected_output):
+    format_datetime_string = macros["format_datetime_string"]
+    assert format_datetime_string(input_value, format) == expected_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
In order to support complex input datetime formats at low code, format_datetime_string macro will allow us to parse any kind of datetime string, so it can be processed to standarized ISO (or any other format as required).

Example:

This is to handle this transformation from low code:
[airbyte/airbyte-integrations/connectors/source-twilio/source_twilio/streams.py](https://github.com/airbytehq/airbyte/blob/9daef0f143d354bd71c1c56777edc094fdefe1e9/airbyte-integrations/connectors/source-twilio/source_twilio/streams.py#L101)

Line 101 in [9daef0f](https://github.com/airbytehq/airbyte/commit/9daef0f143d354bd71c1c56777edc094fdefe1e9)


```
transformations:
        - type: AddFields
          fields:
            - type: AddedFieldDefinition
              path:
                - date_created
              value: '{% set datetime_rfc2822 = format_datetime_string(record["date_created"], "%a, %d %b %Y %H:%M:%S %z") %}{% set formatted_datetime = format_datetime(datetime_rfc2822, "%Y-%m-%dT%H:%M:%SZ") %}{{ formatted_datetime }}'
```
On this way, we can convert any formatted string to datetime and then use format_datetime to make it an actual string.

## Review guide
<!--
1. `macros.py`
-->


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
