### PR TITLE
docs: Add :oss namespace to platform commands

### DIFF
--- a/docs/contributing-to-airbyte/resources/developing-locally.md
+++ b/docs/contributing-to-airbyte/resources/developing-locally.md
@@ -40,12 +40,12 @@ docker compose up
 To compile and build the platform, run the following command in your local `airbyte-platform` repository:
 
 ```bash
-SUB_BUILD=PLATFORM ./gradlew build
+./gradlew build
 ```
 
 This will build all the code and run all the unit tests.
 
-`SUB_BUILD=PLATFORM ./gradlew build` creates all the necessary artifacts \(Webapp, Jars and Docker images\) so that you can run Airbyte locally. Since this builds everything, it can take some time.
+`./gradlew build` creates all the necessary artifacts \(Webapp, Jars and Docker images\) so that you can run Airbyte locally. Since this builds everything, it can take some time.
 
 :::info
 
@@ -54,12 +54,17 @@ Optionally, you may pass a `VERSION` environment variable to the gradle build co
 If unset, gradle will default to using the current VERSION in `.env` for Jars, and `dev` as the Docker image tag.
 
 :::
+:::info
+
+If running tasks on a subproject, you must prepend `:oss` to the project in gradlew. For example, to build the `airbyte-cron` project the command would look like: `./gradlew :oss:airbyte-cron:build`.
+
+:::
 
 :::info
 
 Gradle will use all CPU cores by default. If Gradle uses too much/too little CPU, tuning the number of CPU cores it uses to better suit a dev's need can help.
 
-Adjust this by either, 1. Setting an env var: `export GRADLE_OPTS="-Dorg.gradle.workers.max=3"`. 2. Setting a cli option: `SUB_BUILD=PLATFORM ./gradlew build --max-workers 3` 3. Setting the `org.gradle.workers.max` property in the `gradle.properties` file.
+Adjust this by either, 1. Setting an env var: `export GRADLE_OPTS="-Dorg.gradle.workers.max=3"`. 2. Setting a cli option: `./gradlew build --max-workers 3` 3. Setting the `org.gradle.workers.max` property in the `gradle.properties` file.
 
 A good rule of thumb is to set this to \(\# of cores - 1\).
 
@@ -83,7 +88,7 @@ These instructions explain how to run a version of Airbyte Platform that you are
 In your local `airbyte-platform` repository, run the following commands:
 
 ```bash
-SUB_BUILD=PLATFORM ./gradlew build
+./gradlew build
 VERSION=dev docker compose up
 ```
 
@@ -132,14 +137,14 @@ Now when you run a sync with that connector, it will use your local docker image
 In your local `airbyte-platform` repository, run the following commands to run acceptance \(end-to-end\) tests for the platform:
 
 ```bash
-SUB_BUILD=PLATFORM ./gradlew clean build
-SUB_BUILD=PLATFORM ./gradlew :airbyte-tests:acceptanceTests
+./gradlew clean build
+./gradlew :oss:airbyte-tests:acceptanceTests
 ```
 
 Test containers start Airbyte locally, run the tests, and shutdown Airbyte after running the tests. If you want to run acceptance tests against local Airbyte that is not managed by the test containers, you need to set `USE_EXTERNAL_DEPLOYMENT` environment variable to true:
 
 ```bash
-USE_EXTERNAL_DEPLOYMENT=true SUB_BUILD=PLATFORM ./gradlew :airbyte-tests:acceptanceTests
+USE_EXTERNAL_DEPLOYMENT=true ./gradlew :oss:airbyte-tests:acceptanceTests
 ```
 
 ## Run formatting automation/tests
@@ -150,7 +155,7 @@ The command to run formatting varies slightly depending on which part of the cod
 
 ### Platform
 
-If you are working in the platform run `SUB_BUILD=PLATFORM ./gradlew format` from the root of the `airbyte-platform` repository.
+If you are working in the platform run `./gradlew format` from the root of the `airbyte-platform` repository.
 
 ### Connector
 
@@ -233,7 +238,7 @@ Sometimes you'll want to reset the data in your local environment. One common ca
 - Rebuild the project
 
   ```bash
-   SUB_BUILD=PLATFORM ./gradlew clean build
+   ./gradlew clean build
    VERSION=dev docker compose up -V
   ```
 


### PR DESCRIPTION
## What
* The refactor of gradle in the platform means that to run oss submodules from the oss project the user must prepend the command with `:oss`. This PR updates our docs to reflect that.
* While I was at it `SUB_BUILD` is no longer a thing in the platform, so removed references to it in the docs.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
