### PR TITLE
Update metadata.yaml for all sources with sandbox connections

### DIFF
--- a/airbyte-integrations/connectors/source-aha/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aha/metadata.yaml
@@ -32,6 +32,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: aha_config_dev_null
+          id: 38f3c440-135f-4ca6-9d97-c68104b28cfa
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-AHA__CREDS

--- a/airbyte-integrations/connectors/source-aircall/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aircall/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: aircall_config_dev_null
+          id: 0c9b5c44-50a9-410f-8ed4-01ac9323df46
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-AIRCALL__CREDS

--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -39,6 +39,10 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: airtable_config_dev_null
+          id: 40988f9d-286c-4297-b39b-648bf87418a3
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -67,6 +67,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: amazon-ads_config_report_dev_null
+          id: 60df103e-5b3a-4a2c-928b-d8b3889cf014
+        - name: amazon-ads_config_dev_null
+          id: 671a9aab-eb0f-48c2-a8bb-98d925aaa069
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -55,6 +55,10 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: amazon-seller-partner_config_dev_null
+          id: 17415432-092c-4020-ab55-fbb77cf5196e
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-sqs/metadata.yaml
@@ -27,6 +27,10 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: amazon-sqs_config_dev_null
+          id: 549c80d0-eb61-458e-bc60-45105ba3f89a
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -40,6 +40,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: amplitude_config_dev_null
+          id: 1dbb29a0-973a-49e5-bae3-546e311fd90a
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-apify-dataset/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apify-dataset/metadata.yaml
@@ -38,6 +38,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: apify-dataset_config_dev_null
+          id: 7ec0b62e-9c2d-44d1-bc0f-e9bc1aa50d86
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-APIFY-DATASET__CREDS

--- a/airbyte-integrations/connectors/source-appfollow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appfollow/metadata.yaml
@@ -36,6 +36,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: appfollow_config_dev_null
+          id: 32cc5e26-77ce-4ddd-91e3-1fbcc653d4bf
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-APPFOLLOW__CREDS

--- a/airbyte-integrations/connectors/source-asana/metadata.yaml
+++ b/airbyte-integrations/connectors/source-asana/metadata.yaml
@@ -45,6 +45,10 @@ data:
     ql: 300
     sl: 100
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: asana_config_dev_null
+          id: 43b16e30-c7a1-4b78-9f43-438e325b0435
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-auth0/metadata.yaml
+++ b/airbyte-integrations/connectors/source-auth0/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: auth0_config_dev_null
+          id: 1d14e305-c231-425f-9f99-6c37b7e4f45f
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-AUTH0__CREDS

--- a/airbyte-integrations/connectors/source-aws-cloudtrail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aws-cloudtrail/metadata.yaml
@@ -38,6 +38,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: aws-cloudtrail_config_dev_null
+          id: aa6731d0-9c6f-4b32-bdd4-1c14f0cf0119
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
@@ -35,6 +35,36 @@ data:
     - language:python
     - cdk:python-file-based
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: azure-blob-storage_csv_custom_encoding_config_dev_null
+          id: 04c5ce62-18a9-4dc9-a0de-a2d16af346dc
+        - name: azure-blob-storage_csv_with_null_bools_config_dev_null
+          id: 0ffbb6a6-5d04-422e-b838-ea833e209f71
+        - name: azure-blob-storage_csv_with_nulls_config_dev_null
+          id: 11cce9c4-d762-4d60-a0fa-a33eb9f5b788
+        - name: azure-blob-storage_csv_no_header_config_dev_null
+          id: 15cb71af-cb23-4169-a33d-1c8e51d03203
+        - name: azure-blob-storage_jsonl_config_dev_null
+          id: 2d187c90-27ad-4fa0-9fb2-c1936b89c343
+        - name: azure-blob-storage_csv_skip_rows_config_dev_null
+          id: 344a7838-0180-42f7-a385-21cbd52ee2f6
+        - name: azure-blob-storage_avro_config_dev_null
+          id: 426a81bb-a5b8-4a74-a5a8-b3125e4afed2
+        - name: azure-blob-storage_unstructured_config_dev_null
+          id: 48c894fb-8c76-4dd0-9e33-245cced8834c
+        - name: azure-blob-storage_csv_custom_format_encoding_config_dev_null
+          id: 4b29f20c-c405-4034-aa3e-035988518462
+        - name: azure-blob-storage_config_dev_null
+          id: 5b7e136d-96ea-4d05-a422-5cee140786f9
+        - name: azure-blob-storage_jsonl_newlines_config_dev_null
+          id: 6b10651e-181f-448b-85df-b29c7e4e7030
+        - name: azure-blob-storage_csv_skip_rows_no_header_config_dev_null
+          id: 74319212-dba7-4b3c-91cc-760afa2998b5
+        - name: azure-blob-storage_parquet_config_dev_null
+          id: 778f5870-c9f8-44cb-8602-28eb16bb0d75
+        - name: azure-blob-storage_csv_user_schema_config_dev_null
+          id: c9108e3e-da3b-42c9-8c51-8a3005bd0c21
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-azure-table/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-table/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: azure-table_config_dev_null
+          id: 2a0b88ec-45fe-43bb-9d97-ec98d94f7c57
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-bamboo-hr/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bamboo-hr/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: bamboo-hr_config_dev_null
+          id: 8e16832e-a1c2-449e-80d8-6ac54b62db9d
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-bigcommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigcommerce/metadata.yaml
@@ -35,6 +35,10 @@ data:
   # This connector is not enabled for OSS/Cloud
   #
   # connectorTestSuitesOptions:
+  #   - suite: liveTests
+  #     testConnections:
+  #       - name: bigcommerce_config_dev_null
+  #         id: 793cbddc-1b3c-4f53-ab22-c8ae9b03978b
   #   - suite: acceptanceTests
   #     testSecrets:
   #       - name: SECRET_SOURCE-BIGCOMMERCE__CREDS

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -62,6 +62,16 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: bing-ads_config_old_dev_null
+          id: 21c29326-2309-4226-97f0-5b1bad621887
+        - name: bing-ads_config_dev_null
+          id: 3434a551-958c-49e2-acae-c19b57b69500
+        - name: bing-ads_config_no_date_dev_null
+          id: 4684190a-bf8b-4b1b-8d95-4744e4c0a070
+        - name: bing-ads_config_full_refresh_dev_null
+          id: b4f2dd3d-3ae8-4341-84f9-9abd9f700e50
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-braintree/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braintree/metadata.yaml
@@ -32,6 +32,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: braintree_config_dev_null
+          id: 8f679466-dfd0-4ebf-ac56-29516fdb7a84
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-BRAINTREE__CREDS

--- a/airbyte-integrations/connectors/source-braze/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braze/metadata.yaml
@@ -27,6 +27,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: braze_config_dev_null
+          id: 5df06901-b346-4401-81af-62b20deda255
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-cart/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cart/metadata.yaml
@@ -29,6 +29,12 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: cart_config_central_api_router_dev_null
+          id: 6db729e8-f255-43c7-ad44-5573e556d7aa
+        - name: cart_config_dev_null
+          id: 7b6568b0-89a0-4fb8-97a2-2f37402f9d4b
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-chargebee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/metadata.yaml
@@ -46,6 +46,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: chargebee_config_dev_null
+          id: 092f90df-53ab-4822-9811-96603a7dc8b1
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-chartmogul/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chartmogul/metadata.yaml
@@ -41,6 +41,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: chartmogul_config_dev_null
+          id: 07daa31c-b7d0-4d3e-81c6-e6b7786a5c29
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-CHARTMOGUL__CREDS

