### PR TITLE
✨ Source Asana: add task data to stories schema

### DIFF
--- a/airbyte-integrations/connectors/source-asana/metadata.yaml
+++ b/airbyte-integrations/connectors/source-asana/metadata.yaml
@@ -28,7 +28,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d0243522-dccf-4978-8ba0-37ed47a0bdbf
-  dockerImageTag: 1.0.9
+  dockerImageTag: 1.1.0
   dockerRepository: airbyte/source-asana
   githubIssueLabel: source-asana
   icon: asana.svg

--- a/airbyte-integrations/connectors/source-asana/pyproject.toml
+++ b/airbyte-integrations/connectors/source-asana/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.0.9"
+version = "1.1.0"
 name = "source-asana"
 description = "Source implementation for asana."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-asana/source_asana/manifest.yaml
+++ b/airbyte-integrations/connectors/source-asana/source_asana/manifest.yaml
@@ -1551,6 +1551,27 @@ definitions:
         type:
           - "null"
           - integer
+      task:
+        type:
+          - "null"
+          - object
+        properties:
+          gid:
+            type:
+              - "null"
+              - string
+          resource_type:
+            type:
+              - "null"
+              - string
+          name:
+            type:
+              - "null"
+              - string
+          resource_subtype:
+            type:
+              - "null"
+              - string
 
   workspaces_schema:
     $schema: http://json-schema.org/draft-07/schema#

--- a/docs/integrations/sources/asana.md
+++ b/docs/integrations/sources/asana.md
@@ -106,6 +106,7 @@ The connector is restricted by [Asana rate limits](https://developers.asana.com/
 
 | Version | Date       | Pull Request                                             | Subject                                                           |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------|
+| 1.1.0 | 2024-07-24 | [42488](https://github.com/airbytehq/airbyte/pull/42488) | Add task data to stories stream |
 | 1.0.9 | 2024-07-20 | [42144](https://github.com/airbytehq/airbyte/pull/42144) | Update dependencies |
 | 1.0.8 | 2024-07-13 | [41839](https://github.com/airbytehq/airbyte/pull/41839) | Update dependencies |
 | 1.0.7 | 2024-07-10 | [41573](https://github.com/airbytehq/airbyte/pull/41573) | Update dependencies |


### PR DESCRIPTION
## What
<!--
Allowing stories to be linked to applicable Asana tasks.
https://github.com/airbytehq/airbyte/issues/28939
-->
Allowing stories to be linked to applicable Asana tasks.
https://github.com/airbytehq/airbyte/issues/28939

## How
<!--
Adding task information to the stories schema
-->
Adding task information to the stories schema

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
Users should now be able to link stories to applicable Asana tasks.
-->
Users should now be able to link stories to applicable Asana tasks.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
