### PR TITLE
bulk-cdk: re-export boms, clean up github workflow

### DIFF
--- a/.github/workflows/publish-bulk-cdk.yml
+++ b/.github/workflows/publish-bulk-cdk.yml
@@ -9,13 +9,6 @@ on:
       - "airbyte-cdk/bulk"
   workflow_dispatch:
     inputs:
-      repo:
-        description: "Repo to check out code from. Defaults to the main airbyte repo."
-        type: choice
-        required: true
-        default: airbytehq/airbyte
-        options:
-          - airbytehq/airbyte
       build-number:
         description: "Build Number"
         required: false
@@ -26,8 +19,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Use the provided GITREF or default to the branch triggering the workflow.
-  GITREF: ${{ github.event.inputs.gitref || github.ref }}
   S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
   S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
 
@@ -39,8 +30,6 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
-        with:
-          ref: ${{ env.GITREF }}
 
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -12,17 +12,17 @@ allprojects {
     }
 
     dependencies {
-        implementation platform('org.jetbrains.kotlin:kotlin-bom:2.0.0')
-        implementation platform('org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1')
-        implementation platform('com.fasterxml.jackson:jackson-bom:2.16.1')
-        implementation platform('io.micronaut:micronaut-core-bom:4.3.13')
-        implementation platform('org.junit:junit-bom:5.10.2')
-        implementation platform('org.slf4j:slf4j-bom:2.0.13')
-        implementation platform('org.apache.logging.log4j:log4j-bom:2.21.1')
-        implementation platform('org.testcontainers:testcontainers-bom:1.19.8')
+        api platform('org.jetbrains.kotlin:kotlin-bom:2.0.0')
+        api platform('org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1')
+        api platform('com.fasterxml.jackson:jackson-bom:2.16.1')
+        api platform('io.micronaut:micronaut-core-bom:4.3.13')
+        api platform('org.junit:junit-bom:5.10.2')
+        api platform('org.slf4j:slf4j-bom:2.0.13')
+        api platform('org.apache.logging.log4j:log4j-bom:2.21.1')
+        api platform('org.testcontainers:testcontainers-bom:1.19.8')
 
-        implementation 'org.jetbrains.kotlin:kotlin-stdlib'
-        implementation 'com.google.dagger:dagger-compiler:2.51.1'
+        api 'org.jetbrains.kotlin:kotlin-stdlib'
+        api 'com.google.dagger:dagger-compiler:2.51.1'
         ksp 'com.google.dagger:dagger-compiler:2.51.1'
 
         annotationProcessor platform('io.micronaut:micronaut-core-bom:4.3.13')


### PR DESCRIPTION
## What
Re-export boms imported in the bulk cdk root build.gradle, because our connectors won't build otherwise. 

## How
Changes to newly-added build.gradle and .github workflows. No production dependencies on either of these, hence the approve-and-merge.

## Review guide
Infra-only changes.

## User Impact
None whatsoever.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
