### PR TITLE
✨ Source Paystack: add `reference` field to `Transfers` stream

### DIFF
--- a/airbyte-integrations/connectors/source-paystack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paystack/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 193bdcb8-1dd9-48d1-aade-91cadfd74f9b
-  dockerImageTag: 1.0.7
+  dockerImageTag: 1.0.8
   dockerRepository: airbyte/source-paystack
   githubIssueLabel: source-paystack
   icon: paystack.svg

--- a/airbyte-integrations/connectors/source-paystack/pyproject.toml
+++ b/airbyte-integrations/connectors/source-paystack/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.0.7"
+version = "1.0.8"
 name = "source-paystack"
 description = "Source implementation for paystack."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-paystack/source_paystack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paystack/source_paystack/manifest.yaml
@@ -1,4 +1,4 @@
-version: 1.3.2
+version: 1.3.1
 
 type: DeclarativeSource
 

--- a/airbyte-integrations/connectors/source-paystack/source_paystack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paystack/source_paystack/manifest.yaml
@@ -1,4 +1,4 @@
-version: 1.3.1
+version: 1.3.2
 
 type: DeclarativeSource
 
@@ -1341,6 +1341,10 @@ schemas:
           - "null"
           - integer
       reason:
+        type:
+          - "null"
+          - string
+      reference:
         type:
           - "null"
           - string

--- a/docs/integrations/sources/paystack.md
+++ b/docs/integrations/sources/paystack.md
@@ -68,6 +68,7 @@ The Paystack connector should not run into Paystack API limitations under normal
 
 | Version | Date       | Pull Request                                             | Subject                                                        |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------- |
+| 1.0.8 | 2024-07-31 | [42655](https://github.com/airbytehq/airbyte/pull/42655) | Update dependencies |
 | 1.0.7 | 2024-07-27 | [42655](https://github.com/airbytehq/airbyte/pull/42655) | Update dependencies |
 | 1.0.6 | 2024-07-20 | [42323](https://github.com/airbytehq/airbyte/pull/42323) | Update dependencies |
 | 1.0.5 | 2024-07-13 | [41694](https://github.com/airbytehq/airbyte/pull/41694) | Update dependencies |

--- a/docs/integrations/sources/paystack.md
+++ b/docs/integrations/sources/paystack.md
@@ -68,7 +68,7 @@ The Paystack connector should not run into Paystack API limitations under normal
 
 | Version | Date       | Pull Request                                             | Subject                                                        |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------- |
-| 1.0.8 | 2024-07-31 | [42655](https://github.com/airbytehq/airbyte/pull/42655) | Update dependencies |
+| 1.0.8 | 2024-07-31 | [4290](https://github.com/airbytehq/airbyte/pull/42901) |  New field added for `transfers` stream |
 | 1.0.7 | 2024-07-27 | [42655](https://github.com/airbytehq/airbyte/pull/42655) | Update dependencies |
 | 1.0.6 | 2024-07-20 | [42323](https://github.com/airbytehq/airbyte/pull/42323) | Update dependencies |
 | 1.0.5 | 2024-07-13 | [41694](https://github.com/airbytehq/airbyte/pull/41694) | Update dependencies |

--- a/docs/integrations/sources/paystack.md
+++ b/docs/integrations/sources/paystack.md
@@ -68,7 +68,7 @@ The Paystack connector should not run into Paystack API limitations under normal
 
 | Version | Date       | Pull Request                                             | Subject                                                        |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------- |
-| 1.0.8 | 2024-07-31 | [4290](https://github.com/airbytehq/airbyte/pull/42901) |  New field added for `transfers` stream |
+| 1.0.8 | 2024-07-31 | [42901](https://github.com/airbytehq/airbyte/pull/42901) |  New field added for `transfers` stream |
 | 1.0.7 | 2024-07-27 | [42655](https://github.com/airbytehq/airbyte/pull/42655) | Update dependencies |
 | 1.0.6 | 2024-07-20 | [42323](https://github.com/airbytehq/airbyte/pull/42323) | Update dependencies |
 | 1.0.5 | 2024-07-13 | [41694](https://github.com/airbytehq/airbyte/pull/41694) | Update dependencies |


### PR DESCRIPTION
## What
The Paystack API has a field `reference` available for `Transfers` which is currently not mapped in the connector. This field provides relevant information for the transfers and should be available for users to use.

## How
Added the new field `reference` to the `Transfers` stream, so it's now available for fetch.

## Review guide

## User Impact
New field available for affected stream

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
