### PR TITLE
CATs: add final teardown option

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.6
+
+Allow a final teardown command to be run after all tests.
+
 ## 3.8.5
 
 Update CAT tests for discover to deduplicate on namespace and stream name pair.

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
@@ -166,6 +166,7 @@ class ClientContainerConfig(BaseConfig):
     setup_command: List[str] = Field(None, description="Command for running the setup/teardown container for setup.")
     teardown_command: List[str] = Field(None, description="Command for running the setup/teardown container for teardown.")
     between_syncs_command: Optional[List[str]] = Field(None, description="Command to run between syncs that occur in a test.")
+    final_teardown_command: Optional[List[str]] = Field(None, description="Command for running teardown after all tests have run.")
 
 
 class BasicReadTestConfig(BaseConfig):
@@ -305,6 +306,7 @@ class AcceptanceTestConfigurations(BaseConfig):
     incremental: Optional[GenericTestConfig[IncrementalConfig]]
     connector_attributes: Optional[GenericTestConfig[ConnectorAttributesConfig]]
     connector_documentation: Optional[GenericTestConfig[TestConnectorDocumentationConfig]]
+    client_container_config: Optional[ClientContainerConfig]
 
 
 class Config(BaseConfig):

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
@@ -163,8 +163,8 @@ class ClientContainerConfig(BaseConfig):
     client_container_dockerfile_path: str = Field(
         None, description="Path to Dockerfile to run before each test for which a config is provided."
     )
-    setup_command: List[str] = Field(None, description="Command for running the setup/teardown container for setup.")
-    teardown_command: List[str] = Field(None, description="Command for running the setup/teardown container for teardown.")
+    setup_command: Optional[List[str]] = Field(None, description="Command for running the setup/teardown container for setup.")
+    teardown_command: Optional[List[str]] = Field(None, description="Command for running the setup/teardown container for teardown.")
     between_syncs_command: Optional[List[str]] = Field(None, description="Command to run between syncs that occur in a test.")
     final_teardown_command: Optional[List[str]] = Field(None, description="Command for running teardown after all tests have run.")
 

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py
@@ -140,7 +140,10 @@ def client_container_config_fixture(inputs, base_path, acceptance_test_config) -
 
 @pytest.fixture(name="client_container_config_global", scope="session")
 async def client_container_config_global_fixture(acceptance_test_config: Config) -> ClientContainerConfig:
-    if hasattr(acceptance_test_config.acceptance_tests, "client_container_config") and acceptance_test_config.acceptance_tests.client_container_config:
+    if (
+        hasattr(acceptance_test_config.acceptance_tests, "client_container_config")
+        and acceptance_test_config.acceptance_tests.client_container_config
+    ):
         return acceptance_test_config.acceptance_tests.client_container_config
 
 

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py
@@ -250,7 +250,7 @@ async def setup_and_teardown(
     client_container_config_secrets: Optional[SecretDict],
     base_path: Path,
 ):
-    if client_container:
+    if client_container and hasattr(client_container_config, "setup_command") and client_container_config.setup_command:
         logging.info("Running setup")
         setup_teardown_container = await client_container_runner.do_setup(
             client_container,
@@ -260,7 +260,7 @@ async def setup_and_teardown(
         )
         logging.info(f"Setup stdout: {await setup_teardown_container.stdout()}")
     yield None
-    if client_container:
+    if client_container and hasattr(client_container_config, "teardown_command") and client_container_config.teardown_command:
         logging.info("Running teardown")
         setup_teardown_container = await client_container_runner.do_teardown(
             client_container,

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -882,6 +882,7 @@ def _extract_primary_key_value(record: Mapping[str, Any], primary_key: List[List
 
 
 @pytest.mark.default_timeout(TEN_MINUTES)
+@pytest.mark.usefixtures("final_teardown")
 class TestBasicRead(BaseTest):
     @staticmethod
     def _validate_records_structure(records: List[AirbyteRecordMessage], configured_catalog: ConfiguredAirbyteCatalog):

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_full_refresh.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_full_refresh.py
@@ -37,6 +37,7 @@ def primary_keys_only(record, pks):
 
 
 @pytest.mark.default_timeout(TWENTY_MINUTES)
+@pytest.mark.usefixtures("final_teardown")
 class TestFullRefresh(BaseTest):
     def assert_emitted_at_increase_on_subsequent_runs(self, first_read_records, second_read_records):
         first_read_records_data = [record.data for record in first_read_records]

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
@@ -133,6 +133,7 @@ def naive_diff_records(records_1: List[AirbyteMessage], records_2: List[AirbyteM
 
 
 @pytest.mark.default_timeout(TWENTY_MINUTES)
+@pytest.mark.usefixtures("final_teardown")
 class TestIncremental(BaseTest):
     async def test_two_sequential_reads(
         self,


### PR DESCRIPTION
Adds the option to run a final teardown command, which runs after all tests have finished executing.

This is done by adding a top-level optional `client_container_config` with a `final_teardown_command`. This top-level config also requires a path to a Dockerfile; we need to rebuild the container here because the setup/teardown container is scoped to the function-level and so can't be used for the session-scoped final teardown.

Example of how to modify the `acceptance-test-config.yaml` to use the final teardown command:
```
connector_image: airbyte/source-postgres:dev
custom_environment_variables:
  USE_STREAM_CAPABLE_STATE: true
acceptance_tests:
  client_container_config:
    client_container_dockerfile_path: "integration_tests/Dockerfile"
    final_teardown_command:
      - "echo"
      - "final teardown <<<<<<<<<<<<<,"
  spec:

...

```

DB sources needs this so they aren't affected by a daily limit of replication slots for Postgres.