--- a/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
@@ -31,6 +31,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: clickup-api_config_dev_null
+          id: 09475337-b056-46ad-a8c2-a885d61d3125
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-CLICKUP-API__CREDS

--- a/airbyte-integrations/connectors/source-clockify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clockify/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: clockify_config_dev_null
+          id: 11f79ed9-c1fb-4604-aac8-5bd0b53efbef
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-CLOCKIFY__CREDS

--- a/airbyte-integrations/connectors/source-coda/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coda/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: coda_config_dev_null
+          id: 4a8073c7-08e9-4b74-87cd-f5d66b448726
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-CODA__CREDS

--- a/airbyte-integrations/connectors/source-coin-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coin-api/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: coin-api_config_dev_null
+          id: 3999ec4a-cb58-4bce-b508-7b23e94e1360
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-COIN-API__CREDS

--- a/airbyte-integrations/connectors/source-coinmarketcap/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coinmarketcap/metadata.yaml
@@ -36,6 +36,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: coinmarketcap_config_dev_null
+          id: 61df0386-edca-48a4-b589-7228c0d6a081
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-COINMARKETCAP__CREDS

--- a/airbyte-integrations/connectors/source-configcat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-configcat/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: configcat_config_dev_null
+          id: 052842b9-3f40-422e-ac8c-7c7a6c47770b
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-CONFIGCAT__CREDS

--- a/airbyte-integrations/connectors/source-confluence/metadata.yaml
+++ b/airbyte-integrations/connectors/source-confluence/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: confluence_config_dev_null
+          id: 15570303-3b30-42ac-8b81-c40e8cd1952f
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-CONFLUENCE__CREDS

--- a/airbyte-integrations/connectors/source-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convex/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: convex_config_dev_null
+          id: 929eccf3-8e4c-4f73-af8b-48aa0b04b00c
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-datadog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datadog/metadata.yaml
@@ -35,6 +35,10 @@ data:
     sl: 100
     ql: 100
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: datadog_config_dev_null
+          id: 168fe6d6-d7fd-4d8e-8efb-db69857d7daf
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-DATADOG__CREDS

--- a/airbyte-integrations/connectors/source-datascope/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datascope/metadata.yaml
@@ -26,11 +26,14 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: datascope_config_dev_null
+          id: 17f5b107-4256-48f8-916b-0f61df1ff14f
   # Disable acceptance tests for now
   # They are not passing
   # Low/No Airbyte Cloud usage
-  #
-  # connectorTestSuitesOptions:
   #   - suite: acceptanceTests
   #     testSecrets:
   #       - name: SECRET_SOURCE-DATASCOPE_CREDS

--- a/airbyte-integrations/connectors/source-dockerhub/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dockerhub/metadata.yaml
@@ -34,6 +34,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: dockerhub_config_dev_null
+          id: 1627b271-52c6-410c-ae54-b83b8f98d846
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-DOCKERHUB__CREDS

--- a/airbyte-integrations/connectors/source-dremio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dremio/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: dremio_config_dev_null
+          id: 61228980-e78f-4481-b6d3-d0456a131585
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE_DREMIO_CREDS

--- a/airbyte-integrations/connectors/source-emailoctopus/metadata.yaml
+++ b/airbyte-integrations/connectors/source-emailoctopus/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: emailoctopus_config_dev_null
+          id: 8480109d-c0a1-42ca-a442-66f665a39683
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-EMAILOCTOPUS__CREDS

--- a/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
@@ -34,6 +34,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: exchange-rates_config_dev_null
+          id: 3c8bf30c-26b8-4dfe-af1b-95bc28606fc8
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-EXCHANGE-RATES__CREDS

--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -71,6 +71,12 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: facebook-marketing_config_dev_null
+          id: 33d36a34-1416-4d83-968b-72cd1ede8c43
+        - name: facebook-marketing_config_no_date_dev_null
+          id: 3bfed4a5-9953-4a7f-be8e-f2ad4e70b90b
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
@@ -41,6 +41,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: facebook-pages_config_dev_null
+          id: 4446147a-669a-472b-bda8-6ee069eb3099
     - suite: unitTests
     # Disable acceptance tests for now
     # No/Low cloud usage

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -53,6 +53,12 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: faker_ben_test_config_dev_null
+          id: 64b8f520-d7c1-4328-9451-c88ce03fc771
+        - name: faker_config_dev_null
+          id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: file_config_dev_null
+          id: 91948602-3f4a-45a0-847d-9394ea8198e8
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firebolt/metadata.yaml
@@ -37,6 +37,10 @@ data:
         message: "Use new firebolt-sdk version."
         upgradeDeadline: "2024-06-01"
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: firebolt_config_dev_null
+          id: 63d919ce-b4ff-48d9-9cae-6665b5f56644
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
@@ -6,6 +6,10 @@ data:
     baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
   connectorSubtype: api
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: freshcaller_config_dev_null
+          id: e972eb0c-574a-4360-b6dd-50d638be0a64
     - suite: acceptanceTests
       testSecrets:
         - fileName: config.json

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: freshdesk_config_dev_null
+          id: 5232fac1-675b-4138-abd7-f0ff04a40a8c
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-freshsales/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshsales/metadata.yaml
@@ -45,6 +45,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: freshsales_config_dev_null
+          id: 7825dcaf-24d1-43d6-8a57-8be179ef8f94
     - suite: integrationTests
       testSecrets:
         - name: SECRET_SOURCE-FRESHSALES__CREDS

--- a/airbyte-integrations/connectors/source-freshservice/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshservice/metadata.yaml
@@ -30,6 +30,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: freshservice_config_dev_null
+          id: e47f94ef-d605-4a50-92d9-f6c873f2b2d2
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-FRESHSERVICE__CREDS

--- a/airbyte-integrations/connectors/source-gainsight-px/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gainsight-px/metadata.yaml
@@ -32,6 +32,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: gainsight-px_config_dev_null
+          id: b7c7c482-039e-49ef-8dc2-b5ad34d6ef65
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-GAINSIGHT-PX__CREDS

--- a/airbyte-integrations/connectors/source-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gcs/metadata.yaml
@@ -29,6 +29,12 @@ data:
     - language:python
     - cdk:python-file-based
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: gcs_old_config_dev_null
+          id: 15721043-acf6-4ddf-907b-0930e38d4a00
+        - name: gcs_config_dev_null
+          id: 355ebb52-1126-4275-a77e-a09017c9e5c0
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-GCS_OLD__CREDS

--- a/airbyte-integrations/connectors/source-getlago/metadata.yaml
+++ b/airbyte-integrations/connectors/source-getlago/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: getlago_config_dev_null
+          id: 65a3d708-199d-4f8c-adb1-8e6fee5134a4
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-GETLAGO__CREDS

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -45,6 +45,12 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: github_config_dev_null
+          id: 00d7a7eb-9922-4463-9d9d-fac37438bc12
+        - name: github_config_oauth_dev_null
+          id: 65c98c6e-c8e5-4ff4-a822-32b79d10468b
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -67,6 +67,14 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: gitlab_config_with_ids_dev_null
+          id: 0a232b74-3f4e-492e-b522-cdd87d7e78c1
+        - name: gitlab_config_oauth_dev_null
+          id: 4b892767-e35e-4126-b1ab-b4fd02d08c15
+        - name: gitlab_config_dev_null
+          id: 8e190e6d-1f8f-411f-8468-9ce77fec5b4c
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-glassfrog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-glassfrog/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: glassfrog_config_dev_null
+          id: 08ee4e0c-60c1-4b0b-b05f-5be2302a550d
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-GLASSFROG_CREDS

