### PR TITLE
python-connector-base: use Python 3.10 root image

### DIFF
--- a/airbyte-ci/connectors/base_images/README.md
+++ b/airbyte-ci/connectors/base_images/README.md
@@ -19,7 +19,7 @@ However, we do artificially generate Dockerfiles for debugging and documentation
 
 ### Example for `airbyte/python-connector-base`:
 ```dockerfile
-FROM docker.io/python:3.9.19-slim-bookworm@sha256:e6941b744e8eb9df6cf6baf323d2b9ad1dfe17d118f5efee14634aff4d47c76f
+FROM docker.io/python:3.10.14-slim-bookworm@sha256:3b37199fbc5a730a551909b3efa7b29105c859668b7502451c163f2a4a7ae1ed
 RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN pip install --upgrade pip==24.0 setuptools==70.0.0
 ENV POETRY_VIRTUALENVS_CREATE=false
@@ -41,6 +41,7 @@ RUN mkdir /usr/share/nltk_data
 
 | Version | Published | Docker Image Address | Changelog | 
 |---------|-----------|--------------|-----------|
+|  2.0.0 | ✅| docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916 | Use Python 3.10 |
 |  1.2.3 | ✅| docker.io/airbyte/python-connector-base:1.2.3@sha256:a8abfdc75f8e22931657a1ae15069e7b925e74bb7b5ef36371a85e4caeae5696 | Use latest root image version and update system packages |
 |  1.2.2 | ✅| docker.io/airbyte/python-connector-base:1.2.2@sha256:57703de3b4c4204bd68a7b13c9300f8e03c0189bffddaffc796f1da25d2dbea0 | Fix Python 3.9.19 image digest |
 |  1.2.2-rc.1 | ✅| docker.io/airbyte/python-connector-base:1.2.2-rc.1@sha256:a8abfdc75f8e22931657a1ae15069e7b925e74bb7b5ef36371a85e4caeae5696 |  |

--- a/airbyte-ci/connectors/base_images/base_images/python/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/python/bases.py
@@ -10,12 +10,12 @@ import dagger
 from base_images import bases, published_image
 from base_images import sanity_checks as base_sanity_checks
 from base_images.python import sanity_checks as python_sanity_checks
-from base_images.root_images import PYTHON_3_9_19
+from base_images.root_images import PYTHON_3_10_14
 
 
 class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
 
-    root_image: Final[published_image.PublishedImage] = PYTHON_3_9_19
+    root_image: Final[published_image.PublishedImage] = PYTHON_3_10_14
     repository: Final[str] = "airbyte/python-connector-base"
     pip_cache_name: Final[str] = "pip_cache"
     nltk_data_path: Final[str] = "/usr/share/nltk_data"
@@ -119,7 +119,7 @@ class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
         container = self.get_container(platform)
         await base_sanity_checks.check_timezone_is_utc(container)
         await base_sanity_checks.check_a_command_is_available_using_version_option(container, "bash")
-        await python_sanity_checks.check_python_version(container, "3.9.19")
+        await python_sanity_checks.check_python_version(container, "3.10.14")
         await python_sanity_checks.check_pip_version(container, "24.0")
         await python_sanity_checks.check_poetry_version(container, "1.6.1")
         await python_sanity_checks.check_python_image_has_expected_env_vars(container)

--- a/airbyte-ci/connectors/base_images/base_images/root_images.py
+++ b/airbyte-ci/connectors/base_images/base_images/root_images.py
@@ -17,3 +17,10 @@ PYTHON_3_9_19 = PublishedImage(
     tag="3.9.19-slim-bookworm",
     sha="e6941b744e8eb9df6cf6baf323d2b9ad1dfe17d118f5efee14634aff4d47c76f",
 )
+
+PYTHON_3_10_14 = PublishedImage(
+    registry="docker.io",
+    repository="python",
+    tag="3.10.14-slim-bookworm",
+    sha="3b37199fbc5a730a551909b3efa7b29105c859668b7502451c163f2a4a7ae1ed",
+)

--- a/airbyte-ci/connectors/base_images/generated/changelogs/airbyte_python_connector_base.json
+++ b/airbyte-ci/connectors/base_images/generated/changelogs/airbyte_python_connector_base.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "2.0.0",
+    "changelog_entry": "Use Python 3.10",
+    "dockerfile_example": "FROM docker.io/python:3.10.14-slim-bookworm@sha256:3b37199fbc5a730a551909b3efa7b29105c859668b7502451c163f2a4a7ae1ed\nRUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime\nRUN pip install --upgrade pip==24.0 setuptools==70.0.0\nENV POETRY_VIRTUALENVS_CREATE=false\nENV POETRY_VIRTUALENVS_IN_PROJECT=false\nENV POETRY_NO_INTERACTION=1\nRUN pip install poetry==1.6.1\nRUN sh -c apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get clean\nRUN sh -c apt-get install -y socat=1.7.4.4-2\nRUN sh -c apt-get update && apt-get install -y tesseract-ocr=5.3.0-2 poppler-utils=22.12.0-2+b1\nRUN mkdir /usr/share/nltk_data"
+  },
+  {
     "version": "1.2.3",
     "changelog_entry": "Use latest root image version and update system packages",
     "dockerfile_example": "FROM docker.io/python:3.9.19-slim-bookworm@sha256:e6941b744e8eb9df6cf6baf323d2b9ad1dfe17d118f5efee14634aff4d47c76f\nRUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime\nRUN pip install --upgrade pip==24.0 setuptools==70.0.0\nENV POETRY_VIRTUALENVS_CREATE=false\nENV POETRY_VIRTUALENVS_IN_PROJECT=false\nENV POETRY_NO_INTERACTION=1\nRUN pip install poetry==1.6.1\nRUN sh -c apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get clean\nRUN sh -c apt-get install -y socat=1.7.4.4-2\nRUN sh -c apt-get update && apt-get install -y tesseract-ocr=5.3.0-2 poppler-utils=22.12.0-2+b1\nRUN mkdir /usr/share/nltk_data"

--- a/airbyte-ci/connectors/base_images/tests/test_python/test_bases.py
+++ b/airbyte-ci/connectors/base_images/tests/test_python/test_bases.py
@@ -19,7 +19,7 @@ class TestAirbytePythonConnectorBaseImage:
 
     def test_class_attributes(self):
         """Spot any regression in the class attributes."""
-        assert bases.AirbytePythonConnectorBaseImage.root_image == root_images.PYTHON_3_9_19
+        assert bases.AirbytePythonConnectorBaseImage.root_image == root_images.PYTHON_3_10_14
         assert bases.AirbytePythonConnectorBaseImage.repository == "airbyte/python-connector-base"
         assert bases.AirbytePythonConnectorBaseImage.pip_cache_name == "pip_cache"
 


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/41061
Make our python connector base image use Python 3.10

## How
Change the root image to the latest 3.10 image

## User Impact
Our connectors will get updated to use this image thanks to the `up-to-date` pipeline.
