### PR TITLE
Fix /approve-regression-tests workflow

### DIFF
--- a/.github/workflows/approve-regression-tests-command.yml
+++ b/.github/workflows/approve-regression-tests-command.yml
@@ -1,7 +1,6 @@
 name: Approve Regression Tests
 permissions:
   pull-requests: write
-  status: write # to allow the GITHUB_TOKEN to post a commit status
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This should fix an error in the approve-regression-tests-command.yml workflow:

```
Invalid workflow file: .github/workflows/approve-regression-tests-command.yml#L4The workflow is not valid. .github/workflows/approve-regression-tests-command.yml (Line: 4, Col: 3): Unexpected value 'status'
--


[Invalid workflow file: .github/workflows/approve-regression-tests-command.yml#L4](https://github.com/airbytehq/airbyte/actions/runs/9895409102/workflow)
The workflow is not valid. .github/workflows/approve-regression-tests-command.yml (Line: 4, Col: 3): Unexpected value 'status'
```

Not sure exactly how this line got in there but it appears to have snuck in from copy/paste after testing.