### PR TITLE
airbyte-ci: never consider live tests in overall status

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -49,6 +49,7 @@ class AirbyteEntrypoint(object):
 
     @staticmethod
     def parse_args(args: List[str]) -> argparse.Namespace:
+        print("test!")
         # set up parent parsers
         parent_parser = argparse.ArgumentParser(add_help=False)
         parent_parser.add_argument("--debug", action="store_true", help="enables detailed debug logs related to the sync")

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -666,7 +666,7 @@ class LiveTests(Step):
             stdout=stdout,
             output=container,
             report=regression_test_report,
-            consider_in_overall_status=False,
+            consider_in_overall_status=False if self.context.is_pr else True,
         )
 
     async def _build_test_container(self, target_container_id: str) -> Container:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -666,7 +666,7 @@ class LiveTests(Step):
             stdout=stdout,
             output=container,
             report=regression_test_report,
-            consider_in_overall_status=False if self.context.is_pr else True,
+            consider_in_overall_status=False,
         )
 
     async def _build_test_container(self, target_container_id: str) -> Container:


### PR DESCRIPTION
We shouldn't let live tests fail the connectors test pipeline, regardless of whether the tests were run in the PR context.