### PR TITLE
🐛 Source Braintree: Adds pagination to braintree streams

### DIFF
--- a/airbyte-integrations/connectors/source-braintree/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braintree/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 63cea06f-1c75-458d-88fe-ad48c7cb27fd
-  dockerImageTag: 0.3.4
+  dockerImageTag: 0.3.5
   dockerRepository: airbyte/source-braintree
   documentationUrl: https://docs.airbyte.com/integrations/sources/braintree
   githubIssueLabel: source-braintree

--- a/airbyte-integrations/connectors/source-braintree/pyproject.toml
+++ b/airbyte-integrations/connectors/source-braintree/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.3.4"
+version = "0.3.5"
 name = "source-braintree"
 description = "Source implementation for Braintree."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml
+++ b/airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml
@@ -3756,7 +3756,14 @@ streams:
         extractor:
           class_name: "source_braintree.source.CustomerExtractor"
       paginator:
-        type: NoPagination
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        pagination_strategy:
+          type: PageIncrement
+          start_from_page: 1
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: created_at
@@ -9747,7 +9754,14 @@ streams:
         extractor:
           class_name: "source_braintree.source.TransactionExtractor"
       paginator:
-        type: NoPagination
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        pagination_strategy:
+          type: PageIncrement
+          start_from_page: 1
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: created_at
@@ -15697,7 +15711,14 @@ streams:
         extractor:
           class_name: "source_braintree.source.SubscriptionExtractor"
       paginator:
-        type: NoPagination
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        pagination_strategy:
+          type: PageIncrement
+          start_from_page: 1
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: created_at

--- a/docs/integrations/sources/braintree.md
+++ b/docs/integrations/sources/braintree.md
@@ -72,6 +72,7 @@ The Braintree connector should not run into Braintree API limitations under norm
 
 | Version | Date       | Pull Request                                             | Subject                                              |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------- |
+| 0.3.5 | 2024-07-18 | [42096](https://github.com/airbytehq/airbyte/pull/42096) | Adds pagination to get more than 50 records per sync |
 | 0.3.4 | 2024-07-13 | [41340](https://github.com/airbytehq/airbyte/pull/41340) | Update dependencies |
 | 0.3.3 | 2024-07-09 | [41312](https://github.com/airbytehq/airbyte/pull/41312) | Update dependencies |
 | 0.3.2 | 2024-07-06 | [40863](https://github.com/airbytehq/airbyte/pull/40863) | Update dependencies |


### PR DESCRIPTION
## What
Issue #32197 identified that the braintree connector only syncs 50 records at a time. This is because the connector does not paginate the results for more streams.

## How
The DisputeExtractor had pagination set up, so I copied that configuration to the other incremental streams that use braintree's "advanced search" endpoint.

## Review guide

1. `airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml`


## User Impact
This is what a sync looked like before this change:
![Screenshot 2024-07-18 at 8 49 21 AM](https://github.com/user-attachments/assets/85e17a6e-174c-4814-8c45-423f11a86e70)


And this is what it looks like afterwards:
![Screenshot 2024-07-18 at 8 42 24 AM](https://github.com/user-attachments/assets/52701d66-433e-40d5-9562-55d92f2c54dc)


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
