### PR TITLE
Catherine/cats error on date format issue

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -405,11 +405,11 @@ class TestSpec(BaseTest):
             property_definition = schema_helper.get_parent(format_path)
             pattern = property_definition.get("pattern")
             if format == "date" and not pattern == DATE_PATTERN:
-                detailed_logger.warning(
+                pytest.fail(
                     f"{format_path} is defining a date format without the corresponding pattern. Consider setting the pattern to {DATE_PATTERN} to make it easier for users to edit this field in the UI."
                 )
             if format == "date-time" and not pattern == DATETIME_PATTERN:
-                detailed_logger.warning(
+                pytest.fail(
                     f"{format_path} is defining a date-time format without the corresponding pattern Consider setting the pattern to {DATETIME_PATTERN} to make it easier for users to edit this field in the UI."
                 )
 
@@ -426,11 +426,11 @@ class TestSpec(BaseTest):
                 property_definition = schema_helper.get_parent(pattern_path)
                 format = property_definition.get("format")
                 if not format == "date" and pattern == DATE_PATTERN:
-                    detailed_logger.warning(
+                    pytest.fail(
                         f"{pattern_path} is defining a pattern that looks like a date without setting the format to `date`. Consider specifying the format to make it easier for users to edit this field in the UI."
                     )
                 if not format == "date-time" and pattern == DATETIME_PATTERN:
-                    detailed_logger.warning(
+                    pytest.fail(
                         f"{pattern_path} is defining a pattern that looks like a date-time without setting the format to `date-time`. Consider specifying the format to make it easier for users to edit this field in the UI."
                     )
 

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_spec.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_spec.py
@@ -1638,7 +1638,7 @@ def test_forbidden_complex_types(mocker, connector_spec, should_fail):
 
 
 @pytest.mark.parametrize(
-    "connector_spec, is_warning_logged",
+    "connector_spec, should_fail",
     (
         ({"type": "object", "properties": {"date": {"type": "string"}}}, False),
         ({"type": "object", "properties": {"date": {"type": "string", "format": "date"}}}, True),
@@ -1670,20 +1670,19 @@ def test_forbidden_complex_types(mocker, connector_spec, should_fail):
         ),
     ),
 )
-def test_date_pattern(mocker, connector_spec, is_warning_logged):
+def test_date_pattern(mocker, connector_spec, should_fail):
     mocker.patch.object(conftest.pytest, "fail")
     logger = mocker.Mock()
     t = _TestSpec()
     t.test_date_pattern(ConnectorSpecification(connectionSpecification=connector_spec), logger)
-    conftest.pytest.fail.assert_not_called()
-    if is_warning_logged:
-        _, args, _ = logger.warning.mock_calls[0]
-        msg, *_ = args
-        assert "Consider setting the pattern" in msg
+    if should_fail:
+        conftest.pytest.fail.assert_called_once()
+    else:
+        conftest.pytest.fail.assert_not_called()
 
 
 @pytest.mark.parametrize(
-    "connector_spec, is_warning_logged",
+    "connector_spec, should_fail",
     (
         ({"type": "object", "properties": {"date": {"type": "string"}}}, False),
         ({"type": "object", "properties": {"format": {"type": "string"}}}, False),
@@ -1715,16 +1714,15 @@ def test_date_pattern(mocker, connector_spec, is_warning_logged):
         ),
     ),
 )
-def test_date_format(mocker, connector_spec, is_warning_logged):
+def test_date_format(mocker, connector_spec, should_fail):
     mocker.patch.object(conftest.pytest, "fail")
     logger = mocker.Mock()
     t = _TestSpec()
     t.test_date_format(ConnectorSpecification(connectionSpecification=connector_spec), logger)
-    conftest.pytest.fail.assert_not_called()
-    if is_warning_logged:
-        _, args, _ = logger.warning.mock_calls[0]
-        msg, *_ = args
-        assert "Consider specifying the format" in msg
+    if should_fail:
+        conftest.pytest.fail.assert_called_once()
+    else:
+        conftest.pytest.fail.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/airbyte-integrations/connectors/source-nytimes/source_nytimes/spec.yaml
+++ b/airbyte-integrations/connectors/source-nytimes/source_nytimes/spec.yaml
@@ -23,6 +23,7 @@ connectionSpecification:
       examples:
         - 2022-08
         - 1851-01
+      format: date
       order: 1
     end_date:
       type: string
@@ -32,6 +33,7 @@ connectionSpecification:
       examples:
         - 2022-08
         - 1851-01
+      format: date
       order: 2
     period:
       type: integer

--- a/airbyte-integrations/connectors/source-nytimes/source_nytimes/spec.yaml
+++ b/airbyte-integrations/connectors/source-nytimes/source_nytimes/spec.yaml
@@ -23,7 +23,6 @@ connectionSpecification:
       examples:
         - 2022-08
         - 1851-01
-      format: date
       order: 1
     end_date:
       type: string
@@ -33,7 +32,6 @@ connectionSpecification:
       examples:
         - 2022-08
         - 1851-01
-      format: date
       order: 2
     period:
       type: integer


### PR DESCRIPTION
The source-nytimes connector had a bug where the connector config & spec were considered invalid by the platform, making it impossible to set up the connector.

We actually have a test that could have caught this (`test_date_pattern`), but they're logging a warning instead of failing. This PR updates the tests to actually fail.

Note: Although I only confirmed that one of the control flow codepaths in `test_date_pattern` would have caught this problem, I went ahead and updated all relevant codepaths in `test_date_pattern` and `test_date_format` to fail instead of emitting a warning. I did this because there was no indication in the test history that they were excessively noisy or brittle. If this causes any false alarms we can revisit that decision.

Related conversation: https://airbytehq-team.slack.com/archives/C03VDJ4FMJB/p1720537414878449