### PR TITLE
Catherine/cats running not required

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -1285,9 +1285,7 @@ class TestBasicRead(BaseTest):
         ), "All stream must emit status"
 
         for stream_name, status_list in stream_statuses.items():
-            assert (
-                len(status_list) >= 3
-            ), f"Stream `{stream_name}` statuses should be emitted in the next order: `STARTED`, `RUNNING`,... `COMPLETE`"
+            assert len(status_list) >= 2, f"Stream `{stream_name}` should contain at least : `STARTED` and `COMPLETE`"
             assert status_list[0] == AirbyteStreamStatus.STARTED
             assert status_list[-1] == AirbyteStreamStatus.COMPLETE
             assert all(x == AirbyteStreamStatus.RUNNING for x in status_list[1:-1])

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/client_container_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/client_container_runner.py
@@ -27,14 +27,9 @@ async def _build_container(dagger_client: dagger.Client, dockerfile_path: Path) 
 
 async def _build_client_container(dagger_client: dagger.Client, connector_path: Path, dockerfile_path: Path) -> dagger.Container:
     container = await _build_container(dagger_client, dockerfile_path)
-    return container.with_mounted_cache(
-        str(IN_CONTAINER_CONNECTOR_PATH),
-        dagger_client.cache_volume(connector_path.name),
-        sharing=dagger.CacheSharingMode.SHARED,
+    return container.with_mounted_directory(
+        str(IN_CONTAINER_CONNECTOR_PATH), dagger_client.host().directory(str(connector_path), exclude=get_default_excluded_files())
     )
-    # return container.with_mounted_directory(
-    #     str(IN_CONTAINER_CONNECTOR_PATH), dagger_client.host().directory(str(connector_path), exclude=get_default_excluded_files())
-    # )
 
 
 def get_default_excluded_files() -> List[str]:
@@ -73,6 +68,4 @@ async def do_setup(container: dagger.Container, command: List[str], connector_co
 
 
 async def do_teardown(container: dagger.Container, command: List[str]):
-    container = await _run(container, command)
-    print(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> ", await container.stdout())
-    return container
+    return await _run(container, command)

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/client_container_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/client_container_runner.py
@@ -27,9 +27,14 @@ async def _build_container(dagger_client: dagger.Client, dockerfile_path: Path) 
 
 async def _build_client_container(dagger_client: dagger.Client, connector_path: Path, dockerfile_path: Path) -> dagger.Container:
     container = await _build_container(dagger_client, dockerfile_path)
-    return container.with_mounted_directory(
-        str(IN_CONTAINER_CONNECTOR_PATH), dagger_client.host().directory(str(connector_path), exclude=get_default_excluded_files())
+    return container.with_mounted_cache(
+        str(IN_CONTAINER_CONNECTOR_PATH),
+        dagger_client.cache_volume(connector_path.name),
+        sharing=dagger.CacheSharingMode.SHARED,
     )
+    # return container.with_mounted_directory(
+    #     str(IN_CONTAINER_CONNECTOR_PATH), dagger_client.host().directory(str(connector_path), exclude=get_default_excluded_files())
+    # )
 
 
 def get_default_excluded_files() -> List[str]:
@@ -68,4 +73,6 @@ async def do_setup(container: dagger.Container, command: List[str], connector_co
 
 
 async def do_teardown(container: dagger.Container, command: List[str]):
-    return await _run(container, command)
+    container = await _run(container, command)
+    print(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> ", await container.stdout())
+    return container


### PR DESCRIPTION
Platform does not require a `RUNNING` status to be emitted, and DB sources do not emit one, so we can require only 2 statuses instead of 3.
