### PR TITLE
[p0 - source-zendesk-support] - Rollback to connector v2.6.10

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
-  dockerImageTag: 2.6.11
+  dockerImageTag: 2.6.10
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
   githubIssueLabel: source-zendesk-support


### PR DESCRIPTION
## What
- Rollback dockerImageTag to 2.6.10 (prev version) due to failed syncs

