### PR TITLE
Parse transactions

### DIFF
--- a/airbyte-integrations/connectors/source-plaid/integration_tests/catalog.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/catalog.json
@@ -107,7 +107,7 @@
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
             "personal_finance_category": {
-              "type": "object",
+              "type": ["object", "null"],
               "properties": {
                 "primary": { "type": "string" },
                 "detailed": { "type": "string" },

--- a/airbyte-integrations/connectors/source-plaid/integration_tests/catalog.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/catalog.json
@@ -42,37 +42,50 @@
             "account_id",
             "amount",
             "iso_currency_code",
-            "name",
             "transaction_id",
             "category",
             "date",
-            "transaction_type"
+            "original_description",
+            "payment_channel"
           ],
           "properties": {
             "account_id": { "type": "string" },
             "amount": { "type": "number" },
             "category": { "type": "array", "items": { "type": "string" } },
             "category_id": { "type": ["string", "null"] },
+            "counterparties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "entity_id": { "type": ["string", "null"] },
+                  "type": { "type": "string" },
+                  "reference_number": { "type": ["string", "null"] },
+                  "website": { "type": ["string", "null"] },
+                  "confidence_level": { "type": ["string", "null"] }
+                }
+              }
+            },
             "date": { "type": "string" },
             "iso_currency_code": { "type": "string" },
-            "name": { "type": "string" },
-            "payment_channel": { "type": ["string", "null"] },
-            "pending": { "type": ["boolean", "null"] },
+            "payment_channel": { "type": "string" },
+            "pending": { "type": "boolean" },
             "transaction_id": { "type": "string" },
-            "transaction_type": { "type": "string" },
             "location": {
               "type": ["object", "null"],
               "properties": {
                 "address": { "type": ["string", "null"] },
                 "city": { "type": ["string", "null"] },
                 "country": { "type": ["string", "null"] },
-                "lat": { "type": ["string", "null"] },
-                "lon": { "type": ["string", "null"] },
+                "lat": { "type": ["number", "null"] },
+                "lon": { "type": ["number", "null"] },
                 "postal_code": { "type": ["string", "null"] },
                 "region": { "type": ["string", "null"] },
                 "store_number": { "type": ["string", "null"] }
               }
             },
+            "original_description": { "type": ["string", "null"] },
             "payment_meta": {
               "type": ["object", "null"],
               "properties": {
@@ -93,9 +106,16 @@
             "datetime": { "type": ["string", "null"] },
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
-            "personal_finance_category": { "type": ["string", "null"] },
-            "transaction_code": { "type": ["string", "null"] },
-            "unofficial_currency_code": { "type": ["string", "null"] }
+            "personal_finance_category": {
+              "type": "object",
+              "properties": {
+                "primary": { "type": "string" },
+                "detailed": { "type": "string" },
+                "confidence_level": { "type": ["string", "null"] }
+              },
+              "transaction_code": { "type": ["string", "null"] },
+              "unofficial_currency_code": { "type": ["string", "null"] }
+            }
           }
         }
       }

--- a/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog.json
@@ -108,7 +108,7 @@
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
             "personal_finance_category": {
-              "type": "object",
+              "type": ["object", "null"],
               "properties": {
                 "primary": { "type": "string" },
                 "detailed": { "type": "string" },

--- a/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog.json
@@ -43,37 +43,50 @@
             "account_id",
             "amount",
             "iso_currency_code",
-            "name",
             "transaction_id",
             "category",
             "date",
-            "transaction_type"
+            "original_description",
+            "payment_channel"
           ],
           "properties": {
             "account_id": { "type": "string" },
             "amount": { "type": "number" },
             "category": { "type": "array", "items": { "type": "string" } },
             "category_id": { "type": ["string", "null"] },
+            "counterparties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "entity_id": { "type": ["string", "null"] },
+                  "type": { "type": "string" },
+                  "reference_number": { "type": ["string", "null"] },
+                  "website": { "type": ["string", "null"] },
+                  "confidence_level": { "type": ["string", "null"] }
+                }
+              }
+            },
             "date": { "type": "string" },
             "iso_currency_code": { "type": "string" },
-            "name": { "type": "string" },
-            "payment_channel": { "type": ["string", "null"] },
-            "pending": { "type": ["boolean", "null"] },
+            "payment_channel": { "type": "string" },
+            "pending": { "type": "boolean" },
             "transaction_id": { "type": "string" },
-            "transaction_type": { "type": "string" },
             "location": {
               "type": ["object", "null"],
               "properties": {
                 "address": { "type": ["string", "null"] },
                 "city": { "type": ["string", "null"] },
                 "country": { "type": ["string", "null"] },
-                "lat": { "type": ["string", "null"] },
-                "lon": { "type": ["string", "null"] },
+                "lat": { "type": ["number", "null"] },
+                "lon": { "type": ["number", "null"] },
                 "postal_code": { "type": ["string", "null"] },
                 "region": { "type": ["string", "null"] },
                 "store_number": { "type": ["string", "null"] }
               }
             },
