### PR TITLE
airbyte-ci / connectors-insights: make Syft use local docker config

### DIFF
--- a/airbyte-ci/connectors/connectors_insights/README.md
+++ b/airbyte-ci/connectors/connectors_insights/README.md
@@ -56,6 +56,9 @@ This CLI is currently running nightly in GitHub Actions. The workflow can be fou
 
 ## Changelog
 
+### 0.2.3
+Share `.docker/config.json` with `syft` to benefit from increased DockerHub rate limit.
+
 ### 0.2.2
 - Write the sbom output to a file and not to stdout to avoid issues with large outputs.
 

--- a/airbyte-ci/connectors/connectors_insights/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_insights/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-insights"
-version = "0.2.2"
+version = "0.2.3"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/sbom.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/sbom.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -14,9 +15,23 @@ GRYPE_DOCKER_IMAGE = "anchore/grype:v0.78.0"
 
 
 def get_syft_container(dagger_client: dagger.Client) -> dagger.Container:
+    """Get a Syft container to which the local docker config is mounted to benefit from DockerHub increased rate limit or connect to private registries.
+
+    Args:
+        dagger_client (dagger.Client): The current Dagger client
+
+    Returns:
+            dagger.Container: The Syft container
+    """
+    home_dir = os.path.expanduser("~")
+    config_path = os.path.join(home_dir, ".docker", "config.json")
+    config_file = dagger_client.host().file(config_path)
     return (
-        dagger_client.container().from_(SYFT_DOCKER_IMAGE)
+        dagger_client.container()
+        .from_(SYFT_DOCKER_IMAGE)
         # Syft requires access to the docker daemon. We share the host's docker socket with the Syft container.
+        .with_mounted_file("/config/config.json", config_file)
+        .with_env_variable("DOCKER_CONFIG", "/config")
         .with_unix_socket("/var/run/docker.sock", dagger_client.host().unix_socket("/var/run/docker.sock"))
     )
 

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -761,7 +761,8 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.20.3  | [#40754](https://github.com/airbytehq/airbyte/pull/40754) | Accept and ignore additional args in `migrate-to-poetry` pipeline                                                             |
+| 4.20.4  | [#41029](https://github.com/airbytehq/airbyte/pull/41029)  | `up-to-date`: mount local docker config to `Syft` to pull private images and benefit from increased DockerHub rate limits.   |
+| 4.20.3  | [#40754](https://github.com/airbytehq/airbyte/pull/40754)  | Accept and ignore additional args in `migrate-to-poetry` pipeline                                                            |
 | 4.20.2  | [#40709](https://github.com/airbytehq/airbyte/pull/40709)  | Fix use of GH token.                                                                                                         |
 | 4.20.1  | [#40698](https://github.com/airbytehq/airbyte/pull/40698)  | Add live tests evaluation mode options.                                                                                      |
 | 4.20.0  | [#38816](https://github.com/airbytehq/airbyte/pull/38816)  | Add command for running all live tests (validation + regression).                                                            |

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.20.3"
+version = "4.20.4"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
Syft is used in `up-to-date` and `connectors-insights` to list the dependencies of a connector image.
Syft pulls the targeted image. These pulls are rate limited by DockerHub.
Our enterprise DockerHub account has a `5000` pulls a day which does not benefit to Syft if we're not authenticated to DockerHub.

This change should expose the local docker config to `Syft` so that it can be authenticated to the DockerHub in the same way the host running the workflows are.

## How
Mount the local docker config to the Syft containers