--- a/airbyte-integrations/connectors/source-gnews/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gnews/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: gnews_config_dev_null
+          id: 2f19d7dc-0dc8-4e35-b785-d17270d59106
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -51,6 +51,10 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: google-analytics-data-api_config_dev_null
+          id: 6cee88ef-3893-4498-9812-8b80dbfcab0e
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -36,6 +36,14 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: google-analytics-v4_old_config_dev_null
+          id: 1b9d53c4-ca7f-4beb-90b9-fde974248158
+        - name: google-analytics-v4_config_dev_null
+          id: 202a55ce-a80d-4b88-b5ca-1491d6bf5a11
+        - name: google-analytics-v4_service_config_dev_null
+          id: 5cdb278e-fcc3-498f-adc7-e2c6288aeb11
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-google-directory/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-directory/metadata.yaml
@@ -28,6 +28,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: google-directory_config_oauth_dev_null
+          id: 7059ad42-0dae-41a4-a720-256f5d439d2a
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: google-pagespeed-insights_config_dev_null
+          id: a70b1ba9-2358-49e2-a669-8c6ead853f0b
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-GOOGLE-PAGESPEED-INSIGHTS__CREDS

--- a/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
@@ -42,6 +42,12 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: google-search-console_config_dev_null
+          id: 410eb8be-ba32-49b9-9b07-5d3de995144c
+        - name: google-search-console_service_account_config_dev_null
+          id: 66214692-e620-4005-a186-95355bd99d02
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: google-sheets_service_config_dev_null
+          id: 758d197a-864f-45d3-9d5d-0a52fd9c0a22
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-google-webfonts/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-webfonts/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: google-webfonts_config_dev_null
+          id: 63a92515-377b-46fe-b5a7-99b4e02c1b6f
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-GOOGLE-WEBFONTS__CREDS

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -33,6 +33,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: greenhouse_config_users_only_dev_null
+          id: 2234aee5-c67b-48f7-8c6d-45a1e0303ea1
+        - name: greenhouse_config_dev_null
+          id: 2bcce6b2-2c89-46a4-9980-82a299266774
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-gridly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gridly/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: gridly_config_dev_null
+          id: 67071749-873b-4e4f-b946-7c14f15199d3
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -62,6 +62,16 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: harvest_old_config_dev_null
+          id: 00bcab35-5c37-4b5d-b026-3cb23d71946a
+        - name: harvest_config_with_date_range_dev_null
+          id: 2a1834a4-b9b7-4613-9409-dc348b5fd735
+        - name: harvest_config_oauth_dev_null
+          id: 33b1f04d-ccc0-4b47-9b50-a889b136c0a8
+        - name: harvest_config_dev_null
+          id: 833888cc-1bc4-4126-970a-47edff5e0f00
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-hubplanner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubplanner/metadata.yaml
@@ -31,6 +31,10 @@ data:
     sl: 100
     ql: 100
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: hubplanner_config_dev_null
+          id: 38013098-1955-4daf-9143-630c45670dfb
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-HUBPLANNER__CREDS

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -68,6 +68,14 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: hubspot_config_dev_null
+          id: 52e28dc7-2245-4ebc-a591-0ef954ce4837
+        - name: hubspot_config_oauth_dev_null
+          id: 5a4058bf-0ab3-427e-92e4-9051c0abf655
+        - name: hubspot_config_oauth_no_start_date_dev_null
+          id: 67bf1886-3ae0-4fad-8c37-90eb51b2c748
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-insightly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-insightly/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: insightly_config_dev_null
+          id: 2badde48-2f9c-406e-8fcf-0ef722d177cd
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-INSIGHTLY__CREDS

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -54,6 +54,10 @@ data:
     ql: 400
   supportLevel: certified
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: instagram_config_dev_null
+          id: 39208d11-8b6f-4b0c-bee1-cddcb857e5fd
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-instatus/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instatus/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: instatus_config_dev_null
+          id: 6c2e5836-6ed5-400d-987e-4d6d37fad4b4
     - suite: unitTests
     # Disabling acceptance tests for now
     # No / Low airbyte cloud usage

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -40,6 +40,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: intercom_config_dev_null
+          id: 09ebd6bb-2756-4cd3-8ad5-7120088cc553
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-ip2whois/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ip2whois/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: ip2whois_config_dev_null
+          id: 8d51f477-0dc4-4649-a548-02e3896c3acf
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-IP2WHOIS__CREDS

--- a/airbyte-integrations/connectors/source-iterable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-iterable/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: iterable_config_dev_null
+          id: 4210f42f-47f5-47e1-a96c-e0f11c883c47
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -59,6 +59,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: jira_config_dev_null
+          id: 28344f6b-d2c9-4671-a5e2-81374985156e
+        - name: jira_config_empty_projects_dev_null
+          id: 8f0c8c2b-8bc4-4d13-a2ef-ce234370dbd8
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-k6-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-k6-cloud/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: k6-cloud_config_dev_null
+          id: a4ec2de6-7cf9-40d4-b47b-0c5af67cd96f
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-K6-CLOUD__CREDS

--- a/airbyte-integrations/connectors/source-klarna/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klarna/metadata.yaml
@@ -36,6 +36,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: klarna_config_dev_null
+          id: 0d630411-a503-46d1-8f8b-a106e4e90eab
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-KLARNA__CREDS

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -49,6 +49,10 @@ data:
     ql: 400
   supportLevel: certified
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: klaviyo_config_dev_null
+          id: 7d2eeae8-62d9-4694-8bfa-46b96375cd2d
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-kyve/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kyve/metadata.yaml
@@ -28,6 +28,12 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: kyve_config_dev_null
+          id: 16c974aa-7f7c-41c3-a20c-da11554057b2
+        - name: kyve_config_multiple_pools_dev_null
+          id: 4e3a020e-0b7e-485b-9823-cdad46a6e972
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-launchdarkly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-launchdarkly/metadata.yaml
@@ -36,6 +36,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: launchdarkly_config_dev_null
+          id: 35a44452-e962-4e76-87e0-618c233906f7
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-LAUNCHDARKLY__CREDS

--- a/airbyte-integrations/connectors/source-lemlist/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lemlist/metadata.yaml
@@ -30,6 +30,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: lemlist_config_dev_null
+          id: 51252c87-1637-49a4-a5d5-8ccadd3005c0
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-LEMLIST__CREDS

