### PR TITLE
🐛 Source Braintree: Corrects pagination issues by adding page size to yml

### DIFF
--- a/airbyte-integrations/connectors/source-braintree/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braintree/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 63cea06f-1c75-458d-88fe-ad48c7cb27fd
-  dockerImageTag: 0.3.7
+  dockerImageTag: 0.3.8
   dockerRepository: airbyte/source-braintree
   documentationUrl: https://docs.airbyte.com/integrations/sources/braintree
   githubIssueLabel: source-braintree

--- a/airbyte-integrations/connectors/source-braintree/pyproject.toml
+++ b/airbyte-integrations/connectors/source-braintree/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.3.7"
+version = "0.3.8"
 name = "source-braintree"
 description = "Source implementation for Braintree."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml
+++ b/airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml
@@ -3764,6 +3764,7 @@ streams:
         pagination_strategy:
           type: PageIncrement
           start_from_page: 1
+          page_size: 50
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: created_at
@@ -9762,6 +9763,7 @@ streams:
         pagination_strategy:
           type: PageIncrement
           start_from_page: 1
+          page_size: 50
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: created_at
@@ -15719,6 +15721,7 @@ streams:
         pagination_strategy:
           type: PageIncrement
           start_from_page: 1
+          page_size: 50
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: created_at

--- a/docs/integrations/sources/braintree.md
+++ b/docs/integrations/sources/braintree.md
@@ -72,7 +72,7 @@ The Braintree connector should not run into Braintree API limitations under norm
 
 | Version | Date       | Pull Request                                             | Subject                                              |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------- |
-| 0.3.8 | 2024-07-28 | [0](https://github.com/airbytehq/airbyte/pull/0) | Corrects pagination issues |
+| 0.3.8 | 2024-07-29 | [42848](https://github.com/airbytehq/airbyte/pull/42848) | Corrects pagination issues |
 | 0.3.7 | 2024-07-27 | [42796](https://github.com/airbytehq/airbyte/pull/42796) | Update dependencies |
 | 0.3.6 | 2024-07-20 | [42372](https://github.com/airbytehq/airbyte/pull/42372) | Update dependencies |
 | 0.3.5 | 2024-07-18 | [42096](https://github.com/airbytehq/airbyte/pull/42096) | Adds pagination to get more than 50 records per sync |

--- a/docs/integrations/sources/braintree.md
+++ b/docs/integrations/sources/braintree.md
@@ -72,6 +72,7 @@ The Braintree connector should not run into Braintree API limitations under norm
 
 | Version | Date       | Pull Request                                             | Subject                                              |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------- |
+| 0.3.8 | 2024-07-28 | [0](https://github.com/airbytehq/airbyte/pull/0) | Corrects pagination issues |
 | 0.3.7 | 2024-07-27 | [42796](https://github.com/airbytehq/airbyte/pull/42796) | Update dependencies |
 | 0.3.6 | 2024-07-20 | [42372](https://github.com/airbytehq/airbyte/pull/42372) | Update dependencies |
 | 0.3.5 | 2024-07-18 | [42096](https://github.com/airbytehq/airbyte/pull/42096) | Adds pagination to get more than 50 records per sync |


### PR DESCRIPTION
## What
@valentinfily reported in [this comment](https://github.com/airbytehq/airbyte/pull/42096#issuecomment-2245860946) that the braintree connector stopped working correctly for him after pagination was added. He sent me the logs for his run, and I was able to reproduce the error.


## How
Pagination never reached a stop condition, and the Braintree API would continue to send the same claims over an over again. By adding the "page size" configuration here I was able to get it to stop. Once a page sends fewer than 50 records Airbyte now knows not to pull another page.

After making this change the issue went away.

## Review guide
1. `airbyte-integrations/connectors/source-braintree/source_braintree/manifest.yaml`


## User Impact
Pagination will work correctly for users of the Braintree connector, and they won't be stuck in an endless cycle of syncing data.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
