### PR TITLE
airbyte-ci: fix format cli usage in airbyte-enterprise

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -789,6 +789,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 |---------| ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
+| 4.30.1  | [#43386](https://github.com/airbytehq/airbyte/pull/43386)  | Fix 'format' command usage bug in airbyte-enterprise.                                                                        |
 | 4.30.0  | [#42583](https://github.com/airbytehq/airbyte/pull/42583)  | Updated dependencies                                                                                                         |
 | 4.29.0  | [#42576](https://github.com/airbytehq/airbyte/pull/42576)  | New command: `migrate-to-manifest-only`                                                                                      |
 | 4.28.3  | [#42046](https://github.com/airbytehq/airbyte/pull/42046)  | Trigger connector tests on doc change.                                                                                       |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/configuration.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/configuration.py
@@ -30,7 +30,7 @@ FORMATTERS_CONFIGURATIONS: List[FormatConfiguration] = [
         Formatter.JAVA,
         ["**/*.java", "**/*.kt", "**/*.gradle"],
         format_java_container,
-        ["mvn -f spotless-maven-pom.xml spotless:apply clean"],
+        ["mvn -f spotless-maven-pom.xml --errors --batch-mode spotless:apply clean"],
     ),
     # Run prettier on all json and yaml files.
     FormatConfiguration(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
@@ -12,7 +12,6 @@ LICENSE_FILE_NAME = "LICENSE_SHORT"
 
 # TODO create .airbyte_ci_ignore files?
 DEFAULT_FORMAT_IGNORE_LIST = [
-    AIRBYTE_SUBMODULE_DIR_NAME,  # Required to format the airbyte-enterprise repo.
     "**/__init__.py",  # These files has never been formatted and we don't want to start now (for now) see https://github.com/airbytehq/airbyte/issues/33296
     "**/__pycache__",
     "**/.eggs",
@@ -44,6 +43,12 @@ DEFAULT_FORMAT_IGNORE_LIST = [
     "airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code",  # This is a test directory with badly formatted code
 ]
 
+# In the airbyte-enterprise repo, the airbyte repo is included as a submodule.
+# Glob patterns which don't start with '**/' need to be repeated with a prefix.
+DEFAULT_FORMAT_IGNORE_LIST = DEFAULT_FORMAT_IGNORE_LIST + [
+    f"{AIRBYTE_SUBMODULE_DIR_NAME}/{path}" for path in DEFAULT_FORMAT_IGNORE_LIST if not path.startswith("**/")
+]
+
 
 class Formatter(Enum):
     """An enum for the formatter values which can be ["java", "js", "python", "license"]."""
@@ -62,7 +67,7 @@ class Formatter(Enum):
 WARM_UP_INCLUSIONS = {
     Formatter.JAVA: [
         "spotless-maven-pom.xml",
-        "tools/gradle/codestyle/java-google-style.xml",
+        "tools/",  # Whole directory instead of just 'java-google-style.xml' to support airbyte-enterprise.
     ],
     Formatter.PYTHON: ["pyproject.toml", "poetry.lock"],
     Formatter.LICENSE: [LICENSE_FILE_NAME],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
@@ -2,11 +2,11 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import dagger
 from pipelines.airbyte_ci.format.consts import CACHE_MOUNT_PATH, DEFAULT_FORMAT_IGNORE_LIST, REPO_MOUNT_PATH, WARM_UP_INCLUSIONS, Formatter
-from pipelines.consts import GO_IMAGE, MAVEN_IMAGE, NODE_IMAGE, PYTHON_3_10_IMAGE
+from pipelines.consts import AIRBYTE_SUBMODULE_DIR_NAME, GO_IMAGE, MAVEN_IMAGE, NODE_IMAGE, PYTHON_3_10_IMAGE
 from pipelines.helpers import cache_keys
 from pipelines.helpers.utils import sh_dash_c
 
@@ -69,20 +69,24 @@ def build_container(
     return container
 
 
+def warmup_directory(dagger_client: dagger.Client, formatter: Formatter) -> Union[dagger.Directory, None]:
+    """Creates a Dagger directory which includes the warmup files for the given Formatter."""
+    include = WARM_UP_INCLUSIONS.get(formatter)
+    if not include:
+        return None
+    include = include + [f"{AIRBYTE_SUBMODULE_DIR_NAME}/{i}" for i in include]
+    return dagger_client.host().directory(".", include=include, exclude=DEFAULT_FORMAT_IGNORE_LIST)
+
+
 def format_java_container(dagger_client: dagger.Client, java_code: dagger.Directory) -> dagger.Container:
     """
     Create a Maven container with spotless installed with mounted code to format and a cache volume.
     We warm up the container cache with the spotless configuration and dependencies.
     """
-    warmup_dir = dagger_client.host().directory(
-        ".",
-        include=WARM_UP_INCLUSIONS[Formatter.JAVA],
-        exclude=DEFAULT_FORMAT_IGNORE_LIST,
-    )
     return build_container(
         dagger_client,
         base_image=MAVEN_IMAGE,
-        warmup_dir=warmup_dir,
+        warmup_dir=warmup_directory(dagger_client, Formatter.JAVA),
         install_commands=[
             # Run maven before mounting the sources to download all its dependencies.
             # Dagger will cache the resulting layer to minimize the downloads.
@@ -111,13 +115,12 @@ def format_js_container(dagger_client: dagger.Client, js_code: dagger.Directory,
 
 def format_license_container(dagger_client: dagger.Client, license_code: dagger.Directory) -> dagger.Container:
     """Create a Go container with addlicense installed with mounted code to format."""
-    warmup_dir = dagger_client.host().directory(".", include=WARM_UP_INCLUSIONS[Formatter.LICENSE], exclude=DEFAULT_FORMAT_IGNORE_LIST)
     return build_container(
         dagger_client,
         base_image=GO_IMAGE,
         dir_to_format=license_code,
         install_commands=["go get -u github.com/google/addlicense"],
-        warmup_dir=warmup_dir,
+        warmup_dir=warmup_directory(dagger_client, Formatter.LICENSE),
     )
 
 
@@ -127,8 +130,6 @@ def format_python_container(
     """Create a Python container with pipx and the global pyproject.toml installed with mounted code to format and a cache volume.
     We warm up the container with the pyproject.toml and poetry.lock files to not repeat the pyproject.toml installation.
     """
-
-    warmup_dir = dagger_client.host().directory(".", include=WARM_UP_INCLUSIONS[Formatter.PYTHON], exclude=DEFAULT_FORMAT_IGNORE_LIST)
     return build_container(
         dagger_client,
         base_image=PYTHON_3_10_IMAGE,
@@ -140,7 +141,7 @@ def format_python_container(
             "poetry install --no-root",
         ],
         dir_to_format=python_code,
-        warmup_dir=warmup_dir,
+        warmup_dir=warmup_directory(dagger_client, Formatter.PYTHON),
         # Namespacing the cache volume by black version is likely overkill:
         # Black already manages cache directories by version internally.
         # https://github.com/psf/black/blob/e4ae213f06050e7f76ebcf01578c002e412dafdc/src/black/cache.py#L42

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
@@ -93,6 +93,8 @@ def format_java_container(dagger_client: dagger.Client, java_code: dagger.Direct
             # The go-offline goal purportedly downloads all dependencies.
             # This isn't quite the case, we still need to add spotless goals.
             "mvn -f spotless-maven-pom.xml"
+            " --errors"
+            " --batch-mode"
             " org.apache.maven.plugins:maven-dependency-plugin:3.6.1:go-offline"
             " spotless:apply"
             " spotless:check"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/format_command.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/format_command.py
@@ -12,7 +12,8 @@ import dagger
 from pipelines import main_logger
 from pipelines.airbyte_ci.format.actions import list_files_in_directory
 from pipelines.airbyte_ci.format.configuration import Formatter
-from pipelines.airbyte_ci.format.consts import DEFAULT_FORMAT_IGNORE_LIST, REPO_MOUNT_PATH, WARM_UP_INCLUSIONS
+from pipelines.airbyte_ci.format.consts import DEFAULT_FORMAT_IGNORE_LIST, REPO_MOUNT_PATH
+from pipelines.airbyte_ci.format.containers import warmup_directory
 from pipelines.consts import GIT_IMAGE
 from pipelines.helpers import sentry_utils
 from pipelines.helpers.cli import LogOptions, log_command_results
@@ -170,8 +171,7 @@ class FormatCommand(click.Command):
         """
         format_container = container.with_exec(sh_dash_c(format_commands), skip_entrypoint=True)
         formatted_directory = format_container.directory(REPO_MOUNT_PATH)
-        if warmup_inclusion := WARM_UP_INCLUSIONS.get(self.formatter):
-            warmup_dir = dagger_client.host().directory(".", include=warmup_inclusion, exclude=DEFAULT_FORMAT_IGNORE_LIST)
+        if warmup_dir := warmup_directory(dagger_client, self.formatter):
             not_formatted_code = not_formatted_code.with_directory(".", warmup_dir)
             formatted_directory = formatted_directory.with_directory(".", warmup_dir)
         return (

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.30.0"
+version = "4.30.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
Fixes bugs which prevented `airbyte-ci format fix all` from working in airbyte-enterprise when run straight from the CLI.
Also includes a QoL fix which makes maven run in batch mode instead of interactive mode, this makes the execution logs nicer.

## How
Inclusion and exclusion rules have been corrected to handle symlinks propertly.

## Review guide
One commit at a time.

## User Impact
None.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