--- a/airbyte-integrations/connectors/source-lever-hiring/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lever-hiring/metadata.yaml
@@ -39,6 +39,10 @@ data:
     sl: 100
     ql: 100
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: lever-hiring_config_dev_null
+          id: 68039a49-202d-4889-9e00-55ecd86488f4
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -79,6 +79,16 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: linkedin-ads_config_multiple_account_ids_dev_null
+          id: 105e4dcd-6c79-461d-8b2b-9bbf0424d5b7
+        - name: linkedin-ads_config_dev_null
+          id: 3d35a758-f9ba-4b40-9ebd-454fe21f389d
+        - name: linkedin-ads_config_oauth_dev_null
+          id: 42888b02-5f06-4ccd-b86b-2620d7f87b61
+        - name: linkedin-ads_config_token_dev_null
+          id: a9ae94ba-24e6-406a-b02d-b100e6ffacda
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-linkedin-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-pages/metadata.yaml
@@ -34,6 +34,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: linkedin-pages_config_dev_null
+          id: 4460fd33-21fe-46de-83ee-b886aaf38803
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-LINKEDIN-PAGES__CREDS

--- a/airbyte-integrations/connectors/source-lokalise/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lokalise/metadata.yaml
@@ -29,6 +29,10 @@ data:
   # Disabling acceptance tests for now
   # No / Low airbyte cloud usage
   # connectorTestSuitesOptions:
+  #   - suite: liveTests
+  #     testConnections:
+  #       - name: lokalise_config_dev_null
+  #         id: 1ff2f125-7634-492c-9289-c512dccd2600
   #   - suite: acceptanceTests
   #     testSecrets:
   #       - name: SECRET_SOURCE-LOKALISE__CREDS

--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -51,6 +51,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: mailchimp_config_oauth_dev_null
+          id: 46a5be1e-a798-407b-a7ae-00184e04b690
+        - name: mailchimp_config_dev_null
+          id: 7da811da-0320-407a-8d6e-7120eeead385
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-mailgun/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailgun/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: mailgun_config_dev_null
+          id: 7b0849fb-fa7c-4d91-bdeb-0bdbe1e17e07
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-MAILGUN_CONFIG

--- a/airbyte-integrations/connectors/source-mailjet-sms/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailjet-sms/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: mailjet-sms_config_dev_null
+          id: 88073883-d1b9-4205-97e1-e594ef65214f
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-MAILJET-SMS__CREDS

--- a/airbyte-integrations/connectors/source-marketo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-marketo/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: marketo_config_dev_null
+          id: 4df9fc18-4d29-44c5-aa52-c74d8066d0bd
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-metabase/metadata.yaml
+++ b/airbyte-integrations/connectors/source-metabase/metadata.yaml
@@ -40,6 +40,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: metabase_config_dev_null
+          id: 59057cfd-250a-45b8-a2d5-a0ad74353d27
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-microsoft-teams/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-teams/metadata.yaml
@@ -38,6 +38,14 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: microsoft-teams_old_config_dev_null
+          id: 173d587d-2f13-4289-a5c9-a45641b07f7f
+        - name: microsoft-teams_config_dev_null
+          id: 64010141-ad84-4986-a354-e6613967459e
+        - name: microsoft-teams_config_oauth_dev_null
+          id: 7502d493-2e74-40e4-8e61-ee9cede09b98
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-MICROSOFT-TEAMS_CREDS

--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -65,6 +65,16 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: mixpanel_config_incremental_dev_null
+          id: 1684fa59-b23d-4955-b9f3-f56f77599606
+        - name: mixpanel_config_old_dev_null
+          id: 4158acfe-9e39-46f4-bf0b-6865368ed5a8
+        - name: mixpanel_config_project_secret_dev_null
+          id: 575b938b-35ad-459c-a820-291e1e94c293
+        - name: mixpanel_config_dev_null
+          id: 94ebb422-0a1f-4c4d-b4a1-cc0aa63a4114
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -50,6 +50,14 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: monday_config_oauth_dev_null
+          id: 42a1b99a-0ef5-4442-945e-e4291376fb55
+        - name: monday_config_dev_null
+          id: 4533adbf-ea50-44ae-bafd-62bccad2ddf3
+        - name: monday_config_api_token_dev_null
+          id: 81b8f4db-d37f-4135-9a55-d62e0a163701
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-my-hours/metadata.yaml
+++ b/airbyte-integrations/connectors/source-my-hours/metadata.yaml
@@ -36,6 +36,10 @@ data:
     sl: 100
     ql: 100
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: my-hours_config_dev_null
+          id: 617930a1-8717-49cc-890d-99da6e745bf9
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-MY-HOURS_CREDS

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -50,6 +50,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: notion_config_oauth_dev_null
+          id: 58842b61-7557-4971-829a-5a1cc43d7614
+        - name: notion_config_dev_null
+          id: 8af67fe8-a20e-4eae-816a-2a3c893c0360
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-nytimes/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nytimes/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: nytimes_config_dev_null
+          id: 458374b9-e318-4baa-87ff-d217fe32697e
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-NYTIMES__CREDS

--- a/airbyte-integrations/connectors/source-okta/metadata.yaml
+++ b/airbyte-integrations/connectors/source-okta/metadata.yaml
@@ -32,6 +32,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: okta_config_dev_null
+          id: 64578038-37df-4bc4-9181-b202a3cc20b9
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-omnisend/metadata.yaml
+++ b/airbyte-integrations/connectors/source-omnisend/metadata.yaml
@@ -33,6 +33,10 @@ data:
     sl: 100
     ql: 100
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: omnisend_config_dev_null
+          id: 1da4bd92-4fee-4601-9794-011396cc713d
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-OMNISEND__CREDS

--- a/airbyte-integrations/connectors/source-onesignal/metadata.yaml
+++ b/airbyte-integrations/connectors/source-onesignal/metadata.yaml
@@ -6,6 +6,10 @@ data:
     baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
   connectorSubtype: api
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: onesignal_config_dev_null
+          id: c3a65bec-d1b9-45b9-b31e-893a3ce8e231
     - suite: acceptanceTests
       testSecrets:
         - fileName: config.json

--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: openweather_config_dev_null
+          id: 6e4f9fb3-3b83-4967-adcd-860a57242a9d
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-OPENWEATHER_CREDS

--- a/airbyte-integrations/connectors/source-orb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orb/metadata.yaml
@@ -34,6 +34,12 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: orb_config_dev_null
+          id: 0ce36c2c-7f18-4301-90a9-a24dce6389c4
+        - name: orb_config_credits_ledger_entries_dev_null
+          id: 4f888cde-0456-4c20-ae9c-9b1f73df51d9
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-orbit/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orbit/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: orbit_config_dev_null
+          id: 478f6e39-f483-4896-915a-e4cc4ab12916
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE_ORBIT__CREDS

--- a/airbyte-integrations/connectors/source-outreach/metadata.yaml
+++ b/airbyte-integrations/connectors/source-outreach/metadata.yaml
@@ -43,6 +43,10 @@ data:
     ql: 200
     sl: 100
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: outreach_config_dev_null
+          id: 0d304968-b31b-4777-be96-62c689f78a46
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -45,6 +45,14 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: paypal-transaction_config_oauth_sandbox_dev_null
+          id: 0706e37d-f17e-43fe-9c44-1a8a1f7c8913
+        - name: paypal-transaction_config_dev_null
+          id: 41268924-7130-45f9-9d08-5b2707b14c65
+        - name: paypal-transaction_config_oauth_dev_null
+          id: 9d998f7d-87ac-46a1-bfb1-2c655b0a9838
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-paystack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paystack/metadata.yaml
@@ -36,6 +36,10 @@ data:
     ql: 300
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: paystack_config_dev_null
+          id: 53f674d1-d9f9-4fc1-99c1-0d64844948dc
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-pendo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pendo/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: pendo_config_dev_null
+          id: 8964641e-f0cf-42a2-a1f1-20226b198cf4
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-PENDO__CREDS

