### PR TITLE
🐛 (CDK) Remove use of 3.11 unions

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
@@ -546,7 +546,7 @@ class Stream(ABC):
     def configured_json_schema(self, json_schema: Dict[str, Any]) -> None:
         self._configured_json_schema = self._filter_schema_invalid_properties(json_schema)
 
-    def _filter_schema_invalid_properties(self, configured_catalog_json_schema: Union[Dict[str, Any], Dict[str, Any]]) -> Dict[str, Any]:
+    def _filter_schema_invalid_properties(self, configured_catalog_json_schema: Dict[str, Any]) -> Dict[str, Any]:
         """
         Filters the properties in json_schema that are not present in the stream schema.
         Configured Schemas can have very old fields, so we need to housekeeping ourselves.

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
@@ -546,7 +546,7 @@ class Stream(ABC):
     def configured_json_schema(self, json_schema: Dict[str, Any]) -> None:
         self._configured_json_schema = self._filter_schema_invalid_properties(json_schema)
 
-    def _filter_schema_invalid_properties(self, configured_catalog_json_schema: Dict[str, Any | Dict[str, Any]]) -> Dict[str, Any]:
+    def _filter_schema_invalid_properties(self, configured_catalog_json_schema: Union[Dict[str, Any], Dict[str, Any]]) -> Dict[str, Any]:
         """
         Filters the properties in json_schema that are not present in the stream schema.
         Configured Schemas can have very old fields, so we need to housekeeping ourselves.


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/pull/41678 introduced a Python 3.11 union type definition which is not compatible with Python 3.9.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
