### PR TITLE
live-test: update connnection-retriever

### DIFF
--- a/airbyte-ci/connectors/live-tests/poetry.lock
+++ b/airbyte-ci/connectors/live-tests/poetry.lock
@@ -746,7 +746,7 @@ files = [
 
 [[package]]
 name = "connection-retriever"
-version = "0.6.3"
+version = "0.7.0"
 description = "A tool to retrieve connection information from our Airbyte Cloud config api database"
 optional = false
 python-versions = "^3.10"
@@ -772,7 +772,7 @@ tqdm = "^4.66.2"
 type = "git"
 url = "git@github.com:airbytehq/airbyte-platform-internal"
 reference = "HEAD"
-resolved_reference = "a6e6dd6220995067ca28cfbf11068462f7365a29"
+resolved_reference = "290735d1354d69938c2fffea09be0a7866ed59db"
 subdirectory = "tools/connection-retriever"
 
 [[package]]


### PR DESCRIPTION
## What
An update to the `connection-retriever` was shipped, live test was updated with latest signature but without updating the `connection-retriever` version.