### PR TITLE
⚡️ Speed up method `FullRefreshCheckpointReader.next` by 15%

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
@@ -196,11 +196,10 @@ class FullRefreshCheckpointReader(CheckpointReader):
         self._final_checkpoint = False
 
     def next(self) -> Optional[Mapping[str, Any]]:
-        try:
-            return next(self._stream_slices)
-        except StopIteration:
+        item = next(self._stream_slices, None)
+        if item is None:
             self._final_checkpoint = True
-            return None
+        return item
 
     def observe(self, new_state: Mapping[str, Any]) -> None:
         pass


### PR DESCRIPTION
### 📄 `FullRefreshCheckpointReader.next()` in `airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py`

📈 Performance improved by **`15%`** (**`0.15x` faster**)

⏱️ Runtime went down from **`42.0 microseconds`** to **`36.5 microseconds`**
### Explanation and details

Certainly! The given code is already quite efficient, but we can make a few minor optimizations. One minor improvement is to use the `default` parameter of `next` to avoid handling an exception, which can be slower. Here's the optimized code.


By using `next(self._stream_slices, None)`, we avoid the overhead of a try-except block, which can be slower when a `StopIteration` exception is raised. This small change optimizes both the speed and readability of the code.

This performance optimization was automatically generated with [codeflash.ai](https://codeflash.ai/)
### Correctness verification

The new optimized code was tested for correctness. The results are listed below.
#### 🔘 (none found) − ⚙️ Existing Unit Tests
#### ✅ 28 Passed − 🌀 Generated Regression Tests
<details>
<summary>(click to show generated tests)</summary>

```python
# imports
# function to test
from typing import Any, Iterable, Mapping, Optional

import pytest  # used for our unit tests


class CheckpointReader:
    pass
from airbyte_cdk.sources.streams.checkpoint.checkpoint_reader import \
    FullRefreshCheckpointReader

# unit tests

# Test single element in iterable
def test_single_element():
    reader = FullRefreshCheckpointReader([{"key": "value"}])
    assert reader.next() == {"key": "value"}  # Check first element
    assert reader.next() is None  # Check end of iterator
    assert reader._final_checkpoint is True  # Check final checkpoint flag

# Test multiple elements in iterable
def test_multiple_elements():
    reader = FullRefreshCheckpointReader([{"key1": "value1"}, {"key2": "value2"}])
    assert reader.next() == {"key1": "value1"}  # Check first element
    assert reader.next() == {"key2": "value2"}  # Check second element
    assert reader.next() is None  # Check end of iterator
    assert reader._final_checkpoint is True  # Check final checkpoint flag

# Test empty iterable
def test_empty_iterable():
    reader = FullRefreshCheckpointReader([])
    assert reader.next() is None  # Check end of iterator immediately
    assert reader._final_checkpoint is True  # Check final checkpoint flag

# Test iterable with None elements
def test_none_elements():
    reader = FullRefreshCheckpointReader([None, {"key": "value"}, None])
    assert reader.next() is None  # Check first element (None)
    assert reader.next() == {"key": "value"}  # Check second element
    assert reader.next() is None  # Check third element (None)
    assert reader.next() is None  # Check end of iterator
    assert reader._final_checkpoint is True  # Check final checkpoint flag

# Test iterable with mixed types
def test_mixed_types():
    reader = FullRefreshCheckpointReader([{"key": "value"}, None, {"another_key": 123}])
    assert reader.next() == {"key": "value"}  # Check first element
    assert reader.next() is None  # Check second element (None)
    assert reader.next() == {"another_key": 123}  # Check third element
    assert reader.next() is None  # Check end of iterator
    assert reader._final_checkpoint is True  # Check final checkpoint flag

# Test large number of elements
def test_large_number_of_elements():
    reader = FullRefreshCheckpointReader([{"key": i} for i in range(1000)])
    for i in range(1000):
        assert reader.next() == {"key": i}  # Check each element
    assert reader.next() is None  # Check end of iterator
    assert reader._final_checkpoint is True  # Check final checkpoint flag

# Test different data structures
def test_different_data_structures():
    reader = FullRefreshCheckpointReader([{"key": "value"}, {"key": [1, 2, 3]}, {"key": {"subkey": "subvalue"}}])
    assert reader.next() == {"key": "value"}  # Check first element
    assert reader.next() == {"key": [1, 2, 3]}  # Check second element
    assert reader.next() == {"key": {"subkey": "subvalue"}}  # Check third element
    assert reader.next() is None  # Check end of iterator
    assert reader._final_checkpoint is True  # Check final checkpoint flag

# Test nested dictionaries
def test_nested_dictionaries():
    reader = FullRefreshCheckpointReader([{"key": {"nested_key": "nested_value"}}])
    assert reader.next() == {"key": {"nested_key": "nested_value"}}  # Check first element
    assert reader.next() is None  # Check end of iterator
    assert reader._final_checkpoint is True  # Check final checkpoint flag

# Test non-iterable input
def test_non_iterable_input():
    with pytest.raises(TypeError):  # Expect TypeError
        reader = FullRefreshCheckpointReader("not_an_iterable")

# Test final checkpoint flag
def test_final_checkpoint_flag():
    reader = FullRefreshCheckpointReader([{"key": "value"}])
    assert reader.next() == {"key": "value"}  # Check first element
    assert reader.next() is None  # Check end of iterator
    assert reader._final_checkpoint is True  # Check final checkpoint flag

# Test consistent results
def test_consistent_results():
    reader = FullRefreshCheckpointReader([{"key": "value"}])
    assert reader.next() == {"key": "value"}  # Check first element
    assert reader.next() is None  # Check end of iterator
    assert reader._final_checkpoint is True  # Check final checkpoint flag
    reader = FullRefreshCheckpointReader([{"key": "value"}])
    assert reader.next() == {"key": "value"}  # Check first element
    assert reader.next() is None  # Check end of iterator
    assert reader._final_checkpoint is True  # Check final checkpoint flag
```
</details>

#### 🔘 (none found) − ⏪ Replay Tests
