### PR TITLE
destination-yellowbrick: remove explicit kotlin dependency

### DIFF
--- a/airbyte-integrations/connectors/destination-yellowbrick/build.gradle
+++ b/airbyte-integrations/connectors/destination-yellowbrick/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'airbyte-java-connector'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.23'
 }
 
 airbyteJavaConnector {

--- a/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 1f7bac7e-53ff-4e0b-b6df-b74aa85cf703
-  dockerImageTag: 0.0.2
+  dockerImageTag: 0.0.3
   dockerRepository: airbyte/destination-yellowbrick
   documentationUrl: https://docs.airbyte.com/integrations/destinations/yellowbrick
   githubIssueLabel: destination-yellowbrick

--- a/docs/integrations/destinations/yellowbrick.md
+++ b/docs/integrations/destinations/yellowbrick.md
@@ -174,6 +174,7 @@ Each table will contain 3 columns:
 
 | Version | Date       | Pull Request                                               | Subject         |
 | :------ | :--------- | :--------------------------------------------------------- | :-------------- |
+| 0.0.3 | 2024-08-06 | [\#43342](https://github.com/airbytehq/airbyte/pull/43342) | Remove explicit Kotlin dependency. |
 | 0.0.2   | 2024-05-17 | [\#38329](https://github.com/airbytehq/airbyte/pull/38329) | Update CDK      |
 | 0.0.1   | 2024-03-02 | [\#35775](https://github.com/airbytehq/airbyte/pull/35775) | Initial release |
 


### PR DESCRIPTION
## What
Remove explicit kotlin dependency in destination-yellowbrick.

## Review guide
Gradle CI is expected to fail due to destination-s3 not building. This is addressed in a child PR.

## User Impact
Should be zero. If CI is happy then I'm happy.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
