### PR TITLE
CDK Connectors Tests: Fix NotGitRepo error

### DIFF
--- a/.github/workflows/cdk_connectors_tests.yml
+++ b/.github/workflows/cdk_connectors_tests.yml
@@ -67,8 +67,7 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
-            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+            ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
       - name: Fetch last commit id from remote branch [PULL REQUESTS]
         if: github.event_name == 'pull_request'
         id: fetch_last_commit_id_pr


### PR DESCRIPTION
CDK Connectors Tests were getting a 404, `NotGitRepo` error when setting up the regression tests container. This was caused by the use of a token not scoped for cloning the `connection-retriever`. This PR updates the token.

We previously had a backup token that we could use if the primary token was rate-limited, but no longer have one with the right permissions, so we'll want to create it.