### PR TITLE
airbyte-ci: format should ignore airbyte-enterprise submodule

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -773,6 +773,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.28.1  | [#42972](https://github.com/airbytehq/airbyte/pull/42972)  | Add airbyte-enterprise support for format command.                                                                           |
 | 4.28.0  | [#42849](https://github.com/airbytehq/airbyte/pull/42849)  | Couple selection of strict-encrypt variants (e vice versa)                                                                   |
 | 4.27.0  | [#42574](https://github.com/airbytehq/airbyte/pull/42574)  | Live tests: run from connectors test pipeline for connectors with sandbox connections                                        |
 | 4.26.1  | [#42905](https://github.com/airbytehq/airbyte/pull/42905)  | Rename the docker cache volume to avoid using the corrupted previous volume.                                                 |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
@@ -3,6 +3,8 @@
 #
 from enum import Enum
 
+from pipelines.consts import AIRBYTE_SUBMODULE_DIR_NAME
+
 REPO_MOUNT_PATH = "/src"
 CACHE_MOUNT_PATH = "/cache"
 
@@ -10,6 +12,7 @@ LICENSE_FILE_NAME = "LICENSE_SHORT"
 
 # TODO create .airbyte_ci_ignore files?
 DEFAULT_FORMAT_IGNORE_LIST = [
+    AIRBYTE_SUBMODULE_DIR_NAME,  # Required to format the airbyte-enterprise repo.
     "**/__init__.py",  # These files has never been formatted and we don't want to start now (for now) see https://github.com/airbytehq/airbyte/issues/33296
     "**/__pycache__",
     "**/.eggs",

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.28.0"
+version = "4.28.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
`airbyte-ci format` doesn't work in the airbyte-enterprise repo because (among other things) it applies itself to the `airbyte-submodule` git submodule and the exclusion rules don't quite work. It should just ignore the whole submodule entirely.

## How
Adds the submodule to the exclusion list.

## Review guide
n/a

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
