### PR TITLE
🐛 [source-klaviyo] Add config option disable_fetching_predictive_analytics to prevent 503 Service Unavailable errors

### DIFF
--- a/airbyte-integrations/connectors/source-klaviyo/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-klaviyo/acceptance-test-config.yml
@@ -32,8 +32,5 @@ acceptance_tests:
           future_state_path: integration_tests/abnormal_state.json
         skip_comprehensive_incremental_tests: true
         timeout_seconds: 7200
-  spec:
-    tests:
-      - spec_path: source_klaviyo/spec.json
 connector_image: airbyte/source-klaviyo:dev
 test_strictness_level: high

--- a/airbyte-integrations/connectors/source-klaviyo/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-klaviyo/acceptance-test-config.yml
@@ -32,5 +32,8 @@ acceptance_tests:
           future_state_path: integration_tests/abnormal_state.json
         skip_comprehensive_incremental_tests: true
         timeout_seconds: 7200
+  spec:
+    tests:
+      - spec_path: source_klaviyo/spec.json
 connector_image: airbyte/source-klaviyo:dev
 test_strictness_level: high

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -8,7 +8,7 @@ data:
   definitionId: 95e8cffd-b8c4-4039-968e-d32fb4a69bde
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
-  dockerImageTag: 2.8.1
+  dockerImageTag: 2.8.2
   dockerRepository: airbyte/source-klaviyo
   githubIssueLabel: source-klaviyo
   icon: klaviyo.svg

--- a/airbyte-integrations/connectors/source-klaviyo/pyproject.toml
+++ b/airbyte-integrations/connectors/source-klaviyo/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.8.1"
+version = "2.8.2"
 name = "source-klaviyo"
 description = "Source implementation for Klaviyo."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/manifest.yaml
@@ -87,7 +87,7 @@ definitions:
         Accept: "application/json"
         Revision: "2023-02-22"
       request_parameters:
-        "additional-fields[profile]": "predictive_analytics"
+        "additional-fields[profile]": "{{ 'predictive_analytics' if not config['disable_fetching_predictive_analytics'] else '' }}"
 
   # Base streams
   base_stream:
@@ -919,17 +919,26 @@ spec:
     type: object
     properties:
       api_key:
+        type: string
         title: "Api Key"
         description: 'Klaviyo API Key. See our <a href="https://docs.airbyte.com/integrations/sources/klaviyo">docs</a> if you need help finding this key.'
         airbyte_secret: true
-        type: string
         order: 0
       start_date:
+        type: string
         title: "Start Date"
         description: "UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated. This field is optional - if not provided, all data will be replicated."
         pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
         examples: ["2017-01-25T00:00:00Z"]
-        type: "string"
-        format: "date-time"
+        format: date-time
         order: 1
+      disable_fetching_predictive_analytics:
+        type: boolean
+        title: "Disable Fetching Predictive Analytics"
+        description: >-
+          Certain streams like the profiles stream can retrieve predictive analytics data from Klaviyo's
+          API. However, at high volume, this can lead to service availability issues on the API which can
+          be improved by not fetching this field. WARNING: Enabling this setting will stop the 
+          "predictive_analytics" column from being populated in your downstream destination.
+        order: 2
     required: ["api_key"]

--- a/airbyte-integrations/connectors/source-klaviyo/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-klaviyo/unit_tests/test_streams.py
@@ -283,9 +283,21 @@ class TestSemiIncrementalKlaviyoStream:
 
 
 class TestProfilesStream:
-    def test_request_params(self):
-        stream = get_stream_by_name("profiles", CONFIG)
-        assert stream.retriever.requester.get_request_params() == {"additional-fields[profile]": "predictive_analytics"}
+
+    @pytest.mark.parametrize(
+        "disable_predictive_analytics, expected_additional_fields",
+        [
+            pytest.param(False, {"additional-fields[profile]": "predictive_analytics"}, id="test_config_with_disable_fetching_predictive_analytics"),
+            pytest.param(True, {}, id="test_config_with_disable_fetching_predictive_analytics_turned_on")
+        ]
+    )
+    def test_request_params(self, disable_predictive_analytics, expected_additional_fields):
+        if disable_predictive_analytics:
+            config = {"disable_fetching_predictive_analytics": True} | CONFIG
+        else:
+            config = CONFIG
+        stream = get_stream_by_name("profiles", config)
+        assert stream.retriever.requester.get_request_params() == expected_additional_fields
 
     def test_read_records(self, requests_mock):
         stream = get_stream_by_name("profiles", CONFIG)

--- a/docs/integrations/sources/klaviyo.md
+++ b/docs/integrations/sources/klaviyo.md
@@ -53,11 +53,18 @@ The connector is restricted by Klaviyo [requests limitation](https://apidocs.kla
 
 The Klaviyo connector should not run into Klaviyo API limitations under normal usage. [Create an issue](https://github.com/airbytehq/airbyte/issues) if you encounter any rate limit issues that are not automatically retried successfully.
 
-Stream `Campaigns Detailed` contains fields `estimated_recipient_count` and `campaign_message` in addition to info from the `Campaigns` stream. Additional time is needed to fetch extra data.
+The `Campaigns Detailed` stream contains fields `estimated_recipient_count` and `campaign_message` in addition to info from the `Campaigns` stream. Additional time is needed to fetch extra data.
 
-Stream `Lists Detailed` contains field `profile_count` in addition to info from the `Lists` stream. Additional time is needed to fetch extra data due to Klaviyo API [limitation](https://developers.klaviyo.com/en/reference/get_list).
+The `Lists Detailed` stream contains field `profile_count` in addition to info from the `Lists` stream. Additional time is needed to fetch extra data due to Klaviyo API [limitation](https://developers.klaviyo.com/en/reference/get_list).
 
-Stream `Events Detailed` contains field `name` for `metric` relationship - addition to [info](https://developers.klaviyo.com/en/reference/get_event).
+The `Events Detailed` stream contains field `name` for `metric` relationship - addition to [info](https://developers.klaviyo.com/en/reference/get_event).
+
+The `Profiles` stream can experience transient API errors under heavy load. In order to mitigate this, you can use the "Disable Fetching Predictive Analytics" setting to improve the success rate of syncs.
+
+:::warning
+Using the "Disable Fetching Predictive Analytics" will stop records on the Profiles stream will no longer
+contain the `predictive_analytics` field and workflows depending on this field will stop working.
+:::
 
 ## Data type map
 
@@ -75,41 +82,42 @@ Stream `Events Detailed` contains field `name` for `metric` relationship - addit
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                       |
 |:--------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------|
-| 2.8.1 | 2024-07-27 | [42664](https://github.com/airbytehq/airbyte/pull/42664) | Update dependencies |
-| 2.8.0   | 2024-07-19 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX)   | Migrate to CDK v3.9.0 |
-| 2.7.8 | 2024-07-20 | [42185](https://github.com/airbytehq/airbyte/pull/42185) | Update dependencies |
-| 2.7.7 | 2024-07-08 | [40608](https://github.com/airbytehq/airbyte/pull/40608) | Update the `events_detailed` stream to improve efficiency using the events API |
-| 2.7.6 | 2024-07-13 | [41903](https://github.com/airbytehq/airbyte/pull/41903) | Update dependencies |
-| 2.7.5 | 2024-07-10 | [41548](https://github.com/airbytehq/airbyte/pull/41548) | Update dependencies |
-| 2.7.4 | 2024-07-09 | [41211](https://github.com/airbytehq/airbyte/pull/41211) | Update dependencies |
-| 2.7.3 | 2024-07-06 | [40770](https://github.com/airbytehq/airbyte/pull/40770) | Update dependencies |
-| 2.7.2 | 2024-06-26 | [40401](https://github.com/airbytehq/airbyte/pull/40401) | Update dependencies |
-| 2.7.1 | 2024-06-22 | [40032](https://github.com/airbytehq/airbyte/pull/40032) | Update dependencies |
-| 2.7.0 | 2024-06-08 | [39350](https://github.com/airbytehq/airbyte/pull/39350) | Add `events_detailed` stream |
-| 2.6.4 | 2024-06-06 | [38879](https://github.com/airbytehq/airbyte/pull/38879) | Implement `CheckpointMixin` for handling state in Python streams |
-| 2.6.3 | 2024-06-04 | [38935](https://github.com/airbytehq/airbyte/pull/38935) | [autopull] Upgrade base image to v1.2.1 |
-| 2.6.2 | 2024-05-08 | [37789](https://github.com/airbytehq/airbyte/pull/37789) | Move stream schemas and spec to manifest |
-| 2.6.1 | 2024-05-07 | [38010](https://github.com/airbytehq/airbyte/pull/38010) | Add error handler for `5XX` status codes |
-| 2.6.0 | 2024-04-19 | [37370](https://github.com/airbytehq/airbyte/pull/37370) | Add streams `campaigns_detailed` and `lists_detailed` |
-| 2.5.0 | 2024-04-15 | [36264](https://github.com/airbytehq/airbyte/pull/36264) | Migrate to low-code |
-| 2.4.0 | 2024-04-11 | [36989](https://github.com/airbytehq/airbyte/pull/36989) | Update `Campaigns` schema |
-| 2.3.0 | 2024-03-19 | [36267](https://github.com/airbytehq/airbyte/pull/36267) | Pin airbyte-cdk version to `^0` |
-| 2.2.0 | 2024-02-27 | [35637](https://github.com/airbytehq/airbyte/pull/35637) | Fix `predictive_analytics` field in stream `profiles` |
-| 2.1.3 | 2024-02-15 | [35336](https://github.com/airbytehq/airbyte/pull/35336) | Added type transformer for the `profiles` stream. |
-| 2.1.2 | 2024-02-09 | [35088](https://github.com/airbytehq/airbyte/pull/35088) | Manage dependencies with Poetry. |
-| 2.1.1 | 2024-02-07 | [34998](https://github.com/airbytehq/airbyte/pull/34998) | Add missing fields to stream schemas |
-| 2.1.0 | 2023-12-07 | [33237](https://github.com/airbytehq/airbyte/pull/33237) | Continue syncing streams even when one of the stream fails |
-| 2.0.2 | 2023-12-05 | [33099](https://github.com/airbytehq/airbyte/pull/33099) | Fix filtering for archived records stream |
-| 2.0.1 | 2023-11-08 | [32291](https://github.com/airbytehq/airbyte/pull/32291) | Add logic to have regular checkpointing schedule |
-| 2.0.0 | 2023-11-03 | [32128](https://github.com/airbytehq/airbyte/pull/32128) | Use the latest API for streams `campaigns`, `email_templates`, `events`, `flows`, `global_exclusions`, `lists`, and `metrics` |
-| 1.1.0 | 2023-10-23 | [31710](https://github.com/airbytehq/airbyte/pull/31710) | Make `start_date` config field optional |
-| 1.0.0 | 2023-10-18 | [31565](https://github.com/airbytehq/airbyte/pull/31565) | Add new known fields for 'events' stream |
-| 0.5.0 | 2023-10-19 | [31611](https://github.com/airbytehq/airbyte/pull/31611) | Add `date-time` format for `datetime` field in `Events` stream |
-| 0.4.0 | 2023-10-18 | [31562](https://github.com/airbytehq/airbyte/pull/31562) | Add `archived` field to `Flows` stream |
-| 0.3.3 | 2023-10-13 | [31379](https://github.com/airbytehq/airbyte/pull/31379) | Skip streams that the connector no longer has access to |
-| 0.3.2 | 2023-06-20 | [27498](https://github.com/airbytehq/airbyte/pull/27498) | Do not store state in the future |
-| 0.3.1 | 2023-06-08 | [27162](https://github.com/airbytehq/airbyte/pull/27162) | Anonymize check connection error message |
-| 0.3.0 | 2023-02-18 | [23236](https://github.com/airbytehq/airbyte/pull/23236) | Add ` Email Templates` stream |
+| 2.8.2   | 2024-07-31 | [42895](https://github.com/airbytehq/airbyte/pull/42895)   | Add config option disable_fetching_predictive_analytics to prevent 503 Service Unavailable errors                             |
+| 2.8.1   | 2024-07-27 | [42664](https://github.com/airbytehq/airbyte/pull/42664)   | Update dependencies                                                                                                           |
+| 2.8.0   | 2024-07-19 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX)   | Migrate to CDK v3.9.0                                                                                                         |
+| 2.7.8   | 2024-07-20 | [42185](https://github.com/airbytehq/airbyte/pull/42185)   | Update dependencies                                                                                                           |
+| 2.7.7   | 2024-07-08 | [40608](https://github.com/airbytehq/airbyte/pull/40608)   | Update the `events_detailed` stream to improve efficiency using the events API                                                |
+| 2.7.6   | 2024-07-13 | [41903](https://github.com/airbytehq/airbyte/pull/41903)   | Update dependencies                                                                                                           |
+| 2.7.5   | 2024-07-10 | [41548](https://github.com/airbytehq/airbyte/pull/41548)   | Update dependencies                                                                                                           |
+| 2.7.4   | 2024-07-09 | [41211](https://github.com/airbytehq/airbyte/pull/41211)   | Update dependencies                                                                                                           |
+| 2.7.3   | 2024-07-06 | [40770](https://github.com/airbytehq/airbyte/pull/40770)   | Update dependencies                                                                                                           |
+| 2.7.2   | 2024-06-26 | [40401](https://github.com/airbytehq/airbyte/pull/40401)   | Update dependencies                                                                                                           |
+| 2.7.1   | 2024-06-22 | [40032](https://github.com/airbytehq/airbyte/pull/40032)   | Update dependencies                                                                                                           |
+| 2.7.0   | 2024-06-08 | [39350](https://github.com/airbytehq/airbyte/pull/39350)   | Add `events_detailed` stream                                                                                                  |
+| 2.6.4   | 2024-06-06 | [38879](https://github.com/airbytehq/airbyte/pull/38879)   | Implement `CheckpointMixin` for handling state in Python streams                                                              |
+| 2.6.3   | 2024-06-04 | [38935](https://github.com/airbytehq/airbyte/pull/38935)   | [autopull] Upgrade base image to v1.2.1                                                                                       |
+| 2.6.2   | 2024-05-08 | [37789](https://github.com/airbytehq/airbyte/pull/37789)   | Move stream schemas and spec to manifest                                                                                      |
+| 2.6.1   | 2024-05-07 | [38010](https://github.com/airbytehq/airbyte/pull/38010)   | Add error handler for `5XX` status codes                                                                                      |
+| 2.6.0   | 2024-04-19 | [37370](https://github.com/airbytehq/airbyte/pull/37370)   | Add streams `campaigns_detailed` and `lists_detailed`                                                                         |
+| 2.5.0   | 2024-04-15 | [36264](https://github.com/airbytehq/airbyte/pull/36264)   | Migrate to low-code                                                                                                           |
+| 2.4.0   | 2024-04-11 | [36989](https://github.com/airbytehq/airbyte/pull/36989)   | Update `Campaigns` schema                                                                                                     |
+| 2.3.0   | 2024-03-19 | [36267](https://github.com/airbytehq/airbyte/pull/36267)   | Pin airbyte-cdk version to `^0`                                                                                               |
+| 2.2.0   | 2024-02-27 | [35637](https://github.com/airbytehq/airbyte/pull/35637)   | Fix `predictive_analytics` field in stream `profiles`                                                                         |
+| 2.1.3   | 2024-02-15 | [35336](https://github.com/airbytehq/airbyte/pull/35336)   | Added type transformer for the `profiles` stream.                                                                             |
+| 2.1.2   | 2024-02-09 | [35088](https://github.com/airbytehq/airbyte/pull/35088)   | Manage dependencies with Poetry.                                                                                              |
+| 2.1.1   | 2024-02-07 | [34998](https://github.com/airbytehq/airbyte/pull/34998)   | Add missing fields to stream schemas                                                                                          |
+| 2.1.0   | 2023-12-07 | [33237](https://github.com/airbytehq/airbyte/pull/33237)   | Continue syncing streams even when one of the stream fails                                                                    |
+| 2.0.2   | 2023-12-05 | [33099](https://github.com/airbytehq/airbyte/pull/33099)   | Fix filtering for archived records stream                                                                                     |
+| 2.0.1   | 2023-11-08 | [32291](https://github.com/airbytehq/airbyte/pull/32291)   | Add logic to have regular checkpointing schedule                                                                              |
+| 2.0.0   | 2023-11-03 | [32128](https://github.com/airbytehq/airbyte/pull/32128)   | Use the latest API for streams `campaigns`, `email_templates`, `events`, `flows`, `global_exclusions`, `lists`, and `metrics` |
+| 1.1.0   | 2023-10-23 | [31710](https://github.com/airbytehq/airbyte/pull/31710)   | Make `start_date` config field optional                                                                                       |
+| 1.0.0   | 2023-10-18 | [31565](https://github.com/airbytehq/airbyte/pull/31565)   | Add new known fields for 'events' stream                                                                                      |
+| 0.5.0   | 2023-10-19 | [31611](https://github.com/airbytehq/airbyte/pull/31611)   | Add `date-time` format for `datetime` field in `Events` stream                                                                |
+| 0.4.0   | 2023-10-18 | [31562](https://github.com/airbytehq/airbyte/pull/31562)   | Add `archived` field to `Flows` stream                                                                                        |
+| 0.3.3   | 2023-10-13 | [31379](https://github.com/airbytehq/airbyte/pull/31379)   | Skip streams that the connector no longer has access to                                                                       |
+| 0.3.2   | 2023-06-20 | [27498](https://github.com/airbytehq/airbyte/pull/27498)   | Do not store state in the future                                                                                              |
+| 0.3.1   | 2023-06-08 | [27162](https://github.com/airbytehq/airbyte/pull/27162)   | Anonymize check connection error message                                                                                      |
+| 0.3.0   | 2023-02-18 | [23236](https://github.com/airbytehq/airbyte/pull/23236)   | Add ` Email Templates` stream                                                                                                 |
 | 0.2.0   | 2023-03-13 | [22942](https://github.com/airbytehq/airbyte/pull/23968)   | Add `Profiles` stream                                                                                                         |
 | 0.1.13  | 2023-02-13 | [22942](https://github.com/airbytehq/airbyte/pull/22942)   | Specified date formatting in specification                                                                                    |
 | 0.1.12  | 2023-01-30 | [22071](https://github.com/airbytehq/airbyte/pull/22071)   | Fix `Events` stream schema                                                                                                    |


### PR DESCRIPTION
Fixes https://github.com/airbytehq/oncall/issues/6085

## What

We have had reports that syncs to the Klaviyo source's `profiles` stream were consistently failing with `service unavailable` errors. I confirmed that this is not a problem with our connector and the errors are being emitted by Klaviyo's API. We are properly handling the error and propagating it back.

However, in talks with Klaviyo, we've learned that this endpoint can be unstable due to the `additional-fields[profile]: predictive_analytics` parameter. I've been able to validate the fix locally

## How

Removing the request parameter entirely would be a breaking change because it would stop sending the `predictive_analytics` field data for the `profiles` schema. And given that this likely only happens under a high load, I presume that a majority customers won't run into this issue. Hence why I made this opt in.

## User Impact

Because the field is opt in, this should not affect existing syncs. But customers can now enable this setting. Depending on their workflow, this could be considered breaking, but given the opt in nature, this can be a minor bump

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
