### PR TITLE
airbyte-ci: retry publish on failure

### DIFF
--- a/.github/actions/run-airbyte-ci/action.yml
+++ b/.github/actions/run-airbyte-ci/action.yml
@@ -87,6 +87,15 @@ inputs:
     description: "Whether the PR is from a fork"
     required: false
     default: "false"
+  max_attempts:
+    description: "Number of attempts at running the airbyte-ci command"
+    required: false
+    default: 1
+  retry_wait_seconds:
+    description: "Number of seconds to wait between retry attempts"
+    required: false
+    default: 60
+
 runs:
   using: "composite"
   steps:
@@ -109,7 +118,7 @@ runs:
         is_fork: ${{ inputs.is_fork }}
     - name: Run airbyte-ci
       id: run-airbyte-ci
-      shell: bash
+      uses: nick-fields/retry@v3
       env:
         CI: "True"
         CI_GIT_USER: ${{ github.repository_owner }}
@@ -140,8 +149,14 @@ runs:
         SLACK_WEBHOOK: ${{ inputs.slack_webhook_url }}
         SPEC_CACHE_BUCKET_NAME: ${{ inputs.spec_cache_bucket_name }}
         SPEC_CACHE_GCS_CREDENTIALS: ${{ inputs.spec_cache_gcs_credentials }}
-      run: |
-        airbyte-ci --disable-update-check --disable-dagger-run --is-ci --gha-workflow-run-id=${{ github.run_id }} ${{ inputs.subcommand }} ${{ inputs.options }}
+      with:
+        shell: bash
+        max_attempts: ${{ inputs.max_attempts }}
+        retry_wait_seconds: ${{ inputs.retry_wait_seconds }}
+        # 360mn > 6 hours: it's the GitHub runner max job duration
+        timeout_minutes: 360
+        command: |
+          airbyte-ci --disable-update-check --disable-dagger-run --is-ci --gha-workflow-run-id=${{ github.run_id }} ${{ inputs.subcommand }} ${{ inputs.options }}
     - name: Stop Engine
       id: stop-engine
       if: always()

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -44,6 +44,7 @@ jobs:
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           subcommand: "connectors --concurrency=1 --execute-timeout=3600 --metadata-changes-only publish --main-release"
           python_registry_token: ${{ secrets.PYPI_TOKEN }}
+          max_attempts: 2
 
       - name: Publish connectors [manual]
         id: publish-connectors
@@ -66,6 +67,7 @@ jobs:
           subcommand: "connectors ${{ github.event.inputs.connectors-options }} publish ${{ github.event.inputs.publish-options }}"
           python_registry_token: ${{ secrets.PYPI_TOKEN }}
           airbyte_ci_binary_url: ${{ github.event.inputs.airbyte_ci_binary_url }}
+          max_attempts: 2
 
   set-instatus-incident-on-failure:
     name: Create Instatus Incident on Failure


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/42557
We want to handle transient publish failures with retries.
**This change will make any publish failure retried once.**

## How
* Wrap `airbyte-ci` call in the `run-airbyte-ci/action.yaml`  with the [retry step marketplace action](https://github.com/marketplace/actions/retry-step)
* Set default max attempt to `1`
* Set max attempts to `2` in  `publish_connectors.yml`

## Why doing it this way
Using a marketplace action at the GHA level instead of implementing the retry in `airbyte-ci`  has the following benefit:
**It allows us to retry on `airbyte-ci` transient start up failure like it did [here](https://github.com/airbytehq/airbyte/actions/runs/9716355986/job/26819802925)**

**Setting the retry logic in `run-airbyte-ci/action.yaml`  also means we can implement retry on other workflows if needed**

## Manual testing
### Check that publish is retried once
I run a [manual publish pipeline](https://github.com/airbytehq/airbyte/actions/runs/10211647586/job/28253378880) from this branch on a broken connector: the airbyte-ci command was retried.

<img width="603" alt="Screenshot 2024-08-02 at 09 35 55" src="https://github.com/user-attachments/assets/e4387270-49c9-443d-9008-7269161eb327">

### Check that other airbyte-ci workflow are not retried
As  `run-airbyte-ci/action.yaml` is used for multiple workflow I wanted to double check that the other workflows are not retried on failures.[ I made a unit test fail on an internal package. The `airbyte-ci` command was not retried. ](https://github.com/airbytehq/airbyte/actions/runs/10211642000/job/28253371694?pr=42959)
<img width="593" alt="Screenshot 2024-08-02 at 09 38 02" src="https://github.com/user-attachments/assets/b4299db3-24e8-4a64-a192-89d33bd88ea1">

## User impact
Please note that all per connector failures will still be sent to `#connector-publish-failures` (even the retried one). 
**But when we receive a message *:rotating_light:  Publish workflow failed: <url>*  in this channel it will mean that all retries failed** 
