### PR TITLE
fix(source-google-ads): fix attribute error on check connection

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: 3.6.1
+  dockerImageTag: 3.6.2
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   githubIssueLabel: source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.6.1"
+version = "3.6.2"
 name = "source-google-ads"
 description = "Source implementation for Google Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -226,7 +226,7 @@ class SourceGoogleAds(AbstractSource):
                         login_customer_id=customer.login_customer_id,
                     )
                 except AirbyteTracedException as e:
-                    raise e
+                    raise e from e
                 except Exception as exc:
                     traced_exception(exc, customer.id, False, table_name)
                 # iterate over the response otherwise exceptions will not be raised!

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -225,6 +225,8 @@ class SourceGoogleAds(AbstractSource):
                         customer_id=customer.id,
                         login_customer_id=customer.login_customer_id,
                     )
+                except AirbyteTracedException as e:
+                    raise e
                 except Exception as exc:
                     traced_exception(exc, customer.id, False, table_name)
                 # iterate over the response otherwise exceptions will not be raised!

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -310,6 +310,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version  | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:---------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| `3.6.2`  | 2024-08-02 |                                                          | Fix attribute error on check connection                                                                                              |
 | `3.6.1`  | 2024-08-02 | [42960](https://github.com/airbytehq/airbyte/pull/42960) | Update error message for Interval Server Error                                                                                       |
 | `3.6.0`  | 2024-07-31 | [42544](https://github.com/airbytehq/airbyte/pull/42544) | Migrate to CDK v4.0.2                                                                                                                |
 | `3.5.10` | 2024-07-27 | [42714](https://github.com/airbytehq/airbyte/pull/42714) | Update dependencies                                                                                                                  |

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -310,7 +310,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version  | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:---------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| `3.6.2`  | 2024-08-02 |                                                          | Fix attribute error on check connection                                                                                              |
+| `3.6.2`  | 2024-08-02 | [42971](https://github.com/airbytehq/airbyte/pull/42971) | Fix attribute error on check connection                                                                                              |
 | `3.6.1`  | 2024-08-02 | [42960](https://github.com/airbytehq/airbyte/pull/42960) | Update error message for Interval Server Error                                                                                       |
 | `3.6.0`  | 2024-07-31 | [42544](https://github.com/airbytehq/airbyte/pull/42544) | Migrate to CDK v4.0.2                                                                                                                |
 | `3.5.10` | 2024-07-27 | [42714](https://github.com/airbytehq/airbyte/pull/42714) | Update dependencies                                                                                                                  |


### PR DESCRIPTION
## What
resolved: https://github.com/airbytehq/oncall/issues/6141

## How
We should handle AirbyteTracedException on check separate from Google Ads Exception to avoid attribute error when AirbyteTracedException is passed to traced_exception method.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
