### PR TITLE
auto-request reviewers for builder contributions

### DIFF
--- a/airbyte-ci/connectors/connector_ops/README.md
+++ b/airbyte-ci/connectors/connector_ops/README.md
@@ -37,6 +37,7 @@ poetry run pytest
 ```
 
 ## Changelog
+- 0.7.0: Added required reviewers for manifest-only connector changes/additions.
 - 0.6.1: Simplified gradle dependency discovery logic.
 - 0.6.0: Added manifest-only build.
 - 0.5.0: Added `cloud_usage` property to `Connector` class.

--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -2,14 +2,34 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 import yaml
 from connector_ops import utils
 
 # The breaking change reviewers is still in active use.
 BREAKING_CHANGE_REVIEWERS = {"breaking-change-reviewers"}
+CERTIFIED_MANIFEST_ONLY_CONNECTOR_REVIEWERS = {"dev-python"}
+COMMUNITY_MANIFEST_ONLY_CONNECTOR_REVIEWERS = {"dev-marketplace-contributions"}
 REVIEW_REQUIREMENTS_FILE_PATH = ".github/connector_org_review_requirements.yaml"
+
+
+def find_changed_manifest_only_connectors(support_level: str) -> Set[utils.Connector]:
+    """Find manifest-only connectors modified on the current branch for a given support level.
+
+    Args:
+        support_level (str): The support level of the connectors to find.
+    Returns:
+        Set[utils.Connector]: The set of manifest-only connectors that were modified on the current branch
+        and match the provided support level, if provided.
+    """
+    changed_connectors = utils.get_changed_connectors()
+    manifest_only_connectors = {
+        connector for connector in changed_connectors if connector.language == utils.ConnectorLanguage.MANIFEST_ONLY
+    }
+    if support_level:
+        return {connector for connector in manifest_only_connectors if connector.support_level == support_level}
+    return manifest_only_connectors
 
 
 def find_mandatory_reviewers() -> List[Dict[str, Union[str, Dict[str, List]]]]:
@@ -18,6 +38,16 @@ def find_mandatory_reviewers() -> List[Dict[str, Union[str, Dict[str, List]]]]:
             "name": "Breaking changes",
             "teams": list(BREAKING_CHANGE_REVIEWERS),
             "is_required": utils.get_changed_metadata(diff_regex="upgradeDeadline"),
+        },
+        {
+            "name": "Manifest-only certified connectors",
+            "teams": ["certified-connector-reviewers"],
+            "is_required": find_changed_manifest_only_connectors(support_level="certified"),
+        },
+        {
+            "name": "Manifest-only community connectors",
+            "teams": ["standard-connector-reviewers"],
+            "is_required": find_changed_manifest_only_connectors(support_level="community"),
         },
     ]
 

--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -41,12 +41,12 @@ def find_mandatory_reviewers() -> List[Dict[str, Union[str, Dict[str, List]]]]:
         },
         {
             "name": "Manifest-only certified connectors",
-            "teams": ["certified-connector-reviewers"],
+            "teams": list(CERTIFIED_MANIFEST_ONLY_CONNECTOR_REVIEWERS),
             "is_required": find_changed_manifest_only_connectors(support_level="certified"),
         },
         {
             "name": "Manifest-only community connectors",
-            "teams": ["standard-connector-reviewers"],
+            "teams": list(COMMUNITY_MANIFEST_ONLY_CONNECTOR_REVIEWERS),
             "is_required": find_changed_manifest_only_connectors(support_level="community"),
         },
     ]

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector_ops"
-version = "0.6.1"
+version = "0.7.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
* Close https://github.com/airbytehq/airbyte-internal-issues/issues/8600
* Auto-request either the marketplace team or the python team on builder contributions

## How
<!--
* Describe how code changes achieve the solution.
-->
* For any PR that affects a manifest-only connector (does not distinguish between builder contributions and regular PRs), if the connector is certified, request a review from the python team. if it is community, request a review from the marketplace team. 

## Other
I've created a new connector's metadata file. If it works as expected it should request the marketplace team 🤞🏻 
- [ ] TODO: remove added metadata file

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
