### PR TITLE
feat(airbyte-cdk) Add ability to stop stream when retry-after is greater than a duration

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2421,6 +2421,12 @@ definitions:
         type: string
         examples:
           - "([-+]?\\d+)"
+      max_waiting_time_in_seconds:
+        title: Max Waiting Time in Seconds
+        description: Given the value extracted from the header is greater than this value, stop the stream.
+        type: number
+        examples:
+          - 3600
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -902,6 +902,12 @@ class WaitTimeFromHeader(BaseModel):
         examples=['([-+]?\\d+)'],
         title='Extraction Regex',
     )
+    max_waiting_time_in_seconds: Optional[float] = Field(
+        None,
+        description='Given the value extracted from the header is greater than this value, stop the stream.',
+        examples=[3600],
+        title='Max Waiting Time in Seconds',
+    )
     parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1201,7 +1201,7 @@ class ModelToComponentFactory:
             parameters=model.parameters or {},
             config=config,
             regex=model.regex,
-            max_waiting_time_in_seconds=model.max_waiting_time_in_seconds
+            max_waiting_time_in_seconds=model.max_waiting_time_in_seconds,
         )
 
     @staticmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1201,7 +1201,7 @@ class ModelToComponentFactory:
             parameters=model.parameters or {},
             config=config,
             regex=model.regex,
-            max_waiting_time_in_seconds=model.max_waiting_time_in_seconds,
+            max_waiting_time_in_seconds=model.max_waiting_time_in_seconds if model.max_waiting_time_in_seconds is not None else None,
         )
 
     @staticmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1196,7 +1196,13 @@ class ModelToComponentFactory:
 
     @staticmethod
     def create_wait_time_from_header(model: WaitTimeFromHeaderModel, config: Config, **kwargs: Any) -> WaitTimeFromHeaderBackoffStrategy:
