### PR TITLE
airbyte-ci: always couple selection of strict-encrypt variants (e vice versa)

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -773,6 +773,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.28.0  | [#42849](https://github.com/airbytehq/airbyte/pull/42849)  | Couple selection of strict-encrypt variants (e vice versa)                                                                   |
 | 4.27.0  | [#42574](https://github.com/airbytehq/airbyte/pull/42574)  | Live tests: run from connectors test pipeline for connectors with sandbox connections                                        |
 | 4.26.1  | [#42905](https://github.com/airbytehq/airbyte/pull/42905)  | Rename the docker cache volume to avoid using the corrupted previous volume.                                                 |
 | 4.26.0  | [#42849](https://github.com/airbytehq/airbyte/pull/42849)  | Send publish failures messages to `#connector-publish-failures`                                                              |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/commands.py
@@ -32,7 +32,7 @@ def log_selected_connectors(selected_connectors_with_modified_files: List[Connec
         main_logger.info("No connectors to run.")
 
 
-def get_base_connector_and_variants(connector: Connector):
+def get_base_connector_and_variants(connector: Connector) -> Set[Connector]:
     base_connector_path = connector.relative_connector_path.replace("-strict-encrypt", "")
     base_connector = Connector(base_connector_path)
     strict_encrypt_connector_path = f"{base_connector.relative_connector_path}-strict-encrypt"

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.27.0"
+version = "4.28.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_commands/test_groups/test_connectors.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_commands/test_groups/test_connectors.py
@@ -14,7 +14,7 @@ from pipelines.airbyte_ci.connectors.publish import commands as connectors_publi
 from pipelines.airbyte_ci.connectors.test import commands as connectors_test_command
 from pipelines.helpers.connectors.modifed import ConnectorWithModifiedFiles
 from pipelines.models.secrets import InMemorySecretStore
-from tests.utils import pick_a_random_connector
+from tests.utils import pick_a_random_connector, pick_a_strict_encrypt_variant_pair
 
 
 @pytest.fixture(scope="session")
@@ -225,6 +225,40 @@ def test_get_selected_connectors_with_metadata_query():
     assert isinstance(selected_connectors[0], ConnectorWithModifiedFiles)
     assert selected_connectors[0].technical_name == connector.technical_name
     assert not selected_connectors[0].modified_files
+
+
+def test_strict_encrypt_variant_is_selected():
+    main_connector, strict_encrypt_variant = pick_a_strict_encrypt_variant_pair()
+    selected_connectors = connectors_commands.get_selected_connectors_with_modified_files(
+        selected_names=(main_connector.technical_name,),
+        selected_support_levels=(),
+        selected_languages=(),
+        modified=False,
+        metadata_changes_only=False,
+        metadata_query=None,
+        modified_files={},
+    )
+    assert len(selected_connectors) == 2
+    selected_names = [c.technical_name for c in selected_connectors]
+    assert main_connector.technical_name in selected_names
+    assert strict_encrypt_variant.technical_name in selected_names
+
+
+def test_main_connector_selected_when_variant_is_selected():
+    main_connector, strict_encrypt_variant = pick_a_strict_encrypt_variant_pair()
+    selected_connectors = connectors_commands.get_selected_connectors_with_modified_files(
+        selected_names=(strict_encrypt_variant.technical_name,),
+        selected_support_levels=(),
+        selected_languages=(),
+        modified=False,
+        metadata_changes_only=False,
+        metadata_query=None,
+        modified_files={},
+    )
+    assert len(selected_connectors) == 2
+    selected_names = [c.technical_name for c in selected_connectors]
+    assert main_connector.technical_name in selected_names
+    assert strict_encrypt_variant.technical_name in selected_names
 
 
 @pytest.fixture()

--- a/airbyte-ci/connectors/pipelines/tests/utils.py
+++ b/airbyte-ci/connectors/pipelines/tests/utils.py
@@ -21,10 +21,16 @@ class MockContainerClass:
 
 
 def pick_a_random_connector(
-    language: ConnectorLanguage = None, support_level: str = None, other_picked_connectors: list = None
+    language: ConnectorLanguage = None,
+    support_level: str = None,
+    other_picked_connectors: list = None,
+    ignore_strict_encrypt_variants: bool = True,
 ) -> Connector:
     """Pick a random connector from the list of all connectors."""
-    all_connectors = [c for c in list(ALL_CONNECTORS)]
+    if not ignore_strict_encrypt_variants:
+        all_connectors = [c for c in list(ALL_CONNECTORS)]
+    else:
+        all_connectors = [c for c in list(ALL_CONNECTORS) if "-strict-encrypt" not in c.technical_name]
     if language:
         all_connectors = [c for c in all_connectors if c.language is language]
     if support_level:
@@ -34,6 +40,13 @@ def pick_a_random_connector(
         while picked_connector in other_picked_connectors:
             picked_connector = random.choice(all_connectors)
     return picked_connector
+
+
+def pick_a_strict_encrypt_variant_pair():
+    for c in ALL_CONNECTORS:
+        if c.technical_name.endswith("-strict-encrypt"):
+            main_connector = Connector(c.relative_connector_path.replace("-strict-encrypt", ""))
+            return main_connector, c
 
 
 def mock_container():


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/42530
We want to make sure that when a connector which has a variant is selected the variant is also selected. E vice versa.

## How
* Sightly change the logic of `get_selected_connectors_with_modified_files`
* Add new unit tests 

It works: 

<img width="1266" alt="Screenshot 2024-07-31 at 14 02 24" src="https://github.com/user-attachments/assets/b55ac45b-673f-4e45-8f5b-b69e5caaed13">



