### PR TITLE
chore(destination-langchain): archive destination-langchain in favor of per-provider destinations

### DIFF
--- a/airbyte-integrations/connectors/destination-langchain/README.md
+++ b/airbyte-integrations/connectors/destination-langchain/README.md
@@ -3,6 +3,19 @@
 This is the repository for the Langchain destination connector, written in Python.
 For information about how to use this connector within Airbyte, see [the documentation](https://docs.airbyte.com/integrations/destinations/langchain).
 
+> [!warning]
+> The vector db destination destination has been split into separate destinations per vector database. This destination will not receive any further updates and is not subject to SLAs. The separate destinations support all features of this destination and are actively maintained. Please migrate to the respective destination as soon as possible.
+>
+> Please use the respective destination for the vector database you want to use to ensure you receive updates and support.
+>
+> To following databases are supported:
+>
+> - [Pinecone](https://docs.airbyte.com/integrations/destinations/pinecone)
+> - [Weaviate](https://docs.airbyte.com/integrations/destinations/weaviate)
+> - [Milvus](https://docs.airbyte.com/integrations/destinations/milvus)
+> - [Chroma](https://docs.airbyte.com/integrations/destinations/chroma)
+> - [Qdrant](https://docs.airbyte.com/integrations/destinations/qdrant)
+
 ## Local development
 
 ### Prerequisites

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -22,7 +22,7 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-  supportLevel: community
+  supportLevel: archived
   releases:
     breakingChanges:
       0.1.0:

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -1,9 +1,9 @@
 data:
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
-      enabled: true
+      enabled: false
   connectorSubtype: database
   connectorType: destination
   definitionId: cf98d52c-ba5a-4dfd-8ada-c1baebfa6e73

--- a/docs/integrations/destinations/langchain.md
+++ b/docs/integrations/destinations/langchain.md
@@ -12,7 +12,7 @@ To following databases are supported:
 - [Milvus](https://docs.airbyte.com/integrations/destinations/milvus)
 - [Chroma](https://docs.airbyte.com/integrations/destinations/chroma)
 - [Qdrant](https://docs.airbyte.com/integrations/destinations/qdrant)
-  :::
+:::
 
 ## Overview
 


### PR DESCRIPTION
## What

Per this comment, cleaning up destination-langchain and updating it's README and metadata.
The connector will be archived (moved to archive repo) in the next PR.

Folks who are using the connector today can continue to use it, of course.

