### PR TITLE
fix: use python 3.10 to generate connector builder update CDK pr

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -292,7 +292,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Checkout Airbyte Platform Internal
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Otherwise `pip-compile --upgrade` cannot find airbyte-cdk >=4

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
