### PR TITLE
airbyte-ci: send status check when skipped

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -57,6 +57,15 @@ jobs:
             "context": "Connectors CI tests",
             "target_url": "${{ github.event.workflow_run.html_url }}"
             }' \
+          curl --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --data '{
+            "state": "success",
+            "context": "Regression Test Results Reviewed and Approved",
+            "target_url": "${{ github.event.workflow_run.html_url }}"
+            }' \
 
   connectors_ci:
     needs: changes

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -767,7 +767,8 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.24.1  | [#41642](https://github.com/airbytehq/airbyte/pull/41642) | Use the AIRBYTE_GITHUB_REPO environment variable to run airbyte-ci in other repos.                                             |
+| 4.24.2  | [#41676](https://github.com/airbytehq/airbyte/pull/41676) | Send regression test approval status check when skipped.                                                                     |
+| 4.24.1  | [#41642](https://github.com/airbytehq/airbyte/pull/41642) | Use the AIRBYTE_GITHUB_REPO environment variable to run airbyte-ci in other repos.                                           |
 | 4.24.0  | [#41627](https://github.com/airbytehq/airbyte/pull/41627) | Require manual regression test approval for certified connectors                                                             |
 | 4.23.1  | [#41541](https://github.com/airbytehq/airbyte/pull/41541)  | Add support for submodule use-case.                                                                                          |
 | 4.23.0  | [#39906](https://github.com/airbytehq/airbyte/pull/39906)  | Add manifest only build pipeline                                                          |

--- a/airbyte-ci/connectors/pipelines/pipelines/hacks.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/hacks.py
@@ -82,6 +82,10 @@ def do_regression_test_status_check_maybe(ctx: click.Context, status_check_name:
 
     Only required for certified connectors.
     """
+    commit = ctx.obj["git_revision"]
+    run_url = ctx.obj["gha_workflow_run_url"]
+    should_send = ctx.obj.get("ci_context") == consts.CIContext.PULL_REQUEST
+
     if any(
         [
             (connector.language == ConnectorLanguage.PYTHON and connector.support_level == "certified")
@@ -89,12 +93,23 @@ def do_regression_test_status_check_maybe(ctx: click.Context, status_check_name:
         ]
     ):
         update_commit_status_check(
-            ctx.obj["git_revision"],
+            commit,
             "failure",
-            ctx.obj["gha_workflow_run_url"],
+            run_url,
             description="Check if regression tests have been manually approved",
             context=status_check_name,
             is_optional=False,
-            should_send=ctx.obj.get("ci_context") == consts.CIContext.PULL_REQUEST,
+            should_send=should_send,
+            logger=logger,
+        )
+    else:
+        update_commit_status_check(
+            commit,
+            "success",
+            run_url,
+            description="[Skipped]",
+            context=status_check_name,
+            is_optional=True,
+            should_send=should_send,
             logger=logger,
         )

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.24.1"
+version = "4.24.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
Add a status check when we're skipping the manual regression test approval (e.g. for PRs that don't touch certified python connectors).

This allows us to make regression test approval required without blocking unrelated PRs.