### PR TITLE
🚨🚨Source Xero: Temporarily remove OAuth support due to user limit restrictions

### DIFF
--- a/airbyte-integrations/connectors/source-xero/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-xero/acceptance-test-config.yml
@@ -7,7 +7,7 @@ acceptance_tests:
     tests:
       - spec_path: "source_xero/spec.yaml"
         backward_compatibility_tests_config:
-          disable_for_version: "0.2.5"
+          disable_for_version: "2.0.0" # Disabling Oauth support due to limit restriction.
   connection:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -6,13 +6,18 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: true
       packageName: airbyte-source-xero
   releases:
     breakingChanges:
+      3.0.0:
+        upgradeDeadline: "2024-08-30"
+        message:
+          Due to limitations on the number of OAuth users permitted for the Airbyte application, OAuth support has been disabled. 
+          Consequently, the bearer authentication method has been adopted as the primary authentication type.
       2.0.0:
         upgradeDeadline: "2024-06-30"
         message:
@@ -31,7 +36,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6fd1e833-dd6e-45ec-a727-ab917c5be892
-  dockerImageTag: 2.0.0
+  dockerImageTag: 3.0.0
   dockerRepository: airbyte/source-xero
   githubIssueLabel: source-xero
   icon: xero.svg

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -16,7 +16,7 @@ data:
       3.0.0:
         upgradeDeadline: "2024-08-30"
         message:
-          Due to limitations on the number of OAuth users permitted for the Airbyte application, OAuth support has been disabled. 
+          Due to limitations on the number of OAuth users permitted for the Airbyte application, OAuth support has been disabled.
           Consequently, the bearer authentication method has been adopted as the primary authentication type.
       2.0.0:
         upgradeDeadline: "2024-06-30"

--- a/airbyte-integrations/connectors/source-xero/pyproject.toml
+++ b/airbyte-integrations/connectors/source-xero/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.0.0"
+version = "3.0.0"
 name = "source-xero"
 description = "Source implementation for xero."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-xero/source_xero/manifest.yaml
+++ b/airbyte-integrations/connectors/source-xero/source_xero/manifest.yaml
@@ -2795,33 +2795,33 @@ spec:
         title: Authentication Method
         type: object
         oneOf:
-          - type: object
-            title: OAuth Custom Connection
-            required:
-              - auth_type
-              - client_id
-              - client_secret
-            properties:
-              auth_type:
-                type: string
-                title: Authentication Method
-                const: oauth2_confidential_application
-                order: 0
-              client_id:
-                title: Client ID
-                description: >-
-                  Your Xero application's Client ID.
-                type: string
-                examples:
-                  - "Client_ID"
-              client_secret:
-                title: Client Secret
-                description: >-
-                  Your Xero application's Client Secret.
-                type: string
-                examples:
-                  - "Client_Secret"
-                airbyte_secret: true
+          # - type: object
+          #   title: OAuth Custom Connection
+          #   required:
+          #     - auth_type
+          #     - client_id
+          #     - client_secret
+          #   properties:
+          #     auth_type:
+          #       type: string
+          #       title: Authentication Method
+          #       const: oauth2_confidential_application
+          #       order: 0
+          #     client_id:
+          #       title: Client ID
+          #       description: >-
+          #         Your Xero application's Client ID.
+          #       type: string
+          #       examples:
+          #         - "Client_ID"
+          #     client_secret:
+          #       title: Client Secret
+          #       description: >-
+          #         Your Xero application's Client Secret.
+          #       type: string
+          #       examples:
+          #         - "Client_Secret"
+          #       airbyte_secret: true
           - type: object
             title: Bearer Access Token
             required:

--- a/airbyte-integrations/connectors/source-xero/source_xero/manifest.yaml
+++ b/airbyte-integrations/connectors/source-xero/source_xero/manifest.yaml
@@ -35,11 +35,13 @@ definitions:
     api_token: "{{ config['credentials']['access_token'] }}"
 
   authenticator:
-    type: SelectiveAuthenticator
-    authenticator_selection_path: ["credentials", "auth_type"]
-    authenticators:
-      oauth2_access_token: "#/definitions/bearer_authenticator"
-      oauth2_confidential_application: "#/definitions/oauth_authenticator"
+    # Disabling OAuth support due to restrictions for the number of users.
+    # type: SelectiveAuthenticator
+    # authenticator_selection_path: ["credentials", "auth_type"]
+    # authenticators:
+    #   oauth2_access_token: "#/definitions/bearer_authenticator"
+    #   oauth2_confidential_application: "#/definitions/oauth_authenticator"
+    $ref: "#/definitions/bearer_authenticator"
 
   requester:
     type: HttpRequester

--- a/docs/integrations/sources/xero-migrations.md
+++ b/docs/integrations/sources/xero-migrations.md
@@ -1,5 +1,17 @@
 # Xero Migration Guide
 
+## Upgrading to 3.0.0
+
+Due to limitations on the number of OAuth users permitted for the Airbyte application, OAuth support has been disabled. 
+Consequently, the bearer authentication method has been adopted as the primary authentication type.
+Visit the Xero documentation - https://developer.xero.com/documentation/guides/oauth2/pkce-flow for more detailed information about how to get access token.
+
+Then authorize your source with `access_token`.
+1. Go to set up `The Source` page.
+2. Enter your Xero application's access token.
+3. Click `Reset saved source` button. 
+
+
 ## Upgrading to 2.0.0
 
 You can now choose your preferred xero authentication method. You can choose between `client_credentials` and `bearer_token` authentication methods.

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -120,6 +120,7 @@ The connector is restricted by Xero [API rate limits](https://developer.xero.com
 
 | Version    | Date       | Pull Request                                             | Subject                                 |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------|
+| 3.0.0      | 2024-07-22 | [42128](https://github.com/airbytehq/airbyte/pull/42128) | Remove OAuth due to user limit restriction  |
 | 2.0.0      | 2024-06-06 | [39316](https://github.com/airbytehq/airbyte/pull/39316) | Add OAuth and Bearer strategies         |
 | 1.0.1      | 2024-06-06 | [39264](https://github.com/airbytehq/airbyte/pull/39264) | [autopull] Upgrade base image to v1.2.2 |
 | 1.0.0      | 2024-04-30 | [36878](https://github.com/airbytehq/airbyte/pull/36878) | Migrate to low code                     |


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/42126

## What
OAuth support for the source-Xero connector has been removed due to restrictions on the number of OAuth users allowed for the Airbyte application.

## How
Removed the OAuth authenticator, retained only the bearer authenticator, and released a new version with a breaking change.

## Review guide
1. `manifest.yaml`
2. `metadata.yaml`
3. `xero-migrations.md`

## User Impact
*Breaking Change

