### PR TITLE
airbyte-ci: send publish failures to a dedicated slack channel

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -98,10 +98,10 @@ jobs:
       - name: Publish to OSS Build Failure Slack Channel
         uses: abinoda/slack-action@master
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+          SLACK_BOT_TOKEN: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
         with:
           args: >-
-            {\"channel\":\"C056HGD1QSW\", \"blocks\":[
+            {\"channel\":\"C07F5NUU63S\", \"blocks\":[
             {\"type\":\"divider\"},
             {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\" Publish Connector Failed! :bangbang: \n\n\"}},
             {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"_merged by_: *${{ github.actor }}* \n\"}},

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -81,11 +81,11 @@ jobs:
           body: '{ "trigger": "down", "status": "HASISSUES" }'
 
   notify-failure-slack-channel:
-    name: "Notify Slack Channel on Build Failures"
+    name: "Notify Slack Channel on Publish Failures"
     runs-on: ubuntu-latest
     needs:
       - publish_connectors
-    if: ${{ failure() && github.ref == 'refs/heads/master' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v4
@@ -95,16 +95,16 @@ jobs:
         env:
           AIRBYTE_TEAM_BOT_SLACK_TOKEN: ${{ secrets.SLACK_AIRBYTE_TEAM_READ_USERS }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to OSS Build Failure Slack Channel
-        uses: abinoda/slack-action@master
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+      - name: Send publish failures to connector-publish-failures channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
         with:
-          args: >-
-            {\"channel\":\"C07F5NUU63S\", \"blocks\":[
-            {\"type\":\"divider\"},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\" Publish Connector Failed! :bangbang: \n\n\"}},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"_merged by_: *${{ github.actor }}* \n\"}},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}> \n\"}},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\" :octavia-shocked: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Action Run> :octavia-shocked: \n\"}},
-            {\"type\":\"divider\"}]}
+          # This data can be any valid JSON from a previous step in the GitHub Action
+          payload: |
+            {
+              "channel": "#connector-publish-failures",
+              "username": "Connectors CI/CD Bot",
+              "text": "🚨 Publish workflow failed:\n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -571,8 +571,8 @@ For Python connectors, sets the `airbyte-cdk` dependency in `pyproject.toml` and
 
 #### Arguments
 
-| Argument      | Description                                             |
-| ------------- | ------------------------------------------------------- |
+| Argument      | Description                                                               |
+| ------------- | ------------------------------------------------------------------------- |
 | `CDK_VERSION` | CDK version constraint to set (default to `^{most_recent_patch_version}`) |
 
 #### Notes
@@ -772,7 +772,8 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 ## Changelog
 
 | Version | PR                                                         | Description                                                                                                                  |
-|---------| ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
+| ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.26.0  | [#42849](https://github.com/airbytehq/airbyte/pull/42849)  | Send publish failures messages to `#connector-publish-failures`                                                              |
 | 4.25.4  | [#42463](https://github.com/airbytehq/airbyte/pull/42463) | Add validation before live test runs                                                                                         |
 | 4.25.3  | [#42437](https://github.com/airbytehq/airbyte/pull/42437)  | Ugrade-cdk: Update to work with Python connectors using poetry                                                               |
 | 4.25.2  | [#42077](https://github.com/airbytehq/airbyte/pull/42077)  | Live/regression tests: add status check for regression test runs                                                             |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/python_connectors.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from dagger import Container, Platform
 from pipelines.airbyte_ci.connectors.build_image.steps import build_customization
-from pipelines.airbyte_ci.connectors.build_image.steps.common import BuildConnectorImagesBase, apply_airbyte_docker_labels
+from pipelines.airbyte_ci.connectors.build_image.steps.common import BuildConnectorImagesBase
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.dagger.actions.python.common import apply_python_development_overrides, with_python_connector_installed
 from pipelines.models.steps import StepResult

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/context.py
@@ -56,7 +56,6 @@ class ConnectorContext(PipelineContext):
         pipeline_start_timestamp: Optional[int] = None,
         ci_context: Optional[str] = None,
         slack_webhook: Optional[str] = None,
-        reporting_slack_channel: Optional[str] = None,
         pull_request: Optional[PullRequest.PullRequest] = None,
         should_save_report: bool = True,
         code_tests_only: bool = False,
@@ -88,7 +87,6 @@ class ConnectorContext(PipelineContext):
             pipeline_start_timestamp (Optional[int], optional): Timestamp at which the pipeline started. Defaults to None.
             ci_context (Optional[str], optional): Pull requests, workflow dispatch or nightly build. Defaults to None.
             slack_webhook (Optional[str], optional): The slack webhook to send messages to. Defaults to None.
-            reporting_slack_channel (Optional[str], optional): The slack channel to send messages to. Defaults to None.
             pull_request (PullRequest, optional): The pull request object if the pipeline was triggered by a pull request. Defaults to None.
             code_tests_only (bool, optional): Whether to ignore non-code tests like QA and metadata checks. Defaults to False.
             use_host_gradle_dist_tar (bool, optional): Used when developing java connectors with gradle. Defaults to False.
@@ -131,7 +129,6 @@ class ConnectorContext(PipelineContext):
             pipeline_start_timestamp=pipeline_start_timestamp,
             ci_context=ci_context,
             slack_webhook=slack_webhook,
-            reporting_slack_channel=reporting_slack_channel,
             pull_request=pull_request,
             ci_report_bucket=ci_report_bucket,
             ci_gcp_credentials=ci_gcp_credentials,
@@ -258,11 +255,8 @@ class ConnectorContext(PipelineContext):
         await asyncify(update_commit_status_check)(**self.github_commit_status)
 
         if self.should_send_slack_message:
-            # Using a type ignore here because the should_send_slack_message property is checking for non nullity of the slack_webhook and reporting_slack_channel
-            await asyncify(send_message_to_webhook)(self.create_slack_message(), self.reporting_slack_channel, self.slack_webhook)  # type: ignore
+            # Using a type ignore here because the should_send_slack_message property is checking for non nullity of the slack_webhook
+            await asyncify(send_message_to_webhook)(self.create_slack_message(), self.get_slack_channels(), self.slack_webhook)  # type: ignore
 
         # Supress the exception if any
         return True
-
-    def create_slack_message(self) -> str:
-        raise NotImplementedError

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/commands.py
@@ -57,13 +57,6 @@ from pipelines.models.secrets import Secret
     envvar="SLACK_WEBHOOK",
 )
 @click.option(
-    "--slack-channel",
-    help="The Slack webhook URL to send notifications to.",
-    type=click.STRING,
-    envvar="SLACK_CHANNEL",
-    default="#connector-publish-updates",
-)
-@click.option(
     "--python-registry-token",
     help="Access token for python registry",
     type=click.STRING,
@@ -93,7 +86,6 @@ async def publish(
     metadata_service_bucket_name: str,
     metadata_service_gcs_credentials: Secret,
     slack_webhook: str,
-    slack_channel: str,
     python_registry_token: Secret,
     python_registry_url: str,
     python_registry_check_url: str,
@@ -119,7 +111,6 @@ async def publish(
                 docker_hub_username=Secret("docker_hub_username", ctx.obj["secret_stores"]["in_memory"]),
                 docker_hub_password=Secret("docker_hub_password", ctx.obj["secret_stores"]["in_memory"]),
                 slack_webhook=slack_webhook,
-                reporting_slack_channel=slack_channel,
                 ci_report_bucket=ctx.obj["ci_report_bucket_name"],
                 report_output_prefix=ctx.obj["report_output_prefix"],
                 is_local=ctx.obj["is_local"],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
@@ -4,12 +4,12 @@
 
 """Module declaring context related classes."""
 
-from typing import Optional
+from typing import List, Optional
 
 import asyncclick as click
 from github import PullRequest
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
-from pipelines.consts import ContextState
+from pipelines.consts import PUBLISH_FAILURE_SLACK_CHANNEL, PUBLISH_UPDATES_SLACK_CHANNEL, ContextState
 from pipelines.helpers.connectors.modifed import ConnectorWithModifiedFiles
 from pipelines.helpers.github import AIRBYTE_GITHUB_REPO_URL_PREFIX
 from pipelines.helpers.utils import format_duration
@@ -29,7 +29,6 @@ class PublishConnectorContext(ConnectorContext):
         docker_hub_password: Secret,
         ci_gcp_credentials: Secret,
         slack_webhook: str,
-        reporting_slack_channel: str,
         ci_report_bucket: str,
         report_output_prefix: str,
         is_local: bool,
@@ -78,7 +77,6 @@ class PublishConnectorContext(ConnectorContext):
             pipeline_start_timestamp=pipeline_start_timestamp,
             ci_context=ci_context,
             slack_webhook=slack_webhook,
-            reporting_slack_channel=reporting_slack_channel,
             ci_gcp_credentials=ci_gcp_credentials,
             should_save_report=True,
             use_local_cdk=use_local_cdk,
@@ -107,6 +105,12 @@ class PublishConnectorContext(ConnectorContext):
             return f"{metadata_tag}-dev.{self.pre_release_suffix}"
         else:
             return metadata_tag
+
+    def get_slack_channels(self) -> List[str]:
+        if self.state in [ContextState.FAILURE, ContextState.ERROR]:
+            return [PUBLISH_UPDATES_SLACK_CHANNEL, PUBLISH_FAILURE_SLACK_CHANNEL]
+        else:
+            return [PUBLISH_UPDATES_SLACK_CHANNEL]
 
     def create_slack_message(self) -> str:
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -13,9 +13,8 @@ from enum import Enum
 from functools import cached_property
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, ClassVar, Dict, List, Optional, Set
+from typing import ClassVar, List, Optional, Set
 
-import dagger
 import requests  # type: ignore
 import semver
 import yaml  # type: ignore

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
@@ -7,7 +7,6 @@ import os
 from typing import TYPE_CHECKING
 
 import asyncer
-import click
 import dagger
 import toml
 from pipelines.airbyte_ci.test.models import deserialize_airbyte_ci_config

--- a/airbyte-ci/connectors/pipelines/pipelines/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/consts.py
@@ -68,6 +68,9 @@ MAIN_CONNECTOR_TESTING_SECRET_STORE_ALIAS = "airbyte-connector-testing-secret-st
 AIRBYTE_SUBMODULE_DIR_NAME = "airbyte-submodule"
 MANUAL_PIPELINE_STATUS_CHECK_OVERRIDE_PREFIXES = ["Regression Tests"]
 
+PUBLISH_UPDATES_SLACK_CHANNEL = "#connector-publish-updates"
+PUBLISH_FAILURE_SLACK_CHANNEL = "#connector-publish-failures"
+
 
 class CIContext(str, Enum):
     """An enum for Ci context values which can be ["manual", "pull_request", "nightly_builds"]."""

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/slack.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/slack.py
@@ -1,19 +1,28 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
+from __future__ import annotations
 
 import json
+import typing
 
 import requests
 from pipelines import main_logger
 
+if typing.TYPE_CHECKING:
+    from typing import List
 
-def send_message_to_webhook(message: str, channel: str, webhook: str) -> requests.Response:
-    payload = {"channel": f"#{channel}", "username": "Connectors CI/CD Bot", "text": message}
-    response = requests.post(webhook, data={"payload": json.dumps(payload)})
 
-    # log if the request failed, but don't fail the pipeline
-    if not response.ok:
-        main_logger.error(f"Failed to send message to slack webhook: {response.text}")
+def send_message_to_webhook(message: str, channels: List[str], webhook: str) -> List[requests.Response]:
+    responses = []
+    for channel in channels:
+        channel = channel[1:] if channel.startswith("#") else channel
+        payload = {"channel": f"#{channel}", "username": "Connectors CI/CD Bot", "text": message}
+        response = requests.post(webhook, data={"payload": json.dumps(payload)})
 
-    return response
+        # log if the request failed, but don't fail the pipeline
+        if not response.ok:
+            main_logger.error(f"Failed to send message to slack webhook: {response.text}")
+        responses.append(response)
+
+    return responses

--- a/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/contexts/pipeline_context.py
@@ -78,7 +78,6 @@ class PipelineContext:
         ci_context: Optional[str] = None,
         is_ci_optional: bool = False,
         slack_webhook: Optional[str] = None,
-        reporting_slack_channel: Optional[str] = None,
         pull_request: Optional[PullRequest.PullRequest] = None,
         ci_report_bucket: Optional[str] = None,
         ci_gcp_credentials: Optional[Secret] = None,
@@ -104,7 +103,6 @@ class PipelineContext:
             ci_context (Optional[str], optional): Pull requests, workflow dispatch or nightly build. Defaults to None.
             is_ci_optional (bool, optional): Whether the CI is optional. Defaults to False.
             slack_webhook (Optional[str], optional): Slack webhook to send messages to. Defaults to None.
-            reporting_slack_channel (Optional[str], optional): Slack channel to send messages to. Defaults to None.
             pull_request (PullRequest, optional): The pull request object if the pipeline was triggered by a pull request. Defaults to None.
         """
         self.pipeline_name = pipeline_name
@@ -122,7 +120,6 @@ class PipelineContext:
         self.state = ContextState.INITIALIZED
         self.is_ci_optional = is_ci_optional
         self.slack_webhook = slack_webhook
-        self.reporting_slack_channel = reporting_slack_channel
         self.pull_request = pull_request
         self.logger = logging.getLogger(self.pipeline_name)
         self._dagger_client = None
@@ -200,7 +197,7 @@ class PipelineContext:
 
     @property
     def should_send_slack_message(self) -> bool:
-        return self.slack_webhook is not None and self.reporting_slack_channel is not None
+        return self.slack_webhook is not None
 
     @property
     def has_dagger_cloud_token(self) -> bool:
@@ -267,6 +264,9 @@ class PipelineContext:
     def create_slack_message(self) -> str:
         raise NotImplementedError()
 
+    def get_slack_channels(self) -> List[str]:
+        raise NotImplementedError()
+
     async def __aenter__(self) -> PipelineContext:
         """Perform setup operation for the PipelineContext.
 
@@ -284,10 +284,8 @@ class PipelineContext:
         self.logger.info("Caching the latest CDK version...")
         await asyncify(update_commit_status_check)(**self.github_commit_status)
         if self.should_send_slack_message:
-            # Using a type ignore here because the should_send_slack_message property is checking for non nullity of the slack_webhook and reporting_slack_channel
-            await asyncify(send_message_to_webhook)(
-                self.create_slack_message(), self.reporting_slack_channel, self.slack_webhook  # type: ignore
-            )
+            # Using a type ignore here because the should_send_slack_message property is checking for non nullity of the slack_webhook
+            await asyncify(send_message_to_webhook)(self.create_slack_message(), self.get_slack_channels(), self.slack_webhook)  # type: ignore
         return self
 
     @staticmethod
@@ -343,9 +341,9 @@ class PipelineContext:
 
         await asyncify(update_commit_status_check)(**self.github_commit_status)
         if self.should_send_slack_message:
-            # Using a type ignore here because the should_send_slack_message property is checking for non nullity of the slack_webhook and reporting_slack_channel
+            # Using a type ignore here because the should_send_slack_message property is checking for non nullity of the slack_webhook
             await asyncify(send_message_to_webhook)(
-                self.create_slack_message(), self.reporting_slack_channel, self.slack_webhook  # type: ignore
+                self.create_slack_message(), self.get_slack_channels(), self.slack_webhook  # type: ignore
             )
         # supress the exception if it was handled
         return True

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.25.4"
+version = "4.26.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_actions/test_environments.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_actions/test_environments.py
@@ -31,7 +31,7 @@ def connector_context(dagger_client):
 @pytest.mark.parametrize("use_local_cdk", [True, False])
 async def test_apply_python_development_overrides(connector_context, use_local_cdk):
     connector_context.use_local_cdk = use_local_cdk
-    fake_connector_container = connector_context.dagger_client.container().from_("airbyte/python-connector-base:1.0.0")
+    fake_connector_container = connector_context.dagger_client.container().from_("airbyte/python-connector-base:2.0.0")
     before_override_pip_freeze = await fake_connector_container.with_exec(["pip", "freeze"]).stdout()
 
     assert "airbyte-cdk" not in before_override_pip_freeze.splitlines(), "The base image should not have the airbyte-cdk installed."

--- a/airbyte-ci/connectors/pipelines/tests/test_dagger/test_actions/test_python/test_common.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_dagger/test_actions/test_python/test_common.py
@@ -27,7 +27,11 @@ def latest_cdk_version():
 def python_connector_with_setup_not_latest_cdk(all_connectors):
     for connector in all_connectors:
         if (
-            connector.metadata.get("connectorBuildOptions", {}).get("baseImage", False)
+            connector.metadata.get("connectorBuildOptions", False)
+            # We want to select a connector with a base image version >= 2.0.0 to use Python 3.10
+            and not connector.metadata.get("connectorBuildOptions", {})
+            .get("baseImage", "")
+            .startswith("docker.io/airbyte/python-connector-base:1.")
             and connector.language == "python"
             and connector.code_directory.joinpath("setup.py").exists()
         ):

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -5,7 +5,7 @@ data:
   allowedHosts:
     hosts: []
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
+    baseImage: docker.io/airbyte/python-connector-base:12.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -5,7 +5,7 @@ data:
   allowedHosts:
     hosts: []
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/python-connector-base:12.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
+    baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/42522
Closes https://github.com/airbytehq/airbyte/issues/42521

* Send connector specific publish failure messages from airbyte-ci to `#connector-publish-failures`
* Send workflow failures to `#connector-publish-failures` **(this will catch transient workflow failures when `airbyte-ci` can't start)**
* Continue sending all  messages to `#connector-publish-updates`

## How
* Do not expose a custom option to define which slack channel to send messages to
* Hardcode the list of targeted slack channels
* Declare a `PipelineContext.get_slack_channels` method to return the list of channels to send a message to.
* Implement a `PublishContext.get_slack_channels` method which returns targeted channels according to pipeline state
* Make `send_slack_webhook` accept a list of channels to send a message to

## Example
<img width="833" alt="Screenshot 2024-07-29 at 16 06 29" src="https://github.com/user-attachments/assets/cfbab5a3-52ab-438a-9522-75a3793ba079">


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
