### PR TITLE
source-declarative-manifest: make it pass QA checks

### DIFF
--- a/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
@@ -30,6 +30,7 @@ data:
   supportLevel: community
   tags:
     - language:python
+    - cdk:python
   connectorTestSuitesOptions:
     - suite: unitTests
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What
Make source-declarative-manifest pass QA checks by:
* adding an (empty) icon
* adding a `cdk` tag in `metadata.yaml`