### PR TITLE
fix(airbyte-ci): use logger for formatting helper

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -773,6 +773,7 @@ E.G.: running Poe tasks on the modified internal packages of the current branch:
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.28.2  | [#TODO](TODO)  | user logger for formatting helper output.                                                                           |
 | 4.28.1  | [#42972](https://github.com/airbytehq/airbyte/pull/42972)  | Add airbyte-enterprise support for format command.                                                                           |
 | 4.28.0  | [#42849](https://github.com/airbytehq/airbyte/pull/42849)  | Couple selection of strict-encrypt variants (e vice versa)                                                                   |
 | 4.27.0  | [#42574](https://github.com/airbytehq/airbyte/pull/42574)  | Live tests: run from connectors test pipeline for connectors with sandbox connections                                        |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_inline_schemas/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_inline_schemas/pipeline.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, List
 
 from connector_ops.utils import ConnectorLanguage  # type: ignore
+
 from pipelines import main_logger
 from pipelines.airbyte_ci.connectors.consts import CONNECTOR_TEST_STEP_ID
 from pipelines.airbyte_ci.connectors.context import ConnectorContext, PipelineContext
@@ -196,7 +197,7 @@ class InlineSchemas(Step):
             _update_inline_schema(schema_loader, json_streams, stream_name)
 
         write_yaml(data, manifest_path)
-        await format_prettier([manifest_path])
+        await format_prettier([manifest_path], logger=logger)
 
         for json_stream in json_streams.values():
             logger.info(f"     !! JSON schema not found: {json_stream.name}")

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/format.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/format.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
+import logging
 import subprocess
 from pathlib import Path
 from typing import List
@@ -7,7 +8,7 @@ from typing import List
 from pipelines.cli.ensure_repo_root import get_airbyte_repo_path_with_fallback
 
 
-async def format_prettier(files: List[Path]) -> None:
+async def format_prettier(files: List[Path], logger: logging.Logger) -> None:
     if len(files) == 0:
         return
 
@@ -18,17 +19,19 @@ async def format_prettier(files: List[Path]) -> None:
 
     to_format = [str(file) for file in files]
 
-    print(f"       Formatting files: npx prettier --write {' '.join(to_format)}")
+    logger.info(f"       Formatting files: npx prettier --write {' '.join(to_format)}")
     command = ["npx", "prettier", "--config", str(config_path), "--write"] + to_format
     result = subprocess.run(command, capture_output=True, text=True)
     if result.returncode == 0:
-        print("Files formatted successfully.")
+        logger.info("        Files formatted successfully.")
     else:
-        print("Error formatting files.")
+        logger.warn("        Error formatting files.")
 
 
 def verify_formatters() -> None:
     try:
         subprocess.run(["npx", "--version"], check=True)
     except subprocess.CalledProcessError:
-        raise Exception("npx is required to format files. Please install Node.js and npm.")
+        raise Exception(
+            "npx is required to format files. Please install Node.js and npm."
+        )

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.28.1"
+version = "4.28.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What

This pull request does two things:
1. `connectors migrate-to-inline_schemas` will remove unused remaining json schemas and schemas directory.
2. formatting helper uses logger for output so running this in CLI looks clean and nice.


