### PR TITLE
docs(source-s3): Only show authenticating with IAM role on cloud

### DIFF
--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -62,10 +62,15 @@ Your `Secret Access Key` will only be visible once upon creation. Be sure to cop
 For more information on managing your access keys, please refer to the
 [official AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).
 
-<!-- env:cloud -->
 
 #### Option 2: Using an IAM Role (Most secure)
 
+<!-- env:oss -->
+:::note
+S3 authentication using an IAM role member is not supported using the OSS platform.
+<!-- /env:oss -->
+
+<!-- env:cloud -->
 
 :::note
 S3 authentication using an IAM role member must be enabled by a member of the Airbyte team. If you'd like to use this feature, please [contact the Sales team](https://airbyte.com/company/talk-to-sales) for more information.

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -48,42 +48,31 @@ At this time, object-level permissions alone are not sufficient to successfully 
 
 4. Give your policy a descriptive name, then click **Create policy**.
 
-#### Option 1: Using an IAM Role (Most secure)
+#### Option 1: Using an IAM User
+
+1. In the IAM dashboard, click **Users**. Select an existing IAM user or create a new one by clicking **Add users**.
+2. If you are using an _existing_ IAM user, click the **Add permissions** dropdown menu and select **Add permissions**. If you are creating a _new_ user, you will be taken to the Permissions screen after selecting a name.
+3. Select **Attach policies directly**, then find and check the box for your new policy. Click **Next**, then **Add permissions**.
+4. After successfully creating your user, select the **Security credentials** tab and click **Create access key**. You will be prompted to select a use case and add optional tags to your access key. Click **Create access key** to generate the keys.
+
+:::caution
+Your `Secret Access Key` will only be visible once upon creation. Be sure to copy and store it securely for future use.
+:::
+
+For more information on managing your access keys, please refer to the
+[official AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).
 
 <!-- env:cloud -->
+
+#### Option 2: Using an IAM Role (Most secure)
+
 
 :::note
 S3 authentication using an IAM role member must be enabled by a member of the Airbyte team. If you'd like to use this feature, please [contact the Sales team](https://airbyte.com/company/talk-to-sales) for more information.
 :::
 
-<!-- /env:cloud -->
 
-1. In the IAM dashboard, click **Roles**, then **Create role**. <!-- env:oss -->
-2. Choose the appropriate trust entity and attach the policy you created.
-3. Set up a trust relationship for the role. For example for **AWS account** trusted entity use default AWS account on your instance (it will be used to assume role). To use **External ID** set it to environment variables as `export AWS_ASSUME_ROLE_EXTERNAL_ID="{your-external-id}"`. Edit the trust relationship policy to reflect this:
-
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam::{your-aws-account-id}:user/{your-username}"
-            },
-            "Action": "sts:AssumeRole",
-            "Condition": {
-                "StringEquals": {
-                    "sts:ExternalId": "{your-external-id}"
-                }
-            }
-        }
-    ]
-}
-```
-
-<!-- /env:oss -->
-<!-- env:cloud -->
+1. In the IAM dashboard, click **Roles**, then **Create role**.
 
 2. Choose the **AWS account** trusted entity type.
 3. Set up a trust relationship for the role. This allows the Airbyte instance's AWS account to assume this role. You will also need to specify an external ID, which is a secret key that the trusting service (Airbyte) and the trusted role (the role you're creating) both know. This ID is used to prevent the "confused deputy" problem. The External ID should be your Airbyte workspace ID, which can be found in the URL of your workspace page. Edit the trust relationship policy to include the external ID:
@@ -108,23 +97,9 @@ S3 authentication using an IAM role member must be enabled by a member of the Ai
 }
 ```
 
-<!-- /env:cloud -->
-
 4. Complete the role creation and note the Role ARN.
 
-#### Option 2: Using an IAM User
-
-1. In the IAM dashboard, click **Users**. Select an existing IAM user or create a new one by clicking **Add users**.
-2. If you are using an _existing_ IAM user, click the **Add permissions** dropdown menu and select **Add permissions**. If you are creating a _new_ user, you will be taken to the Permissions screen after selecting a name.
-3. Select **Attach policies directly**, then find and check the box for your new policy. Click **Next**, then **Add permissions**.
-4. After successfully creating your user, select the **Security credentials** tab and click **Create access key**. You will be prompted to select a use case and add optional tags to your access key. Click **Create access key** to generate the keys.
-
-:::caution
-Your `Secret Access Key` will only be visible once upon creation. Be sure to copy and store it securely for future use.
-:::
-
-For more information on managing your access keys, please refer to the
-[official AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).
+<!-- /env:cloud -->
 
 ### Step 2: Set up the Amazon S3 connector in Airbyte
 


### PR DESCRIPTION
## What
Hide instructions for authenticating with IAM role on OSS because we explicitly do not support it.

## How
1. Make authenticating with a IAM user the first option
2. Only render the second option on cloud

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
