### PR TITLE
community-ci: remove airbyte-ci from protected paths

### DIFF
--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -30,7 +30,6 @@ jobs:
           filters: |
             protected_paths:
               - '.github/**'
-              - 'airbyte-ci/**'
 
       - name: Fail if changes in protected paths
         if: steps.check_for_changes_in_protected_paths.outputs.protected_paths == 'true'


### PR DESCRIPTION
## What
This community PR https://github.com/airbytehq/airbyte/pull/40731 is legitimately modifying `airbyte-ci`.
We shall remove `airbyte-ci` from the protected path to get CI to run on this PR.
