### PR TITLE
.github: fix bulk cdk publish workflow trigger

### DIFF
--- a/.github/workflows/publish-bulk-cdk.yml
+++ b/.github/workflows/publish-bulk-cdk.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
     paths:
-      - "airbyte-cdk/bulk"
+      - "airbyte-cdk/bulk/**"
   workflow_dispatch:
     inputs:
       build-number:

--- a/airbyte-cdk/bulk/README.md
+++ b/airbyte-cdk/bulk/README.md
@@ -9,6 +9,7 @@ It's written in Kotlin and consists of a _core_ and a bunch of _toolkits_:
 
 While the CDK is incubating, its published version numbers are 0.X where X is monotonically
 increasing based on the maximum version value found on the maven repository that the jars are
-published to.
+published to: https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars/io/airbyte/bulk-cdk/
+
 Jar publication happens via a github workflow triggered by pushes to the master branch, i.e. after
 merging a pull request.


### PR DESCRIPTION
## What
Fix bug in github workflow for Bulk CDK publication.

## User Impact
None.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
