### PR TITLE
airbyte-ci: support cloning private git repo

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -767,6 +767,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.22.0  | [#41623](https://github.com/airbytehq/airbyte/pull/41623)  | Make `airbyte-ci` run on private forks.                                                                                      |
 | 4.21.1  | [#41029](https://github.com/airbytehq/airbyte/pull/41029)  | `up-to-date`: mount local docker config to `Syft` to pull private images and benefit from increased DockerHub rate limits.   |
 | 4.21.0  | [#40547](https://github.com/airbytehq/airbyte/pull/40547)  | Make bump-version accept a `--pr-number` option.                                                                             |
 | 4.20.3  | [#40754](https://github.com/airbytehq/airbyte/pull/40754)  | Accept and ignore additional args in `migrate-to-poetry` pipeline                                                            |

--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/containers/git.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/containers/git.py
@@ -1,9 +1,14 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
+import os
 from typing import Optional
 
 from dagger import Client, Container
-from pipelines.helpers.utils import AIRBYTE_REPO_URL
+from pipelines.helpers.utils import AIRBYTE_REPO_URL, sh_dash_c
+
+
+def get_authenticated_repo_url(url: str, github_token: str) -> str:
+    return url.replace("https://github.com", f"https://{github_token}@github.com")
 
 
 async def checked_out_git_container(
@@ -19,30 +24,25 @@ async def checked_out_git_container(
     We fetch the diffed branch from the origin remote and the current branch from the target remote.
     We then checkout the current branch.
     """
+    origin_repo_url = AIRBYTE_REPO_URL
     current_git_branch = current_git_branch.removeprefix("origin/")
     diffed_branch = current_git_branch if diffed_branch is None else diffed_branch.removeprefix("origin/")
+    if github_token := os.environ.get("CI_GITHUB_ACCESS_TOKEN"):
+        origin_repo_url = get_authenticated_repo_url(origin_repo_url, github_token)
+        target_repo_url = get_authenticated_repo_url(repo_url, github_token)
+    origin_repo_url_secret = dagger_client.set_secret("ORIGIN_REPO_URL", origin_repo_url)
+    target_repo_url_secret = dagger_client.set_secret("TARGET_REPO_URL", target_repo_url)
+
     git_container = (
         dagger_client.container()
         .from_("alpine/git:latest")
         .with_workdir("/repo")
         .with_exec(["init"])
         .with_env_variable("CACHEBUSTER", current_git_revision)
-        .with_exec(
-            [
-                "remote",
-                "add",
-                "origin",
-                AIRBYTE_REPO_URL,
-            ]
-        )
-        .with_exec(
-            [
-                "remote",
-                "add",
-                "target",
-                repo_url,
-            ]
-        )
+        .with_secret_variable("ORIGIN_REPO_URL", origin_repo_url_secret)
+        .with_secret_variable("TARGET_REPO_URL", target_repo_url_secret)
+        .with_exec(sh_dash_c(["git remote add origin ${ORIGIN_REPO_URL}"]), skip_entrypoint=True)
+        .with_exec(sh_dash_c(["git remote add target ${TARGET_REPO_URL}"]), skip_entrypoint=True)
         .with_exec(["fetch", "origin", diffed_branch])
     )
     if diffed_branch != current_git_branch:

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from pipelines.airbyte_ci.connectors.context import ConnectorContext
 
 DAGGER_CONFIG = Config(log_output=sys.stderr)
-AIRBYTE_REPO_URL = "https://github.com/airbytehq/airbyte.git"
+AIRBYTE_REPO_URL = os.environ.get("AIRBYTE_REPO_URL", "https://github.com/airbytehq/airbyte.git")
 METADATA_FILE_NAME = "metadata.yaml"
 MANIFEST_FILE_NAME = "manifest.yaml"
 METADATA_ICON_FILE_NAME = "icon.svg"

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.21.1"
+version = "4.22.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
@postamar is working on a private fork of our repo.
Subtle changes to `airbyte-ci` have to be made to make it run flawlessly on a private repo

## How
`airbyte-ci` has to clone the repo it runs on to perform a `git diff`.
If this repo is private we need to authenticate the `git` container to `github`.

1. Update repo urls with PAT tokens if it's available.
2. Make `AIRBYTE_REPO_URL`  configurable via env var.

