### PR TITLE
airbyte-ci: do the regression test status check on all PRs

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -767,6 +767,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.24.3  | [#42040](https://github.com/airbytehq/airbyte/pull/42040) | Always send regression test approval status check.                                                              |
 | 4.24.2  | [#41676](https://github.com/airbytehq/airbyte/pull/41676) | Send regression test approval status check when skipped.                                                                     |
 | 4.24.1  | [#41642](https://github.com/airbytehq/airbyte/pull/41642) | Use the AIRBYTE_GITHUB_REPO environment variable to run airbyte-ci in other repos.                                           |
 | 4.24.0  | [#41627](https://github.com/airbytehq/airbyte/pull/41627) | Require manual regression test approval for certified connectors                                                             |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -767,7 +767,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.24.3  | [#42040](https://github.com/airbytehq/airbyte/pull/42040) | Always send regression test approval status check.                                                              |
+| 4.24.3  | [#42040](https://github.com/airbytehq/airbyte/pull/42040) | Always send regression test approval status check; skip on auto-merge PRs.                                                   |
 | 4.24.2  | [#41676](https://github.com/airbytehq/airbyte/pull/41676) | Send regression test approval status check when skipped.                                                                     |
 | 4.24.1  | [#41642](https://github.com/airbytehq/airbyte/pull/41642) | Use the AIRBYTE_GITHUB_REPO environment variable to run airbyte-ci in other repos.                                           |
 | 4.24.0  | [#41627](https://github.com/airbytehq/airbyte/pull/41627) | Require manual regression test approval for certified connectors                                                             |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
@@ -15,7 +15,7 @@ from pipelines.airbyte_ci.connectors.test.steps.common import LiveTests
 from pipelines.cli.click_decorators import click_ci_requirements_option
 from pipelines.cli.dagger_pipeline_command import DaggerPipelineCommand
 from pipelines.consts import LOCAL_BUILD_PLATFORM, MAIN_CONNECTOR_TESTING_SECRET_STORE_ALIAS, ContextState
-from pipelines.hacks import do_regression_test_status_check_maybe
+from pipelines.hacks import do_regression_test_status_check
 from pipelines.helpers.execution import argument_parsing
 from pipelines.helpers.execution.run_steps import RunStepOptions
 from pipelines.helpers.github import update_global_commit_status_check_for_tests
@@ -124,9 +124,9 @@ async def test(
     if ctx.obj["is_ci"]:
         fail_if_missing_docker_hub_creds(ctx)
 
+    do_regression_test_status_check(ctx, REGRESSION_TEST_MANUAL_APPROVAL_CONTEXT, main_logger)
     if ctx.obj["selected_connectors_with_modified_files"]:
         update_global_commit_status_check_for_tests(ctx.obj, "pending")
-        do_regression_test_status_check_maybe(ctx, REGRESSION_TEST_MANUAL_APPROVAL_CONTEXT, main_logger)
     else:
         main_logger.warn("No connector were selected for testing.")
         update_global_commit_status_check_for_tests(ctx.obj, "success")

--- a/airbyte-ci/connectors/pipelines/pipelines/hacks.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/hacks.py
@@ -86,7 +86,7 @@ def do_regression_test_status_check(ctx: click.Context, status_check_name: str, 
     run_url = ctx.obj["gha_workflow_run_url"]
     should_send = ctx.obj.get("ci_context") == consts.CIContext.PULL_REQUEST
 
-    if not is_automerge_pull_request(ctx.obj["pull_request"]) and any(
+    if not is_automerge_pull_request(ctx.obj.get("pull_request")) and any(
         [
             (connector.language == ConnectorLanguage.PYTHON and connector.support_level == "certified")
             for connector in ctx.obj["selected_connectors_with_modified_files"]

--- a/airbyte-ci/connectors/pipelines/pipelines/hacks.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/hacks.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Callable, List
 import asyncclick as click
 from connector_ops.utils import ConnectorLanguage  # type: ignore
 from pipelines import consts
-from pipelines.helpers.github import update_commit_status_check
+from pipelines.helpers.github import is_automerge_pull_request, update_commit_status_check
 
 if TYPE_CHECKING:
     from dagger import Container
@@ -86,7 +86,7 @@ def do_regression_test_status_check(ctx: click.Context, status_check_name: str, 
     run_url = ctx.obj["gha_workflow_run_url"]
     should_send = ctx.obj.get("ci_context") == consts.CIContext.PULL_REQUEST
 
-    if any(
+    if is_automerge_pull_request(ctx.obj["pull_request"]) and any(
         [
             (connector.language == ConnectorLanguage.PYTHON and connector.support_level == "certified")
             for connector in ctx.obj["selected_connectors_with_modified_files"]

--- a/airbyte-ci/connectors/pipelines/pipelines/hacks.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/hacks.py
@@ -76,7 +76,7 @@ def never_fail_exec(command: List[str]) -> Callable[[Container], Container]:
     return never_fail_exec_inner
 
 
-def do_regression_test_status_check_maybe(ctx: click.Context, status_check_name: str, logger: Logger) -> None:
+def do_regression_test_status_check(ctx: click.Context, status_check_name: str, logger: Logger) -> None:
     """
     Emit a failing status check that requires a manual override, via a /-command.
 

--- a/airbyte-ci/connectors/pipelines/pipelines/hacks.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/hacks.py
@@ -86,7 +86,7 @@ def do_regression_test_status_check(ctx: click.Context, status_check_name: str, 
     run_url = ctx.obj["gha_workflow_run_url"]
     should_send = ctx.obj.get("ci_context") == consts.CIContext.PULL_REQUEST
 
-    if is_automerge_pull_request(ctx.obj["pull_request"]) and any(
+    if not is_automerge_pull_request(ctx.obj["pull_request"]) and any(
         [
             (connector.language == ConnectorLanguage.PYTHON and connector.support_level == "certified")
             for connector in ctx.obj["selected_connectors_with_modified_files"]

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/github.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/github.py
@@ -220,3 +220,10 @@ def create_or_update_github_pull_request(
         logger.info(f"Added label {label} to pull request")
 
     return pull_request
+
+
+def is_automerge_pull_request(pull_request: Optional[github_sdk.PullRequest.PullRequest]) -> bool:
+    labels = [label.name for label in pull_request.get_labels()] if pull_request else []
+    if labels and "auto-merge" in labels:
+        return True
+    return False

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.24.2"
+version = "4.24.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
We were skipping the status check `success` call if the PR had no connector changes, but we should always send it.

Also sends `success` if the PR is marked for auto-merge.