### PR TITLE
fix[low-code] follow up #38829

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1030,7 +1030,7 @@ class ModelToComponentFactory:
         self,
         model: RecordSelectorModel,
         config: Config,
-        decoder: Optional[Decoder],
+        decoder: Optional[Decoder] = None,
         *,
         transformations: List[RecordTransformation],
         client_side_incremental_sync: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
## What
Follow up for #38829
Arguments for custom components can only be passed to the instance if they are named.

## How
Add decoder default value for record selector factory 

## User Impact
No

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
