### PR TITLE
Rename scope for `contact_lists` to an available one

### DIFF
--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -71,7 +71,7 @@ Next, you need to configure the appropriate scopes for the following streams. Pl
 | :-------------------------- | :----------------------------------------------------------------------------------------------------------- |
 | `campaigns`                 | `content`                                                                                                    |
 | `companies`                 | `crm.objects.companies.read`, `crm.schemas.companies.read`                                                   |
-| `contact_lists`             | `crm.objects.lists.read`                                                                                     |
+| `contact_lists`             | `crm.lists.read`                                                                                     |
 | `contacts`                  | `crm.objects.contacts.read`                                                                                  |
 | `contacts_list_memberships` | `crm.objects.contacts.read`                                                                                  |
 | `contacts_form_submissions` | `crm.objects.contacts.read`                                                                                  |


### PR DESCRIPTION
## What
I have been testing our Airbyte and am connecting it to a HubSpot source. The documentation is excellent, so thank you for that! One of the scopes for a private app listed in the documentation is `crm.objects.lists.read`, but I couldn't find that scope in Hubspot, whereas I did find a `crm.lists.read` that purports to cover the same data. I haven't end-to-end tested this and would love a second set of eyes.

## How
Renamed the string in the documentation.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
An easier setup experience of the Hubspot source :)

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
