### PR TITLE
docs: add abctl download buttons with fallback with link to release page

### DIFF
--- a/docs/using-airbyte/getting-started/oss-quickstart.md
+++ b/docs/using-airbyte/getting-started/oss-quickstart.md
@@ -48,11 +48,16 @@ brew upgrade abctl
 </TabItem>
 <TabItem value="abctl-linux" label="Linux" default>
 
-**1: Download the latest release of `abctl` [here](https://github.com/airbytehq/abctl/releases)**
+**1: Download the latest release of `abctl`.**
+
+<a class="abctl-download button button--primary disabled" data-architecture="linux-amd64" href="#" style={{ marginRight: '10px' }} download>Loading...</a>
+<a class="abctl-download button button--primary disabled" data-architecture="linux-arm64" href="#" download>Loading...</a>
+<br/>
+<br/>
 
 :::info
-Be sure to download the file that is compatible with your machine's processor architecture. 
-:::
+<details>
+<summary>Be sure to download the file that is compatible with your machine's processor architecture.</summary>
 
 You'll see two options: `linux-amd64` and `linux-arm64`
 If you're unsure which one you need, running the following command will help:
@@ -63,6 +68,8 @@ uname -m
 
 - If the output is `x86_64`, you have an x86-64 processor.
 - If the output is `aarch64` or something similar, you have an ARM-based processor.
+</details>
+:::
 
 **2: Extract the archive**
 
@@ -99,7 +106,11 @@ If this command prints the installed version of the Airbyte Command Line Tool, i
 </TabItem>
 <TabItem value="abctl-windows" label="Windows" default>
 
-**1: Download the latest release of `abctl` [here](https://github.com/airbytehq/abctl/releases)**
+**1: Download the latest release of `abctl`.**
+
+<a class="abctl-download button button--primary disabled" data-architecture="windows-amd64" href="#" download>Loading...</a>
+<br/>
+<br/>
 
 **2: Extract the archive**
 - Right click the zip file you've downloaded and select `Extract All...`, then choose a destination folder. 
@@ -211,3 +222,5 @@ On Udemy, [The Complete Hands-on Introduction to Airbyte](https://www.udemy.com/
 
 **Bug Reports:**<br/>If you find an issue with the `abctl` command, please report it as a github
 issue [here](https://github.com/airbytehq/airbyte/issues) with the type of `🐛 [abctl] Report an issue with the abctl tool`.
+
+**Releases:**<br/>If you'd like to select which release of abctl to run, you can find the list of releases [here](https://github.com/airbytehq/abctl/releases/).

--- a/docs/using-airbyte/getting-started/oss-quickstart.md
+++ b/docs/using-airbyte/getting-started/oss-quickstart.md
@@ -50,8 +50,8 @@ brew upgrade abctl
 
 **1: Download the latest release of `abctl`.**
 
-<a class="abctl-download button button--primary disabled" data-architecture="linux-amd64" href="#" style={{ marginRight: '10px' }} download>Loading...</a>
-<a class="abctl-download button button--primary disabled" data-architecture="linux-arm64" href="#" download>Loading...</a>
+<a class="abctl-download button button--primary" data-architecture="linux-amd64" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" style={{ marginRight: '10px' }} download>Latest linux-amd64 Release</a>
+<a class="abctl-download button button--primary" data-architecture="linux-arm64" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" download>Latest linux-arm64 Release</a>
 <br/>
 <br/>
 
@@ -108,7 +108,7 @@ If this command prints the installed version of the Airbyte Command Line Tool, i
 
 **1: Download the latest release of `abctl`.**
 
-<a class="abctl-download button button--primary disabled" data-architecture="windows-amd64" href="#" download>Loading...</a>
+<a class="abctl-download button button--primary" data-architecture="windows-amd64" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" download>Latest windows-amd64 Release</a>
 <br/>
 <br/>
 

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -79,8 +79,9 @@ const config = {
   ],
 
   clientModules: [
-    require.resolve("./src/scripts/fontAwesomeIcons.js"),
     require.resolve("./src/scripts/cloudStatus.js"),
+    require.resolve('./src/scripts/download-abctl-buttons.js'),
+    require.resolve("./src/scripts/fontAwesomeIcons.js"),
   ],
 
   presets: [

--- a/docusaurus/src/scripts/download-abctl-buttons.js
+++ b/docusaurus/src/scripts/download-abctl-buttons.js
@@ -1,0 +1,51 @@
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+
+if (ExecutionEnvironment.canUseDOM) {
+  // Pre-fetch the urls for the binaries.
+  const binaries = fetch(
+      'https://api.github.com/repos/airbytehq/abctl/releases/latest')
+  .then(response => response.json())
+  .then(data => data.assets);
+
+  // Initialize button by choosing the relevant binary based on the data-architecture tag.
+  function initializeDownloadButton(button) {
+    binaries.then(assets => {
+      const architecture = button.getAttribute('data-architecture');
+      const binary = assets.find(
+          b => b.name.toLowerCase().includes(architecture.toLowerCase()));
+      if (binary) {
+        button.href = binary.browser_download_url;
+        button.innerText = `Download ${architecture}`;
+        button.classList.remove('disabled');
+      } else {
+        fallback(button);
+      }
+    })
+    .catch(error => {
+      console.error('Error fetching latest release:', error);
+      fallback(button);
+    });
+  }
+
+  // If loading fails for some reason or we can't find the asset, fallback on just
+  // making a link to the latest releases page.
+  function fallback(button) {
+    const architecture = button.getAttribute('data-architecture');
+    button.href = 'https://github.com/airbytehq/abctl/releases/latest';
+    button.innerText = `Latest ${architecture} Release`
+    button.target = '_blank';  // Opens the link in a new tab
+    button.classList.remove('disabled');
+  }
+
+  // All buttons with this behavior have the class abctl-download.
+  function initializeAllDownloadButtons() {
+    const buttons = document.getElementsByClassName('abctl-download');
+    Array.from(buttons).forEach(initializeDownloadButton);
+  }
+
+  // Document load is a bit weird in docusaurus.
+  // https://stackoverflow.com/a/74736980/4195169
+  window.addEventListener('load', () => {
+    setTimeout(initializeAllDownloadButtons, 1000);
+  });
+}

--- a/docusaurus/src/scripts/download-abctl-buttons.js
+++ b/docusaurus/src/scripts/download-abctl-buttons.js
@@ -16,25 +16,11 @@ if (ExecutionEnvironment.canUseDOM) {
       if (binary) {
         button.href = binary.browser_download_url;
         button.innerText = `Download ${architecture}`;
-        button.classList.remove('disabled');
-      } else {
-        fallback(button);
       }
     })
     .catch(error => {
       console.error('Error fetching latest release:', error);
-      fallback(button);
     });
-  }
-
-  // If loading fails for some reason or we can't find the asset, fallback on just
-  // making a link to the latest releases page.
-  function fallback(button) {
-    const architecture = button.getAttribute('data-architecture');
-    button.href = 'https://github.com/airbytehq/abctl/releases/latest';
-    button.innerText = `Latest ${architecture} Release`
-    button.target = '_blank';  // Opens the link in a new tab
-    button.classList.remove('disabled');
   }
 
   // All buttons with this behavior have the class abctl-download.


### PR DESCRIPTION
The issue with the original PR https://github.com/airbytehq/airbyte/pull/41613 was that there were cases where the user would need to do a hard reload to get the javascript to run. The problem with that is that the fallback for if we couldn't get the abctl releases was also handled by the javascript. That left the user stuck if they didn't think to do a hard refresh. This new version hardcodes the fallback logic into the html so that if there javascript doesn't run, the degraded experience of just being a link to the github releases page is guaranteed to be possible.