### PR TITLE
fix(source-goldcast): fix headings in Goldcast source docs 

### DIFF
--- a/docs/integrations/sources/goldcast.md
+++ b/docs/integrations/sources/goldcast.md
@@ -1,4 +1,4 @@
-# Google Ads
+# Goldcast
 
 This page contains the setup guide and reference information for the Goldcast source connector.
 
@@ -25,7 +25,7 @@ A simple access token is all that is needed to access Goldcast API. This token i
 
 #### For Airbyte Cloud:
 
-To set up Google Ads as a source in Airbyte Cloud:
+To set up Goldcast as a source in Airbyte Cloud:
 
 1. [Log in to your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
@@ -62,7 +62,7 @@ Incremental modes are not supported as the Goldcast API does not contain a curso
 
 ## Supported Streams
 
-The Google Ads source connector can sync the following tables. It can also sync custom queries using GAQL.
+The Goldcast source connector can sync the following tables. It can also sync custom queries using GAQL.
 
 ### Main Tables
 
@@ -74,7 +74,7 @@ Link to Goldcast API documentation [here](https://customapi.goldcast.io/swagger-
 
 - [event_members](https://customapi.goldcast.io/swagger-ui/#/Event%20members/List%20event%20members)
 
-This is a child stream of the events stream representing users associated to events. 
+This is a child stream of the events stream representing users associated to events.
 
 - [webinars](https://customapi.goldcast.io/swagger-ui/#/Webinars/Retrieve%20webinars)
 


### PR DESCRIPTION
## What

I've missed a problem in source-goldcast docs in @FVidalCarneiro's PR that copied and pasted docs from google ads. This PR fixes it. 

Can't wait for auto-generated / templated docs ;) 

## User Impact
None.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
