### PR TITLE
CATs: only export /integration_tests

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.4
+
+Only export /integration-tests directory back to host (for use by DB sources).
+
 ## 3.8.3
 
 Add handling for global state messages (for use by DB sources).

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
@@ -159,6 +159,7 @@ class FileTypesConfig(BaseConfig):
 
 
 class ClientContainerConfig(BaseConfig):
+    secrets_path: str = Field(None, description="Path in the setup/teardown container at which to copy connector secrets.")
     client_container_dockerfile_path: str = Field(
         None, description="Path to Dockerfile to run before each test for which a config is provided."
     )

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/client_container_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/client_container_runner.py
@@ -63,7 +63,7 @@ async def get_client_container(dagger_client: dagger.Client, connector_path: Pat
 
 async def do_setup(container: dagger.Container, command: List[str], connector_config: SecretDict, connector_path: Path):
     container = await _run_with_config(container, command, connector_config)
-    await container.directory(str(IN_CONTAINER_CONNECTOR_PATH)).export(str(connector_path))
+    await container.directory(str(IN_CONTAINER_CONNECTOR_PATH / "integration_tests")).export(str(connector_path / "integration_tests"))
     return container
 
 

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "3.8.3"
+version = "3.8.4"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
## What
Fixes an error, `device or resource busy`, that was being hit by DB sources when we attempt to export the container files to the host (see conversation [here](https://airbytehq-team.slack.com/archives/C07ADHDBJAU/p1721416563165229)). This error was due to `secrets/config.py` being overwritten; when it exists on the host we can't overwrite it with the container.

## How
The error is fixed by
1) Writing a new test config file instead of using the existing `secrets/config.py`, by adding a new `secrets_config` key to the `ClientContainerConfig` in `acceptance-test-config.yml`. This will allow us to differentiate between the secrets used during setup and the secrets used in the course of the test.
2) A slight refactor of `conftest.py` so we don't try to read the test config before it's been created. For this we add a new fixture for reading `secrets_config` separately from the test config.

Example of the new config:
```
  basic_read:
    tests:
      - config_path: "integration_tests/config2.json"  # This is the config written by hook.py
        configured_catalog_path: "integration_tests/temp/configured_catalog_copy.json"
        expect_records:
          path: "integration_tests/expected_records.txt"
        client_container_config:
          secrets_path: "secrets/config.json"  # This is the config required for setup
          client_container_dockerfile_path: "integration_tests/Dockerfile"
          setup_command:
            - "python"
            - "./hook.py"
            - "setup"
          teardown_command:
            - "python"
            - "./hook.py"
            - "teardown"
```

Example modification to hook.py:
```
...

secret_config_file = '/connector/secrets/config.json'
secret_config_out_file = '/connector/integration_tests/config2.json'

...

def connect_to_db():
    with open(secret_config_file) as f:
        secret = json.load(f)

    try:
        # Define connection parameters
        connection = psycopg2.connect(
            dbname=secret["database"],
            user=secret["username"],
            password=secret["password"],
            host=secret["host"],
            port=secret["port"]
        )
        print("Connected to the database successfully")
        return connection
    except Exception as error:
        print(f"Error connecting to the database: {error}")
        return None

...

def write_supporting_file(schema_name):
    print(f"writing schema name to files: {schema_name}")
    Path("/connector/integration_tests/temp").mkdir(parents=False, exist_ok=True)

    with open(catalog_write_file, "w") as file:
        with open(catalog_source_file, 'r') as source_file:
            file.write(source_file.read() % schema_name)
    with open(catalog_incremental_write_file, "w") as file:
        with open(catalog_incremental_source_file, 'r') as source_file:
            file.write(source_file.read() % schema_name)
    with open(abnormal_state_write_file, "w") as file:
        with open(abnormal_state_file, 'r') as source_file:
            file.write(source_file.read() % (schema_name, schema_name))
    # update configs:
    with open(secret_config_file) as base_config:
      secret = json.load(base_config)
      secret["schemas"] = [schema_name]
    with open(secret_config_out_file, 'w') as f:
      json.dump(secret, f)
```