### PR TITLE
live-tests: fix cert path for proxy binding

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -280,6 +280,10 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.17.8
+
+Fix the self-signed certificate path we bind to Python connectors.
+
 ### 0.17.7
 
 Explicitly pass the control version to the connection retriever. Defaults to the latest released version of the connector under test.

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.17.7"
+version = "0.17.8"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/proxy.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/proxy.py
@@ -112,8 +112,12 @@ class Proxy:
             dagger.Container: The container with the proxy service bound and environment variables set.
         """
         cert_path_in_volume = "/mitmproxy_dir/mitmproxy-ca.pem"
-        requests_cert_path = "/usr/local/lib/python3.9/site-packages/certifi/cacert.pem"
         ca_certificate_path = "/usr/local/share/ca-certificates/mitmproxy.crt"
+
+        python_version_output = (await container.with_exec(["python", "--version"], skip_entrypoint=True).stdout()).strip()
+        python_version = python_version_output.split(" ")[-1]
+        python_version_minor_only = ".".join(python_version.split(".")[:-1])
+        requests_cert_path = f"/usr/local/lib/python{python_version_minor_only}/site-packages/certifi/cacert.pem"
         try:
             return await (
                 container.with_service_binding(self.hostname, await self.get_service())


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/41666
We hardcoded the path to the self signed certificate we share with connector to bind the proxy.
This path is python version dependent.
Now that we have multiple Python version across our connectors (3.9 / 3.10) we have to make this path dynamic.

