### PR TITLE
bug(source-datadog) Reenabled datadog in cloud

### DIFF
--- a/airbyte-integrations/connectors/source-datadog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datadog/metadata.yaml
@@ -14,7 +14,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   connectorSubtype: api
   connectorType: source
   definitionId: 1cfc30c7-82db-43f4-9fd7-ac1b42312cda


### PR DESCRIPTION
## What
I believe we disabled source-datadog accidentally in cloud in August
https://github.com/airbytehq/airbyte/pull/29885

## How
This reenables it.

## Risks
This has been awhile since it was tested