### PR TITLE
airbyte-ci: skip regression test approval requirement on forks

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -767,6 +767,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 |---------| ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
+| 4.25.1  | [#42410](https://github.com/airbytehq/airbyte/pull/42410) | Live/regression tests: add support for selecting from a subset of connections                                                |
 | 4.25.0  | [#42044](https://github.com/airbytehq/airbyte/pull/42044) | Live/regression tests: add support for selecting from a subset of connections                                                |
 | 4.24.3  | [#42040](https://github.com/airbytehq/airbyte/pull/42040) | Always send regression test approval status check; skip on auto-merge PRs.                                                   |
 | 4.24.2  | [#41676](https://github.com/airbytehq/airbyte/pull/41676) | Send regression test approval status check when skipped.                                                                     |

--- a/airbyte-ci/connectors/pipelines/pipelines/hacks.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/hacks.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Callable, List
 import asyncclick as click
 from connector_ops.utils import ConnectorLanguage  # type: ignore
 from pipelines import consts
-from pipelines.helpers.github import is_automerge_pull_request, update_commit_status_check
+from pipelines.helpers.github import AIRBYTE_GITHUB_REPO_URL, is_automerge_pull_request, update_commit_status_check
 
 if TYPE_CHECKING:
     from dagger import Container
@@ -86,11 +86,15 @@ def do_regression_test_status_check(ctx: click.Context, status_check_name: str, 
     run_url = ctx.obj["gha_workflow_run_url"]
     should_send = ctx.obj.get("ci_context") == consts.CIContext.PULL_REQUEST
 
-    if not is_automerge_pull_request(ctx.obj.get("pull_request")) and any(
-        [
-            (connector.language == ConnectorLanguage.PYTHON and connector.support_level == "certified")
-            for connector in ctx.obj["selected_connectors_with_modified_files"]
-        ]
+    if (
+        (not is_automerge_pull_request(ctx.obj.get("pull_request")))
+        and (ctx.obj["git_repo_url"] == AIRBYTE_GITHUB_REPO_URL)
+        and any(
+            [
+                (connector.language == ConnectorLanguage.PYTHON and connector.support_level == "certified")
+                for connector in ctx.obj["selected_connectors_with_modified_files"]
+            ]
+        )
     ):
         update_commit_status_check(
             commit,

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.25.0"
+version = "4.25.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
The /-command `/approve-regression-tests` is not working on forks. Disabling for now.