### PR TITLE
fix(source-ashby): fix typo in applications connector

### DIFF
--- a/airbyte-integrations/connectors/source-ashby/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ashby/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4e8c9fa0-3634-499b-b948-11581b5c3efa
-  dockerImageTag: 0.1.9
+  dockerImageTag: 0.1.10
   dockerRepository: airbyte/source-ashby
   githubIssueLabel: source-ashby
   icon: ashby.svg

--- a/airbyte-integrations/connectors/source-ashby/pyproject.toml
+++ b/airbyte-integrations/connectors/source-ashby/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.9"
+version = "0.1.10"
 name = "source-ashby"
 description = "Source implementation for Ashby."
 authors = [ "Elliot Trabac <elliot.trabac1@gmail.com>",]

--- a/airbyte-integrations/connectors/source-ashby/source_ashby/manifest.yaml
+++ b/airbyte-integrations/connectors/source-ashby/source_ashby/manifest.yaml
@@ -18,7 +18,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /applications.list
+          path: /application.list
           http_method: POST
           request_body_json:
             createdAfter: "{{ timestamp(config['start_date']) * 1000 }}"

--- a/docs/integrations/sources/ashby.md
+++ b/docs/integrations/sources/ashby.md
@@ -48,6 +48,7 @@ The Ashby connector should not run into Ashby API limitations under normal usage
 
 | Version | Date       | Pull Request                                             | Subject                                     |
 |:--------| :--------- | :------------------------------------------------------- |:--------------------------------------------|
+| 0.1.10 | 2024-07-17 | [42028](https://github.com/airbytehq/airbyte/pull/42028) | Fix typo in application stream |
 | 0.1.9 | 2024-07-13 | [41818](https://github.com/airbytehq/airbyte/pull/41818) | Update dependencies |
 | 0.1.8 | 2024-07-10 | [41379](https://github.com/airbytehq/airbyte/pull/41379) | Update dependencies |
 | 0.1.7 | 2024-07-09 | [41271](https://github.com/airbytehq/airbyte/pull/41271) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
The Application stream is broken because it's trying to call `applications.list` instead of the correct `application.list`
Issue: https://github.com/airbytehq/airbyte/issues/42026

## How
<!--
* Describe how code changes achieve the solution.
-->
I changed the manifest for it to point to the correct route

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
`manifest.yml` typo in the application stream

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Will make the ashby syncs not fail

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
