### PR TITLE
airbyte-ci: trigger test on doc change

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -38,7 +38,7 @@ jobs:
           # Note: expressions within a filter are OR'ed
           filters: |
             connectors:
-              - '*'
+              - 'docs/integrations/**/*'
               - 'airbyte-ci/**/*'
               - 'airbyte-integrations/connectors/**/*'
               - 'airbyte-cdk/java/**/*'

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -773,6 +773,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.28.3  | [#42046](https://github.com/airbytehq/airbyte/pull/42046)  | Trigger connector tests on doc change.                                                                                       |
 | 4.28.2  | [#43297](https://github.com/airbytehq/airbyte/pull/43297)  | `migrate-to-inline_schemas` removes unused schema files and empty schema dirs.                                               |
 | 4.28.1  | [#42972](https://github.com/airbytehq/airbyte/pull/42972)  | Add airbyte-enterprise support for format commandi                                                                           |
 | 4.28.0  | [#42849](https://github.com/airbytehq/airbyte/pull/42849)  | Couple selection of strict-encrypt variants (e vice versa)                                                                   |

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
@@ -27,7 +27,7 @@ def _find_modified_connectors(
     modified_connectors = set()
 
     for connector in all_connectors:
-        if Path(file_path).is_relative_to(Path(connector.code_directory)):
+        if Path(file_path).is_relative_to(Path(connector.code_directory)) or file_path == connector.documentation_file_path:
             main_logger.info(f"Adding connector '{connector}' due to connector file modification: {file_path}.")
             modified_connectors.add(connector)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
@@ -32,7 +32,7 @@ METADATA_FILE_NAME = "metadata.yaml"
 MANIFEST_FILE_NAME = "manifest.yaml"
 METADATA_ICON_FILE_NAME = "icon.svg"
 DIFF_FILTER = "MADRT"  # Modified, Added, Deleted, Renamed, Type changed
-IGNORED_FILE_EXTENSIONS = [".md"]
+IGNORED_FILE_EXTENSIONS: List[str] = []
 
 
 # This utils will probably be redundant once https://github.com/dagger/dagger/issues/3764 is implemented

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.28.2"
+version = "4.28.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/8960
A connector doc modification did not trigger connector tests.
This has to change now that we have tests on docs (in QA checks).

All connector tests will be triggered on doc change. If this turns out to be annoying we can change the control flow to skip code tests if only docs were modified.

@clnoll this implementation is slighlty different from what we groomed together. Please check out this [comment](https://github.com/airbytehq/airbyte-internal-issues/issues/8960) for details.