### PR TITLE
chore(python): gitignore .ruff_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ __pycache__
 .eggs
 .venv
 .mypy_cache
+.ruff_cache
 .ipynb_checkpoints
 .pytest_
 


### PR DESCRIPTION
## What
Somehow, we didn't have `.ruff_cache` in gitignore. Fixed it.

