### PR TITLE
improve(docs): clarify gcs crednetials configuration for helm chart

### DIFF
--- a/docs/enterprise-setup/implementation-guide.md
+++ b/docs/enterprise-setup/implementation-guide.md
@@ -356,20 +356,19 @@ Set `authenticationType` to `instanceProfile` if the compute infrastructure runn
 </TabItem>
 <TabItem value="GCS" label="GCS" default>
 
-Ensure you've already created a Kubernetes secret containing the credentials blob for the service account to be assumed by the cluster. By default, secrets are expected in the `gcp-cred-secrets` Kubernetes secret, under a `gcp.json` file. Steps to configure these are in the above [prerequisites](#configure-kubernetes-secrets).
+Ensure you've already created a Kubernetes secret containing the credentials blob for the service account to be assumed by the cluster. Steps to configure these are in the above [prerequisites](#configure-kubernetes-secrets).
 
 ```yaml
 global:
   storage:
     type: "GCS"
-    storageSecretName: gcp-cred-secrets
+    storageSecretName: airbyte-config-secrets
     bucket: ## GCS bucket names that you've created. We recommend storing the following all in one bucket.
       log: airbyte-bucket
       state: airbyte-bucket
       workloadOutput: airbyte-bucket
     gcs:
       projectId: <project-id>
-      credentialsPath: /secrets/gcs-log-creds/gcp.json
 ```
 
 </TabItem>


### PR DESCRIPTION
## What
There has been a lot of confusion around providing GCS creds for the log and storage buckets. This cleans up the docs so that we:
- Instruct users to reference the secret they were instructed to create in the prerequisites section
- Removes any mention of `credentialsPath` which is not intended for external use and only leads to confusion.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the implementation guide for configuring Kubernetes secrets for Google Cloud Storage (GCS).
	- Streamlined text by changing the secret name to `airbyte-config-secrets`.
	- Removed references to `credentialsPath` for improved clarity in credential management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->