### PR TITLE
fix(source-ashby): fix typo in applications connector

### DIFF
--- a/airbyte-integrations/connectors/source-ashby/source_ashby/manifest.yaml
+++ b/airbyte-integrations/connectors/source-ashby/source_ashby/manifest.yaml
@@ -18,7 +18,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /applications.list
+          path: /application.list
           http_method: POST
           request_body_json:
             createdAfter: "{{ timestamp(config['start_date']) * 1000 }}"


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
The Application stream is broken because it's trying to call `applications.list` instead of the correct `application.list`
Issue: https://github.com/airbytehq/airbyte/issues/42026

## How
<!--
* Describe how code changes achieve the solution.
-->
I changed the manifest for it to point to the correct route

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
`manifest.yml` typo in the application stream

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Will make the ashby syncs not fail

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
