### PR TITLE
fix(python-cdk): catch StopIteration when empty page

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/cursor_pagination_strategy.py
@@ -50,7 +50,10 @@ class CursorPaginationStrategy(PaginationStrategy):
         return self._initial_cursor
 
     def next_page_token(self, response: requests.Response, last_page_size: int, last_record: Optional[Record]) -> Optional[Any]:
-        decoded_response = next(self.decoder.decode(response))
+        try:
+            decoded_response = next(self.decoder.decode(response))
+        except StopIteration:
+            return None
 
         # The default way that link is presented in requests.Response is a string of various links (last, next, etc). This
         # is not indexable or useful for parsing the cursor, so we replace it with the link dictionary from response.links

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
@@ -57,7 +57,10 @@ class OffsetIncrement(PaginationStrategy):
         return None
 
     def next_page_token(self, response: requests.Response, last_page_size: int, last_record: Optional[Record]) -> Optional[Any]:
-        decoded_response = next(self.decoder.decode(response))
+        try:
+            decoded_response = next(self.decoder.decode(response))
+        except StopIteration:
+            return None
 
         # Stop paginating when there are fewer records than the page size or the current page has no records
         if (self._page_size and last_page_size < self._page_size.eval(self.config, response=decoded_response)) or last_page_size == 0:

--- a/airbyte-integrations/connectors/source-woocommerce/poetry.lock
+++ b/airbyte-integrations/connectors/source-woocommerce/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "airbyte-cdk"
-version = "3.8.2"
+version = "4.3.0"
 description = "A framework for writing Airbyte Connectors."
 optional = false
-python-versions = "<4.0,>=3.9"
+python-versions = "<4.0,>=3.10"
 files = [
-    {file = "airbyte_cdk-3.8.2-py3-none-any.whl", hash = "sha256:66503cd86d8d515aac256a77f00d158b118365b465eb80c9e798e6d4fd36b7ba"},
-    {file = "airbyte_cdk-3.8.2.tar.gz", hash = "sha256:ce8abb5d208338d8d1084ab4d2afa9463fab6336f7ef6b431d80c7bcf9136599"},
+    {file = "airbyte_cdk-4.3.0-py3-none-any.whl", hash = "sha256:004816eddc73f13f6b2dbd2e24af4eb952c320c903363de8962dd48029811a0b"},
+    {file = "airbyte_cdk-4.3.0.tar.gz", hash = "sha256:3f6481ec4f1690b10c2414a77f892d089e337ae739893ae6b207d43e1c52de61"},
 ]
 
 [package.dependencies]
@@ -591,13 +591,13 @@ extended-testing = ["jinja2 (>=3,<4)"]
 
 [[package]]
 name = "langsmith"
-version = "0.1.94"
+version = "0.1.96"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.94-py3-none-any.whl", hash = "sha256:0d01212086d58699f75814117b026784218042f7859877ce08a248a98d84aa8d"},
-    {file = "langsmith-0.1.94.tar.gz", hash = "sha256:e44afcdc9eee6f238f6a87a02bba83111bd5fad376d881ae299834e06d39d712"},
+    {file = "langsmith-0.1.96-py3-none-any.whl", hash = "sha256:1e8285c3f84cffebc761ff5624647de20686dbbf659f5d1135918261f85bad13"},
+    {file = "langsmith-0.1.96.tar.gz", hash = "sha256:01b7fa7d538b6409ee74bff458cc3dcdc1799fc70d329f79eb26ba54c32991ae"},
 ]
 
 [package.dependencies]
@@ -954,19 +954,19 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pyjwt"
-version = "2.8.0"
+version = "2.9.0"
 description = "JSON Web Token implementation in Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "PyJWT-2.8.0-py3-none-any.whl", hash = "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320"},
-    {file = "PyJWT-2.8.0.tar.gz", hash = "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de"},
+    {file = "PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850"},
+    {file = "pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c"},
 ]
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
-docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
+dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
 tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
