### PR TITLE
Remove unnecessary + vulnerable zookeeper dependency

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -27,11 +27,13 @@ dependencies {
     implementation ('org.apache.hadoop:hadoop-common:3.3.3') {
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
         exclude group: 'org.slf4j', module: 'slf4j-reload4j'
+        exclude group: 'org.apache.zookeeper'
     }
     implementation ('org.apache.hadoop:hadoop-aws:3.3.3') { exclude group: 'org.slf4j', module: 'slf4j-log4j12'}
     implementation ('org.apache.hadoop:hadoop-mapreduce-client-core:3.3.3') {
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
         exclude group: 'org.slf4j', module: 'slf4j-reload4j'
+        exclude group: 'org.apache.zookeeper'
     }
     implementation ('org.apache.parquet:parquet-avro:1.12.3') { exclude group: 'org.slf4j', module: 'slf4j-log4j12'}
     implementation ('com.github.airbytehq:json-avro-converter:1.1.0') { exclude group: 'ch.qos.logback', module: 'logback-classic'}

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 0.6.3
+  dockerImageTag: 0.6.4
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -513,7 +513,8 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
   <summary>Expand to review</summary>
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                              |
-| :------ | :--------- | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+| :------ |:-----------| :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.6.4   | 2024-04-16 | [38204]() | remove unnecessary zookeeper dependency |
 | 0.6.3   | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204)   | convert all production code to kotlin                                                                                                                                 |
 | 0.6.2   | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204)   | add assume role auth                                                                                                                                 |
 | 0.6.1   | 2024-04-08 | [37546](https://github.com/airbytehq/airbyte/pull/37546)   | Adapt to CDK 0.30.8;                                                                                                                                 |

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -514,8 +514,8 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                              |
 | :------ |:-----------| :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.6.4   | 2024-04-16 | [38204]() | remove unnecessary zookeeper dependency |
-| 0.6.3   | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204)   | convert all production code to kotlin                                                                                                                                 |
+| 0.6.4   | 2024-04-16 | [42006](https://github.com/airbytehq/airbyte/pull/42006)   | remove unnecessary zookeeper dependency                                                                                                              |
+| 0.6.3   | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204)   | convert all production code to kotlin                                                                                                                |
 | 0.6.2   | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204)   | add assume role auth                                                                                                                                 |
 | 0.6.1   | 2024-04-08 | [37546](https://github.com/airbytehq/airbyte/pull/37546)   | Adapt to CDK 0.30.8;                                                                                                                                 |
 | 0.6.0   | 2024-04-08 | [36869](https://github.com/airbytehq/airbyte/pull/36869)   | Adapt to CDK 0.29.8; Kotlin converted code.                                                                                                          |


### PR DESCRIPTION
## What
[This issue](https://app.zenhub.com/workspaces/destinations-6332532d6893ce001c7a56a7/issues/gh/airbytehq/airbyte-internal-issues/8697).

## How
Before:
```
jschmidt@Johnny-Schmidt-MacBook-Pro---C2WMR2G02N airbyte % ./gradlew :airbyte-integrations:connectors:destination-s3:dependencies | grep zookeeper
| sort -u
|    +--- org.apache.zookeeper:zookeeper:3.5.6 -> 3.6.3 (*)
|    |    +--- org.apache.zookeeper:zookeeper:3.5.6 -> 3.6.3 (*)
|    |    |    |    |    +--- org.apache.zookeeper:zookeeper:3.6.3
|    |    |    |    |    |    +--- org.apache.zookeeper:zookeeper-jute:3.6.3
jschmidt@Johnny-Schmidt-MacBook-Pro---C2WMR2G02N airbyte %
```

After:
```
jschmidt@Johnny-Schmidt-MacBook-Pro---C2WMR2G02N airbyte % ./gradlew :airbyte-integrations:connectors:destination-s3:dependencies | grep zookeeper | sort -u
jschmidt@Johnny-Schmidt-MacBook-Pro---C2WMR2G02N airbyte %
```

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
