### PR TITLE
🐛 Source Railz: fix Python MRO bug

### DIFF
--- a/airbyte-integrations/connectors/source-railz/metadata.yaml
+++ b/airbyte-integrations/connectors/source-railz/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9b6cc0c0-da81-4103-bbfd-5279e18a849a
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   dockerRepository: airbyte/source-railz
   githubIssueLabel: source-railz
   icon: railz.svg

--- a/airbyte-integrations/connectors/source-railz/pyproject.toml
+++ b/airbyte-integrations/connectors/source-railz/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.2"
+version = "0.1.3"
 name = "source-railz"
 description = "Source implementation for Railz."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-railz/source_railz/components.py
+++ b/airbyte-integrations/connectors/source-railz/source_railz/components.py
@@ -19,7 +19,7 @@ from isodate import Duration, parse_duration
 
 
 @dataclass
-class ShortLivedTokenAuthenticator(AbstractHeaderAuthenticator, DeclarativeAuthenticator):
+class ShortLivedTokenAuthenticator(DeclarativeAuthenticator):
     """
     [Low-Code Custom Component] ShortLivedTokenAuthenticator
     https://github.com/airbytehq/airbyte/issues/22872

--- a/docs/integrations/sources/railz.md
+++ b/docs/integrations/sources/railz.md
@@ -95,6 +95,8 @@ The Railz connector should gracefully handle Railz API limitations under normal 
 
 | Version | Date       | Pull Request                                             | Subject           |
 | :------ | :--------- | :------------------------------------------------------- | :---------------- |
+| 0.1.3 | 2024-07-19 | [42125](https://github.com/airbytehq/airbyte/pull/42125) | Fix Python MRO bug |
+
 | 0.1.2 | 2024-05-21 | [38545](https://github.com/airbytehq/airbyte/pull/38545) | [autopull] base image + poetry + up_to_date |
 | 0.1.1 | 2023-02-16 | [20960](https://github.com/airbytehq/airbyte/pull/20960) | New Source: Railz |
 


### PR DESCRIPTION
## What
<!--
* When running this connector, you get an MRO error:
* Cannot create a consistent method resolution\norder (MRO) for bases AbstractHeaderAuthenticator, DeclarativeAuthenticator
-->

## How
<!--
* Since DeclarativeAuthenticator already inherits from AbstractHeaderAuthenticator, multiple inheritance is unneeded here so ShortLivedTokenAuthenticator does not need to directly inherit from AbstractHeaderAuthenticator.
-->

## Review guide
<!--
1. `airbyte-integrations/connectors/source-railz/source_railz/components.py`
-->

## User Impact
<!--
* Railz connector should now work as intended and connecting testing should succeed
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌

as mentioned in #42124 