### PR TITLE
chore(oss contrib): request community dev code reviews from marketplace-contributions instead of extensibility

### DIFF
--- a/.github/workflows/contractors_review_requirements.yml
+++ b/.github/workflows/contractors_review_requirements.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types:
       - opened
-      - pull_request_review
       - ready_for_review
       - reopened
       - synchronize
@@ -34,7 +33,8 @@ jobs:
           request-reviews: true
           fail: true
           requirements: |
-            - paths: unmatched
+            - paths:
+                - "airbyte-integrations/connectors/source-**"
+                - "airbyte-integrations/connectors/destination-**"
               teams:
-                - connector-extensibility
-                - gl-python
+                - dev-marketplace-contributions


### PR DESCRIPTION
## What

Changes our workflow so @btkcodedev and @pabloescoder code requests reviews from the marketplace team instead of the extensibility team.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