### PR TITLE
destination-postgres: republish 2.0.15

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 2.2.0
+  dockerImageTag: 2.0.15
   dockerRepository: airbyte/destination-postgres-strict-encrypt
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 2.2.0
+  dockerImageTag: 2.0.15
   dockerRepository: airbyte/destination-postgres
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres


### PR DESCRIPTION
we had a publishing issue where destination-postgres-2.0.15 was overriden with code from 2.1.1 (which was broken).
We did a hard-rollback in https://github.com/airbytehq/airbyte/pull/42460 but 2.0.15 is still a bad image.
This change is only intended to republish 2.0.15 so that it has the correct (old) code and behavior 