### PR TITLE
🐛 airbyte-ci: allow migrate-to-poetry to accept and ignore additional args

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -761,7 +761,8 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.20.2  | [#40709](https://github.com/airbytehq/airbyte/pull/40709)  | Fix use of GH token.                                                                                                                           |
+| 4.20.3  | [#40754](https://github.com/airbytehq/airbyte/pull/40754) | Accept and ignore additional args in `migrate-to-poetry` pipeline                                                             |
+| 4.20.2  | [#40709](https://github.com/airbytehq/airbyte/pull/40709)  | Fix use of GH token.                                                                                                         |
 | 4.20.1  | [#40698](https://github.com/airbytehq/airbyte/pull/40698)  | Add live tests evaluation mode options.                                                                                      |
 | 4.20.0  | [#38816](https://github.com/airbytehq/airbyte/pull/38816)  | Add command for running all live tests (validation + regression).                                                            |
 | 4.19.0  | [#39600](https://github.com/airbytehq/airbyte/pull/39600)  | Productionize the `up-to-date` command                                                                                       |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/commands.py
@@ -5,7 +5,7 @@
 
 import asyncclick as click
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
-from pipelines.airbyte_ci.connectors.migrate_to_poetry.pipeline import run_connector_migration_to_poetry_pipeline
+from pipelines.airbyte_ci.connectors.migrate_to_poetry.pipeline import run_connector_migration_to_poetry_pipeline_wrapper
 from pipelines.airbyte_ci.connectors.pipeline import run_connectors_pipelines
 from pipelines.cli.dagger_pipeline_command import DaggerPipelineCommand
 
@@ -61,7 +61,7 @@ async def migrate_to_poetry(ctx: click.Context, changelog: bool, bump: str | Non
 
     await run_connectors_pipelines(
         connectors_contexts,
-        run_connector_migration_to_poetry_pipeline,
+        run_connector_migration_to_poetry_pipeline_wrapper,
         "Migration to poetry pipeline",
         ctx.obj["concurrency"],
         ctx.obj["dagger_logs_path"],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
@@ -21,7 +21,7 @@ from pipelines.helpers.execution.run_steps import STEP_TREE, StepToRun, run_step
 from pipelines.models.steps import Step, StepResult, StepStatus
 
 if TYPE_CHECKING:
-    from typing import Iterable, List, Optional
+    from typing import Any, Iterable, List, Optional
 
     from anyio import Semaphore
 
@@ -458,7 +458,7 @@ async def run_connector_migration_to_poetry_pipeline(context: ConnectorContext, 
     return report
 
 
-async def run_connector_migration_to_poetry_pipeline_wrapper(context: ConnectorContext, semaphore: "Sephamore", *args) -> Report:
+async def run_connector_migration_to_poetry_pipeline_wrapper(context: ConnectorContext, semaphore: Semaphore, *args: Any) -> Report:
     """
     Wrapper for running the connector migration to poetry pipeline,
     allowing it to match the expected signature for run_connectors_pipelines without accepting any additional arguments.

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
@@ -460,7 +460,7 @@ async def run_connector_migration_to_poetry_pipeline(context: ConnectorContext, 
 
 async def run_connector_migration_to_poetry_pipeline_wrapper(context: ConnectorContext, semaphore: "Sephamore", *args) -> Report:
     """
-    Wrapper for running the connector migration to poetry pipeline, 
+    Wrapper for running the connector migration to poetry pipeline,
     allowing it to match the expected signature for run_connectors_pipelines without accepting any additional arguments.
     """
     return await run_connector_migration_to_poetry_pipeline(context, semaphore)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
@@ -456,3 +456,11 @@ async def run_connector_migration_to_poetry_pipeline(context: ConnectorContext, 
             context.report = report
 
     return report
+
+
+async def run_connector_migration_to_poetry_pipeline_wrapper(context: ConnectorContext, semaphore: "Sephamore", *args) -> Report:
+    """
+    Wrapper for running the connector migration to poetry pipeline, 
+    allowing it to match the expected signature for run_connectors_pipelines without accepting any additional arguments.
+    """
+    return await run_connector_migration_to_poetry_pipeline(context, semaphore)

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.20.2"
+version = "4.20.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
While attempting to migrate the few remaining outliers to poetry, I've been encountering the following error when running the `airbyte-ci migrate-to-poetry` command:

```
Traceback (most recent call last):
  File "airbyte_ci.py", line 217, in <module>
  File "asyncclick/core.py", line 1205, in __call__
  File "anyio/_core/_eventloop.py", line 68, in run
  File "anyio/_backends/_asyncio.py", line 204, in run
  File "asyncio/runners.py", line 44, in run
  File "asyncio/base_events.py", line 649, in run_until_complete
  File "anyio/_backends/_asyncio.py", line 199, in wrapper
  File "asyncclick/core.py", line 1208, in _main
  File "asyncclick/core.py", line 1120, in main
  File "asyncclick/core.py", line 1739, in invoke
  File "asyncclick/core.py", line 1739, in invoke
  File "dagger_pipeline_command.py", line 48, in invoke
    pipeline_success = await super().invoke(ctx)
  File "asyncclick/core.py", line 1485, in invoke
  File "asyncclick/core.py", line 824, in invoke
  File "pipelines/airbyte_ci/connectors/migrate_to_poetry/commands.py", line 62, in migrate_to_poetry
    await run_connectors_pipelines(
  File "pipelines/airbyte_ci/connectors/pipeline.py", line 113, in run_connectors_pipelines
    tg_connectors.start_soon(
  File "anyio/_backends/_asyncio.py", line 729, in start_soon
  File "anyio/_backends/_asyncio.py", line 705, in _spawn
TypeError: run_connector_migration_to_poetry_pipeline() takes 2 positional arguments but 4 were given
```

It seems the `run_connector_migration_to_poetry_pipeline` function was designed to take only two arguments (context and semaphore), but the `run_connectors_pipelines` function was passing additional arguments, leading to the `TypeError`.

## How

Rather than do a full investigation, I made a quick wrapper to accept and ignore any additional args other than those explicitly used by the `run_connector_migration_to_poetry_pipeline` function.

I ran the command again with this change and am able to successfully complete the pipeline with a full HTML report at the end.

## User Impact
Mostly unblocking myself to run this command so I don't have to do things manually (#lazydev).

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
