### PR TITLE
Cleanup an unused route in the SME ingress config.

### DIFF
--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -460,14 +460,6 @@ spec:
                   number: 8180
             path: /auth
             pathType: Prefix
-          - backend:
-              service:
-                # format is ${RELEASE_NAME}-airbyte--server-svc
-                name: airbyte-enterprise-airbyte-server-svc
-                port:
-                  number: 8001
-            path: /api/public
-            pathType: Prefix
 ```
 
 </TabItem>
@@ -512,14 +504,6 @@ spec:
                 port:
                   number: 8180
             path: /auth
-            pathType: Prefix
-          - backend:
-              service:
-                # format is ${RELEASE_NAME}-airbyte-server-svc
-                name: airbyte-enterprise-airbyte-server-svc
-                port:
-                  number: 8001
-            path: /api/public
             pathType: Prefix
 ```
 


### PR DESCRIPTION
## What
Removes a section from the ingress in the SME documentation for the api-server that is now deprecated.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
