### PR TITLE
Regression tests approval workflow: add statuses: write permission

### DIFF
--- a/.github/workflows/approve-regression-tests-command.yml
+++ b/.github/workflows/approve-regression-tests-command.yml
@@ -28,6 +28,8 @@ jobs:
   approve-regression-tests:
     name: "Approve Regression Tests"
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Get job variables
         id: job-vars


### PR DESCRIPTION
Fix 403 in the /approve-regression-tests workflow.