### PR TITLE
publish-python-cdk: Retry steps that can fail transiently

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -302,7 +302,7 @@ jobs:
           repository: airbytehq/airbyte-platform-internal
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
       - name: Update CDK version
-        uses: Wandalen/wretry.action@3.5.0
+        uses: Wandalen/wretry.action@v3.5.0
         with:
           attempt_limit: 3
           command: |

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -302,7 +302,7 @@ jobs:
           repository: airbytehq/airbyte-platform-internal
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
       - name: Update CDK version
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@3.5.0
         with:
           attempt_limit: 3
           command: |

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -154,7 +154,7 @@ jobs:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
       - name: Build and publish to pypi
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v3.5.0
         with:
           attempt_limit: 3
           action: JRubics/poetry-publish@v2.0

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -154,11 +154,14 @@ jobs:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v2.0
+        uses: Wandalen/wretry.action@master
         with:
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
-          python_version: "3.10"
-          package_directory: "airbyte-cdk/python"
+          attempt_limit: 3
+          action: JRubics/poetry-publish@v2.0
+          with: |
+            pypi_token: ${{ secrets.PYPI_TOKEN }}
+            python_version: "3.10"
+            package_directory: "airbyte-cdk/python"
       - name: Post failure to Slack channel dev-connectors-extensibility
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.23.0
@@ -299,15 +302,18 @@ jobs:
           repository: airbytehq/airbyte-platform-internal
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
       - name: Update CDK version
-        run: |
-          PREVIOUS_VERSION=$(cat oss/airbyte-connector-builder-resources/CDK_VERSION)
-          sed -i "s/${PREVIOUS_VERSION}/${{needs.bump-version.outputs.new_cdk_version}}/g" oss/airbyte-connector-builder-server/Dockerfile
-          sed -i "s/${PREVIOUS_VERSION}/${{needs.bump-version.outputs.new_cdk_version}}/g" cloud/airbyte-connector-builder-server-wrapped/Dockerfile
-          sed -i "s/airbyte-cdk==${PREVIOUS_VERSION}/airbyte-cdk==${{needs.bump-version.outputs.new_cdk_version}}/g" oss/airbyte-connector-builder-server/requirements.in
-          echo ${{needs.bump-version.outputs.new_cdk_version}} > oss/airbyte-connector-builder-resources/CDK_VERSION
-          cd oss/airbyte-connector-builder-server
-          pip install pip-tools
-          pip-compile --upgrade
+        uses: Wandalen/wretry.action@master
+        with:
+          attempt_limit: 3
+          command: |
+            PREVIOUS_VERSION=$(cat oss/airbyte-connector-builder-resources/CDK_VERSION)
+            sed -i "s/${PREVIOUS_VERSION}/${{needs.bump-version.outputs.new_cdk_version}}/g" oss/airbyte-connector-builder-server/Dockerfile
+            sed -i "s/${PREVIOUS_VERSION}/${{needs.bump-version.outputs.new_cdk_version}}/g" cloud/airbyte-connector-builder-server-wrapped/Dockerfile
+            sed -i "s/airbyte-cdk==${PREVIOUS_VERSION}/airbyte-cdk==${{needs.bump-version.outputs.new_cdk_version}}/g" oss/airbyte-connector-builder-server/requirements.in
+            echo ${{needs.bump-version.outputs.new_cdk_version}} > oss/airbyte-connector-builder-resources/CDK_VERSION
+            cd oss/airbyte-connector-builder-server
+            pip install pip-tools
+            pip-compile --upgrade
       - name: Create Pull Request
         id: create-pull-request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
## What
Update the CDK publish workflow to retry the steps that can fail transiently.

This PR is scope to
1. Publishing the package to pypi
2. Updating the connector builder server

We can update other steps as needed

## How
Wrap the steps in `Wandalen/wretry.action@v3.5.0` with a maximum of 3 attempts.

Link to retry action: https://github.com/Wandalen/wretry.action

## Review guide
I didn't test the change on the CDK publish workflow, but I did test the retry action with the regression workflow.
- [This action failed and retry 3 times](https://github.com/airbytehq/airbyte/actions/runs/10258300907)
- [This workflow](https://github.com/airbytehq/airbyte/actions/runs/10258233524/job/28380726270) had a retry, but did not fail

## User Impact
The CDK publish workflow should fail less frequently

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
