### PR TITLE
publish pipeline: send pager duty alert on worfklow failure

### DIFF
--- a/.github/actions/send-pager-duty-event/action.yml
+++ b/.github/actions/send-pager-duty-event/action.yml
@@ -1,0 +1,36 @@
+name: "Send PagerDuty event"
+description: "Use Event API V2 to send a PagerDuty event."
+inputs:
+  integration_key:
+    description: "The integration key for the PagerDuty service."
+    required: true
+  summary:
+    description: "A brief text summary of the event."
+    required: true
+  severity:
+    description: "The severity of the event. (info, warning, error, critical)"
+    required: true
+  source:
+    description: "Specific human-readable unique identifier, such as a hostname, for the system having the problem."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Send PagerDuty event
+      id: send-pager-duty-event
+      shell: bash
+      run: |
+        curl --request 'POST' \
+          --fail \
+          --url "https://events.pagerduty.com/v2/enqueue" \
+          --header 'Content-Type: application/json' \
+          --data '{
+            "payload": {
+              "summary": "${{ inputs.summary }}",
+              "severity": "${{ inputs.severity }}",
+              "source": "${{ inputs.source }}"
+            },
+            "event_action": "trigger",
+            "routing_key": "${{ inputs.integration_key }}"
+          }'

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -69,19 +69,6 @@ jobs:
           airbyte_ci_binary_url: ${{ github.event.inputs.airbyte_ci_binary_url }}
           max_attempts: 2
 
-  set-instatus-incident-on-failure:
-    name: Create Instatus Incident on Failure
-    runs-on: ubuntu-latest
-    needs:
-      - publish_connectors
-    if: ${{ failure() && github.ref == 'refs/heads/master' }}
-    steps:
-      - name: Call Instatus Webhook
-        uses: joelwmale/webhook-action@master
-        with:
-          url: ${{ secrets.INSTATUS_CONNECTOR_PUBLISH_PIPELINE_WEBHOOK_URL }}
-          body: '{ "trigger": "down", "status": "HASISSUES" }'
-
   notify-failure-slack-channel:
     name: "Notify Slack Channel on Publish Failures"
     runs-on: ubuntu-latest
@@ -106,7 +93,25 @@ jobs:
             {
               "channel": "#connector-publish-failures",
               "username": "Connectors CI/CD Bot",
-              "text": "🚨 Publish workflow failed:\n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "🚨 Publish workflow failed:\n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \n merged by ${{ github.actor }} (<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}>). "
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+
+  notify-failure-pager-duty:
+    name: "Notify PagerDuty on Publish Failures"
+    runs-on: ubuntu-latest
+    needs:
+      - publish_connectors
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/master' }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v4
+      - name: Notify PagerDuty
+        id: pager-duty
+        uses: ./.github/actions/send-pager-duty-event
+        with:
+          integration_key: ${{ secrets.PAGER_DUTY_PUBLISH_FAILURES_INTEGRATION_KEY }}
+          summary: "Publish workflow failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} merged by ${{ github.actor }}"
+          severity: "critical"
+          source: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/9128
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/8998
We want to send a pager duty alerts to a service when a publish workflow fails.

## How
- Create a reusable action to send alerts via the PagerDuty Events API V2.
- Send a "critical" alerts on publish workflow failure
- Remove the instatus integration as its not relevant to use Instatus for this use case (a failure does not mean our whole publish flow is down).

## Bonus
- Tag the person who merged the triggering PR in the slack message on failure
