### PR TITLE
feat(destination-snowflake): Update host regex to allow connecting to LocalStack Snowflake

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 424892c4-daac-4491-b35d-c6688ba547ba
-  dockerImageTag: 3.11.3
+  dockerImageTag: 3.11.4
   dockerRepository: airbyte/destination-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake
   githubIssueLabel: destination-snowflake

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
@@ -19,7 +19,7 @@
         ],
         "type": "string",
         "title": "Host",
-        "pattern": "^(http(s)?:\\/\\/)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.snowflakecomputing\\.com)$",
+        "pattern": "^(http(s)?:\\/\\/)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.(snowflakecomputing\\.com|localstack\\.cloud))$",
         "pattern_descriptor": "{account_name}.snowflakecomputing.com or {accountname}.{aws_location}.aws.snowflakecomputing.com",
         "order": 0
       },

--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -268,6 +268,7 @@ desired namespace.
 
 | Version         | Date       | Pull Request                                               | Subject                                                                                                                                                          |
 |:----------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.11.4          | 2024-07-18 | [\#41940](https://github.com/airbytehq/airbyte/pull/41940) | Update host regex to allow connecting to LocalStack Snowflake |
 | 3.11.3          | 2024-07-15 | [\#41968](https://github.com/airbytehq/airbyte/pull/41968) | Don't hang forever on empty stream list; shorten error message on INCOMPLETE stream status                                                                       |
 | 3.11.2          | 2024-07-12 | [\#41674](https://github.com/airbytehq/airbyte/pull/41674) | Upgrade to latest CDK                                                                                                                                            |
 | 3.11.1          | 2024-07-08 | [\#41041](https://github.com/airbytehq/airbyte/pull/41041) | Fix resume logic in truncate refreshes to prevent data loss                                                                                                      |


### PR DESCRIPTION
First of all, big kudos for building Airbyte - it's really an awesome product! 🚀 🤩  

## What

This PR updates the host regex for Snowflake destinations, to allow connecting to LocalStack Snowflake.

**Motivation:** At LocalStack, we have recently started building a Snowflake emulator that allows running SF queries entirely on the local machine: https://blog.localstack.cloud/2024-05-22-introducing-localstack-for-snowflake/ . As part of building out a repo with sample applications (see [here](https://github.com/localstack-samples/localstack-snowflake-samples)), we are putting together an illustrative Airbyte application that connects to the local Snowflake emulator (running on `localhost`) and performs various data transformations / migrations.

The LocalStack Snowflake emulator is accessible on `snowflake.localhost.localstack.cloud`, which is a domain name that maps to a local IP address. Currently, when attempting to configure this host in the Airbyte destination settings, the UI raises an error message as it doesn't match the expected pattern:
<img width="713" alt="image" src="https://github.com/user-attachments/assets/4f8b675d-4177-4f25-9c2d-3230dbe53a3b">


## How

In this PR, we update the regular expression in `spec.json` to allow specifying subdomains pointing to the LocalStack Snowflake emulator, in particular also `snowflake.localhost.localstack.cloud`.


## Review guide
<!--
1. `x.py`
2. `y.py`
-->

Looking forward to getting your feedback! Please let me know if I should add any unit tests, provide more details, etc. 🙌 Thank you

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
