### PR TITLE
destination-postgres: bump version to 2.2.1

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 2.0.15
+  dockerImageTag: 2.2.1
   dockerRepository: airbyte/destination-postgres-strict-encrypt
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
-  dockerImageTag: 2.0.15
+  dockerImageTag: 2.2.1
   dockerRepository: airbyte/destination-postgres
   documentationUrl: https://docs.airbyte.com/integrations/destinations/postgres
   githubIssueLabel: destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/PostgresDestination.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/PostgresDestination.kt
@@ -207,9 +207,9 @@ class PostgresDestination :
         fun main(args: Array<String>) {
             addThrowableForDeinterpolation(PSQLException::class.java)
             val destination = sshWrappedDestination()
-            LOGGER.info("starting destination: {}", PostgresDestination::class.java)
+            LOGGER.info("starting destination-postgres: {}", PostgresDestination::class.java)
             IntegrationRunner(destination).run(args)
-            LOGGER.info("completed destination: {}", PostgresDestination::class.java)
+            LOGGER.info("completed destination-postgres: {}", PostgresDestination::class.java)
         }
     }
 }

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -267,6 +267,7 @@ _where_ it is deployed.
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                  |
 |:--------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------|
+| 2.2.1   | 2024-07-22 | [\#42423](https://github.com/airbytehq/airbyte/pull/42423) | no-op. Bumping to a clean image                                                                                 |
 | 2.2.0   | 2024-07-22 | [\#42423](https://github.com/airbytehq/airbyte/pull/42423) | Revert refreshes support                                                                                 |
 | 2.1.1   | 2024-07-22 | [\#42415](https://github.com/airbytehq/airbyte/pull/42415) | fixing PostgresSqlOperations.isOtherGenerationIdInTable to close the streams coming from JdbcDatabase.unsafeQuery |
 | 2.1.0   | 2024-07-22 | [\#41954](https://github.com/airbytehq/airbyte/pull/41954) | Support for [refreshes](../../operator-guides/refreshes.md) and resumable full refresh. WARNING: You must upgrade to platform 0.63.7 before upgrading to this connector version.                                                          |


### PR DESCRIPTION
the previous PR (#42469) moved the dockerImageTag back to 2.0.15. For sake of clarity, we want to move it forward to the latest version (2.2.0), but the behavior regarding re-publishing isn't clear, so we're instead bumping to 2.2.1