### PR TITLE
regression-test workflow: disable dagger cache

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -91,7 +91,7 @@ jobs:
         uses: ./.github/actions/run-airbyte-ci
         with:
           context: "manual"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_2 }}
+          #dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_2 }}
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}


### PR DESCRIPTION
## What
Our regression test workflow is leveraging dagger cache volumes to share proxy dump between control/target at execution time. 
We empty these volumes on teardown but Dagger Cloud still creates, upload and syncs them for other Dagger workflows.
This adds a lot of overhead on the majority of our CI workflows.



**I suggest to disable the Dagger Cloud cache for our regression test workflow to avoid this problem.**

<img width="751" alt="Screenshot 2024-07-10 at 09 53 23" src="https://github.com/airbytehq/airbyte/assets/5551758/9113356b-b097-412c-8b8f-b0f448dc262a">
