### PR TITLE
feat(airbyte-cdk): Add limitation for number of partitions to PerPartitionCursor

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -4,7 +4,7 @@
 
 import logging
 from collections import OrderedDict
-from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Union
+from typing import Any, Callable, Iterable, Mapping, Optional, Union
 
 from airbyte_cdk.sources.declarative.incremental.declarative_cursor import DeclarativeCursor
 from airbyte_cdk.sources.declarative.partition_routers.partition_router import PartitionRouter
@@ -12,24 +12,6 @@ from airbyte_cdk.sources.streams.checkpoint.per_partition_key_serializer import 
 from airbyte_cdk.sources.types import Record, StreamSlice, StreamState
 from airbyte_cdk.utils import AirbyteTracedException
 from airbyte_protocol.models import FailureType
-
-
-class PerPartitionKeySerializer:
-    """
-    We are concerned of the performance of looping through the `states` list and evaluating equality on the partition. To reduce this
-    concern, we wanted to use dictionaries to map `partition -> cursor`. However, partitions are dict and dict can't be used as dict keys
-    since they are not hashable. By creating json string using the dict, we can have a use the dict as a key to the dict since strings are
-    hashable.
-    """
-
-    @staticmethod
-    def to_partition_key(to_serialize: Any) -> str:
-        # separators have changed in Python 3.4. To avoid being impacted by further change, we explicitly specify our own value
-        return json.dumps(to_serialize, indent=None, separators=(",", ":"), sort_keys=True)
-
-    @staticmethod
-    def to_partition(to_deserialize: Any) -> Mapping[str, Any]:
-        return json.loads(to_deserialize)  # type: ignore # The partition is known to be a dict, but the type hint is Any
 
 
 class CursorFactory:
@@ -70,7 +52,7 @@ class PerPartitionCursor(DeclarativeCursor):
     def __init__(self, cursor_factory: CursorFactory, partition_router: PartitionRouter):
         self._cursor_factory = cursor_factory
         self._partition_router = partition_router
-        self._cursor_per_partition: MutableMapping[str, DeclarativeCursor] = OrderedDict()
+        self._cursor_per_partition: OrderedDict[str, DeclarativeCursor] = OrderedDict()
         self._partition_serializer = PerPartitionKeySerializer()
 
     def stream_slices(self) -> Iterable[StreamSlice]:
@@ -87,7 +69,7 @@ class PerPartitionCursor(DeclarativeCursor):
             for cursor_slice in cursor.stream_slices():
                 yield StreamSlice(partition=partition, cursor_slice=cursor_slice)
 
-    def _ensure_partition_limit(self):
+    def _ensure_partition_limit(self) -> None:
         """
         Ensure the maximum number of partitions is not exceeded. If so, the oldest added partition will be dropped.
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -52,6 +52,8 @@ class PerPartitionCursor(DeclarativeCursor):
     def __init__(self, cursor_factory: CursorFactory, partition_router: PartitionRouter):
         self._cursor_factory = cursor_factory
         self._partition_router = partition_router
+        # The dict is ordered to ensure that once the maximum number of partitions is reached,
+        # the oldest partitions can be efficiently removed, maintaining the most recent partitions.
         self._cursor_per_partition: OrderedDict[str, DeclarativeCursor] = OrderedDict()
         self._partition_serializer = PerPartitionKeySerializer()
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -3,9 +3,8 @@
 #
 
 import logging
-from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Union
 from collections import OrderedDict
-
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Union
 
 from airbyte_cdk.sources.declarative.incremental.declarative_cursor import DeclarativeCursor
 from airbyte_cdk.sources.declarative.partition_routers.partition_router import PartitionRouter

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -61,7 +61,7 @@ class PerPartitionCursor(DeclarativeCursor):
     Therefore, we need to manage state per partition.
     """
 
-    DEFAULT_MAX_PARTITIONS_NUMBER = 5
+    DEFAULT_MAX_PARTITIONS_NUMBER = 10000
     _NO_STATE: Mapping[str, Any] = {}
     _NO_CURSOR_STATE: Mapping[str, Any] = {}
     _KEY = 0

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_per_partition_cursor_integration.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_per_partition_cursor_integration.py
@@ -2,10 +2,21 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from airbyte_cdk.models import SyncMode
-from airbyte_cdk.sources.declarative.incremental.per_partition_cursor import StreamSlice
+from airbyte_cdk.models import (
+    AirbyteStateBlob,
+    AirbyteStateMessage,
+    AirbyteStateType,
+    AirbyteStream,
+    AirbyteStreamState,
+    ConfiguredAirbyteCatalog,
+    ConfiguredAirbyteStream,
+    DestinationSyncMode,
+    StreamDescriptor,
+    SyncMode,
+)
+from airbyte_cdk.sources.declarative.incremental.per_partition_cursor import PerPartitionCursor, StreamSlice
 from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
 from airbyte_cdk.sources.declarative.retrievers.simple_retriever import SimpleRetriever
 from airbyte_cdk.sources.types import Record
