### PR TITLE
Replace GCP CredentialsPath with CredentialsJson

### DIFF
--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -373,7 +373,7 @@ global:
       workloadOutput: airbyte-bucket
     gcs:
       projectId: <project-id>
-      credentialsPath: /secrets/gcs-log-creds/gcp.json
+      credentialsJson: #Base64 encoded value of the gcp.json file
 ```
 
 </TabItem>


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Replace credentialsPath with credentialsJson as customers are being impacted when they do not input any values in credentialsJson

## How
<!--
* Describe how code changes achieve the solution.
-->

credentialsPath exists to control the mount point, but we also have a default path where we mount it. Therefore, this should be optional for users, not a requirement. credentialsJson is the actual content that will be placed into the file mounted at credentialsPath.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
