### PR TITLE
Do not auto-resolve publish failures in Instatus

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -77,21 +77,8 @@ jobs:
       - name: Call Instatus Webhook
         uses: joelwmale/webhook-action@master
         with:
-          url: ${{ secrets.INSTATUS_CONNECTOR_CI_WEBHOOK_URL }}
+          url: ${{ secrets.INSTATUS_CONNECTOR_PUBLISH_PIPELINE_WEBHOOK_URL }}
           body: '{ "trigger": "down", "status": "HASISSUES" }'
-
-  set-instatus-incident-on-success:
-    name: Create Instatus Incident on Success
-    runs-on: ubuntu-latest
-    needs:
-      - publish_connectors
-    if: ${{ success() && github.ref == 'refs/heads/master' }}
-    steps:
-      - name: Call Instatus Webhook
-        uses: joelwmale/webhook-action@master
-        with:
-          url: ${{ secrets.INSTATUS_CONNECTOR_CI_WEBHOOK_URL }}
-          body: '{ "trigger": "up" }'
 
   notify-failure-slack-channel:
     name: "Notify Slack Channel on Build Failures"


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/42499
This will make sure all subscribers to our internal status activities are notified on a publish failure.
The incident will not auto-resolv itself on new publish success
Failures will have to be manually investigated in order to then manually declare the incident as closed.

## How
* Do not auto-resolve incidents on new publish success
* Use a webhook specific to connector publish

