### PR TITLE
destination-postgres: close streams in PostgresSqlOperations.isOtherGenerationIdInTable

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 2.1.0
+  dockerImageTag: 2.1.1
   dockerRepository: airbyte/destination-postgres-strict-encrypt
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 2.1.0
+  dockerImageTag: 2.1.1
   dockerRepository: airbyte/destination-postgres
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/PostgresSqlOperations.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/PostgresSqlOperations.kt
@@ -156,22 +156,25 @@ class PostgresSqlOperations : JdbcSqlOperations() {
             database
                 .unsafeQuery(
                     """SELECT 1 
-            |               FROM pg_namespace n
+            |               FROM pg_catalog.pg_namespace n
             |               JOIN pg_catalog.pg_class c
             |               ON c.relnamespace=n.oid
-            |               WHERE n.nspname='$namespace'
+            |               WHERE n.nspname=?
             |               AND c.relkind='r'
-            |               AND c.relname='$name'
-        """.trimMargin()
+            |               AND c.relname=?
+            |               LIMIT 1
+        """.trimMargin(),
+                    namespace,
+                    name
                 )
-                .toList()
+                .use { it.toList() }
         if (selectTableResultSet.isEmpty()) {
             return false
         } else {
             val selectGenIdResultSet =
                 database
                     .unsafeQuery("SELECT _airbyte_generation_id FROM $namespace.$name LIMIT 1;")
-                    .toList()
+                    .use { it.toList() }
             if (selectGenIdResultSet.isEmpty()) {
                 return false
             } else {

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -267,7 +267,8 @@ _where_ it is deployed.
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                  |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------|
-| 2.1.0   | 2024-07-16 | [\#41954](https://github.com/airbytehq/airbyte/pull/41954) | Support for [refreshes](../../operator-guides/refreshes.md) and resumable full refresh. WARNING: You must upgrade to platform 0.63.7 before upgrading to this connector version.                                                          |
+| 2.1.1   | 2024-07-22 | [\#42415](https://github.com/airbytehq/airbyte/pull/42415) | fixing PostgresSqlOperations.isOtherGenerationIdInTable to close the streams coming from JdbcDatabase.unsafeQuery |
+| 2.1.0   | 2024-07-22 | [\#41954](https://github.com/airbytehq/airbyte/pull/41954) | Support for [refreshes](../../operator-guides/refreshes.md) and resumable full refresh. WARNING: You must upgrade to platform 0.63.7 before upgrading to this connector version.                                                          |
 | 2.0.15  | 2024-06-26 | [\#40554](https://github.com/airbytehq/airbyte/pull/40554) | Convert all strict-encrypt prod code to kotlin.                                                          |
 | 2.0.14  | 2024-06-26 | [\#40563](https://github.com/airbytehq/airbyte/pull/40563) | Convert all test code to kotlin.                                                          |
 | 2.0.13  | 2024-06-13 | [\#40159](https://github.com/airbytehq/airbyte/pull/40159) | Config error on drop failure when cascade is disabled                                                    |


### PR DESCRIPTION
kotlin doesn't have an obvious warning for unclosed `AutoCloseable` instances, and we were forgetting to close 2 streams in `isOtherGenerationIdInTable`.
The proper kotlin construct is to use `autoCloseable.use {}`