+            "original_description": { "type": ["string", "null"] },
             "payment_meta": {
               "type": ["object", "null"],
               "properties": {
@@ -94,9 +107,16 @@
             "datetime": { "type": ["string", "null"] },
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
-            "personal_finance_category": { "type": ["string", "null"] },
-            "transaction_code": { "type": ["string", "null"] },
-            "unofficial_currency_code": { "type": ["string", "null"] }
+            "personal_finance_category": {
+              "type": "object",
+              "properties": {
+                "primary": { "type": "string" },
+                "detailed": { "type": "string" },
+                "confidence_level": { "type": ["string", "null"] }
+              },
+              "transaction_code": { "type": ["string", "null"] },
+              "unofficial_currency_code": { "type": ["string", "null"] }
+            }
           }
         }
       },

--- a/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog_incremental.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog_incremental.json
@@ -108,7 +108,7 @@
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
             "personal_finance_category": {
-              "type": "object",
+              "type": ["object", "null"],
               "properties": {
                 "primary": { "type": "string" },
                 "detailed": { "type": "string" },

--- a/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog_incremental.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog_incremental.json
@@ -43,37 +43,50 @@
             "account_id",
             "amount",
             "iso_currency_code",
-            "name",
             "transaction_id",
             "category",
             "date",
-            "transaction_type"
+            "original_description",
+            "payment_channel"
           ],
           "properties": {
             "account_id": { "type": "string" },
             "amount": { "type": "number" },
             "category": { "type": "array", "items": { "type": "string" } },
             "category_id": { "type": ["string", "null"] },
+            "counterparties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "entity_id": { "type": ["string", "null"] },
+                  "type": { "type": "string" },
+                  "reference_number": { "type": ["string", "null"] },
+                  "website": { "type": ["string", "null"] },
+                  "confidence_level": { "type": ["string", "null"] }
+                }
+              }
+            },
             "date": { "type": "string" },
             "iso_currency_code": { "type": "string" },
-            "name": { "type": "string" },
-            "payment_channel": { "type": ["string", "null"] },
-            "pending": { "type": ["boolean", "null"] },
+            "payment_channel": { "type": "string" },
+            "pending": { "type": "boolean" },
             "transaction_id": { "type": "string" },
-            "transaction_type": { "type": "string" },
             "location": {
               "type": ["object", "null"],
               "properties": {
                 "address": { "type": ["string", "null"] },
                 "city": { "type": ["string", "null"] },
                 "country": { "type": ["string", "null"] },
-                "lat": { "type": ["string", "null"] },
-                "lon": { "type": ["string", "null"] },
+                "lat": { "type": ["number", "null"] },
+                "lon": { "type": ["number", "null"] },
                 "postal_code": { "type": ["string", "null"] },
                 "region": { "type": ["string", "null"] },
                 "store_number": { "type": ["string", "null"] }
               }
             },
+            "original_description": { "type": ["string", "null"] },
             "payment_meta": {
               "type": ["object", "null"],
               "properties": {
@@ -94,9 +107,16 @@
             "datetime": { "type": ["string", "null"] },
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
-            "personal_finance_category": { "type": ["string", "null"] },
-            "transaction_code": { "type": ["string", "null"] },
-            "unofficial_currency_code": { "type": ["string", "null"] }
+            "personal_finance_category": {
+              "type": "object",
+              "properties": {
+                "primary": { "type": "string" },
+                "detailed": { "type": "string" },
+                "confidence_level": { "type": ["string", "null"] }
+              },
+              "transaction_code": { "type": ["string", "null"] },
+              "unofficial_currency_code": { "type": ["string", "null"] }
+            }
           }
         }
       },

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/components.py
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/components.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+import requests
+
+from airbyte_cdk.sources.declarative.decoders.decoder import Decoder
+from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
+from airbyte_cdk.sources.declarative.extractors.record_extractor import RecordExtractor
+
+
+@dataclass
+class PlaidTransactionExtractor(RecordExtractor):
+    """
+    Record extractor that searches a decoded response over multiple paths. Each field is
+    a separate path that points to an array (unless it doesn't exist at all).
+
+    If the field path points to an array, that array is returned.
+    If the field path points to a non-existing path, an empty array is returned.
+
+    Examples of instantiating this transform:
+    ```
+      extractor:
+        type: CustomRecordExtractor
+        class_name: source_plaid.components.PlaidTransactionExtractor
+        field_path:
+          - "added"
+          - "modified"
+    ```
+
+    Attributes:
+        field_path (list[str]): Path to the fields that should be extracted
+        decoder (Decoder): The decoder responsible to transfom the response in a Mapping
+    """
+
+    field_path: list[str]
+    decoder: Decoder = field(default_factory=lambda: JsonDecoder(parameters={}))
+
+    def extract_records(self, response: requests.Response) -> Iterable[Mapping[str, Any]]:
+        body = self.decoder.decode(response)
+        for path in self.field_path:
+            extracted = body.get(path, [])
+            yield from extracted

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -336,26 +336,6 @@ streams:
         type: DefaultPaginator
         pagination_strategy:
           type: OffsetIncrement
