### PR TITLE
airbyte-ci: new step for skipping regression test approval

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -43,8 +43,8 @@ jobs:
               - 'airbyte-integrations/connectors/**/*'
               - 'airbyte-cdk/java/**/*'
               - 'buildSrc/**/*'
-      # The Connector CI Tests is a status check emitted by airbyte-ci
-      # We make it pass once we have determined that there are no changes to the connectors
+      # The Connector CI Tests & Regression Test Results Reviewed and Approved are status checks emitted by airbyte-ci
+      # We make them pass once we have determined that there are no changes to the connectors
       - name: "Skip Connectors CI tests"
         if: steps.changes.outputs.connectors != 'true' && github.event_name == 'pull_request'
         run: |
@@ -57,12 +57,16 @@ jobs:
             "context": "Connectors CI tests",
             "target_url": "${{ github.event.workflow_run.html_url }}"
             }' \
+      - name: "Skip Regression Test Results Reviewed and Approved"
+        if: steps.changes.outputs.connectors != 'true' && github.event_name == 'pull_request'
+        run: |
           curl --request POST \
           --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
           --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
           --header 'content-type: application/json' \
           --data '{
             "state": "success",
+            "description": "[Skipped]",
             "context": "Regression Test Results Reviewed and Approved",
             "target_url": "${{ github.event.workflow_run.html_url }}"
             }' \


### PR DESCRIPTION
In https://github.com/airbytehq/airbyte/pull/41676 I updated the step for skipping connectors tests to update the regression tests approval status check, but when testing realized that for debugging it should be in its own step.