--- a/airbyte-integrations/connectors/source-persistiq/metadata.yaml
+++ b/airbyte-integrations/connectors/source-persistiq/metadata.yaml
@@ -30,6 +30,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: persistiq_config_dev_null
+          id: 4e03433a-ea59-42a5-b922-81372f438a69
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-PERSISTIQ__CREDS

--- a/airbyte-integrations/connectors/source-pexels-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pexels-api/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: pexels-api_config_dev_null
+          id: 0db7dc91-997c-4ee7-abbd-4793086e7836
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-PEXELS-API__CREDS

--- a/airbyte-integrations/connectors/source-pinterest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pinterest/metadata.yaml
@@ -62,6 +62,12 @@ data:
     ql: 400
   supportLevel: certified
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: pinterest_config_dev_null
+          id: 4bf1f050-10fd-4ae5-8d7a-05d6fd59820d
+        - name: pinterest_config_oauth_dev_null
+          id: 8d06a86f-fc9a-44b6-b3ef-db633636bc2c
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
@@ -38,6 +38,12 @@ data:
     - cdk:low-code
     - language:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: pipedrive_old_config_dev_null
+          id: 7bd5c95e-ead8-42a7-8c5a-6cfd50b1f0e0
+        - name: pipedrive_config_dev_null
+          id: 8278c55c-e9e9-4403-a001-b47aaac3535f
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-pocket/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pocket/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: pocket_config_dev_null
+          id: 40715200-70aa-481b-be17-5d4a87ce0a22
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: pokeapi_config_dev_null
+          id: 5a290dcf-b2cf-4768-ac2d-a1aaca90c186
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-POKEAPI__CREDS

--- a/airbyte-integrations/connectors/source-polygon-stock-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-polygon-stock-api/metadata.yaml
@@ -32,6 +32,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: polygon-stock-api_config_dev_null
+          id: 7affa2ff-0b68-428d-bf9a-78fc68d71bd6
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-POLYGON-STOCK-API__CREDS

--- a/airbyte-integrations/connectors/source-posthog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-posthog/metadata.yaml
@@ -38,6 +38,10 @@ data:
     - cdk:low-code
     - language:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: posthog_config_dev_null
+          id: 6982b1ce-2255-4ea2-a2f6-38fd56a6f5f1
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-postmarkapp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postmarkapp/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: postmarkapp_config_dev_null
+          id: 2c3b45cb-13d7-4883-a982-17188cf3dcae
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-POSTMARKAPP__CREDS

--- a/airbyte-integrations/connectors/source-public-apis/metadata.yaml
+++ b/airbyte-integrations/connectors/source-public-apis/metadata.yaml
@@ -30,6 +30,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: public-apis_config_dev_null
+          id: 365fbda3-5613-493a-8a2e-5a0c220a9fc1
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-PUBLIC-APIS__CREDS

--- a/airbyte-integrations/connectors/source-punk-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-punk-api/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: archived
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: punk-api_config_dev_null
+          id: 061efb1b-1c03-4d1e-b31a-aebcc85e3ecd
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-PUNK-API__CREDS

--- a/airbyte-integrations/connectors/source-pypi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pypi/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: pypi_config_dev_null
+          id: 23e31426-34f6-474d-9917-ad1e8631c8e2
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-PYPI__CREDS

--- a/airbyte-integrations/connectors/source-qualaroo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-qualaroo/metadata.yaml
@@ -27,18 +27,22 @@ data:
   tags:
     - language:python
     - cdk:low-code
-  # Disable acceptance tests for now
-  # They are not passing
-  # No Airbyte Cloud usage
-  # connectorTestSuitesOptions:
-  #   - suite: unitTests
-  #   - suite: acceptanceTests
-  #     testSecrets:
-  #       - name: SECRET_SOURCE-QUALAROO_CREDS
-  #         fileName: config.json
-  #         secretStore:
-  #           type: GSM
-  #           alias: airbyte-connector-testing-secret-store
+  connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: qualaroo_config_dev_null
+          id: 8178b8f4-9511-442c-9ddf-4cd31713266c
+    # Disable acceptance tests for now
+    # They are not passing
+    # No Airbyte Cloud usage
+    #   - suite: unitTests
+    #   - suite: acceptanceTests
+    #     testSecrets:
+    #       - name: SECRET_SOURCE-QUALAROO_CREDS
+    #         fileName: config.json
+    #         secretStore:
+    #           type: GSM
+    #           alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -47,6 +47,10 @@ data:
   # Low/No Airbyte Cloud usage
   #
   # connectorTestSuitesOptions:
+  #   - suite: liveTests
+  #     testConnections:
+  #       - name: quickbooks_config_dev_null
+  #         id: 211394cc-91d6-4450-9563-fa0be54a6c25
   #   - suite: unitTests
   #   - suite: acceptanceTests
   #     testSecrets:

--- a/airbyte-integrations/connectors/source-recharge/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recharge/metadata.yaml
@@ -41,6 +41,12 @@ data:
     ql: 400
   supportLevel: certified
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: recharge_config_dev_null
+          id: 2ef8f5fb-332d-49fc-8576-ea889d1c262d
+        - name: recharge_config_order_modern_api_dev_null
+          id: 414cb0e3-dbfd-4efb-b2af-0b961e689454
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-recreation/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recreation/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: recreation_config_dev_null
+          id: 0d2e5a57-e433-4e4c-8961-88a0521e1cae
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-RECREATION__CREDS

--- a/airbyte-integrations/connectors/source-recruitee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recruitee/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: recruitee_config_dev_null
+          id: f12dfde4-006e-4aa7-83af-0e5059fc6f95
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-RECRUITEE__CREDS

--- a/airbyte-integrations/connectors/source-recurly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recurly/metadata.yaml
@@ -34,6 +34,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: recurly_config_dev_null
+          id: 33f9384f-dbd1-4f14-86b8-f20f7f0e140f
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-retently/metadata.yaml
+++ b/airbyte-integrations/connectors/source-retently/metadata.yaml
@@ -32,6 +32,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: retently_config_dev_null
+          id: 20c4bd1a-a150-4e92-a2e6-ffb374589e20
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-RETENTLY_CREDS