-    incremental_sync:
-      type: DatetimeBasedCursor
-      cursor_field: date
-      datetime_format: "%Y-%m-%d"
-      start_time_option:
-        type: RequestOption
-        field_name: start_date
-        inject_into: body_json
-      end_time_option:
-        type: RequestOption
-        field_name: end_date
-        inject_into: body_json
-      start_datetime:
-        type: MinMaxDatetime
-        datetime: "{{config['start_date']}}"
-        datetime_format: "%Y-%m-%d"
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
-        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
 spec:
   connection_specification:
     $schema: http://json-schema.org/draft-07/schema#

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -218,8 +218,6 @@ streams:
             type:
               - string
               - "null"
-          name:
-            type: string
           original_description:
             type:
               - string

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -281,6 +281,9 @@ streams:
                 type:
                   - string
                   - "null"
+            type:
+              - object
+              - "null"
           transaction_code:
             type:
               - string

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -328,10 +328,11 @@ streams:
       record_selector:
         type: RecordSelector
         extractor:
-          type: DpathExtractor
+          type: CustomRecordExtractor
+          class_name: source_plaid.components.PlaidTransactionExtractor
           field_path:
-            - transactions
-            - "*"
+            - "added"
+            - "modified"
       paginator:
         type: DefaultPaginator
         pagination_strategy:

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -318,7 +318,7 @@ streams:
           type: NoAuth
         request_body_json:
           secret: "{{config['api_key']}}"
-          cursor: null
+          cursor: "{{ next_page_token.next_page_token }}"
           count: 500
           options:
             include_original_description: true
@@ -335,7 +335,9 @@ streams:
       paginator:
         type: DefaultPaginator
         pagination_strategy:
-          type: OffsetIncrement
+          type: CursorPagination
+          cursor_value: "{{ response.get('next_cursor') }}"
+          stop_condition: "{{ response.has_more is false }}"
 spec:
   connection_specification:
     $schema: http://json-schema.org/draft-07/schema#

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -145,6 +145,28 @@ streams:
             type:
               - string
               - "null"
+          counterparties:
+            items:
+              properties:
+                name:
+                  type:
+                    - string
+                entity_id:
+                  type:
+                    - string
+                    - "null"
+                type:
+                  type:
+                    - string
+                website:
+                  type:
+                    - string
+                    - "null"
+                confidence_level:
+                  type:
+                    - string
+                    - "null"
+            type: array
           date:
             type: string
           datetime:
@@ -152,7 +174,9 @@ streams:
               - string
               - "null"
           iso_currency_code:
-            type: string
+            type:
+              - string
+              - "null"
           location:
             properties:
               address:
@@ -169,11 +193,11 @@ streams:
                   - "null"
               lat:
                 type:
-                  - string
+                  - number
                   - "null"
               lon:
                 type:
-                  - string
+                  - number
                   - "null"
               postal_code:
                 type:
@@ -196,10 +220,13 @@ streams:
               - "null"
           name:
             type: string
-          payment_channel:
+          original_description:
             type:
               - string
               - "null"
+          payment_channel:
+            type:
+              - string
           payment_meta:
             properties:
               by_order_of:
@@ -240,22 +267,27 @@ streams:
           pending:
             type:
               - boolean
-              - "null"
           pending_transaction_id:
             type:
               - string
               - "null"
           personal_finance_category:
-            type:
-              - string
-              - "null"
+            properties:
+              primary:
+                type:
+                  - string
+              detailed:
+                type:
+                  - string
+              confidence_level:
+                type:
+                  - string
+                  - "null"
           transaction_code:
             type:
               - string
               - "null"
           transaction_id:
-            type: string
-          transaction_type:
             type: string
           unofficial_currency_code:
             type:

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -318,7 +318,7 @@ streams:
           type: NoAuth
         request_body_json:
           secret: "{{config['api_key']}}"
-          cursor: "{{ next_page_token['next_page_token'] }}"
+          cursor: null
           count: 500
           options:
             include_original_description: true

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -309,7 +309,7 @@ streams:
       requester:
         type: HttpRequester
         url_base: https://{{config['plaid_env']}}.plaid.com
-        path: /transactions/get
+        path: /transactions/sync
         http_method: POST
         request_parameters: {}
         request_headers: {}
@@ -317,8 +317,11 @@ streams:
           type: NoAuth
         request_body_json:
           secret: "{{config['api_key']}}"
+          cursor: "{{ next_page_token['next_page_token'] }}"
+          count: 500
           options:
-            offset: "{{ next_page_token['next_page_token'] }}"
+            include_original_description: true
+            days_requested: 730
           client_id: "{{config['client_id']}}"
           access_token: "{{config['access_token']}}"
       record_selector:

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -301,7 +301,8 @@ streams:
           - transaction_id
           - category
           - date
-          - transaction_type
+          - original_description
+          - payment_channel
         type: object
     retriever:
       type: SimpleRetriever


### PR DESCRIPTION
## What
- Parse transactions that have been added and modified.
- Does not handle deletions, which we'll need to do differently since we don't get whole transaction objects in the `deleted` section.
- Also "fixes" pagination enough to check that we can import transactions, but it's still broken.

## How
- Overrides the default record extractor with `source_plaid.components.PlaidTransactionExtractor`.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
