### PR TITLE
docs: update the security document to link to the Authentication page and remove reference to docker compose

### DIFF
--- a/docs/operating-airbyte/security.md
+++ b/docs/operating-airbyte/security.md
@@ -60,13 +60,8 @@ You can secure access to Airbyte using the following methods:
     }
   }
   ```
-- _Only for docker compose deployments:_ Change the default username and password in your environment's `.env` file:
-  ```
-  	# Proxy Configuration
-  	# Set to empty values, e.g. "" to disable basic auth
-  	BASIC_AUTH_USERNAME=your_new_username_here
-  	BASIC_AUTH_PASSWORD=your_new_password_here
-  ```
+- Change the default password by following the instructions [here](deploying-airbyte/integrations/authentication)
+
 - If you deployed Airbyte on a cloud provider:
   - GCP: use the [Identity-Aware proxy](https://cloud.google.com/iap) service
   - AWS: use the [AWS Systems Manager Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html) service

--- a/docs/operating-airbyte/security.md
+++ b/docs/operating-airbyte/security.md
@@ -60,7 +60,7 @@ You can secure access to Airbyte using the following methods:
     }
   }
   ```
-- Change the default password by following the instructions [here](deploying-airbyte/integrations/authentication)
+- Change the default password by following the instructions [here](../deploying-airbyte/integrations/authentication)
 
 - If you deployed Airbyte on a cloud provider:
   - GCP: use the [Identity-Aware proxy](https://cloud.google.com/iap) service

--- a/docs/operating-airbyte/security.md
+++ b/docs/operating-airbyte/security.md
@@ -61,7 +61,7 @@ You can secure access to Airbyte using the following methods:
   }
   ```
 - By default, Airbyte generates a secure password during a deploy (either via Helm or `abctl`). To change the default 
-password by following the instructions [here](../deploying-airbyte/integrations/authentication)
+password follow the instructions found [here](../deploying-airbyte/integrations/authentication)
 
 - If you deployed Airbyte on a cloud provider:
   - GCP: use the [Identity-Aware proxy](https://cloud.google.com/iap) service

--- a/docs/operating-airbyte/security.md
+++ b/docs/operating-airbyte/security.md
@@ -60,7 +60,8 @@ You can secure access to Airbyte using the following methods:
     }
   }
   ```
-- Change the default password by following the instructions [here](../deploying-airbyte/integrations/authentication)
+- By default, Airbyte generates a secure password during a deploy (either via Helm or `abctl`). To change the default 
+password by following the instructions [here](../deploying-airbyte/integrations/authentication)
 
 - If you deployed Airbyte on a cloud provider:
   - GCP: use the [Identity-Aware proxy](https://cloud.google.com/iap) service


### PR DESCRIPTION
## What
Update the security document to link to the Authentication page and remove reference to docker compose.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
