### PR TITLE
Remove redundant version key

### DIFF
--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.20.4"
 version = "4.21.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]


### PR DESCRIPTION
Fixes a bug introduced [here](https://github.com/airbytehq/airbyte/pull/41029/files#diff-087e2c37602bbd6824f875004abddcb4e1a374da12bf84201671ed0900882ce0R7) that is blocking (at least me?) building master.

Causes the error `Cannot overwrite a value (at line 8, column 19)`

I'm not sure which version key is correct tho.