--- a/airbyte-integrations/connectors/source-rki-covid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rki-covid/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: rki-covid_config_dev_null
+          id: 4f1784b1-f6b3-4bb2-9009-cb8ba2328bab
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-rss/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rss/metadata.yaml
@@ -41,6 +41,10 @@ data:
     sl: 100
     ql: 100
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: rss_config_dev_null
+          id: 09453f70-3d9d-4075-bf9d-6d29f34e2aba
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-RSS__CREDS

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -41,6 +41,70 @@ data:
     - language:python
     - cdk:python-file-based
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: s3_v4_jsonl_config_dev_null
+          id: 01f508b1-5690-47af-940c-a777d471762f
+        - name: s3_v4_csv_skip_rows_no_header_config_dev_null
+          id: 0bc29171-b589-45be-b59c-0bc3138eaf41
+        - name: s3_v4_parquet_duration_list_struct_config_dev_null
+          id: 0e53811c-f26c-487c-a493-b068ae663f81
+        - name: s3_parquet_dataset_config_dev_null
+          id: 0f06e5a2-da09-4615-a7bc-83a71043866b
+        - name: s3_v4_parquet_decimal_config_dev_null
+          id: 13d94db7-2e54-44ab-aae8-1b4c96a2f605
+        - name: s3_jsonl_config_dev_null
+          id: 18e4fed1-f4ca-441f-b5bd-fd80aed40831
+        - name: s3_v4_avro_duration_config_dev_null
+          id: 1a0868c0-1491-43bf-8aa0-9d5ebd36e128
+        - name: s3_v4_csv_user_schema_cast_complex_config_dev_null
+          id: 2124602b-0617-4646-bf5f-39482f8fdcee
+        - name: s3_v4_csv_user_schema_config_dev_null
+          id: 231c0fcb-41e4-414c-980b-4d86f5b8c377
+        - name: s3_v4_avro_decimal_as_float_config_dev_null
+          id: 277832c6-2554-4cd8-8b5e-85bc19fcfe8a
+        - name: s3_v4_csv_custom_encoding_config_dev_null
+          id: 28680b58-f086-4187-9bbe-acef00f11e67
+        - name: s3_v4_avro_config_dev_null
+          id: 2d04cf3c-d641-424c-bb88-101a70d8bba8
+        - name: s3_v4_parquet_config_dev_null
+          id: 32976729-6872-4fc5-ad65-1b7024b234b9
+        - name: s3_jsonl_newlines_config_dev_null
+          id: 3497d077-2714-42ac-b379-3e02b54ff481
+        - name: s3_v4_csv_no_header_config_dev_null
+          id: 38cb2686-3480-4411-84d3-ff9464342ef3
+        - name: s3_config_dev_null
+          id: 40ed8b50-0322-43ef-99d5-1dc4e4995f8a
+        - name: s3_unstructured_config_dev_null
+          id: 44884944-3708-489f-b8e2-df7922c9a167
+        - name: s3_v4_csv_with_null_bools_config_dev_null
+          id: 47a8291a-56b6-4865-b66f-0f0cba8abdb8
+        - name: s3_zip_config_avro_dev_null
+          id: 4dc5f34b-f335-4a93-8816-2064f838d0a0
+        - name: s3_v4_parquet_dataset_config_dev_null
+          id: 4f4eb9d4-8b04-4af7-8de0-0e311185fa60
+        - name: s3_avro_config_dev_null
+          id: 5abf0b35-a5b5-40c2-a9c6-f525027aef9e
+        - name: s3_v4_parquet_decimal_as_float_config_dev_null
+          id: 5b4f179e-a27c-4fbf-bcfe-19b792e8b001
+        - name: s3_v4_jsonl_newlines_config_dev_null
+          id: 5e0ea12a-0629-4de7-9597-348be8599f32
+        - name: s3_v4_csv_custom_format_config_dev_null
+          id: 6e6e9c11-c068-4eae-9faa-f02c643dc52b
+        - name: s3_zip_config_csv_custom_encoding_dev_null
+          id: 70e97267-8a4c-48a1-bdef-30609e5d27f9
+        - name: s3_v4_csv_with_nulls_config_dev_null
+          id: 8ddea3b4-fb78-44fe-81db-7cdb4e68cae5
+        - name: s3_v4_avro_decimal_config_dev_null
+          id: 8eb9a0f5-1fcc-418a-85f3-8f81c13e0a73
+        - name: s3_zip_config_csv_dev_null
+          id: 9e73e8ca-4486-4f14-982c-d26f27792aae
+        - name: s3_zip_config_jsonl_dev_null
+          id: ad846359-1348-4c75-9c7e-1717f42a249e
+        - name: s3_zip_config_parquet_dev_null
+          id: b796ca5b-d5c0-4472-9f63-c277b79f534b
+        - name: s3_v4_csv_skip_rows_config_dev_null
+          id: ba0c3a18-d120-4e29-8fca-467634e00300
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-S3_AVRO__CREDS

--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -33,6 +33,14 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: salesforce_config_bulk_dev_null
+          id: 114d8a58-804d-49cd-be0f-14d8f20012b6
+        - name: salesforce_config_dev_null
+          id: 36b229e8-cea8-4d92-8b3d-cdfe488b00a5
+        - name: salesforce_config_sandbox_dev_null
+          id: 4cfaad00-8911-450e-a8f0-d31c6acd2fe2
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-salesloft/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesloft/metadata.yaml
@@ -36,6 +36,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: salesloft_config_oauth_dev_null
+          id: 1b6c8a60-5505-49b6-9d33-e9163b0c12b2
+        - name: salesloft_config_dev_null
+          id: 3c4e1c30-251d-4ff5-9534-3be0f7c8fa17
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-sap-fieldglass/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sap-fieldglass/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: sap-fieldglass_config_dev_null
+          id: 59b8a28e-0784-4eb5-adb3-9a7d4b9c6fa4
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-SAP-FIELDGLASS__CREDS

--- a/airbyte-integrations/connectors/source-secoda/metadata.yaml
+++ b/airbyte-integrations/connectors/source-secoda/metadata.yaml
@@ -30,6 +30,10 @@ data:
   # They are not passing
   # No Airbyte Cloud usage
   # connectorTestSuitesOptions:
+  #   - suite: liveTests
+  #     testConnections:
+  #       - name: secoda_config_dev_null
+  #         id: 431ebdb2-24a3-4c09-a1f0-b841a5422eca
   #   - suite: acceptanceTests
   #     testSecrets:
   #       - name: SECRET_SOURCE-SECODA__CREDS

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -38,6 +38,16 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: sendgrid_python_config_dev_null
+          id: 06851e4b-cd7f-4ee9-bf0a-a405050fd9b2
+        - name: sendgrid_config_dev_null
+          id: 0a1b625d-23c5-4bf1-bfd6-d2d517aa9765
+        - name: sendgrid_lowcode_config_dev_null
+          id: 312c3f32-7411-447d-b35b-37c07218d8f9
+        - name: sendgrid_old_config_dev_null
+          id: 5f1f419f-2477-4528-b348-d9900ec86c61
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-sendinblue/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendinblue/metadata.yaml
@@ -36,6 +36,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: sendinblue_config_dev_null
+          id: 9dc930cc-4faa-47e7-b45d-f63f60b8ee9e
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-SENDINBLUE__CREDS

--- a/airbyte-integrations/connectors/source-senseforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-senseforce/metadata.yaml
@@ -35,6 +35,10 @@ data:
   # No/Low Airbyte Cloud usage
   #
   # connectorTestSuitesOptions:
