### PR TITLE
🐛 Source Braintree: Reverts braintree pagination

### DIFF
--- a/airbyte-integrations/connectors/source-braintree/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braintree/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 63cea06f-1c75-458d-88fe-ad48c7cb27fd
-  dockerImageTag: 0.3.6
+  dockerImageTag: 0.3.7
   dockerRepository: airbyte/source-braintree
   documentationUrl: https://docs.airbyte.com/integrations/sources/braintree
   githubIssueLabel: source-braintree

--- a/airbyte-integrations/connectors/source-braintree/pyproject.toml
+++ b/airbyte-integrations/connectors/source-braintree/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.3.6"
+version = "0.3.7"
 name = "source-braintree"
 description = "Source implementation for Braintree."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml
+++ b/airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml
@@ -3756,14 +3756,7 @@ streams:
         extractor:
           class_name: "source_braintree.source.CustomerExtractor"
       paginator:
-        type: DefaultPaginator
-        page_token_option:
-          type: RequestOption
-          inject_into: request_parameter
-          field_name: page
-        pagination_strategy:
-          type: PageIncrement
-          start_from_page: 1
+        type: NoPagination
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: created_at
@@ -9754,14 +9747,7 @@ streams:
         extractor:
           class_name: "source_braintree.source.TransactionExtractor"
       paginator:
-        type: DefaultPaginator
-        page_token_option:
-          type: RequestOption
-          inject_into: request_parameter
-          field_name: page
-        pagination_strategy:
-          type: PageIncrement
-          start_from_page: 1
+        type: NoPagination
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: created_at
@@ -15711,14 +15697,7 @@ streams:
         extractor:
           class_name: "source_braintree.source.SubscriptionExtractor"
       paginator:
-        type: DefaultPaginator
-        page_token_option:
-          type: RequestOption
-          inject_into: request_parameter
-          field_name: page
-        pagination_strategy:
-          type: PageIncrement
-          start_from_page: 1
+        type: NoPagination
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: created_at

--- a/docs/integrations/sources/braintree.md
+++ b/docs/integrations/sources/braintree.md
@@ -72,6 +72,7 @@ The Braintree connector should not run into Braintree API limitations under norm
 
 | Version | Date       | Pull Request                                             | Subject                                              |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------- |
+| 0.3.7 | 2024-07-24 | [42486](https://github.com/airbytehq/airbyte/pull/42486) | Reverts pagination
 | 0.3.6 | 2024-07-20 | [42372](https://github.com/airbytehq/airbyte/pull/42372) | Update dependencies |
 | 0.3.5 | 2024-07-18 | [42096](https://github.com/airbytehq/airbyte/pull/42096) | Adds pagination to get more than 50 records per sync |
 | 0.3.4 | 2024-07-13 | [41340](https://github.com/airbytehq/airbyte/pull/41340) | Update dependencies |


### PR DESCRIPTION
## What
An issue with pagination in Braintree was reported here: https://github.com/airbytehq/airbyte/pull/42096#issuecomment-2245860946

This PR reverts #42096 so we have it as an option to fix the problem. I'm not able to replicate the problem on my side, so I'm not sure how to fix it.

## How
Reverts #42096

## Review guide

`airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml`

## User Impact
Users will once again be limited to a maximum of 50 records per sync. The seemingly full resyncs it's attempting now should stop.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
