### PR TITLE
chore: mention tooling team instead of extensibility on connector publishing alerts 

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: connector-publish-large
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Publish modified connectors [On merge to master]
         id: publish-modified-connectors
         if: github.event_name == 'push'
@@ -101,7 +101,7 @@ jobs:
     if: ${{ failure() && github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Match GitHub User to Slack User
         id: match-github-to-slack-user
         uses: ./.github/actions/match-github-to-slack-user

--- a/.github/workflows/run-mypy-on-modified-cdk-files.yml
+++ b/.github/workflows/run-mypy-on-modified-cdk-files.yml
@@ -1,4 +1,4 @@
-name: Connector Extensibility - Run mypy on modified cdk files
+name: Python CDK - Run mypy on modified cdk files
 
 on:
   pull_request:

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/secret_access.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/secret_access.py
@@ -28,7 +28,7 @@ def get_secret_value(secret_manager_client: secretmanager.SecretManagerServiceCl
         return response.payload.data.decode("UTF-8")
     except PermissionDenied as e:
         logging.exception(
-            f"Permission denied while trying to access secret {secret_id}. Please write to #dev-extensibility in Airbyte Slack for help.",
+            f"Permission denied while trying to access secret {secret_id}. Please write to #dev-tooling in Airbyte Slack for help.",
             exc_info=e,
         )
         raise e

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
@@ -132,5 +132,5 @@ class PublishConnectorContext(ConnectorContext):
             assert self.report is not None, "Report should be set when state is successful"
             message += f"⏲️ Run duration: {format_duration(self.report.run_duration)}\n"
         if self.state is ContextState.FAILURE:
-            message += "\ncc. <!subteam^S03BQLNTFNC>"
+            message += "\ncc. <!subteam^S077R8636CV>"
         return message


### PR DESCRIPTION
## What
Minor connector publishing github workflow cleanup:
- Use `checkout@v4` instead of `v3`. 
- Mention @airbytehq/dev-tooling instead of extensibility


## User Impact

None.

Automerge on.