### PR TITLE
[airbyte-cdk] add name property to http_client for convience

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http_client.py
@@ -354,6 +354,10 @@ class HttpClient:
 
         return response  # type: ignore # will either return a valid response of type requests.Response or raise an exception
 
+    @property
+    def name(self) -> str:
+        return self._name
+
     def send_request(
         self,
         http_method: str,


### PR DESCRIPTION
## What

When reviewing https://github.com/airbytehq/airbyte/pull/42095, it showed there are some cases where knowing the `http_client`s name field is convenient. Let's expose the field to make things a little easier in some of our python connectors

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
