### PR TITLE
airbyte-ci: add validation before live test runs

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -773,6 +773,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 |---------| ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
+| 4.25.4  | [#42463](https://github.com/airbytehq/airbyte/pull/42463) | Add validation before live test runs                                                                                         |
 | 4.25.3  | [#42437](https://github.com/airbytehq/airbyte/pull/42437)  | Ugrade-cdk: Update to work with Python connectors using poetry                                                               |
 | 4.25.2  | [#42077](https://github.com/airbytehq/airbyte/pull/42077)  | Live/regression tests: add status check for regression test runs                                                             |
 | 4.25.1  | [#42410](https://github.com/airbytehq/airbyte/pull/42410)  | Live/regression tests: disable approval requirement on forks                                                                 |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -580,7 +580,9 @@ class LiveTests(Step):
         connector_subtype = self.context.connector.metadata.get("connectorSubtype")
         assert connector_type == "source", f"Live tests can only run against source connectors, got `connectorType={connector_type}`."
         if connector_subtype == "database":
-            assert self.connection_subset == "sandboxes", f"Live tests for database sources may only be run against sandbox connections, got `connection_subset={self.connection_subset}`."
+            assert (
+                self.connection_subset == "sandboxes"
+            ), f"Live tests for database sources may only be run against sandbox connections, got `connection_subset={self.connection_subset}`."
 
     async def _run(self, connector_under_test_container: Container) -> StepResult:
         """Run the regression test suite.

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -575,7 +575,7 @@ class LiveTests(Step):
         self.run_id = os.getenv("GITHUB_RUN_ID") or str(int(time.time()))
         self._validate_job_can_run()
 
-    async def _validate_job_can_run(self) -> None:
+    def _validate_job_can_run(self) -> None:
         connector_type = self.context.connector.metadata.get("connectorType")
         connector_subtype = self.context.connector.metadata.get("connectorSubtype")
         assert connector_type == "source", f"Live tests can only run against source connectors, got `connectorType={connector_type}`."

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -573,6 +573,14 @@ class LiveTests(Step):
         self.test_evaluation_mode = "strict" if self.context.connector.metadata.get("supportLevel") == "certified" else "diagnostic"
         self.connection_subset = self.context.run_step_options.get_item_or_default(options, "connection-subset", "sandboxes")
         self.run_id = os.getenv("GITHUB_RUN_ID") or str(int(time.time()))
+        self._validate_job_can_run()
+
+    async def _validate_job_can_run(self) -> None:
+        connector_type = self.context.connector.metadata.get("connectorType")
+        connector_subtype = self.context.connector.metadata.get("connectorSubtype")
+        assert connector_type == "source", f"Live tests can only run against source connectors, got `connectorType={connector_type}`."
+        if connector_subtype == "database":
+            assert self.connection_subset == "sandboxes", f"Live tests for database sources may only be run against sandbox connections, got `connection_subset={self.connection_subset}`."
 
     async def _run(self, connector_under_test_container: Container) -> StepResult:
         """Run the regression test suite.

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.25.3"
+version = "4.25.4"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
Validates that the input connector for live tests is a source, and that if it is a database source that the connection subset is limited to sandboxes.

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/6794.