+  #   - suite: liveTests
+  #     testConnections:
+  #       - name: senseforce_config_dev_null
+  #         id: 3f2f621c-59e2-4cc4-9922-f3735da8a162
   #   - suite: acceptanceTests
   #     testSecrets:
   #       - name: SECRET_SOURCE-SENSEFORCE__CREDS

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -37,6 +37,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: sentry_config_dev_null
+          id: 54bf1bc8-404c-4e4c-b253-7d8b4c4ffacb
+        - name: sentry_config_limited_scopes_dev_null
+          id: aa4573bd-4681-4906-9877-d6afe4060a28
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -34,6 +34,10 @@ data:
     - language:python
     - cdk:python-file-based
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: sftp-bulk_config_dev_null
+          id: 35b9a87f-e585-45b7-b7f8-617e9ff47cc5
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -114,6 +114,16 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: shopify_config_dev_null
+          id: 1de7c985-bcce-425a-a762-57389cea3900
+        - name: shopify_config_old_dev_null
+          id: 1f3550b3-740a-4841-8337-0e28a7b23458
+        - name: shopify_config_transactions_with_user_id_dev_null
+          id: 5f1d6da1-87bc-46b4-8de7-1b3fe1a2be90
+        - name: shopify_config_oauth_dev_null
+          id: a08529a9-618c-4bfc-884f-f5dccba1c1ab
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-shortio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shortio/metadata.yaml
@@ -34,6 +34,10 @@ data:
     sl: 100
     ql: 100
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: shortio_config_dev_null
+          id: a894245b-5471-4f6c-9a97-699199047bf9
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-SHORTIO__CREDS

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -49,6 +49,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: slack_config_oauth_dev_null
+          id: 4219c9e8-af56-4eaf-bf7d-b5578d446a74
+        - name: slack_config_dev_null
+          id: b6e9e649-2899-4589-81c4-79df81a7a210
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-smaily/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smaily/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: smaily_config_dev_null
+          id: 13d7f046-ccb7-4f8a-bcbb-9a19da21a4da
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-SMAILY__CREDS

--- a/airbyte-integrations/connectors/source-smartengage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smartengage/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: smartengage_config_dev_null
+          id: 801ae179-411b-4d4a-aa33-816121360b38
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-SMARTENGAGE__CREDS

--- a/airbyte-integrations/connectors/source-smartsheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smartsheets/metadata.yaml
@@ -31,6 +31,12 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: smartsheets_config_dev_null
+          id: 5f50a932-3717-48de-99bd-613259aaa378
+        - name: smartsheets_config_oauth_dev_null
+          id: 848c3e7d-802a-4b61-bd28-132ba3f55d25
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -66,6 +66,10 @@ data:
     ql: 400
   supportLevel: certified
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: snapchat-marketing_config_dev_null
+          id: 1aea074b-0b53-49ec-85d3-b1d10ed3c83d
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-sonar-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sonar-cloud/metadata.yaml
@@ -32,6 +32,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: sonar-cloud_config_dev_null
+          id: 11b168e2-9dc7-4972-81f8-6cdf948562ba
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-SONAR-CLOUD__CREDS

--- a/airbyte-integrations/connectors/source-spacex-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-spacex-api/metadata.yaml
@@ -36,6 +36,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: spacex-api_config_dev_null
+          id: 644824f1-d1d8-4790-9157-b626cc498127
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-SPACEX-API__CREDS

--- a/airbyte-integrations/connectors/source-square/metadata.yaml
+++ b/airbyte-integrations/connectors/source-square/metadata.yaml
@@ -33,6 +33,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: square_config_oauth_dev_null
+          id: 83af0127-0962-4e07-ac73-c19f37326810
+        - name: square_config_dev_null
+          id: ac295afb-3984-45cc-9a67-73d35297671d
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -55,6 +55,14 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: stripe_config_dev_null
+          id: 0f3c8a84-53e2-4a33-89a9-26bf36a2367c
+        - name: stripe_performance-config_dev_null
+          id: 4f738e2c-a1d2-48b4-9b93-f56e2258068d
+        - name: stripe_connected_account_config_dev_null
+          id: 97d55640-b443-49c5-a9d9-aed28396841d
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-survey-sparrow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-survey-sparrow/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: survey-sparrow_config_dev_null
+          id: 29c6c6f2-217f-48e7-9a36-b3a235531b63
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-SURVEY-SPARROW__CREDS

--- a/airbyte-integrations/connectors/source-surveymonkey/metadata.yaml
+++ b/airbyte-integrations/connectors/source-surveymonkey/metadata.yaml
@@ -33,6 +33,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: surveymonkey_config_old_dev_null
+          id: 033d4d57-53e0-40e1-8019-e80a8e830ebf
+        - name: surveymonkey_config_dev_null
+          id: 72674bcc-f4f7-422e-af80-021f551d2734
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-tempo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tempo/metadata.yaml
@@ -31,6 +31,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: tempo_accounts_only_config_dev_null
+          id: 1bffaa9d-68f0-4b31-9544-ecd2391551d8
+        - name: tempo_config_dev_null
+          id: 27804e86-37c0-46d3-a863-242ab459ce75
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-TEMPO__CREDS

--- a/airbyte-integrations/connectors/source-the-guardian-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-the-guardian-api/metadata.yaml
@@ -6,6 +6,10 @@ data:
     baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
   connectorSubtype: api
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: the-guardian-api_config_dev_null
+          id: 28833186-4803-4694-926e-1b0c5d534df8
     - suite: acceptanceTests
       testSecrets:
         - fileName: config.json

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -87,6 +87,26 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: tiktok-marketing_prod_config_with_lifetime_granularity_dev_null
+          id: 2a53fa01-351c-45af-84d8-a9f200a0c988
+        - name: tiktok-marketing_prod_config_with_day_granularity_dev_null
+          id: 35e62f0f-903a-4fcd-afc6-98259a4f2fea
+        - name: tiktok-marketing_sandbox_config_dev_null
+          id: 36e6778b-a04d-4356-a670-e41123fe9596
+        - name: tiktok-marketing_config_dev_null
+          id: 4da9b9c1-10bd-46c1-915b-bb3d1651153b
+        - name: tiktok-marketing_new_config_prod_dev_null
+          id: 59935970-bbee-4122-88c9-219e97dae272
+        - name: tiktok-marketing_prod_config_dev_null
+          id: 5b364ce8-b98d-4ccf-9a43-56ebd53d481a
+        - name: tiktok-marketing_config_oauth_dev_null
+          id: 60c12fbb-bc41-4df1-9b33-9a5455312b0e
+        - name: tiktok-marketing_new_config_sandbox_dev_null
+          id: 9aab8bf6-b4cd-4bad-b319-ed39bcddfe2a
+        - name: tiktok-marketing_prod_config_day_dev_null
+          id: bb8311bf-6def-4119-bf32-38c001a1e549
     - suite: unitTests
       testSecrets:
         - name: SECRET_SOURCE-TIKTOK-MARKETING_SANDBOX_CREDS

--- a/airbyte-integrations/connectors/source-todoist/metadata.yaml
+++ b/airbyte-integrations/connectors/source-todoist/metadata.yaml
@@ -33,6 +33,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: todoist_config_dev_null
+          id: 2fe1267b-52cf-4f76-88f0-7e99a52992fc
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-TODOIST__CREDS

--- a/airbyte-integrations/connectors/source-trello/metadata.yaml
+++ b/airbyte-integrations/connectors/source-trello/metadata.yaml
@@ -38,6 +38,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: trello_config_dev_null
+          id: 791d4aa0-8fe2-4b8d-9ed3-131a5549821b
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-trustpilot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-trustpilot/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: trustpilot_config_dev_null
+          id: 2a99ef5e-0861-4eae-bcaa-be86b80fce95
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-tvmaze-schedule/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tvmaze-schedule/metadata.yaml
@@ -26,10 +26,14 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: tvmaze-schedule_config_dev_null
+          id: 61af6e50-3c58-4b66-b005-7e2f255d0d32
   # Disabling acceptance tests for now
   # They are not passing
   # Low/No Airbyte Cloud usage
