### PR TITLE
connectors-insights: do no generate insights for scaffolds and strict encrypt connectors

### DIFF
--- a/airbyte-ci/connectors/connectors_insights/README.md
+++ b/airbyte-ci/connectors/connectors_insights/README.md
@@ -56,6 +56,9 @@ This CLI is currently running nightly in GitHub Actions. The workflow can be fou
 
 ## Changelog
 
+### 0.2.4
+Do not generate insights for `*-scaffold-*` and `*-strict-encrypt` connectors.
+
 ### 0.2.3
 Share `.docker/config.json` with `syft` to benefit from increased DockerHub rate limit.
 

--- a/airbyte-ci/connectors/connectors_insights/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_insights/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-insights"
-version = "0.2.3"
+version = "0.2.4"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/cli.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/cli.py
@@ -104,7 +104,6 @@ async def generate(
         )
     else:
         logger.info(f"Generating insights for {len(connectors)} connectors.")
-
     semaphore = Semaphore(concurrency)
     soon_results = []
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as dagger_client:

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/utils.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/utils.py
@@ -45,8 +45,12 @@ def get_all_connectors_in_directory(directory: Path) -> Set[Connector]:
     """
     connectors = []
     for connector_directory in directory.iterdir():
-        if connector_directory.is_dir() and (connector_directory / METADATA_FILE_NAME).exists():
-            connectors.append(Connector(connector_directory.name))
+        if (
+            connector_directory.is_dir()
+            and (connector_directory / METADATA_FILE_NAME).exists()
+            and "scaffold" not in str(connector_directory)
+        ):
+            connectors.append(Connector(remove_strict_encrypt_suffix(connector_directory.name)))
     return set(connectors)
 
 


### PR DESCRIPTION
## What
`*-scaffold` and `*-strict-encrypt` connectors are not real/full connectors. We don't want to generate insights for them.