@@ -37,9 +48,8 @@ class ManifestBuilder:
                     "stream": "#/definitions/Rates",
                     "parent_key": "id",
                     "partition_field": "parent_id",
-
                 }
-            ]
+            ],
         }
         return self
 
@@ -100,10 +110,7 @@ class ManifestBuilder:
                     },
                 },
             },
-            "streams": [
-                {"$ref": "#/definitions/Rates"},
-                {"$ref": "#/definitions/AnotherStream"}
-            ],
+            "streams": [{"$ref": "#/definitions/Rates"}, {"$ref": "#/definitions/AnotherStream"}],
             "spec": {
                 "connection_specification": {
                     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -180,11 +187,9 @@ def test_given_record_for_partition_when_read_then_update_state():
     stream_instance = source.streams({})[0]
     list(stream_instance.stream_slices(sync_mode=SYNC_MODE))
 
-    stream_slice = StreamSlice(partition={"partition_field": "1"},
-                               cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"})
+    stream_slice = StreamSlice(partition={"partition_field": "1"}, cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"})
     with patch.object(
-            SimpleRetriever, "_read_pages",
-            side_effect=[[Record({"a record key": "a record value", CURSOR_FIELD: "2022-01-15"}, stream_slice)]]
+        SimpleRetriever, "_read_pages", side_effect=[[Record({"a record key": "a record value", CURSOR_FIELD: "2022-01-15"}, stream_slice)]]
     ):
         list(
             stream_instance.read_records(
@@ -236,19 +241,43 @@ def test_substream_without_input_state():
 
     # This mocks the resulting records of the Rates stream which acts as the parent stream of the SubstreamPartitionRouter being tested
     with patch.object(
-            SimpleRetriever, "_read_pages", side_effect=[[Record({"id": "1", CURSOR_FIELD: "2022-01-15"}, parent_stream_slice)],
-                                                         [Record({"id": "2", CURSOR_FIELD: "2022-01-15"}, parent_stream_slice)]]
+        SimpleRetriever,
+        "_read_pages",
+        side_effect=[
+            [Record({"id": "1", CURSOR_FIELD: "2022-01-15"}, parent_stream_slice)],
+            [Record({"id": "2", CURSOR_FIELD: "2022-01-15"}, parent_stream_slice)],
+        ],
     ):
         slices = list(stream_instance.stream_slices(sync_mode=SYNC_MODE))
         assert list(slices) == [
-            StreamSlice(partition={"parent_id": "1", "parent_slice": {}, },
-                        cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"}),
-            StreamSlice(partition={"parent_id": "1", "parent_slice": {}, },
-                        cursor_slice={"start_time": "2022-02-01", "end_time": "2022-02-28"}),
-            StreamSlice(partition={"parent_id": "2", "parent_slice": {}, },
-                        cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"}),
-            StreamSlice(partition={"parent_id": "2", "parent_slice": {}, },
-                        cursor_slice={"start_time": "2022-02-01", "end_time": "2022-02-28"}),
+            StreamSlice(
+                partition={
+                    "parent_id": "1",
+                    "parent_slice": {},
+                },
+                cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"},
+            ),
+            StreamSlice(
+                partition={
+                    "parent_id": "1",
+                    "parent_slice": {},
+                },
+                cursor_slice={"start_time": "2022-02-01", "end_time": "2022-02-28"},
+            ),
+            StreamSlice(
+                partition={
+                    "parent_id": "2",
+                    "parent_slice": {},
+                },
+                cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"},
+            ),
+            StreamSlice(
+                partition={
+                    "parent_id": "2",
+                    "parent_slice": {},
+                },
+                cursor_slice={"start_time": "2022-02-01", "end_time": "2022-02-28"},
+            ),
         ]
 
 
@@ -267,57 +296,76 @@ def test_partition_limitation():
         )
         .build()
     )
-    stream_instance = source.streams({})[0]
 
-    stream_slices = [
-        StreamSlice(partition={"partition_field": "1"},
-                    cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"}),
-        StreamSlice(partition={"partition_field": "2"},
-                    cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"}),
-        StreamSlice(partition={"partition_field": "3"},
-                    cursor_slice={"start_time": "2022-01-01", "end_time": "2022-01-31"})
+    partition_slices = [
+        StreamSlice(partition={"partition_field": "1"}, cursor_slice={}),
+        StreamSlice(partition={"partition_field": "2"}, cursor_slice={}),
+        StreamSlice(partition={"partition_field": "3"}, cursor_slice={}),
     ]
 
     records_list = [
-        [Record({"a record key": "a record value", CURSOR_FIELD: "2022-01-15"}, stream_slices[0])],
-        [Record({"a record key": "a record value", CURSOR_FIELD: "2022-01-16"}, stream_slices[1])],
-        [Record({"a record key": "a record value", CURSOR_FIELD: "2022-01-17"}, stream_slices[2])]
+        [
+            Record({"a record key": "a record value", CURSOR_FIELD: "2022-01-15"}, partition_slices[0]),
+            Record({"a record key": "a record value", CURSOR_FIELD: "2022-01-16"}, partition_slices[0]),
+        ],
+        [Record({"a record key": "a record value", CURSOR_FIELD: "2022-02-15"}, partition_slices[0])],
+        [Record({"a record key": "a record value", CURSOR_FIELD: "2022-01-16"}, partition_slices[1])],
+        [],
+        [],
+        [Record({"a record key": "a record value", CURSOR_FIELD: "2022-02-17"}, partition_slices[2])],
     ]
 
     configured_stream = ConfiguredAirbyteStream(
-                stream=AirbyteStream(name=stream_name, json_schema={}, supported_sync_modes=[SyncMode.full_refresh, SyncMode.incremental]),
-                sync_mode=SyncMode.incremental,
-                destination_sync_mode=DestinationSyncMode.append,
-            )
+        stream=AirbyteStream(name="Rates", json_schema={}, supported_sync_modes=[SyncMode.full_refresh, SyncMode.incremental]),
+        sync_mode=SyncMode.incremental,
+        destination_sync_mode=DestinationSyncMode.append,
+    )
+    catalog = ConfiguredAirbyteCatalog(streams=[configured_stream])
 
+    initial_state = [
+        AirbyteStateMessage(
+            type=AirbyteStateType.STREAM,
+            stream=AirbyteStreamState(
+                stream_descriptor=StreamDescriptor(name="post_comment_votes", namespace=None),
+                stream_state=AirbyteStateBlob.parse_obj(
+                    {
+                        "states": [
+                            {
+                                "partition": {"partition_field": "1"},
+                                "cursor": {CURSOR_FIELD: "2022-01-01"},
+                            },
+                            {
+                                "partition": {"partition_field": "2"},
+                                "cursor": {CURSOR_FIELD: "2022-01-02"},
+                            },
+                            {
+                                "partition": {"partition_field": "3"},
+                                "cursor": {CURSOR_FIELD: "2022-01-03"},
+                            },
+                        ]
+                    }
+                ),
+            ),
+        )
+    ]
     logger = MagicMock()
-    return list(source.read(logger, config, catalog, state))
 
-    with patch.object(SimpleRetriever, "stream_slices", return_value=stream_slices):
-        stream_instance.retriever.cursor.DEFAULT_MAX_PARTITIONS_NUMBER = 2
+    # with patch.object(PerPartitionCursor, "stream_slices", return_value=partition_slices):
+    with patch.object(SimpleRetriever, "_read_pages", side_effect=records_list):
+        with patch.object(PerPartitionCursor, "DEFAULT_MAX_PARTITIONS_NUMBER", 2):
+            output = list(source.read(logger, {}, catalog, initial_state))
 
-        with patch.object(
-                SimpleRetriever, "_read_pages",
-                side_effect=records_list
-        ):
-            list(
-                stream_instance.read(
-                    sync_mode=SYNC_MODE,
-                    stream_slice=stream_slice,
-                    stream_state={"states": []},
-                    cursor_field=CURSOR_FIELD,
-                )
-            )
-
-    assert stream_instance.state == {
+    # assert output_data == expected_records
+    final_state = [message.state.stream.stream_state.dict() for message in output if message.state]
+    assert final_state[-1] == {
         "states": [
             {
                 "partition": {"partition_field": "2"},
-                "cursor": {CURSOR_FIELD: "2022-01-15"},
+                "cursor": {CURSOR_FIELD: "2022-01-16"},
             },
             {
                 "partition": {"partition_field": "3"},
-                "cursor": {CURSOR_FIELD: "2022-01-15"},
-            }
+                "cursor": {CURSOR_FIELD: "2022-02-17"},
+            },
         ]
     }


### PR DESCRIPTION
## What
Add limitation for the number of partitions in PerPartitionCursor

## How
Reused the approach from file-based CDK. Old partitions are deleted when the state overflows. 

## User Impact
This update should help to avoid OOM errors. 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