@@ -1420,5 +1420,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9,<3.12"
-content-hash = "fe5009a50818aa185f186481406270126e4fdf2b5f2e76279a3e9f75ae704b6f"
+python-versions = "^3.10,<3.12"
+content-hash = "a2525e40c6dcb8920fe90ab208311e21ae38e8e410f8c3d8b64375cee1555689"

--- a/airbyte-integrations/connectors/source-woocommerce/pyproject.toml
+++ b/airbyte-integrations/connectors/source-woocommerce/pyproject.toml
@@ -16,8 +16,9 @@ repository = "https://github.com/airbytehq/airbyte"
 include = "source_woocommerce"
 
 [tool.poetry.dependencies]
-python = "^3.9,<3.12"
-airbyte-cdk = "3.8.2"
+python = "^3.10,<3.12"
+airbyte-cdk = "^4"
+
 
 [tool.poetry.scripts]
 source-woocommerce = "source_woocommerce.run:run"

--- a/airbyte-integrations/connectors/source-woocommerce/unit_tests/integration/test_coupons.py
+++ b/airbyte-integrations/connectors/source-woocommerce/unit_tests/integration/test_coupons.py
@@ -3,8 +3,9 @@
 from unittest import TestCase
 
 from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput
-from airbyte_cdk.test.mock_http import HttpMocker
+from airbyte_cdk.test.mock_http import HttpMocker, HttpResponse
 from airbyte_protocol.models import SyncMode
+from freezegun import freeze_time
 
 from .config import ConfigBuilder
 from .request_builder import get_coupons_request
@@ -20,7 +21,30 @@ class TestFullRefresh(TestCase):
         return read_output(config_, _STREAM_NAME, SyncMode.full_refresh)
 
     @HttpMocker()
+    @freeze_time("2017-01-29T00:00:00Z")
     def test_read_records(self, http_mocker: HttpMocker) -> None:
+        # Register mock response
+        http_mocker.get(
+            get_coupons_request()
+            .with_param("orderby", "id")
+            .with_param("order", "asc")
+            .with_param("dates_are_gmt", "true")
+            .with_param("per_page", "100")
+            .with_param("modified_after", "2017-01-01T00:00:00")
+            .with_param("modified_before", "2017-01-29T00:00:00")
+            .build(),
+            get_json_http_response("coupons.json", 200),
+        )
+
+        # Read records
+        output = self._read(config())
+
+        # Check record count
+        assert len(output.records) == 2
+
+    @HttpMocker()
+    @freeze_time("2017-02-10T00:00:00Z")
+    def test_read_with_records_then_empty_page(self, http_mocker: HttpMocker) -> None:
         # Register mock response
         http_mocker.get(
             get_coupons_request()
@@ -32,10 +56,22 @@ class TestFullRefresh(TestCase):
             .with_param("modified_before", "2017-01-30T23:59:59")
             .build(),
             get_json_http_response("coupons.json", 200),
-        )
+            )
+        http_mocker.get(
+            get_coupons_request()
+            .with_param("orderby", "id")
+            .with_param("order", "asc")
+            .with_param("dates_are_gmt", "true")
+            .with_param("per_page", "100")
+            .with_param("modified_after", "2017-01-31T00:00:00")
+            .with_param("modified_before", "2017-02-10T00:00:00")
+            .build(),
+            HttpResponse("[]", 200),
+            )
 
         # Read records
         output = self._read(config())
 
-        # Check record count
+        # Check that StopIteration is not present in logs and 2 records are returned
+        assert all(["StopIteration" not in entry.log.message for entry in output.logs])
         assert len(output.records) == 2


### PR DESCRIPTION
## What
Generator of the page_toke raises a StopIterator exception when we reach the last page with empty array. This fixes that behavior by catching the exception. This should be followed by a CDK update. This is related to this [P1 issue](https://github.com/airbytehq/oncall/issues/6151https://github.com/airbytehq/oncall/issues/6151)

## How
Add an `except` catch for the StopIteration exception.

## Review guide
1. `cursor_pagination_strategy.py` - added try-except
2. `offset_increment.py` - added try-except

## User Impact
This should fix the StopIteration error in multiple connectors using CDK 3.9 or above.

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [x] NO ❌
