### PR TITLE
Regression tests approval workflow: make permissions workflow-level

### DIFF
--- a/.github/workflows/approve-regression-tests-command.yml
+++ b/.github/workflows/approve-regression-tests-command.yml
@@ -1,6 +1,7 @@
 name: Approve Regression Tests
 permissions:
   pull-requests: write
+  statuses: write
 on:
   workflow_dispatch:
     inputs:
@@ -28,9 +29,6 @@ jobs:
   approve-regression-tests:
     name: "Approve Regression Tests"
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      issues: write
     steps:
       - name: Get job variables
         id: job-vars


### PR DESCRIPTION
Fixing permissions issue with the /-command.