-        return WaitTimeFromHeaderBackoffStrategy(header=model.header, parameters=model.parameters or {}, config=config, regex=model.regex)
+        return WaitTimeFromHeaderBackoffStrategy(
+            header=model.header,
+            parameters=model.parameters or {},
+            config=config,
+            regex=model.regex,
+            max_waiting_time_in_seconds=model.max_waiting_time_in_seconds
+        )
 
     @staticmethod
     def create_wait_until_time_from_header(

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
@@ -23,6 +23,7 @@ class WaitTimeFromHeaderBackoffStrategy(BackoffStrategy):
     Attributes:
         header (str): header to read wait time from
         regex (Optional[str]): optional regex to apply on the header to extract its value
+        max_waiting_time_in_seconds: (Optional[float]): given the value extracted from the header is greater than this value, stop the stream
     """
 
     header: Union[InterpolatedString, str]

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
@@ -7,11 +7,11 @@ from dataclasses import InitVar, dataclass
 from typing import Any, Mapping, Optional, Union
 
 import requests
-from airbyte_cdk.utils import AirbyteTracedException
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.requesters.error_handlers.backoff_strategies.header_helper import get_numeric_value_from_header
 from airbyte_cdk.sources.declarative.requesters.error_handlers.backoff_strategy import BackoffStrategy
 from airbyte_cdk.sources.types import Config
+from airbyte_cdk.utils import AirbyteTracedException
 from airbyte_protocol.models import FailureType
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategies/wait_time_from_header_backoff_strategy.py
@@ -48,7 +48,7 @@ class WaitTimeFromHeaderBackoffStrategy(BackoffStrategy):
             if self.max_waiting_time_in_seconds and header_value and header_value >= self.max_waiting_time_in_seconds:
                 raise AirbyteTracedException(
                     internal_message=f"Rate limit wait time {header_value} is greater than max waiting time of {self.max_waiting_time_in_seconds} seconds. Stopping the stream...",
-                    message=f"The rate limit is greater than max waiting time has been reached.",
+                    message="The rate limit is greater than max waiting time has been reached.",
                     failure_type=FailureType.transient_error,
                 )
         return header_value

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/error_handlers/backoff_strategies/test_wait_time_from_header.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/error_handlers/backoff_strategies/test_wait_time_from_header.py
@@ -5,12 +5,11 @@
 from unittest.mock import MagicMock
 
 import pytest
-from airbyte_protocol.models import FailureType
-
 from airbyte_cdk import AirbyteTracedException
 from airbyte_cdk.sources.declarative.requesters.error_handlers.backoff_strategies.wait_time_from_header_backoff_strategy import (
     WaitTimeFromHeaderBackoffStrategy,
 )
+from airbyte_protocol.models import FailureType
 from requests import Response
 
 SOME_BACKOFF_TIME = 60

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/error_handlers/backoff_strategies/test_wait_time_from_header.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/error_handlers/backoff_strategies/test_wait_time_from_header.py
@@ -5,12 +5,17 @@
 from unittest.mock import MagicMock
 
 import pytest
+from airbyte_protocol.models import FailureType
+
+from airbyte_cdk import AirbyteTracedException
 from airbyte_cdk.sources.declarative.requesters.error_handlers.backoff_strategies.wait_time_from_header_backoff_strategy import (
     WaitTimeFromHeaderBackoffStrategy,
 )
 from requests import Response
 
 SOME_BACKOFF_TIME = 60
+_A_RETRY_HEADER = "retry-header"
+_A_MAX_TIME = 100
 
 
 @pytest.mark.parametrize(
@@ -29,8 +34,27 @@ SOME_BACKOFF_TIME = 60
 def test_wait_time_from_header(test_name, header, header_value, regex, expected_backoff_time):
     response_mock = MagicMock(spec=Response)
     response_mock.headers = {"wait_time": header_value}
-    backoff_stratery = WaitTimeFromHeaderBackoffStrategy(
+    backoff_strategy = WaitTimeFromHeaderBackoffStrategy(
         header=header, regex=regex, parameters={"wait_time": "wait_time"}, config={"wait_time": "wait_time"}
     )
-    backoff = backoff_stratery.backoff_time(response_mock, 1)
+    backoff = backoff_strategy.backoff_time(response_mock, 1)
     assert backoff == expected_backoff_time
+
+
+def test_given_retry_after_smaller_than_max_time_then_raise_transient_error():
+    response_mock = MagicMock(spec=Response)
+    retry_after = _A_MAX_TIME - 1
+    response_mock.headers = {_A_RETRY_HEADER: str(retry_after)}
+    backoff_strategy = WaitTimeFromHeaderBackoffStrategy(header=_A_RETRY_HEADER, max_waiting_time_in_seconds=_A_MAX_TIME, parameters={}, config={})
+
+    assert backoff_strategy.backoff_time(response_mock, 1) == retry_after
+
+
+def test_given_retry_after_greater_than_max_time_then_raise_transient_error():
+    response_mock = MagicMock(spec=Response)
+    response_mock.headers = {_A_RETRY_HEADER: str(_A_MAX_TIME + 1)}
+    backoff_strategy = WaitTimeFromHeaderBackoffStrategy(header=_A_RETRY_HEADER, max_waiting_time_in_seconds=_A_MAX_TIME, parameters={}, config={})
+
+    with pytest.raises(AirbyteTracedException) as exception:
+        backoff_strategy.backoff_time(response_mock, 1)
+    assert exception.value.failure_type == FailureType.transient_error


### PR DESCRIPTION
## What
While increasing the airbyte-cdk version in pinterest, we found out that there is some duplicated logic where if the retry-after is bigger than a specific duration, we crash the stream:
* Klaviyo: https://github.com/airbytehq/airbyte/blob/d34d7e627a50d38c73fb85e27905737b2bac1677/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/components/klaviyo_backoff_strategy.py
* Pinterest: https://github.com/airbytehq/airbyte/blob/d34d7e627a50d38c73fb85e27905737b2bac1677/airbyte-integrations/connectors/source-pinterest/source_pinterest/streams.py#L89-L97

Hence, we are moving this logic in the CDK. The Klaviyo implemention can be removed in favor of:
```
    def get_backoff_strategy(self) -> BackoffStrategy:
        return WaitTimeFromHeaderBackoffStrategy(header="Retry-After", max_waiting_time_in_seconds=self.max_time, parameters={}, config={})
```

Discrepancies with the current Klaviyo implementation:
* `Retry-After` header will be honored whatever the HTTP status is if the response action is `RETRY`
* The error message is different and does not contain the name of the stream

## How
Adding `WaitTimeFromHeaderBackoffStrategy.max_waiting_time_in_seconds` and raising a transient exception if the retry after header is greater than this value.

## User Impact
source-klaviyo and source-pinterest can use `WaitTimeFromHeaderBackoffStrategy` to perform backoff strategies instead of having their own implementations

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
