### PR TITLE
🐛 bug(Source facebook-marketing): remove unused discriminator from spec

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
@@ -521,7 +521,10 @@
         "type": "string"
       }
     },
-    "required": ["account_ids"]
+    "required": [
+      "account_ids",
+      "credentials"
+    ]
   },
   "supportsIncremental": true,
   "supported_destination_sync_modes": ["append"],

--- a/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
@@ -30,13 +30,6 @@
         "title": "Authentication",
         "description": "Credentials for connecting to the Facebook Marketing API",
         "type": "object",
-        "discriminator": {
-          "propertyName": "auth_type",
-          "mapping": {
-            "Client": "#/definitions/OAuthCredentials",
-            "Service": "#/definitions/ServiceAccountCredentials"
-          }
-        },
         "oneOf": [
           {
             "title": "Authenticate via Facebook Marketing (Oauth)",

--- a/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
@@ -521,10 +521,7 @@
         "type": "string"
       }
     },
-    "required": [
-      "account_ids",
-      "credentials"
-    ]
+    "required": ["account_ids", "credentials"]
   },
   "supportsIncremental": true,
   "supported_destination_sync_modes": ["append"],

--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
-  dockerImageTag: 3.3.11
+  dockerImageTag: 3.3.12
   dockerRepository: airbyte/source-facebook-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-marketing
   githubIssueLabel: source-facebook-marketing

--- a/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.3.11"
+version = "3.3.12"
 name = "source-facebook-marketing"
 description = "Source implementation for Facebook Marketing."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -35,7 +35,6 @@ EMPTY_PATTERN = "^$"
 class OAuthCredentials(BaseModel):
     class Config(OneOfOptionConfig):
         title = "Authenticate via Facebook Marketing (Oauth)"
-        discriminator = "auth_type"
 
     auth_type: Literal["Client"] = Field("Client", const=True)
     client_id: str = Field(
@@ -61,7 +60,6 @@ class OAuthCredentials(BaseModel):
 class ServiceAccountCredentials(BaseModel):
     class Config(OneOfOptionConfig):
         title = "Service Account Key Authentication"
-        discriminator = "auth_type"
 
     auth_type: Literal["Service"] = Field("Service", const=True)
     access_token: str = Field(
@@ -202,7 +200,6 @@ class ConnectorConfig(BaseConfig):
     credentials: Optional[Union[OAuthCredentials, ServiceAccountCredentials]] = Field(
         title="Authentication",
         description="Credentials for connecting to the Facebook Marketing API",
-        discriminator="auth_type",
         type="object",
     )
 

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -35,6 +35,7 @@ EMPTY_PATTERN = "^$"
 class OAuthCredentials(BaseModel):
     class Config(OneOfOptionConfig):
         title = "Authenticate via Facebook Marketing (Oauth)"
+        discriminator = "auth_type"
 
     auth_type: Literal["Client"] = Field("Client", const=True)
     client_id: str = Field(
@@ -60,6 +61,7 @@ class OAuthCredentials(BaseModel):
 class ServiceAccountCredentials(BaseModel):
     class Config(OneOfOptionConfig):
         title = "Service Account Key Authentication"
+        discriminator = "auth_type"
 
     auth_type: Literal["Service"] = Field("Service", const=True)
     access_token: str = Field(
@@ -197,7 +199,7 @@ class ConnectorConfig(BaseConfig):
         airbyte_secret=True,
     )
 
-    credentials: Optional[Union[OAuthCredentials, ServiceAccountCredentials]] = Field(
+    credentials: Union[OAuthCredentials, ServiceAccountCredentials] = Field(
         title="Authentication",
         description="Credentials for connecting to the Facebook Marketing API",
         type="object",

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -215,6 +215,7 @@ This response indicates that the Facebook Graph API requires you to reduce the f
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                           |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.3.12 | 2024-07-11 | [41644](https://github.com/airbytehq/airbyte/pull/41644) | Remove discriminator with missing schemas  |
 | 3.3.11 | 2024-07-10 | [41039](https://github.com/airbytehq/airbyte/pull/41039) | Pick request fields from configured json schema properties if present  |
 | 3.3.10 | 2024-07-10 | [41458](https://github.com/airbytehq/airbyte/pull/41458) | Update dependencies |
 | 3.3.9 | 2024-07-09 | [41106](https://github.com/airbytehq/airbyte/pull/41106) | Update dependencies |


### PR DESCRIPTION
## What
 It appears that the registry was updated, and Facebook Marketing’s spec now contains a credentials block that references definitions that are not found anywhere.
```
 "credentials": {
              "title": "Authentication",
              "description": "Credentials for connecting to the Facebook Marketing API",
              "type": "object",
              "discriminator": {
                "propertyName": "auth_type",
                "mapping": {
                  "Client": "#/definitions/OAuthCredentials",
                  "Service": "#/definitions/ServiceAccountCredentials"
                }
              },
```
That’s causing issues with generating the terraform provider. 

[Here is the conversation](https://airbytehq-team.slack.com/archives/C02UF50V9HA/p1720657497281509) related if you want to make a deep dive.

## How
Let's remove unused discriminator

## Review guide

1. `integration_tests/spec.json`: discrimintor being removed


## User Impact
Terraform provider can be generated now

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
