### PR TITLE
fix(source-activecampaign): disable pypi in metadata

### DIFF
--- a/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
@@ -9,7 +9,7 @@ data:
       enabled: false
   remoteRegistries:
     pypi:
-      enabled: true
+      enabled: false
       packageName: airbyte-source-activecampaign
   connectorSubtype: api
   connectorType: source


### PR DESCRIPTION
## What

Hotfixes source-activecampaign to publish successfully without pypi package.