### PR TITLE
chore: add display-name to enterprise implementation guide

### DIFF
--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -241,6 +241,7 @@ auth:
     oidc:
       domain: ## e.g. company.example
       app-name: ## e.g. airbyte
+      display-name: ## e.g. Company SSO - optional, falls back to app-name if not provided
       clientIdSecretKey: client-id
       clientSecretSecretKey: client-secret
 ```
@@ -272,6 +273,7 @@ global:
       oidc:
         domain: ## e.g. company.example
         app-name: ## e.g. airbyte
+        display-name: ## e.g. Company SSO - optional, falls back to app-name if not provided
         clientIdSecretKey: client-id
         clientSecretSecretKey: client-secret
 ```


### PR DESCRIPTION
## What
Updates the Enterprise Implementation Guide to account for [this PR](https://github.com/airbytehq/airbyte-platform-internal/pull/13263) which allows users to optionally define a custom `display-name` for their OIDC app.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
