### PR TITLE
Regression tests approval workflow: add issues: write permission

### DIFF
--- a/.github/workflows/approve-regression-tests-command.yml
+++ b/.github/workflows/approve-regression-tests-command.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
+      issues: write
     steps:
       - name: Get job variables
         id: job-vars


### PR DESCRIPTION
Fixes `RequestError [HttpError]: Resource not accessible by integration` from /approve-regression-tests commad.
