### PR TITLE
🐛 [RFR for API Sources] Fix bug where checkpoint reader stops syncing too early if first partition is complete

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
@@ -119,7 +119,8 @@ class CursorBasedCheckpointReader(CheckpointReader):
                     next_slice = self._get_next_slice()
                     state_for_slice = self._cursor.select_state(next_slice)
                     if state_for_slice == FULL_REFRESH_COMPLETE_STATE:
-                        next_candidate_slice = None
+                        # This is a dummy initialization since we'll iterate at least once to get the next slice
+                        next_candidate_slice = StreamSlice(cursor_slice={}, partition={})
                         has_more = True
                         while has_more:
                             next_candidate_slice = self._get_next_slice()

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
@@ -115,6 +115,9 @@ class CursorBasedCheckpointReader(CheckpointReader):
 
         try:
             if self._read_state_from_cursor:
+                # We need to check that `current_slice is None` as opposed to `not current_slice` because the current_slice
+                # could be the empty StreamSlice() which derives to the falsy empty mapping {}. The slice still requires
+                # iterating over the cursor state in the else block until it hits the terminal value
                 if self.current_slice is None:
                     next_slice = self._get_next_slice()
                     state_for_slice = self._cursor.select_state(next_slice)


### PR DESCRIPTION
Fixes https://github.com/airbytehq/airbyte-internal-issues/issues/8668

## What

Fixes a bug where if for a substream, the first parent has already successfully synced and had the success terminal value, then we would stop iterating over parent slices too soon and miss unfinished parent record slices.

Note: This does not have any customer impact because we've gated substreams off for all sources. I just noticed this in another PR.

## How

We need to add logic to skip over completed streams if the state is set to the sentinel value indicating a successful sync. And we continue reading the slice iterator until we find an incomplete parent slice or finish going over all parents in which case we are done syncing

I originally found this while implementing https://github.com/airbytehq/airbyte/pull/39450 , but i split out the fix to unblock lwo-code RFR which would have been affected by the bug

## Review guide

it's two files

## User Impact

None

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
