### PR TITLE
Destination S3:  Connector reacting to generationId and minGenId

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/BlobStorageOperations.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/BlobStorageOperations.kt
@@ -30,7 +30,8 @@ abstract class BlobStorageOperations protected constructor() {
     abstract fun uploadRecordsToBucket(
         recordsData: SerializableBuffer,
         namespace: String?,
-        objectPath: String
+        objectPath: String,
+        generationId: Long? = null
     ): String?
 
     /** Remove files that were just stored in the bucket */
@@ -60,5 +61,18 @@ abstract class BlobStorageOperations protected constructor() {
 
     fun addBlobDecorator(blobDecorator: BlobDecorator) {
         blobDecorators.add(blobDecorator)
+    }
+
+    /**
+     * Provides the generationId from the last written object's metadata. If there are no objects in
+     * the given path format, returns nullå
+     */
+    open fun getStageGeneration(
+        namespace: String?,
+        streamName: String,
+        objectPath: String,
+        pathFormat: String
+    ): Long? {
+        return null
     }
 }

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/S3StorageOperations.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/S3StorageOperations.kt
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
+import kotlin.Comparator
 import org.apache.commons.io.FilenameUtils
 import org.joda.time.DateTime
 
@@ -113,7 +114,8 @@ open class S3StorageOperations(
     override fun uploadRecordsToBucket(
         recordsData: SerializableBuffer,
         namespace: String?,
-        objectPath: String
+        objectPath: String,
+        generationId: Long?
     ): String {
         val exceptionsThrown: MutableList<Exception> = ArrayList()
         while (exceptionsThrown.size < UPLOAD_RETRY_LIMIT) {
@@ -126,7 +128,7 @@ open class S3StorageOperations(
             }
 
             try {
-                val fileName: String = loadDataIntoBucket(objectPath, recordsData)
+                val fileName: String = loadDataIntoBucket(objectPath, recordsData, generationId)
                 logger.info {
                     "Successfully loaded records to stage $objectPath with ${exceptionsThrown.size} re-attempt(s)"
                 }
@@ -164,7 +166,11 @@ open class S3StorageOperations(
      * </extension></partId>
      */
     @Throws(IOException::class)
-    private fun loadDataIntoBucket(objectPath: String, recordsData: SerializableBuffer): String {
+    private fun loadDataIntoBucket(
+        objectPath: String,
+        recordsData: SerializableBuffer,
+        generationId: Long?
+    ): String {
         val partSize: Long = DEFAULT_PART_SIZE.toLong()
         val bucket: String? = s3Config.bucketName
         val partId: String = getPartId(objectPath)
@@ -186,6 +192,11 @@ open class S3StorageOperations(
         val metadata: MutableMap<String, String> = HashMap()
         for (blobDecorator: BlobDecorator in blobDecorators) {
             blobDecorator.updateMetadata(metadata, getMetadataMapping())
+        }
+        // Note when looking in the S3 object, the metadata is appended with x-amz-meta-
+        // and when retrieving, sdk takes care of removing the prefix
+        if (generationId != null) {
+            metadata[GENERATION_ID_USER_META_KEY] = generationId.toString()
         }
         val uploadManager: StreamTransferManager =
             StreamTransferManagerFactory.create(
@@ -286,14 +297,9 @@ open class S3StorageOperations(
         cleanUpBucketObject(objectPath, listOf())
     }
 
-    override fun cleanUpBucketObject(
-        namespace: String?,
-        streamName: String,
-        objectPath: String,
-        pathFormat: String
-    ) {
-        val bucket: String? = s3Config.bucketName
-        var objects: ObjectListing =
+    private fun listObjects(objectPath: String): ObjectListing {
+        val bucket: String = s3Config.bucketName!!
+        val objects: ObjectListing =
             s3Client.listObjects(
                 ListObjectsRequest()
                     .withBucketName(bucket)
@@ -303,6 +309,17 @@ open class S3StorageOperations(
                     // so we need to recursively list them and filter files matching the pathFormat
                     .withDelimiter(""),
             )
+        return objects
+    }
+
+    override fun cleanUpBucketObject(
+        namespace: String?,
+        streamName: String,
+        objectPath: String,
+        pathFormat: String
+    ) {
+        val bucket: String = s3Config.bucketName!!
+        var objects: ObjectListing = listObjects(objectPath)
         val regexFormat: Pattern =
             Pattern.compile(getRegexFormat(namespace, streamName, pathFormat))
         while (objects.objectSummaries.size > 0) {
@@ -331,6 +348,64 @@ open class S3StorageOperations(
                 break
             }
         }
+    }
+
+    override fun getStageGeneration(
+        namespace: String?,
+        streamName: String,
+        objectPath: String,
+        pathFormat: String
+    ): Long? {
+        val bucket: String = s3Config.bucketName!!
+        var objects: ObjectListing = listObjects(objectPath)
+        val regexFormat: Pattern =
+            Pattern.compile(getRegexFormat(namespace, streamName, pathFormat))
+        val descendingComparator: Comparator<S3ObjectSummary> =
+            Comparator.comparingLong { o: S3ObjectSummary -> o.lastModified.time }.reversed()
+        var lastModifiedObject: S3ObjectSummary? = null
+
+        // We could be retrieving multiple pages of results based on when the last sync ran spanning
+        // across multiple
+        // date boundaries of object path format patterns.
+        // Maintaining a local maxima across pages and sorting at the end to get global maxima
+        // of last modified object to retrieve the object metadata header.
+        // Note: This logic will fall apart if the path format is changed between syncs
+        while (objects.objectSummaries.size > 0) {
+            val localMaximaLastModified: S3ObjectSummary =
+                objects.objectSummaries
+                    .filter { obj: S3ObjectSummary -> regexFormat.matcher(obj.key).matches() }
+                    .sortedWith(descendingComparator)
+                    .first()
+            if (
+                lastModifiedObject == null ||
+                    descendingComparator.compare(lastModifiedObject, localMaximaLastModified) > 0
+            ) {
+                lastModifiedObject = localMaximaLastModified
+            }
+            if (objects.isTruncated) {
+                objects = s3Client.listNextBatchOfObjects(objects)
+            } else {
+                break
+            }
+        }
+        if (lastModifiedObject == null) {
+            // Nothing to retrieve, fallback to null genId behavior
+            return null
+        }
+        // val lastModifiedObject = maxLastModifiedObjects.sortedWith(descendingComparator).first()
+        val objectMetadata = s3Client.getObjectMetadata(bucket, lastModifiedObject.key)
+        try {
+            val generationId = objectMetadata.getUserMetaDataOf(GENERATION_ID_USER_META_KEY)
+            if (!generationId.isNullOrBlank()) {
+                return generationId.toLong()
+            }
+        } catch (nfe: NumberFormatException) {
+            logger.warn {
+                "$GENERATION_ID_USER_META_KEY object metadata found in object ${lastModifiedObject.key} is not a number"
+            }
+        }
+        // If genId is missing or not parseable we return null
+        return null
     }
 
     fun getRegexFormat(namespace: String?, streamName: String, pathFormat: String): String {
@@ -433,6 +508,7 @@ open class S3StorageOperations(
         private const val FORMAT_VARIABLE_EPOCH: String = "\${EPOCH}"
         private const val FORMAT_VARIABLE_UUID: String = "\${UUID}"
         private const val GZ_FILE_EXTENSION: String = "gz"
+        private const val GENERATION_ID_USER_META_KEY = "ab-generation-id"
         @VisibleForTesting
         @JvmStatic
         fun getFilename(fullPath: String): String {

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/WriteConfig.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/WriteConfig.kt
@@ -15,6 +15,8 @@ constructor(
     val pathFormat: String,
     val fullOutputPath: String,
     val syncMode: DestinationSyncMode,
+    val generationId: Long?,
+    val minimumGenerationId: Long?,
     val storedFiles: MutableList<String> = arrayListOf(),
 ) {
 

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/destination/s3/S3DestinationAcceptanceTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/destination/s3/S3DestinationAcceptanceTest.kt
@@ -9,20 +9,39 @@ import com.amazonaws.services.s3.model.S3ObjectSummary
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.google.common.collect.ImmutableMap
 import io.airbyte.cdk.integrations.destination.NamingConventionTransformer
 import io.airbyte.cdk.integrations.destination.s3.util.S3NameTransformer
 import io.airbyte.cdk.integrations.standardtest.destination.DestinationAcceptanceTest
+import io.airbyte.cdk.integrations.standardtest.destination.argproviders.DataArgumentsProvider
 import io.airbyte.cdk.integrations.standardtest.destination.comparator.AdvancedTestDataComparator
 import io.airbyte.cdk.integrations.standardtest.destination.comparator.TestDataComparator
 import io.airbyte.commons.io.IOs
 import io.airbyte.commons.jackson.MoreMappers
 import io.airbyte.commons.json.Jsons
+import io.airbyte.commons.resources.MoreResources
+import io.airbyte.protocol.models.v0.AirbyteCatalog
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
+import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
+import io.airbyte.protocol.models.v0.AirbyteTraceMessage
+import io.airbyte.protocol.models.v0.CatalogHelpers
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
+import io.airbyte.protocol.models.v0.DestinationSyncMode
+import io.airbyte.protocol.models.v0.StreamDescriptor
+import io.airbyte.protocol.models.v0.SyncMode
+import io.airbyte.workers.exception.TestHarnessException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
+import java.time.Instant
 import java.util.*
 import org.apache.commons.lang3.RandomStringUtils
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
+import org.junit.jupiter.api.Assumptions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
 import org.mockito.Mockito.mock
 
 private val LOGGER = KotlinLogging.logger {}
@@ -180,6 +199,397 @@ protected constructor(protected val outputFormat: FileUploadFormat) :
 
     fun storageProvider(): StorageProvider {
         return StorageProvider.AWS_S3
+    }
+
+    private fun getTestCatalog(
+        syncMode: SyncMode,
+        destinationSyncMode: DestinationSyncMode,
+        syncId: Long?,
+        minimumGenerationId: Long?,
+        generationId: Long?
+    ): Pair<ConfiguredAirbyteCatalog, AirbyteCatalog> {
+        val catalog =
+            Jsons.deserialize(
+                MoreResources.readResource(
+                    DataArgumentsProvider.Companion.EXCHANGE_RATE_CONFIG.getCatalogFileVersion(
+                        getProtocolVersion()
+                    )
+                ),
+                AirbyteCatalog::class.java
+            )
+        val configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(catalog)
+        configuredCatalog.streams.forEach {
+            it.withSyncMode(syncMode)
+                .withDestinationSyncMode(destinationSyncMode)
+                .withSyncId(syncId)
+                .withGenerationId(generationId)
+                .withMinimumGenerationId(minimumGenerationId)
+        }
+        return Pair(configuredCatalog, catalog)
+    }
+
+    private fun getFirstSyncMessagesFixture1(
+        configuredCatalog: ConfiguredAirbyteCatalog,
+        streamStatus: AirbyteStreamStatusTraceMessage.AirbyteStreamStatus
+    ): List<AirbyteMessage> {
+        val descriptor = StreamDescriptor().withName(configuredCatalog.streams[0].stream.name)
+        return listOf(
+            AirbyteMessage()
+                .withType(AirbyteMessage.Type.RECORD)
+                .withRecord(
+                    AirbyteRecordMessage()
+                        .withStream(configuredCatalog.streams[0].stream.name)
+                        .withEmittedAt(Instant.now().toEpochMilli())
+                        .withData(
+                            Jsons.jsonNode(
+                                ImmutableMap.builder<Any, Any>()
+                                    .put("id", 1)
+                                    .put("currency", "USD")
+                                    .put("date", "2020-03-31T00:00:00Z")
+                                    .put("HKD", 10.1)
+                                    .put("NZD", 700.1)
+                                    .build(),
+                            ),
+                        ),
+                ),
+            AirbyteMessage()
+                .withType(AirbyteMessage.Type.STATE)
+                .withState(
+                    AirbyteStateMessage()
+                        .withData(Jsons.jsonNode(ImmutableMap.of("checkpoint", 2))),
+                ),
+            AirbyteMessage()
+                .withType(AirbyteMessage.Type.TRACE)
+                .withTrace(
+                    AirbyteTraceMessage()
+                        .withType(AirbyteTraceMessage.Type.STREAM_STATUS)
+                        .withStreamStatus(
+                            AirbyteStreamStatusTraceMessage()
+                                .withStreamDescriptor(descriptor)
+                                .withStatus(streamStatus)
+                        ),
+                ),
+        )
+    }
+
+    private fun getSyncMessagesFixture2(): List<AirbyteMessage> {
+        return MoreResources.readResource(
+                DataArgumentsProvider.Companion.EXCHANGE_RATE_CONFIG.getMessageFileVersion(
+                    getProtocolVersion(),
+                ),
+            )
+            .trim()
+            .lines()
+            .map { Jsons.deserialize(it, AirbyteMessage::class.java) }
+    }
+
+    /**
+     * Test 2 runs before refreshes support and after refreshes support in OVERWRITE mode. Verifies
+     * we clean up after ourselves correctly.
+     */
+    @Test
+    fun testOverwriteSyncPreRefreshAndPostSupport() {
+        assumeTrue(
+            implementsOverwrite(),
+            "Destination's spec.json does not support overwrite sync mode."
+        )
+
+        // Run sync with some messages
+        val catalogPair =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.OVERWRITE, 42, null, null)
+        val config = getConfig()
+        val firstSyncMessages =
+            getFirstSyncMessagesFixture1(
+                catalogPair.first,
+                AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+            )
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+
+        // This simulates first sync after enabling generationId in connector. null -> 1.
+        // legend has it that platform always increments to 1 and sends min and gen id as 1.
+        val catalogPair2 =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.OVERWRITE, 43, 1, 1)
+
+        // Run and verify only second sync messages are present.
+        val secondSyncMessages = getSyncMessagesFixture2()
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first, false)
+
+        val defaultSchema = getDefaultSchema(config)
+        retrieveRawRecordsAndAssertSameMessages(
+            catalogPair2.second,
+            secondSyncMessages,
+            defaultSchema
+        )
+    }
+
+    /**
+     * This test is an impractical case. Running twice in APPEND mode with incrementing
+     * generationIds, switching to OVERWRITE mode without incrementing generationId This verifies
+     * that the previous data (including old generations data) is preserved. We don't know if the
+     * old data is synced in which mode this uses generationId as source of truth to NOT touch
+     * existing data.
+     */
+    @Test
+    fun testSwitchingModesSyncWithPreviousData() {
+        assumeTrue(
+            implementsOverwrite(),
+            "Destination's spec.json does not support overwrite sync mode."
+        )
+
+        // Run sync with some messages and send incomplete status.
+        // This is to simulate crash
+        val catalogPair =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.APPEND, 42, 0, 1)
+        val config = getConfig()
+        val firstSyncMessages = getSyncMessagesFixture2()
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+
+        // Run second sync, even though the previous one was incomplete, intentionally incrementing
+        // genId and minGenId
+        // to test erratic behavior and we don't accidentally clean up stuff.
+        val catalogPair2 =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.APPEND, 43, 0, 2)
+
+        // Run and verify only second sync messages are present.
+        val secondSyncMessages = getSyncMessagesFixture2()
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first, false)
+
+        // Run third sync.
+        val catalogPair3 =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.OVERWRITE, 44, 2, 2)
+
+        // Run and verify only second sync messages are present.
+        val thirdSyncMessages = getSyncMessagesFixture2()
+        runSyncAndVerifyStateOutput(config, thirdSyncMessages, catalogPair3.first, false)
+
+        val defaultSchema = getDefaultSchema(config)
+        retrieveRawRecordsAndAssertSameMessages(
+            catalogPair3.second,
+            firstSyncMessages + secondSyncMessages + thirdSyncMessages,
+            defaultSchema
+        )
+    }
+
+    /** Test runs 2 successfull overwrite syncs and verifies last sync is preserved */
+    @Test
+    fun testOverwriteSyncSubsequentGenerations() {
+        assumeTrue(
+            implementsOverwrite(),
+            "Destination's spec.json does not support overwrite sync mode."
+        )
+
+        // Run sync with some messages
+        val catalogPair =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.OVERWRITE, 42, 12, 12)
+        val config = getConfig()
+        val firstSyncMessages =
+            getFirstSyncMessagesFixture1(
+                catalogPair.first,
+                AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+            )
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+
+        // Change the generationId, we always assume platform sends a monotonically increasing
+        // number
+        val catalogPair2 =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.OVERWRITE, 43, 13, 13)
+
+        // Run and verify only second sync messages are present.
+        val secondSyncMessages = getSyncMessagesFixture2()
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first, false)
+
+        val defaultSchema = getDefaultSchema(config)
+        retrieveRawRecordsAndAssertSameMessages(
+            catalogPair2.second,
+            secondSyncMessages,
+            defaultSchema
+        )
+    }
+
+    /**
+     * Test runs 1 failed and 1 successful OVERWRITE sync of same generation. Verified data from
+     * both syncs are preserved.
+     */
+    @Test
+    fun testOverwriteSyncFailedResumedGeneration() {
+        assumeTrue(
+            implementsOverwrite(),
+            "Destination's spec.json does not support overwrite sync mode."
+        )
+        val config = getConfig()
+
+        // Run sync with some messages and incomplete stream status
+        val catalogPair =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.OVERWRITE, 42, 12, 12)
+        val firstSyncMessages: List<AirbyteMessage> =
+            getFirstSyncMessagesFixture1(
+                catalogPair.first,
+                AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.INCOMPLETE
+            )
+        try {
+            runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+            fail { "Should not succeed the sync when Trace message is INCOMPLETE" }
+        } catch (_: TestHarnessException) {}
+
+        // Run second sync with the same messages from the previous failed sync.
+        val secondSyncMessages = getSyncMessagesFixture2()
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair.first, false)
+
+        // verify records are preserved from first failed sync + second sync.
+        val defaultSchema = getDefaultSchema(config)
+        retrieveRawRecordsAndAssertSameMessages(
+            catalogPair.second,
+            firstSyncMessages + secondSyncMessages,
+            defaultSchema
+        )
+    }
+
+    /**
+     * Test runs 2 successful OVERWRITE syncs but with same generation and a sync to another catalog
+     * with no generationId, this shouldn't happen from platform but acts as a simulation for
+     * failure of first sync. This verifies that data from both syncs are preserved and the
+     * unrelated catalog sync data is untouched too.
+     */
+    @Test
+    fun testOverwriteSyncWithGenerationId() {
+        assumeTrue(
+            implementsOverwrite(),
+            "Destination's spec.json does not support overwrite sync mode."
+        )
+
+        val config = getConfig()
+
+        // First Sync
+        val catalogPair =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.OVERWRITE, 42, 12, 12)
+        val firstSyncMessages: List<AirbyteMessage> =
+            getFirstSyncMessagesFixture1(
+                catalogPair.first,
+                AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE
+            )
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+
+        // We need to make sure that other streams\tables\files in the same location will not be
+        // affected\deleted\overridden by our activities during first, second or any future sync.
+        // So let's create a dummy data that will be checked after all sync. It should remain the
+        // same
+        val dummyCatalogStream = "DummyStream"
+        val dummyCatalog =
+            Jsons.deserialize(
+                MoreResources.readResource(
+                    DataArgumentsProvider.Companion.EXCHANGE_RATE_CONFIG.getCatalogFileVersion(
+                        getProtocolVersion()
+                    )
+                ),
+                AirbyteCatalog::class.java
+            )
+        dummyCatalog.streams[0].name = dummyCatalogStream
+        val configuredDummyCatalog = CatalogHelpers.toDefaultConfiguredCatalog(dummyCatalog)
+        // update messages to set new dummy stream name
+        firstSyncMessages
+            .filter { message: AirbyteMessage -> message.record != null }
+            .forEach { message: AirbyteMessage -> message.record.stream = dummyCatalogStream }
+        firstSyncMessages
+            .filter { message: AirbyteMessage -> message.type == AirbyteMessage.Type.TRACE }
+            .forEach { message: AirbyteMessage ->
+                message.trace.streamStatus.streamDescriptor.name = dummyCatalogStream
+            }
+        // sync dummy data
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, configuredDummyCatalog, false)
+
+        // Run second sync
+        val secondSyncMessages: List<AirbyteMessage> = getSyncMessagesFixture2()
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair.first, false)
+
+        // Verify records of both syncs are preserved.
+        val defaultSchema = getDefaultSchema(config)
+        retrieveRawRecordsAndAssertSameMessages(
+            catalogPair.second,
+            firstSyncMessages + secondSyncMessages,
+            defaultSchema
+        )
+        // verify that other streams in the same location were not affected. If something fails
+        // here,
+        // then this need to be fixed in connectors logic to override only required streams
+        retrieveRawRecordsAndAssertSameMessages(dummyCatalog, firstSyncMessages, defaultSchema)
+    }
+
+    /**
+     * This test is similar to testIncrementalSync with adding generationId to the ConfiguredCatalog
+     * This verifies that the core behavior of APPEND mode sync is unaltered when the
+     * minimumGenerationId is set to 0
+     */
+    @Test
+    @Throws(Exception::class)
+    fun testIncrementalSyncWithGenerationId() {
+        assumeTrue(
+            implementsAppend(),
+            "Destination's spec.json does not include '\"supportsIncremental\" ; true'"
+        )
+
+        val catalogPair =
+            getTestCatalog(SyncMode.INCREMENTAL, DestinationSyncMode.APPEND, 42, 0, 12)
+        val config = getConfig()
+
+        // First sync
+        val firstSyncMessages: List<AirbyteMessage> =
+            getFirstSyncMessagesFixture1(
+                catalogPair.first,
+                AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+            )
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+
+        // Second sync
+        val secondSyncMessages: List<AirbyteMessage> = getSyncMessagesFixture2()
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair.first, false)
+
+        // Verify records
+        val defaultSchema = getDefaultSchema(config)
+        retrieveRawRecordsAndAssertSameMessages(
+            catalogPair.second,
+            firstSyncMessages + secondSyncMessages,
+            defaultSchema
+        )
+    }
+
+    /**
+     * Test 2 runs before refreshes support and after refreshes support in APPEND mode. Verifies we
+     * don't accidentally delete any data when generationId is encountered.
+     */
+    @Test
+    fun testAppendSyncPreRefreshAndPostSupport() {
+        assumeTrue(
+            implementsOverwrite(),
+            "Destination's spec.json does not support overwrite sync mode."
+        )
+
+        // Run sync with some messages
+        val catalogPair =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.APPEND, 42, null, null)
+        val config = getConfig()
+        val firstSyncMessages =
+            getFirstSyncMessagesFixture1(
+                catalogPair.first,
+                AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
+            )
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+
+        // This simulates first sync after enabling generationId in connector. null -> 0.
+        // Apparently we encountered a behavior where for APPEND mode min and genID are not
+        // incremented and sent as 0
+        val catalogPair2 =
+            getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.APPEND, 43, 0, 0)
+
+        // Run and verify only second sync messages are present.
+        val secondSyncMessages = getSyncMessagesFixture2()
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first, false)
+
+        val defaultSchema = getDefaultSchema(config)
+        retrieveRawRecordsAndAssertSameMessages(
+            catalogPair2.second,
+            firstSyncMessages + secondSyncMessages,
+            defaultSchema
+        )
     }
 
     companion object {


### PR DESCRIPTION
## What
Add support for refreshes by preserving the data between failed run in `OVERWRITE` sync mode. This is complementary to the changes down the stack with S3 Async framework migration. This PR preserves backward compatibility in the absence of `generationId` or `minimumGenerationId`

## How
* Plumbing `generationId` to persist as `ObjectMetadata` in S3. This is intentionally left as `nullable` because 0 vs not existing has different meaning. 
*  Retrieving the last generationId for comparison with the Catalog's generationId by sorting the objects by `lastModified` and retrieving the last object's generationId.

## Review guide
* `S3ConsumerFactory` has the `mustCleanUpObjects` logic to determine both old behavior vs new genId based behavior for cleaning up the objects. 
* S3 ListObjectsV2 API does not return the whole metadata, only important ones like `Etag` and `lastModified`. To get the latest object's `lastModified`, the code iterates over each page of list results, stores localMaxima and get global maxima across pages and issue a single GET call to get the user metadata of the object. 
* Existing tests passing verifies that the old behavior is unaltered. 
* Following new scenarios are added in `S3Base...Test`
    * Overwrite mode
       * Sync 1 w/o genId, Sync 2 with genId : verifies Sync1 data is deleted.
       * Sync 1 with genId, Sync2 with incremented genId: verifies Sync1 data is deleted.
       * Sync 1 with genId crashes, Sync 2 with same genId: verifies Sync1 data is preserved. 
    * Append mode
       * Tests to check backward compatible behavior preserved and when minimumGenerationId = 0, treat as append mode (There is also a defensive check to validate if syncMode is not overwrite)


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
