### PR TITLE
live-tests: explicitely pass the control version to the connection retriever

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -280,6 +280,10 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.17.7
+
+Explicitly pass the control version to the connection retriever. Defaults to the latest released version of the connector under test.
+
 ### 0.17.6
 
 Display diagnostic test with warning.

--- a/airbyte-ci/connectors/live-tests/poetry.lock
+++ b/airbyte-ci/connectors/live-tests/poetry.lock
@@ -746,7 +746,7 @@ files = [
 
 [[package]]
 name = "connection-retriever"
-version = "0.6.2"
+version = "0.6.3"
 description = "A tool to retrieve connection information from our Airbyte Cloud config api database"
 optional = false
 python-versions = "^3.10"
@@ -772,7 +772,7 @@ tqdm = "^4.66.2"
 type = "git"
 url = "git@github.com:airbytehq/airbyte-platform-internal"
 reference = "HEAD"
-resolved_reference = "7c886731fcf100bfdb0f57ce4c14dafb121ba263"
+resolved_reference = "a6e6dd6220995067ca28cfbf11068462f7365a29"
 subdirectory = "tools/connection-retriever"
 
 [[package]]
@@ -999,6 +999,7 @@ files = [
     {file = "duckdb-0.10.1-cp39-cp39-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48d84577216010ee407913bad9dc47af4cbc65e479c91e130f7bd909a32caefe"},
     {file = "duckdb-0.10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6e65f00294c3b8576ae651e91e732ea1cefc4aada89c307fb02f49231fd11e1f"},
     {file = "duckdb-0.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:30aa9dbbfc1f9607249fc148af9e6d6fd253fdc2f4c9924d4957d6a535558b4f"},
+    {file = "duckdb-0.10.1.tar.gz", hash = "sha256:0d5b6daa9bb54a635e371798994caa08f26d2f145ebcbc989e16b0a0104e84fb"},
 ]
 
 [[package]]
@@ -1163,12 +1164,12 @@ files = [
 google-auth = ">=2.14.1,<3.0.dev0"
 googleapis-common-protos = ">=1.56.2,<2.0.dev0"
 grpcio = [
-    {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
     {version = ">=1.33.2,<2.0dev", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
 ]
 grpcio-status = [
-    {version = ">=1.49.1,<2.0.dev0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
     {version = ">=1.33.2,<2.0.dev0", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.49.1,<2.0.dev0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
 ]
 proto-plus = ">=1.22.3,<2.0.0dev"
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0.dev0"
@@ -1338,8 +1339,8 @@ google-cloud-audit-log = ">=0.1.0,<1.0.0dev"
 google-cloud-core = ">=2.0.0,<3.0.0dev"
 grpc-google-iam-v1 = ">=0.12.4,<1.0.0dev"
 proto-plus = [
-    {version = ">=1.22.2,<2.0.0dev", markers = "python_version >= \"3.11\""},
     {version = ">=1.22.0,<2.0.0dev", markers = "python_version < \"3.11\""},
+    {version = ">=1.22.2,<2.0.0dev", markers = "python_version >= \"3.11\""},
 ]
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 
@@ -2552,7 +2553,6 @@ files = [
     {file = "pandas-2.2.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0cace394b6ea70c01ca1595f839cf193df35d1575986e484ad35c4aeae7266c1"},
     {file = "pandas-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:873d13d177501a28b2756375d59816c365e42ed8417b41665f346289adc68d24"},
     {file = "pandas-2.2.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9dfde2a0ddef507a631dc9dc4af6a9489d5e2e740e226ad426a05cabfbd7c8ef"},
-    {file = "pandas-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e9b79011ff7a0f4b1d6da6a61aa1aa604fb312d6647de5bad20013682d1429ce"},
     {file = "pandas-2.2.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cb51fe389360f3b5a4d57dbd2848a5f033350336ca3b340d1c53a1fad33bcad"},
     {file = "pandas-2.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eee3a87076c0756de40b05c5e9a6069c035ba43e8dd71c379e68cab2c20f16ad"},
     {file = "pandas-2.2.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3e374f59e440d4ab45ca2fffde54b81ac3834cf5ae2cdfa69c90bc03bde04d76"},
@@ -2569,8 +2569,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3303,7 +3303,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.17.6"
+version = "0.17.7"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/connection_objects_retrieval.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/connection_objects_retrieval.py
@@ -92,6 +92,7 @@ def get_connection_objects(
     retrieval_reason: Optional[str],
     fail_if_missing_objects: bool = True,
     connector_image: Optional[str] = None,
+    connector_version: Optional[str] = None,
     auto_select_connection: bool = False,
     selected_streams: Optional[set[str]] = None,
 ) -> ConnectionObjects:
@@ -109,6 +110,7 @@ def get_connection_objects(
         retrieval_reason (Optional[str]): The reason to access the connection objects.
         fail_if_missing_objects (bool, optional): Whether to raise a ValueError if a required object is missing. Defaults to True.
         connector_image (Optional[str]): The image name for the connector under test.
+        connector_version (Optional[str]): The version for the connector under test.
         auto_select_connection (bool, optional): Whether to automatically select a connection if no connection id is passed. Defaults to False.
         selected_streams (Optional[Set[str]]): The set of selected streams to use when auto selecting a connection.
     Raises:
@@ -137,6 +139,7 @@ def get_connection_objects(
             requested_objects,
             retrieval_reason=retrieval_reason,
             source_docker_repository=connector_image,
+            source_docker_image_tag=connector_version,
             prompt_for_connection_selection=False,
             selected_streams=selected_streams,
             connection_id=connection_id,
@@ -151,6 +154,7 @@ def get_connection_objects(
                 requested_objects,
                 retrieval_reason=retrieval_reason,
                 source_docker_repository=connector_image,
+                source_docker_image_tag=connector_version,
                 prompt_for_connection_selection=not is_ci,
                 selected_streams=selected_streams,
                 custom_config=custom_config,
@@ -187,6 +191,7 @@ def _get_connection_objects_from_retrieved_objects(
     requested_objects: Set[ConnectionObject],
     retrieval_reason: str,
     source_docker_repository: str,
+    source_docker_image_tag: str,
     prompt_for_connection_selection: bool,
     selected_streams: Optional[Set[str]],
     connection_id: Optional[str] = None,
@@ -199,6 +204,7 @@ def _get_connection_objects_from_retrieved_objects(
         requested_objects,
         retrieval_reason=retrieval_reason,
         source_docker_repository=source_docker_repository,
+        source_docker_image_tag=source_docker_image_tag,
         prompt_for_connection_selection=prompt_for_connection_selection,
         with_streams=selected_streams,
         connection_id=connection_id,

--- a/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
@@ -14,7 +14,7 @@ import dagger
 import pytest
 from airbyte_protocol.models import AirbyteCatalog, AirbyteStateMessage, ConfiguredAirbyteCatalog, ConnectorSpecification  # type: ignore
 from connection_retriever.audit_logging import get_user_email  # type: ignore
-from connection_retriever.retrieval import ConnectionNotFoundError, NotPermittedError  # type: ignore
+from connection_retriever.retrieval import ConnectionNotFoundError, NotPermittedError, get_current_docker_image_tag  # type: ignore
 from live_tests import stash_keys
 from live_tests.commons.connection_objects_retrieval import ConnectionObject, get_connection_objects
 from live_tests.commons.connector_runner import ConnectorRunner, Proxy
@@ -127,6 +127,7 @@ def pytest_configure(config: Config) -> None:
     config.stash[stash_keys.AUTO_SELECT_CONNECTION] = _connection_id == "auto"
     config.stash[stash_keys.CONNECTOR_IMAGE] = get_option_or_fail(config, "--connector-image")
     config.stash[stash_keys.TARGET_VERSION] = get_option_or_fail(config, "--target-version")
+    config.stash[stash_keys.CONTROL_VERSION] = get_control_version(config)
     custom_source_config_path = config.getoption("--config-path")
     custom_configured_catalog_path = config.getoption("--catalog-path")
     custom_state_path = config.getoption("--state-path")
@@ -161,6 +162,7 @@ def pytest_configure(config: Config) -> None:
             retrieval_reason,
             fail_if_missing_objects=False,
             connector_image=config.stash[stash_keys.CONNECTOR_IMAGE],
+            connector_version=config.stash[stash_keys.CONTROL_VERSION],
             auto_select_connection=config.stash[stash_keys.AUTO_SELECT_CONNECTION],
             selected_streams=config.stash[stash_keys.SELECTED_STREAMS],
         )
@@ -171,10 +173,10 @@ def pytest_configure(config: Config) -> None:
 
     config.stash[stash_keys.CONNECTION_ID] = config.stash[stash_keys.CONNECTION_OBJECTS].connection_id  # type: ignore
 
-    if source_docker_image := config.stash[stash_keys.CONNECTION_OBJECTS].source_docker_image:
-        config.stash[stash_keys.CONTROL_VERSION] = source_docker_image.split(":")[-1]
-    else:
-        config.stash[stash_keys.CONTROL_VERSION] = "latest"
+    if config.stash[stash_keys.CONTROL_VERSION] != config.stash[stash_keys.CONNECTION_OBJECTS].source_docker_image.split(":")[-1]:
+        raise ValueError(
+            f"The control version fetched by the connection retriever ({config.stash[stash_keys.CONNECTION_OBJECTS].source_docker_image}) does not match the control version passed by live tests ({config.stash[stash_keys.CONTROL_VERSION]})"
+        )
 
     if config.stash[stash_keys.CONTROL_VERSION] == config.stash[stash_keys.TARGET_VERSION]:
         pytest.exit(f"Control and target versions are the same: {control_version}. Please provide different versions.")
@@ -268,6 +270,14 @@ def get_option_or_fail(config: pytest.Config, option: str) -> str:
     if option_value := config.getoption(option):
         return option_value
     pytest.fail(f"Missing required option: {option}")
+
+
+def get_control_version(config: pytest.Config) -> str:
+    if control_version := config.getoption("--control-version"):
+        return control_version
+    if connector_docker_repository := config.getoption("--connector-image"):
+        return get_current_docker_image_tag(connector_docker_repository)
+    raise ValueError("The control version can't be determined, please pass a --control-version or a --connector-image")
 
 
 def prompt_for_confirmation(user_email: str) -> None:


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/8557
Depends on https://github.com/airbytehq/airbyte-platform-internal/pull/13099

## How
Pass the control version to use to the connection retriever.
Default to the latest released version in the registry.