-  # connectorTestSuitesOptions:
   #   - suite: acceptanceTests
   #     testSecrets:
   #       - name: SECRET_SOURCE-TVMAZE-SCHEDULE__CREDS

--- a/airbyte-integrations/connectors/source-twilio-taskrouter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio-taskrouter/metadata.yaml
@@ -29,6 +29,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: twilio-taskrouter_config_dev_null
+          id: 7cc6b91e-1169-406d-aa41-14fe80acec4b
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-TWILIO-TASKROUTER__CREDS

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -36,6 +36,12 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: twilio_config_with_lookback_dev_null
+          id: 57c28219-3a06-48db-9aec-df3cd20be9f6
+        - name: twilio_config_dev_null
+          id: 91aac9a6-6ece-42e2-9ed5-c6f6a226cc3e
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-twitter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twitter/metadata.yaml
@@ -30,6 +30,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: twitter_config_dev_null
+          id: 7ed4842f-7a28-4407-a684-c2c547797648
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-TWITTER__CREDS

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -39,6 +39,14 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: typeform_config_oauth_dev_null
+          id: 1522cc4d-04d2-4d44-9152-0854b38e15ee
+        - name: typeform_config_dev_null
+          id: 2b707284-7c35-46da-b1ed-1cb09779a43c
+        - name: typeform_incremental_config_dev_null
+          id: 681b2010-52af-4d44-b2e1-1b5f50581509
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-us-census/metadata.yaml
+++ b/airbyte-integrations/connectors/source-us-census/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: us-census_config_dev_null
+          id: b313e43c-2807-4105-b662-10ed1c830743
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-vantage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-vantage/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: vantage_config_dev_null
+          id: 28e38531-1fd2-4bce-8f99-fd1f73b82539
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-VANTAGE__CREDS

--- a/airbyte-integrations/connectors/source-webflow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-webflow/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: webflow_config_dev_null
+          id: 6ddee540-ff2c-4c62-a4ef-d118c074ffee
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-whisky-hunter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-whisky-hunter/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: whisky-hunter_config_dev_null
+          id: 49d04005-71c9-4c96-8349-bafc629ea7ee
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-WHISKY-HUNTER__CREDS

--- a/airbyte-integrations/connectors/source-wikipedia-pageviews/metadata.yaml
+++ b/airbyte-integrations/connectors/source-wikipedia-pageviews/metadata.yaml
@@ -36,6 +36,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: wikipedia-pageviews_config_dev_null
+          id: 4c4d6da5-9b4e-4201-86e2-11504073bede
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-WIKIPEDIA-PAGEVIEWS__CREDS

--- a/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
@@ -30,6 +30,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: woocommerce_config_dev_null
+          id: 26705957-7051-4c95-bd93-0c031fde9b67
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-WOOCOMMERCE__CREDS

--- a/airbyte-integrations/connectors/source-xkcd/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xkcd/metadata.yaml
@@ -32,6 +32,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: xkcd_config_dev_null
+          id: 45a67896-b7f4-4d4e-bbed-1aa66801d668
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-yandex-metrica/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yandex-metrica/metadata.yaml
@@ -32,6 +32,10 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: yandex-metrica_config_dev_null
+          id: 1d2dc4a5-f40f-4b50-a2fd-d41e4d104c7d
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-yotpo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yotpo/metadata.yaml
@@ -27,6 +27,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: yotpo_config_dev_null
+          id: 2d3fa28a-6d15-461b-8e8e-8a679c0ff0c3
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE_YOTPO_CREDS

--- a/airbyte-integrations/connectors/source-younium/metadata.yaml
+++ b/airbyte-integrations/connectors/source-younium/metadata.yaml
@@ -30,6 +30,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: younium_config_dev_null
+          id: bcc0a350-b9df-478f-8c08-1cd996b05026
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-YOUNIUM__CREDS

--- a/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
@@ -33,6 +33,14 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: zendesk-chat_config_oauth_dev_null
+          id: 3801d70c-d197-4bc2-a989-c48888a47fb2
+        - name: zendesk-chat_config_old_dev_null
+          id: 39ac48ce-6b9d-4b1d-9b62-3fd899ae1981
+        - name: zendesk-chat_config_dev_null
+          id: 5f92e2b6-8d51-4517-8c9a-6a1a1b29cebe
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE_ZENDESK_CHAT_CREDS

--- a/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
@@ -30,6 +30,10 @@ data:
     ql: 100
   supportLevel: community
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: zendesk-sell_config_dev_null
+          id: 0f954007-88f7-494e-a8a0-8a12fb659200
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-ZENDESK-SELL__CREDS

--- a/airbyte-integrations/connectors/source-zendesk-sunshine/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-sunshine/metadata.yaml
@@ -33,6 +33,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: zendesk-sunshine_config_oauth_dev_null
+          id: 3bf2af38-8489-4938-8d5e-2245fa0e22ee
+        - name: zendesk-sunshine_config_api_token_dev_null
+          id: 4320214d-cda0-4859-a4f0-dc123c1b8523
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-ZENDESK-SUNSHINE_API_TOKEN__CREDS

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -57,6 +57,14 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: zendesk-support_config_dev_null
+          id: 0c87dd87-c04e-4fed-a86a-fa4b6acdfef6
+        - name: zendesk-support_config_ticket_metrics_dev_null
+          id: 36dad615-075b-46ed-8191-6436ca0abc29
+        - name: zendesk-support_config_oauth_dev_null
+          id: 3fef7ac6-3265-457d-9d18-cb0906ba6dde
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -40,6 +40,12 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: zendesk-talk_config_dev_null
+          id: 22e00a6c-7c05-4a2a-bbbe-2b74dd788b7b
+        - name: zendesk-talk_config_old_dev_null
+          id: 7bfa51b9-6c79-43fa-8b5b-291d979dd710
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-zenloop/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/metadata.yaml
@@ -32,6 +32,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: zenloop_config_dev_null
+          id: a01d7d51-5f99-46b1-9efb-b988ea042735
     - suite: acceptanceTests
       testSecrets:
         - name: SECRET_SOURCE-ZENLOOP__CREDS

--- a/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
@@ -27,6 +27,10 @@ data:
     - language:python
     - cdk:python
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: zoho-crm_config_dev_null
+          id: 0000da93-11f4-4e8f-8ede-42b9789b974d
     - suite: unitTests
     - suite: integrationTests
       testSecrets:

--- a/airbyte-integrations/connectors/source-zoom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoom/metadata.yaml
@@ -37,6 +37,10 @@ data:
     - language:python
     - cdk:low-code
   connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: zoom_config_dev_null
+          id: 284c062a-8164-46cb-a8ba-71ecbecaf395
     - suite: unitTests
     - suite: acceptanceTests
       testSecrets:


### PR DESCRIPTION
## What
Add test configuration info for live tests to metadata.yaml for all connections for which there is a sandbox connection in the [integration-test-sandboxes workspace](https://cloud.airbyte.com/workspaces/112412bb-78aa-4ca6-aace-ae0b83be2215/connections).

This will be used in https://github.com/airbytehq/airbyte/pull/42574 to automatically run live tests on PRs against sandbox accounts.

With https://github.com/airbytehq/airbyte/pull/42574 and https://github.com/airbytehq/airbyte/pull/42860, closes https://github.com/airbytehq/airbyte/issues/42465.