### PR TITLE
Destinations CDK: Correctly detect when real raw/final table is correct generation during truncate sync

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -174,6 +174,7 @@ corresponds to that version.
 
 | Version    | Date       | Pull Request                                                 | Subject                                                                                                                                                        |
 |:-----------|:-----------|:-------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.44.14    | 2024-08-19 | [\#42503](https://github.com/airbytehq/airbyte/pull/42503)   | Destinations (refreshes) - correctly detect existing raw/final table of the correct generation during truncate sync                                            |
 | 0.44.13    | 2024-08-14 | [\#42579](https://github.com/airbytehq/airbyte/pull/42579)   | S3 destination - OVERWRITE: keep files until successful sync of same generationId                                                                              |
 | 0.44.5     | 2024-08-09 | [\#43374](https://github.com/airbytehq/airbyte/pull/43374)   | S3 destination V2 fields, conversion improvements, bugfixes                                                                                                    |
 | 0.44.4     | 2024-08-08 | [\#43410](https://github.com/airbytehq/airbyte/pull/43330)   | Better logs for counting info to state message.                                                                                                                |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.44.13
+version=0.44.14

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/kotlin/io/airbyte/integrations/base/destination/operation/AbstractStreamOperation.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/kotlin/io/airbyte/integrations/base/destination/operation/AbstractStreamOperation.kt
@@ -54,9 +54,9 @@ abstract class AbstractStreamOperation<DestinationState : MinimumDestinationStat
             }
 
         if (isTruncateSync) {
-            prepareStageForTruncate(destinationInitialStatus, stream)
-            rawTableSuffix = TMP_TABLE_SUFFIX
-            initialRawTableStatus = destinationInitialStatus.initialTempRawTableStatus
+            val (rawTableStatus, suffix) = prepareStageForTruncate(destinationInitialStatus, stream)
+            initialRawTableStatus = rawTableStatus
+            rawTableSuffix = suffix
         } else {
             rawTableSuffix = NO_SUFFIX
             initialRawTableStatus = prepareStageForNormalSync(stream, destinationInitialStatus)
@@ -132,7 +132,17 @@ abstract class AbstractStreamOperation<DestinationState : MinimumDestinationStat
     private fun prepareStageForTruncate(
         destinationInitialStatus: DestinationInitialStatus<DestinationState>,
         stream: StreamConfig
-    ) {
+    ): Pair<InitialRawTableStatus, String> {
+        /*
+        tl;dr:
+        * if a temp raw table exists, check whether it belongs to the correct generation.
+          * if wrong generation, truncate it.
+          * regardless, write into the temp raw table.
+        * else, if a real raw table exists, check its generation.
+          * if wrong generation, write into a new temp raw table.
+          * else, write into the preexisting real raw table.
+        * else, create a new temp raw table and write into it.
+         */
         if (destinationInitialStatus.initialTempRawTableStatus.rawTableExists) {
             val tempStageGeneration =
                 storageOperation.getStageGeneration(stream.id, TMP_TABLE_SUFFIX)
@@ -146,6 +156,7 @@ abstract class AbstractStreamOperation<DestinationState : MinimumDestinationStat
                     stream.id,
                     TMP_TABLE_SUFFIX,
                 )
+                return Pair(destinationInitialStatus.initialTempRawTableStatus, TMP_TABLE_SUFFIX)
             } else {
                 log.info {
                     "${stream.id.originalNamespace}.${stream.id.originalName}: truncate sync, and existing temp raw table belongs to generation $tempStageGeneration (!= current generation ${stream.generationId}). Truncating it."
@@ -156,16 +167,65 @@ abstract class AbstractStreamOperation<DestinationState : MinimumDestinationStat
                     TMP_TABLE_SUFFIX,
                     replace = true,
                 )
+                // We nuked the temp raw table, so create a new initial raw table status.
+                return Pair(
+                    InitialRawTableStatus(
+                        rawTableExists = true,
+                        hasUnprocessedRecords = false,
+                        maxProcessedTimestamp = Optional.empty(),
+                    ),
+                    TMP_TABLE_SUFFIX,
+                )
             }
-            // (if the existing temp stage is from the correct generation, then we're resuming
-            // a truncate refresh, and should keep the previous temp stage).
+        } else if (destinationInitialStatus.initialRawTableStatus.rawTableExists) {
+            // It's possible to "resume" a truncate sync that was previously already finalized.
+            // In this case, there is no existing temp raw table, and there is a real raw table
+            // which already belongs to the correct generation.
+            // Check for that case now.
+            val realStageGeneration = storageOperation.getStageGeneration(stream.id, NO_SUFFIX)
+            if (realStageGeneration == null || realStageGeneration == stream.generationId) {
+                log.info {
+                    "${stream.id.originalNamespace}.${stream.id.originalName}: truncate sync, no existing temp raw table, and existing real raw table belongs to generation $realStageGeneration (== current generation ${stream.generationId}). Retaining it."
+                }
+                // The real raw table is from the correct generation. Set up any other resources
+                // (staging file, etc.), but leave the table untouched.
+                storageOperation.prepareStage(stream.id, NO_SUFFIX)
+                return Pair(destinationInitialStatus.initialRawTableStatus, NO_SUFFIX)
+            } else {
+                log.info {
+                    "${stream.id.originalNamespace}.${stream.id.originalName}: truncate sync, existing real raw table belongs to generation $realStageGeneration (!= current generation ${stream.generationId}), and no preexisting temp raw table. Creating a temp raw table."
+                }
+                // We're initiating a new truncate refresh. Create a new temp stage.
+                storageOperation.prepareStage(
+                    stream.id,
+                    TMP_TABLE_SUFFIX,
+                )
+                return Pair(
+                    // Create a fresh raw table status, since we created a fresh temp stage.
+                    InitialRawTableStatus(
+                        rawTableExists = true,
+                        hasUnprocessedRecords = false,
+                        maxProcessedTimestamp = Optional.empty(),
+                    ),
+                    TMP_TABLE_SUFFIX,
+                )
+            }
         } else {
             log.info {
-                "${stream.id.originalNamespace}.${stream.id.originalName}: truncate sync, and no preexisting temp raw table. Creating it."
+                "${stream.id.originalNamespace}.${stream.id.originalName}: truncate sync, and no preexisting temp or  raw table. Creating a temp raw table."
             }
             // We're initiating a new truncate refresh. Create a new temp stage.
             storageOperation.prepareStage(
                 stream.id,
+                TMP_TABLE_SUFFIX,
+            )
+            return Pair(
+                // Create a fresh raw table status, since we created a fresh temp stage.
+                InitialRawTableStatus(
+                    rawTableExists = true,
+                    hasUnprocessedRecords = false,
+                    maxProcessedTimestamp = Optional.empty(),
+                ),
                 TMP_TABLE_SUFFIX,
             )
         }
@@ -188,8 +248,39 @@ abstract class AbstractStreamOperation<DestinationState : MinimumDestinationStat
         // The table already exists. Decide whether we're writing to it directly, or
         // using a tmp table.
         if (isTruncateSync) {
-            // Truncate refresh. Use a temp final table.
-            return prepareFinalTableForOverwrite(initialStatus)
+            if (initialStatus.isFinalTableEmpty || initialStatus.finalTableGenerationId == null) {
+                if (!initialStatus.isSchemaMismatch) {
+                    log.info {
+                        "Truncate sync, and final table is empty and has correct schema. Writing to it directly."
+                    }
+                    return NO_SUFFIX
+                } else {
+                    // No point soft resetting an empty table. We'll just do an overwrite later.
+                    log.info {
+                        "Truncate sync, and final table is empty, but has the wrong schema. Using a temp final table."
+                    }
+                    return prepareFinalTableForOverwrite(initialStatus)
+                }
+            } else if (
+                initialStatus.finalTableGenerationId >=
+                    initialStatus.streamConfig.minimumGenerationId
+            ) {
+                if (!initialStatus.isSchemaMismatch) {
+                    log.info {
+                        "Truncate sync, and final table matches our generation and has correct schema. Writing to it directly."
+                    }
+                    return NO_SUFFIX
+                } else {
+                    log.info {
+                        "Truncate sync, and final table matches our generation, but has the wrong schema. Writing to it directly, but triggering a soft reset first."
+                    }
+                    storageOperation.softResetFinalTable(stream)
+                    return NO_SUFFIX
+                }
+            } else {
+                // The final table is in the wrong generation. Use a temp final table.
+                return prepareFinalTableForOverwrite(initialStatus)
+            }
         } else {
             if (initialStatus.isSchemaMismatch || initialStatus.destinationState.needsSoftReset()) {
                 // We're loading data directly into the existing table.
@@ -257,14 +348,14 @@ abstract class AbstractStreamOperation<DestinationState : MinimumDestinationStat
         // which is possible (`typeAndDedupe(streamConfig.id.copy(rawName = streamConfig.id.rawName
         // + suffix))`
         // but annoying and confusing.
-        if (isTruncateSync && streamSuccessful) {
+        if (isTruncateSync && streamSuccessful && rawTableSuffix.isNotEmpty()) {
             log.info {
-                "Overwriting raw table for ${streamConfig.id.originalNamespace}.${streamConfig.id.originalName} because this is a truncate sync and we received a stream success message."
+                "Overwriting raw table for ${streamConfig.id.originalNamespace}.${streamConfig.id.originalName} because this is a truncate sync, we received a stream success message, and are using a temporary raw table."
             }
             storageOperation.overwriteStage(streamConfig.id, rawTableSuffix)
         } else {
             log.info {
-                "Not overwriting raw table for ${streamConfig.id.originalNamespace}.${streamConfig.id.originalName}. Truncate sync: $isTruncateSync; stream success: $streamSuccessful"
+                "Not overwriting raw table for ${streamConfig.id.originalNamespace}.${streamConfig.id.originalName}. Truncate sync: $isTruncateSync; stream success: $streamSuccessful; raw table suffix: \"$rawTableSuffix\""
             }
         }
 
@@ -303,10 +394,11 @@ abstract class AbstractStreamOperation<DestinationState : MinimumDestinationStat
                 "Skipping typing and deduping for stream ${streamConfig.id.originalNamespace}.${streamConfig.id.originalName} running as truncate sync. Stream success: $streamSuccessful; records written: ${syncSummary.recordsWritten}; temp raw table already existed: ${initialRawTableStatus.rawTableExists}; temp raw table had records: ${initialRawTableStatus.hasUnprocessedRecords}"
             }
         } else {
-            // In truncate mode, we want to read all the raw records. Typically, this is equivalent
+            // When targeting the temp final table, we want to read all the raw records
+            // because the temp final table is always a full rebuild. Typically, this is equivalent
             // to filtering on timestamp, but might as well be explicit.
             val timestampFilter =
-                if (!isTruncateSync) {
+                if (finalTmpTableSuffix.isEmpty()) {
                     initialRawTableStatus.maxProcessedTimestamp
                 } else {
                     Optional.empty()

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/test/kotlin/io/airbyte/integrations/base/destination/operation/AbstractStreamOperationTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/test/kotlin/io/airbyte/integrations/base/destination/operation/AbstractStreamOperationTest.kt
@@ -78,7 +78,7 @@ class AbstractStreamOperationTest {
             val initialState =
                 mockk<DestinationInitialStatus<MinimumDestinationState.Impl>> {
                     every { streamConfig } returns this@Truncate.streamConfig
-                    every { initialRawTableStatus } returns mockk<InitialRawTableStatus>()
+                    every { initialRawTableStatus.rawTableExists } returns false
                     every { initialTempRawTableStatus.rawTableExists } returns false
                     every { isFinalTablePresent } returns false
                     every {
@@ -122,7 +122,7 @@ class AbstractStreamOperationTest {
             val initialState =
                 mockk<DestinationInitialStatus<MinimumDestinationState.Impl>> {
                     every { streamConfig } returns this@Truncate.streamConfig
-                    every { initialRawTableStatus } returns mockk<InitialRawTableStatus>()
+                    every { initialRawTableStatus.rawTableExists } returns true
                     every { initialTempRawTableStatus.rawTableExists } returns false
                     every { isFinalTablePresent } returns true
                     every { isFinalTableEmpty } returns true
@@ -134,10 +134,12 @@ class AbstractStreamOperationTest {
                         destinationState.withSoftReset<MinimumDestinationState.Impl>(any())
                     } returns destinationState
                 }
+            every { storageOperation.getStageGeneration(streamId, "") } returns -1
 
             val streamOperations = TestStreamOperation(storageOperation, initialState)
 
             verifySequence {
+                storageOperation.getStageGeneration(streamId, "")
                 storageOperation.prepareStage(streamId, EXPECTED_SUFFIX)
                 storageOperation.createFinalTable(streamConfig, EXPECTED_SUFFIX, replace = true)
             }
@@ -172,7 +174,7 @@ class AbstractStreamOperationTest {
             val initialState =
                 mockk<DestinationInitialStatus<MinimumDestinationState.Impl>> {
                     every { streamConfig } returns this@Truncate.streamConfig
-                    every { initialRawTableStatus } returns mockk<InitialRawTableStatus>()
+                    every { initialRawTableStatus.rawTableExists } returns true
                     every { initialTempRawTableStatus.rawTableExists } returns false
                     every { isFinalTablePresent } returns true
                     every { isFinalTableEmpty } returns true
@@ -181,10 +183,12 @@ class AbstractStreamOperationTest {
                         destinationState.withSoftReset<MinimumDestinationState.Impl>(any())
                     } returns destinationState
                 }
+            every { storageOperation.getStageGeneration(streamId, "") } returns -1
 
             val streamOperations = TestStreamOperation(storageOperation, initialState)
 
             verifySequence {
+                storageOperation.getStageGeneration(streamId, "")
                 storageOperation.prepareStage(streamId, EXPECTED_SUFFIX)
                 // No table creation - we can just reuse the existing table.
             }
@@ -218,18 +222,21 @@ class AbstractStreamOperationTest {
             val initialState =
                 mockk<DestinationInitialStatus<MinimumDestinationState.Impl>> {
                     every { streamConfig } returns this@Truncate.streamConfig
-                    every { initialRawTableStatus } returns mockk<InitialRawTableStatus>()
+                    every { initialRawTableStatus.rawTableExists } returns true
                     every { initialTempRawTableStatus.rawTableExists } returns false
                     every { isFinalTablePresent } returns true
                     every { isFinalTableEmpty } returns false
                     every {
                         destinationState.withSoftReset<MinimumDestinationState.Impl>(any())
                     } returns destinationState
+                    every { finalTableGenerationId } returns -1
                 }
+            every { storageOperation.getStageGeneration(streamId, "") } returns -1
 
             val streamOperations = TestStreamOperation(storageOperation, initialState)
 
             verifySequence {
+                storageOperation.getStageGeneration(streamId, "")
                 storageOperation.prepareStage(streamId, EXPECTED_SUFFIX)
                 storageOperation.createFinalTable(streamConfig, EXPECTED_SUFFIX, replace = true)
             }
@@ -264,14 +271,16 @@ class AbstractStreamOperationTest {
             val initialState =
                 mockk<DestinationInitialStatus<MinimumDestinationState.Impl>> {
                     every { streamConfig } returns this@Truncate.streamConfig
-                    every { initialRawTableStatus } returns mockk<InitialRawTableStatus>()
+                    every { initialRawTableStatus.rawTableExists } returns true
                     every { initialTempRawTableStatus.rawTableExists } returns false
                     every { isFinalTablePresent } returns true
                     every { isFinalTableEmpty } returns false
                     every {
                         destinationState.withSoftReset<MinimumDestinationState.Impl>(any())
                     } returns destinationState
+                    every { finalTableGenerationId } returns -1
                 }
+            every { storageOperation.getStageGeneration(streamId, "") } returns -1
 
             val streamOperations = TestStreamOperation(storageOperation, initialState)
             // No point in verifying setup, completely identical to existingNonEmptyTable
@@ -298,18 +307,21 @@ class AbstractStreamOperationTest {
             val initialState =
                 mockk<DestinationInitialStatus<MinimumDestinationState.Impl>> {
                     every { streamConfig } returns this@Truncate.streamConfig
-                    every { initialRawTableStatus } returns mockk<InitialRawTableStatus>()
+                    every { initialRawTableStatus.rawTableExists } returns true
                     every { initialTempRawTableStatus.rawTableExists } returns false
                     every { isFinalTablePresent } returns true
                     every { isFinalTableEmpty } returns false
                     every {
                         destinationState.withSoftReset<MinimumDestinationState.Impl>(any())
                     } returns destinationState
+                    every { finalTableGenerationId } returns -1
                 }
+            every { storageOperation.getStageGeneration(streamId, "") } returns -1
 
             val streamOperations = TestStreamOperation(storageOperation, initialState)
 
             verifySequence {
+                storageOperation.getStageGeneration(streamId, "")
                 storageOperation.prepareStage(streamId, EXPECTED_SUFFIX)
                 storageOperation.createFinalTable(streamConfig, EXPECTED_SUFFIX, replace = true)
             }
@@ -357,6 +369,7 @@ class AbstractStreamOperationTest {
                     every {
                         destinationState.withSoftReset<MinimumDestinationState.Impl>(any())
                     } returns destinationState
+                    every { finalTableGenerationId } returns -1
                 }
             every { storageOperation.getStageGeneration(streamId, EXPECTED_SUFFIX) } returns 21
 
@@ -405,6 +418,8 @@ class AbstractStreamOperationTest {
                 mockk<DestinationInitialStatus<MinimumDestinationState.Impl>> {
                     every { streamConfig } returns this@Truncate.streamConfig
                     every { initialTempRawTableStatus.rawTableExists } returns true
+                    every { initialTempRawTableStatus.maxProcessedTimestamp } returns
+                        Optional.empty()
                     every { isFinalTablePresent } returns false
                     every {
                         destinationState.withSoftReset<MinimumDestinationState.Impl>(any())
@@ -460,6 +475,107 @@ class AbstractStreamOperationTest {
                 storageOperation.getStageGeneration(streamId, EXPECTED_SUFFIX)
                 storageOperation.prepareStage(streamId, EXPECTED_SUFFIX, replace = true)
                 storageOperation.createFinalTable(streamConfig, "", false)
+            }
+            confirmVerified(storageOperation)
+
+            clearMocks(storageOperation)
+            streamOperations.finalizeTable(
+                streamConfig,
+                StreamSyncSummary(42, AirbyteStreamStatus.COMPLETE)
+            )
+
+            verifySequence {
+                storageOperation.cleanupStage(streamId)
+                storageOperation.overwriteStage(streamId, EXPECTED_SUFFIX)
+                storageOperation.typeAndDedupe(
+                    streamConfig,
+                    Optional.empty(),
+                    "",
+                )
+            }
+            confirmVerified(storageOperation)
+            checkUnnecessaryStub(initialState, initialState.destinationState)
+        }
+
+        /**
+         * Verify some recovery behaviors. In particular, this is a truncate sync where:
+         * * The real raw table already contains the current generation
+         * * The real final table already contains the current generation, but has a schema mismatch
+         *
+         * In this case, we should retain both the raw and final tables, and trigger a soft reset.
+         */
+        @ParameterizedTest
+        @MethodSource(
+            "io.airbyte.integrations.base.destination.operation.AbstractStreamOperationTest#generationIds"
+        )
+        fun existingRealTablesMatchingGeneration(existingRealTableGeneration: Long?) {
+            val initialState =
+                mockk<DestinationInitialStatus<MinimumDestinationState.Impl>> {
+                    every { streamConfig } returns this@Truncate.streamConfig
+                    every { initialRawTableStatus.rawTableExists } returns true
+                    // If we're in this state, then presumably the previous sync ran T+D.
+                    every { initialRawTableStatus.maxProcessedTimestamp } returns
+                        maxProcessedTimestamp
+                    every { initialTempRawTableStatus.rawTableExists } returns false
+                    every { isFinalTablePresent } returns true
+                    every { isFinalTableEmpty } returns false
+                    every { isSchemaMismatch } returns true
+                    every { finalTableGenerationId } returns 21
+                    every {
+                        destinationState.withSoftReset<MinimumDestinationState.Impl>(any())
+                    } returns destinationState
+                }
+            every { storageOperation.getStageGeneration(streamId, "") } returns
+                existingRealTableGeneration
+
+            val streamOperations = TestStreamOperation(storageOperation, initialState)
+
+            verifySequence {
+                storageOperation.getStageGeneration(streamId, "")
+                storageOperation.prepareStage(streamId, "")
+                storageOperation.softResetFinalTable(streamConfig)
+            }
+            confirmVerified(storageOperation)
+
+            clearMocks(storageOperation)
+            streamOperations.finalizeTable(
+                streamConfig,
+                StreamSyncSummary(42, AirbyteStreamStatus.COMPLETE)
+            )
+
+            verifySequence {
+                storageOperation.cleanupStage(streamId)
+                storageOperation.typeAndDedupe(
+                    streamConfig,
+                    maxProcessedTimestamp,
+                    "",
+                )
+            }
+            confirmVerified(storageOperation)
+            checkUnnecessaryStub(initialState, initialState.destinationState)
+        }
+
+        @Test
+        fun existingRealRawTableWrongGeneration() {
+            val initialState =
+                mockk<DestinationInitialStatus<MinimumDestinationState.Impl>> {
+                    every { streamConfig } returns this@Truncate.streamConfig
+                    every { initialRawTableStatus.rawTableExists } returns true
+                    every { initialRawTableStatus.maxProcessedTimestamp } returns Optional.empty()
+                    every { initialTempRawTableStatus.rawTableExists } returns false
+                    every { isFinalTablePresent } returns false
+                    every {
+                        destinationState.withSoftReset<MinimumDestinationState.Impl>(any())
+                    } returns destinationState
+                }
+            every { storageOperation.getStageGeneration(streamId, "") } returns -1
+
+            val streamOperations = TestStreamOperation(storageOperation, initialState)
+
+            verifySequence {
+                storageOperation.getStageGeneration(streamId, "")
+                storageOperation.prepareStage(streamId, EXPECTED_SUFFIX, replace = false)
+                storageOperation.createFinalTable(streamConfig, "", replace = false)
             }
             confirmVerified(storageOperation)
 
@@ -798,6 +914,7 @@ class AbstractStreamOperationTest {
 
         const val EXPECTED_SUFFIX = "_airbyte_tmp"
         val maxProcessedTimestamp = Optional.of(Instant.parse("2024-01-23T12:34:56Z"))
+        val arbitraryTimestamp = Optional.of(Instant.ofEpochMilli(42))
 
         private val appendStreamConfig =
             StreamConfig(

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.kt
@@ -1117,9 +1117,7 @@ abstract class BaseTypingDedupingTest {
         val expectedRawRecords0 = readRecords("dat/sync2_expectedrecords_raw.jsonl")
         val expectedFinalRecords0 =
             readRecords("dat/sync2_expectedrecords_fullrefresh_append_final.jsonl")
-        (expectedFinalRecords0 + expectedRawRecords0).forEach {
-            (it as ObjectNode).put(JavaBaseConstants.COLUMN_NAME_AB_GENERATION_ID, 41)
-        }
+        fixGenerationId(expectedRawRecords0, expectedFinalRecords0, 41)
         verifySyncResult(expectedRawRecords0, expectedFinalRecords0, disableFinalTableComparison())
 
         val catalog =
@@ -1201,6 +1199,138 @@ abstract class BaseTypingDedupingTest {
         val expectedRawRecords2 = readRecords("dat/sync2_expectedrecords_raw.jsonl")
         val expectedFinalRecords2 =
             readRecords("dat/sync2_expectedrecords_fullrefresh_append_final.jsonl")
+        verifySyncResult(expectedRawRecords2, expectedFinalRecords2, disableFinalTableComparison())
+    }
+
+    /**
+     * Emulates this sequence of events:
+     * 1. User runs a normal incremental sync
+     * 2. User initiates a truncate refresh, but it fails.
+     * 3. User cancels the truncate refresh, and initiates a normal incremental sync.
+     *
+     * In particular, we must retain all records from both the first sync, _and_ the truncate sync's
+     * temporary raw table.
+     */
+    @Test
+    @Throws(Exception::class)
+    open fun resumeAfterCancelledTruncate() {
+        val catalog1 =
+            io.airbyte.protocol.models.v0
+                .ConfiguredAirbyteCatalog()
+                .withStreams(
+                    java.util.List.of(
+                        ConfiguredAirbyteStream()
+                            .withSyncId(42)
+                            .withGenerationId(43)
+                            .withMinimumGenerationId(0)
+                            .withSyncMode(SyncMode.INCREMENTAL)
+                            .withCursorField(listOf("updated_at"))
+                            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+                            .withStream(
+                                AirbyteStream()
+                                    .withNamespace(streamNamespace)
+                                    .withName(streamName)
+                                    .withJsonSchema(SCHEMA)
+                            )
+                    )
+                )
+
+        // Normal sync
+        runSync(catalog1, readMessages("dat/sync1_messages.jsonl"))
+
+        val expectedRawRecords1 = readRecords("dat/sync1_expectedrecords_raw.jsonl")
+        val expectedFinalRecords1 = readRecords("dat/sync1_expectedrecords_nondedup_final.jsonl")
+        verifySyncResult(expectedRawRecords1, expectedFinalRecords1, disableFinalTableComparison())
+
+        val catalog2 =
+            io.airbyte.protocol.models.v0
+                .ConfiguredAirbyteCatalog()
+                .withStreams(
+                    java.util.List.of(
+                        ConfiguredAirbyteStream()
+                            .withSyncId(42)
+                            // Generation ID is incremented
+                            .withGenerationId(44)
+                            .withMinimumGenerationId(44)
+                            .withSyncMode(SyncMode.INCREMENTAL)
+                            .withCursorField(listOf("updated_at"))
+                            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+                            .withStream(
+                                AirbyteStream()
+                                    .withNamespace(streamNamespace)
+                                    .withName(streamName)
+                                    .withJsonSchema(SCHEMA)
+                            )
+                    )
+                )
+        // Interrupted truncate sync
+        assertThrows<Exception> {
+            runSync(
+                catalog2,
+                readMessages("dat/sync2_messages.jsonl"),
+                streamStatus = AirbyteStreamStatus.INCOMPLETE,
+            )
+        }
+
+        // We should still have the exact same records as after the initial sync
+        verifySyncResult(expectedRawRecords1, expectedFinalRecords1, disableFinalTableComparison())
+
+        val catalog3 =
+            io.airbyte.protocol.models.v0
+                .ConfiguredAirbyteCatalog()
+                .withStreams(
+                    java.util.List.of(
+                        ConfiguredAirbyteStream()
+                            .withSyncId(42)
+                            // Same generation as the truncate sync, but now with
+                            // min gen = 0
+                            .withGenerationId(44)
+                            .withMinimumGenerationId(0)
+                            .withSyncMode(SyncMode.INCREMENTAL)
+                            .withCursorField(listOf("updated_at"))
+                            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+                            .withStream(
+                                AirbyteStream()
+                                    .withNamespace(streamNamespace)
+                                    .withName(streamName)
+                                    .withJsonSchema(SCHEMA)
+                            )
+                    )
+                )
+
+        // Third sync
+        runSync(catalog3, readMessages("dat/sync2_messages.jsonl"))
+
+        // We wrote the sync2 records twice, so expect duplicates.
+        // But we didn't write the sync1 records twice, so filter those out in a dumb way.
+        // Also override the generation ID to the correct value on the sync2 records,
+        // but leave the sync1 records with their original generation.
+        val expectedRawRecords2 =
+            readRecords("dat/sync2_expectedrecords_raw.jsonl").let { baseRecords ->
+                val sync2Records =
+                    baseRecords.subList(expectedRawRecords1.size, baseRecords.size).onEach {
+                        (it as ObjectNode).put(
+                            JavaBaseConstants.COLUMN_NAME_AB_GENERATION_ID,
+                            44,
+                        )
+                    }
+                expectedRawRecords1 + sync2Records + sync2Records
+            }
+        val expectedFinalRecords2 =
+            readRecords("dat/sync2_expectedrecords_fullrefresh_append_final.jsonl").let {
+                baseRecords ->
+                val sync2Records =
+                    baseRecords.subList(expectedFinalRecords1.size, baseRecords.size).onEach {
+                        (it as ObjectNode).put(
+                            finalMetadataColumnNames.getOrDefault(
+                                JavaBaseConstants.COLUMN_NAME_AB_GENERATION_ID,
+                                JavaBaseConstants.COLUMN_NAME_AB_GENERATION_ID
+                            ),
+                            44,
+                        )
+                    }
+                expectedFinalRecords1 + sync2Records + sync2Records
+            }
         verifySyncResult(expectedRawRecords2, expectedFinalRecords2, disableFinalTableComparison())
     }
 


### PR DESCRIPTION
from https://github.com/airbytehq/airbyte-internal-issues/issues/8784, for the new interfaces. I'll stack PRs on top of this for bigquery+redshift+snowflake.

add a new check for the real raw table during truncate sync startup, to see if it belongs to the correct generation. Also handle this new behavior during sync finalization (i.e. don't overwrite the raw table if we weren't using a temp raw table to begin with).

Adds two new unit tests for this.