### PR TITLE
[airbyte-cdk] update 3.4.0 changelog to reflect RFR bug fix that was released

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -8,6 +8,7 @@ resumable full refresh: Fix bug where checkpoint reader stops syncing too early 
 
 ## 3.4.0
 file-based cdk: add config option to limit number of files for schema discover
+resumable full refresh: Fix bug for substreams depending on RFR parent stream would not paginate over parent
 
 ## 3.3.0
 CDK: add incomplete status to availability check during read


### PR DESCRIPTION
In between the merge of https://github.com/airbytehq/airbyte/pull/40671, another change was merged and the CDK was released. The changelog is now missing a record of the RFR bug fix which can be a bit misleading in the event of a bug