### PR TITLE
destination-snowflake: speed up SnowflakeDestinationHandler.getInitialRawTableState by running explicit SHOW commands

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 424892c4-daac-4491-b35d-c6688ba547ba
-  dockerImageTag: 3.11.7
+  dockerImageTag: 3.11.8
   dockerRepository: airbyte/destination-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake
   githubIssueLabel: destination-snowflake

--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -268,6 +268,7 @@ desired namespace.
 
 | Version         | Date       | Pull Request                                               | Subject                                                                                                                                                                          |
 |:----------------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.11.8          | 2024-08-07 | [\#43315](https://github.com/airbytehq/airbyte/pull/43315) | speed up SnowflakeDestinationHandler.getInitialRawTableState by running explicit SHOW commands |
 | 3.11.7          | 2024-08-07 | [\#42977](https://github.com/airbytehq/airbyte/pull/42977) | remove contention on destination_statetable by only deleting once every 100 updates |
 | 3.11.6          | 2024-08-07 | [\#43332](https://github.com/airbytehq/airbyte/pull/43332) | bump Java CDK |
 | 3.11.5          | 2024-08-07 | [\#43348](https://github.com/airbytehq/airbyte/pull/43348) | SnowflakeSqlGen cleanup to Kotlin string interpolation                                                                                                                           |


### PR DESCRIPTION
When running tests, I realized that the current calls to databaseMetadata.getTable can take 20seconds each (so 40 seconds per stream), and they're serialized. That caused some tests to timeout.
The reason behind the time cost is that the snowflake implementation of getTable executes a `SHOW OBJECTS IN DATABASE`, even if there's a schema specified (the schema parameter is a schema pattern, which isn't SQL `LIKE` compliant, so it needs to be evaluated in the client.
There's 2 issues with the statement:
1) `SHOW OBJECTS` internally iterates over all the object types
2) `SHOW OBJECTS/TABLES IN DATABASE` will internally start by executing a `SHOW SCHEMAS IN DATABASE`, and then iterate over all the schemas and execute a `SHOW OBJECTS/TABLES IN SCHEMA`, which can be very time consuming.

The solution is to execute a `SHOW TABLES IN SCHEMA`, which executes in 50ms.

The handling of `QUOTED_IDENTIFIER_IGNORE_CASE` seems approximate at best and probably contains pre-existing bugs