### PR TITLE
Source SpaceX API: Migrate to manifest only

### DIFF
--- a/airbyte-integrations/connectors/source-spacex-api/README.md
+++ b/airbyte-integrations/connectors/source-spacex-api/README.md
@@ -1,88 +1,63 @@
-# Spacex-Api source connector
+# Spacex api source connector
 
+This directory contains the manifest-only connector for `source-spacex-api`.
+This _manifest-only_ connector is not a Python package on its own, as it runs inside of the base `source-declarative-manifest` image.
 
-This is the repository for the Spacex-Api source connector, written in Python.
-For information about how to use this connector within Airbyte, see [the documentation](https://docs.airbyte.com/integrations/sources/spacex-api).
+For information about how to configure and use this connector within Airbyte, see [the connector's full documentation](https://docs.airbyte.com/integrations/sources/spacex-api).
 
 ## Local development
 
-### Prerequisites
-* Python (~=3.9)
-* Poetry (~=1.7) - installation instructions [here](https://python-poetry.org/docs/#installation)
+We recommend using the Connector Builder to edit this connector.
+Using either Airbyte Cloud or your local Airbyte OSS instance, navigate to the **Builder** tab and select **Import a YAML**.
+Then select the connector's `manifest.yaml` file to load the connector into the Builder. You're now ready to make changes to the connector!
 
-
-### Installing the connector
-From this connector directory, run:
-```bash
-poetry install --with dev
-```
-
-
-### Create credentials
-**If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.com/integrations/sources/spacex-api)
-to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `source_spacex_api/spec.yaml` file.
-Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
-See `sample_files/sample_config.json` for a sample config file.
-
-
-### Locally running the connector
-```
-poetry run source-spacex-api spec
-poetry run source-spacex-api check --config secrets/config.json
-poetry run source-spacex-api discover --config secrets/config.json
-poetry run source-spacex-api read --config secrets/config.json --catalog sample_files/configured_catalog.json
-```
-
-### Running unit tests
-To run unit tests locally, from the connector directory run:
-```
-poetry run pytest unit_tests
-```
+If you prefer to develop locally, you can follow the instructions below.
 
 ### Building the docker image
+
+You can build any manifest-only connector with `airbyte-ci`:
+
 1. Install [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md)
 2. Run the following command to build the docker image:
+
 ```bash
 airbyte-ci connectors --name=source-spacex-api build
 ```
 
 An image will be available on your host with the tag `airbyte/source-spacex-api:dev`.
 
+### Creating credentials
+
+**If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.com/integrations/sources/spacex-api)
+to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `spec` object in the connector's `manifest.yaml` file.
+Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
+
 ### Running as a docker container
-Then run any of the connector commands as follows:
-```
+
+Then run any of the standard source connector commands:
+
+```bash
 docker run --rm airbyte/source-spacex-api:dev spec
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-spacex-api:dev check --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-spacex-api:dev discover --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/source-spacex-api:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
 ```
 
-### Running our CI test suite
+### Running the CI test suite
+
 You can run our full test suite locally using [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md):
+
 ```bash
 airbyte-ci connectors --name=source-spacex-api test
 ```
 
-### Customizing acceptance Tests
-Customize `acceptance-test-config.yml` file to configure acceptance tests. See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference) for more information.
-If your connector requires to create or destroy resources for use during acceptance tests create fixtures for it and place them inside integration_tests/acceptance.py.
-
-### Dependency Management
-All of your dependencies should be managed via Poetry. 
-To add a new dependency, run:
-```bash
-poetry add <package-name>
-```
-
-Please commit the changes to `pyproject.toml` and `poetry.lock` files.
-
 ## Publishing a new version of the connector
-You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
-1. Make sure your changes are passing our test suite: `airbyte-ci connectors --name=source-spacex-api test`
-2. Bump the connector version (please follow [semantic versioning for connectors](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#semantic-versioning-for-connectors)): 
+
+If you want to contribute changes to `source-spacex-api`, here's how you can do that:
+1. Make your changes locally, or load the connector's manifest into Connector Builder and make changes there.
+2. Make sure your changes are passing our test suite with `airbyte-ci connectors --name=source-spacex-api test`
+3. Bump the connector version (please follow [semantic versioning for connectors](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#semantic-versioning-for-connectors)):
     - bump the `dockerImageTag` value in in `metadata.yaml`
-    - bump the `version` value in `pyproject.toml`
-3. Make sure the `metadata.yaml` content is up to date.
 4. Make sure the connector documentation and its changelog is up to date (`docs/integrations/sources/spacex-api.md`).
 5. Create a Pull Request: use [our PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#pull-request-title-convention).
 6. Pat yourself on the back for being an awesome contributor.

--- a/airbyte-integrations/connectors/source-spacex-api/README.md
+++ b/airbyte-integrations/connectors/source-spacex-api/README.md
@@ -1,4 +1,4 @@
-# Spacex api source connector
+# SpaceX API source connector
 
 This directory contains the manifest-only connector for `source-spacex-api`.
 This _manifest-only_ connector is not a Python package on its own, as it runs inside of the base `source-declarative-manifest` image.

--- a/airbyte-integrations/connectors/source-spacex-api/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-spacex-api/acceptance-test-config.yml
@@ -3,7 +3,7 @@
 connector_image: airbyte/source-spacex-api:dev
 tests:
   spec:
-    - spec_path: "source_spacex_api/spec.yaml"
+    - spec_path: "manifest.yaml"
   connection:
     - config_path: "secrets/config.json"
       status: "succeed"

--- a/airbyte-integrations/connectors/source-spacex-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-spacex-api/manifest.yaml
@@ -1,0 +1,4588 @@
+version: 4.3.0
+type: DeclarativeSource
+check:
+  type: CheckStream
+  stream_names:
+    - launches
+    - capsules
+    - company
+    - crew
+    - cores
+    - dragons
+    - landpads
+    - payloads
+    - history
+    - rockets
+    - roadster
+    - ships
+    - starlink
+definitions:
+  streams:
+    launches:
+      type: DeclarativeStream
+      name: launches
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /launches/{{config['options'] or config['id'] or 'latest'}}
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            auto_update:
+              type: boolean
+            capsules:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            cores:
+              type: array
+              items:
+                type: object
+                properties:
+                  core:
+                    type:
+                      - "null"
+                      - string
+                  flight:
+                    type: number
+                  gridfins:
+                    type: boolean
+                  landing_attempt:
+                    type: boolean
+                  landing_success:
+                    type: boolean
+                  landing_type:
+                    type:
+                      - "null"
+                      - string
+                  landpad:
+                    type:
+                      - "null"
+                      - string
+                  legs:
+                    type: boolean
+                  reused:
+                    type: boolean
+            crew:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            date_local:
+              type:
+                - "null"
+                - string
+            date_precision:
+              type:
+                - "null"
+                - string
+            date_unix:
+              type: number
+            date_utc:
+              type:
+                - "null"
+                - string
+            details:
+              type: string
+            failures:
+              type: array
+            fairings:
+              type: object
+              properties:
+                recovered:
+                  type: boolean
+                recovery_attempt:
+                  type: boolean
+                reused:
+                  type: boolean
+                ships:
+                  type: array
+                  items:
+                    type:
+                      - "null"
+                      - string
+            flight_number:
+              type: number
+            id:
+              type:
+                - "null"
+                - string
+            launch_library_id:
+              type:
+                - "null"
+                - string
+            launchpad:
+              type:
+                - "null"
+                - string
+            links:
+              type: object
+              properties:
+                article:
+                  type:
+                    - "null"
+                    - string
+                flickr:
+                  type: object
+                  properties:
+                    original:
+                      type: array
+                      items:
+                        type:
+                          - "null"
+                          - string
+                    small:
+                      type: array
+                patch:
+                  type: object
+                  properties:
+                    large:
+                      type:
+                        - "null"
+                        - string
+                    small:
+                      type:
+                        - "null"
+                        - string
+                reddit:
+                  type: object
+                  properties:
+                    launch:
+                      type:
+                        - "null"
+                        - string
+                webcast:
+                  type:
+                    - "null"
+                    - string
+                wikipedia:
+                  type:
+                    - "null"
+                    - string
+                youtube_id:
+                  type:
+                    - "null"
+                    - string
+            name:
+              type:
+                - "null"
+                - string
+            net:
+              type: boolean
+            payloads:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            rocket:
+              type:
+                - "null"
+                - string
+            ships:
+              type: array
+            static_fire_date_unix:
+              type:
+                - "null"
+                - number
+            static_fire_date_utc:
+              type:
+                - "null"
+                - string
+            success:
+              type: boolean
+            tbd:
+              type: boolean
+            upcoming:
+              type: boolean
+            window:
+              type:
+                - "null"
+                - number
+          additionalProperties: true
+    capsules:
+      type: DeclarativeStream
+      name: capsules
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /capsules
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            type:
+              type:
+                - "null"
+                - string
+            id:
+              type:
+                - "null"
+                - string
+            land_landings:
+              type: number
+            last_update:
+              type:
+                - "null"
+                - string
+            launches:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            reuse_count:
+              type: number
+            serial:
+              type:
+                - "null"
+                - string
+            status:
+              type:
+                - "null"
+                - string
+            water_landings:
+              type: number
+          additionalProperties: true
+    company:
+      type: DeclarativeStream
+      name: company
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /company
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            ceo:
+              type:
+                - "null"
+                - string
+            coo:
+              type:
+                - "null"
+                - string
+            cto:
+              type:
+                - "null"
+                - string
+            cto_propulsion:
+              type:
+                - "null"
+                - string
+            employees:
+              type: number
+            founded:
+              type: number
+            founder:
+              type:
+                - "null"
+                - string
+            headquarters:
+              type: object
+              properties:
+                address:
+                  type:
+                    - "null"
+                    - string
+                city:
+                  type:
+                    - "null"
+                    - string
+                state:
+                  type:
+                    - "null"
+                    - string
+            id:
+              type:
+                - "null"
+                - string
+            launch_sites:
+              type: number
+            links:
+              type: object
+              properties:
+                elon_twitter:
+                  type:
+                    - "null"
+                    - string
+                flickr:
+                  type:
+                    - "null"
+                    - string
+                twitter:
+                  type:
+                    - "null"
+                    - string
+                website:
+                  type:
+                    - "null"
+                    - string
+            name:
+              type:
+                - "null"
+                - string
+            summary:
+              type:
+                - "null"
+                - string
+            test_sites:
+              type: number
+            valuation:
+              type: number
+            vehicles:
+              type: number
+          additionalProperties: true
+    crew:
+      type: DeclarativeStream
+      name: crew
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /crew
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            agency:
+              type:
+                - "null"
+                - string
+            id:
+              type:
+                - "null"
+                - string
+            image:
+              type:
+                - "null"
+                - string
+            launches:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            name:
+              type:
+                - "null"
+                - string
+            status:
+              type:
+                - "null"
+                - string
+            wikipedia:
+              type:
+                - "null"
+                - string
+          additionalProperties: true
+    cores:
+      type: DeclarativeStream
+      name: cores
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /cores
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            asds_attempts:
+              type: number
+            asds_landings:
+              type: number
+            block:
+              type:
+                - "null"
+                - number
+            id:
+              type:
+                - "null"
+                - string
+            last_update:
+              type:
+                - "null"
+                - string
+            launches:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            reuse_count:
+              type: number
+            rtls_attempts:
+              type: number
+            rtls_landings:
+              type: number
+            serial:
+              type:
+                - "null"
+                - string
+            status:
+              type:
+                - "null"
+                - string
+          additionalProperties: true
+    dragons:
+      type: DeclarativeStream
+      name: dragons
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /dragons
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            type:
+              type:
+                - "null"
+                - string
+            active:
+              type: boolean
+            crew_capacity:
+              type: number
+            description:
+              type:
+                - "null"
+                - string
+            diameter:
+              type: object
+              properties:
+                feet:
+                  type: number
+                meters:
+                  type: number
+            dry_mass_kg:
+              type: number
+            dry_mass_lb:
+              type: number
+            first_flight:
+              type:
+                - "null"
+                - string
+            flickr_images:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            heat_shield:
+              type: object
+              properties:
+                dev_partner:
+                  type:
+                    - "null"
+                    - string
+                material:
+                  type:
+                    - "null"
+                    - string
+                size_meters:
+                  type: number
+                temp_degrees:
+                  type: number
+            height_w_trunk:
+              type: object
+              properties:
+                feet:
+                  type: number
+                meters:
+                  type: number
+            id:
+              type:
+                - "null"
+                - string
+            launch_payload_mass:
+              type: object
+              properties:
+                kg:
+                  type: number
+                lb:
+                  type: number
+            launch_payload_vol:
+              type: object
+              properties:
+                cubic_feet:
+                  type: number
+                cubic_meters:
+                  type: number
+            name:
+              type:
+                - "null"
+                - string
+            orbit_duration_yr:
+              type: number
+            pressurized_capsule:
+              type: object
+              properties:
+                payload_volume:
+                  type: object
+                  properties:
+                    cubic_feet:
+                      type: number
+                    cubic_meters:
+                      type: number
+            return_payload_mass:
+              type: object
+              properties:
+                kg:
+                  type: number
+                lb:
+                  type: number
+            return_payload_vol:
+              type: object
+              properties:
+                cubic_feet:
+                  type: number
+                cubic_meters:
+                  type: number
+            sidewall_angle_deg:
+              type: number
+            thrusters:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type:
+                      - "null"
+                      - string
+                  amount:
+                    type: number
+                  fuel_1:
+                    type:
+                      - "null"
+                      - string
+                  fuel_2:
+                    type:
+                      - "null"
+                      - string
+                  isp:
+                    type: number
+                  pods:
+                    type: number
+                  thrust:
+                    type: object
+                    properties:
+                      kN:
+                        type: number
+                      lbf:
+                        type: number
+            trunk:
+              type: object
+              properties:
+                cargo:
+                  type: object
+                  properties:
+                    solar_array:
+                      type: number
+                    unpressurized_cargo:
+                      type: boolean
+                trunk_volume:
+                  type: object
+                  properties:
+                    cubic_feet:
+                      type: number
+                    cubic_meters:
+                      type: number
+            wikipedia:
+              type:
+                - "null"
+                - string
+          additionalProperties: true
+    landpads:
+      type: DeclarativeStream
+      name: landpads
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /landpads
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            type:
+              type:
+                - "null"
+                - string
+            details:
+              type:
+                - "null"
+                - string
+            full_name:
+              type:
+                - "null"
+                - string
+            id:
+              type:
+                - "null"
+                - string
+            images:
+              type: object
+              properties:
+                large:
+                  type: array
+                  items:
+                    type:
+                      - "null"
+                      - string
+            landing_attempts:
+              type: number
+            landing_successes:
+              type: number
+            latitude:
+              type: number
+            launches:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            locality:
+              type:
+                - "null"
+                - string
+            longitude:
+              type: number
+            name:
+              type:
+                - "null"
+                - string
+            region:
+              type:
+                - "null"
+                - string
+            status:
+              type:
+                - "null"
+                - string
+            wikipedia:
+              type:
+                - "null"
+                - string
+          additionalProperties: true
+    payloads:
+      type: DeclarativeStream
+      name: payloads
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /payloads
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            type:
+              type:
+                - "null"
+                - string
+            apoapsis_km:
+              type:
+                - "null"
+                - number
+            arg_of_pericenter:
+              type:
+                - "null"
+                - number
+            customers:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            dragon:
+              type: object
+              properties:
+                capsule:
+                  type:
+                    - "null"
+                    - string
+                flight_time_sec:
+                  type:
+                    - "null"
+                    - number
+                land_landing:
+                  type:
+                    - boolean
+                    - "null"
+                manifest:
+                  type:
+                    - "null"
+                    - string
+                mass_returned_kg:
+                  type:
+                    - "null"
+                    - number
+                mass_returned_lbs:
+                  type:
+                    - "null"
+                    - number
+                water_landing:
+                  type:
+                    - boolean
+                    - "null"
+            eccentricity:
+              type:
+                - "null"
+                - number
+            epoch:
+              type:
+                - "null"
+                - string
+            id:
+              type:
+                - "null"
+                - string
+            inclination_deg:
+              type:
+                - "null"
+                - number
+            launch:
+              type:
+                - "null"
+                - string
+            lifespan_years:
+              type:
+                - "null"
+                - number
+            longitude:
+              type:
+                - "null"
+                - number
+            manufacturers:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            mass_kg:
+              type:
+                - "null"
+                - number
+            mass_lbs:
+              type:
+                - "null"
+                - number
+            mean_anomaly:
+              type:
+                - "null"
+                - number
+            mean_motion:
+              type:
+                - "null"
+                - number
+            name:
+              type:
+                - "null"
+                - string
+            nationalities:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            norad_ids:
+              type: array
+              items:
+                type: number
+            orbit:
+              type:
+                - "null"
+                - string
+            periapsis_km:
+              type:
+                - "null"
+                - number
+            period_min:
+              type:
+                - "null"
+                - number
+            raan:
+              type:
+                - "null"
+                - number
+            reference_system:
+              type:
+                - "null"
+                - string
+            regime:
+              type:
+                - "null"
+                - string
+            reused:
+              type: boolean
+            semi_major_axis_km:
+              type:
+                - "null"
+                - number
+          additionalProperties: true
+    history:
+      type: DeclarativeStream
+      name: history
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /history
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            details:
+              type:
+                - "null"
+                - string
+            event_date_unix:
+              type: number
+            event_date_utc:
+              type:
+                - "null"
+                - string
+            id:
+              type:
+                - "null"
+                - string
+            links:
+              type: object
+              properties:
+                article:
+                  type:
+                    - "null"
+                    - string
+            title:
+              type:
+                - "null"
+                - string
+          additionalProperties: true
+    rockets:
+      type: DeclarativeStream
+      name: rockets
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /rockets
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            type:
+              type:
+                - "null"
+                - string
+            active:
+              type: boolean
+            boosters:
+              type: number
+            company:
+              type:
+                - "null"
+                - string
+            cost_per_launch:
+              type: number
+            country:
+              type:
+                - "null"
+                - string
+            description:
+              type:
+                - "null"
+                - string
+            diameter:
+              type: object
+              properties:
+                feet:
+                  type: number
+                meters:
+                  type: number
+            engines:
+              type: object
+              properties:
+                version:
+                  type:
+                    - "null"
+                    - string
+                type:
+                  type:
+                    - "null"
+                    - string
+                engine_loss_max:
+                  type:
+                    - "null"
+                    - number
+                isp:
+                  type: object
+                  properties:
+                    sea_level:
+                      type: number
+                    vacuum:
+                      type: number
+                layout:
+                  type:
+                    - "null"
+                    - string
+                number:
+                  type: number
+                propellant_1:
+                  type:
+                    - "null"
+                    - string
+                propellant_2:
+                  type:
+                    - "null"
+                    - string
+                thrust_sea_level:
+                  type: object
+                  properties:
+                    kN:
+                      type: number
+                    lbf:
+                      type: number
+                thrust_to_weight:
+                  type: number
+                thrust_vacuum:
+                  type: object
+                  properties:
+                    kN:
+                      type: number
+                    lbf:
+                      type: number
+            first_flight:
+              type:
+                - "null"
+                - string
+            first_stage:
+              type: object
+              properties:
+                burn_time_sec:
+                  type:
+                    - "null"
+                    - number
+                engines:
+                  type: number
+                fuel_amount_tons:
+                  type: number
+                reusable:
+                  type: boolean
+                thrust_sea_level:
+                  type: object
+                  properties:
+                    kN:
+                      type: number
+                    lbf:
+                      type: number
+                thrust_vacuum:
+                  type: object
+                  properties:
+                    kN:
+                      type: number
+                    lbf:
+                      type: number
+            flickr_images:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            height:
+              type: object
+              properties:
+                feet:
+                  type: number
+                meters:
+                  type: number
+            id:
+              type:
+                - "null"
+                - string
+            landing_legs:
+              type: object
+              properties:
+                material:
+                  type:
+                    - "null"
+                    - string
+                number:
+                  type: number
+            mass:
+              type: object
+              properties:
+                kg:
+                  type: number
+                lb:
+                  type: number
+            name:
+              type:
+                - "null"
+                - string
+            payload_weights:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type:
+                      - "null"
+                      - string
+                  kg:
+                    type: number
+                  lb:
+                    type: number
+                  name:
+                    type:
+                      - "null"
+                      - string
+            second_stage:
+              type: object
+              properties:
+                burn_time_sec:
+                  type:
+                    - "null"
+                    - number
+                engines:
+                  type: number
+                fuel_amount_tons:
+                  type: number
+                payloads:
+                  type: object
+                  properties:
+                    composite_fairing:
+                      type: object
+                      properties:
+                        diameter:
+                          type: object
+                          properties:
+                            feet:
+                              type:
+                                - "null"
+                                - number
+                            meters:
+                              type:
+                                - "null"
+                                - number
+                        height:
+                          type: object
+                          properties:
+                            feet:
+                              type:
+                                - "null"
+                                - number
+                            meters:
+                              type:
+                                - "null"
+                                - number
+                    option_1:
+                      type:
+                        - "null"
+                        - string
+                reusable:
+                  type: boolean
+                thrust:
+                  type: object
+                  properties:
+                    kN:
+                      type: number
+                    lbf:
+                      type: number
+            stages:
+              type: number
+            success_rate_pct:
+              type: number
+            wikipedia:
+              type:
+                - "null"
+                - string
+          additionalProperties: true
+    roadster:
+      type: DeclarativeStream
+      name: roadster
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /roadster
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            apoapsis_au:
+              type: number
+            details:
+              type:
+                - "null"
+                - string
+            earth_distance_km:
+              type: number
+            earth_distance_mi:
+              type: number
+            eccentricity:
+              type: number
+            epoch_jd:
+              type: number
+            flickr_images:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            id:
+              type:
+                - "null"
+                - string
+            inclination:
+              type: number
+            launch_date_unix:
+              type: number
+            launch_date_utc:
+              type:
+                - "null"
+                - string
+            launch_mass_kg:
+              type: number
+            launch_mass_lbs:
+              type: number
+            longitude:
+              type: number
+            mars_distance_km:
+              type: number
+            mars_distance_mi:
+              type: number
+            name:
+              type:
+                - "null"
+                - string
+            norad_id:
+              type: number
+            orbit_type:
+              type:
+                - "null"
+                - string
+            periapsis_arg:
+              type: number
+            periapsis_au:
+              type: number
+            period_days:
+              type: number
+            semi_major_axis_au:
+              type: number
+            speed_kph:
+              type: number
+            speed_mph:
+              type: number
+            video:
+              type:
+                - "null"
+                - string
+            wikipedia:
+              type:
+                - "null"
+                - string
+          additionalProperties: true
+    ships:
+      type: DeclarativeStream
+      name: ships
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /ships
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            type:
+              type:
+                - "null"
+                - string
+            abs:
+              type:
+                - "null"
+                - number
+            active:
+              type: boolean
+            class:
+              type:
+                - "null"
+                - number
+            course_deg:
+              type:
+                - "null"
+                - number
+            home_port:
+              type:
+                - "null"
+                - string
+            id:
+              type:
+                - "null"
+                - string
+            image:
+              type:
+                - "null"
+                - string
+            imo:
+              type:
+                - "null"
+                - number
+            last_ais_update:
+              type:
+                - "null"
+                - string
+            latitude:
+              type:
+                - "null"
+                - number
+            launches:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            legacy_id:
+              type:
+                - "null"
+                - string
+            link:
+              type:
+                - "null"
+                - string
+            longitude:
+              type:
+                - "null"
+                - number
+            mass_kg:
+              type:
+                - "null"
+                - number
+            mass_lbs:
+              type:
+                - "null"
+                - number
+            mmsi:
+              type:
+                - "null"
+                - number
+            model:
+              type:
+                - "null"
+                - string
+            name:
+              type:
+                - "null"
+                - string
+            roles:
+              type: array
+              items:
+                type:
+                  - "null"
+                  - string
+            speed_kn:
+              type:
+                - "null"
+                - number
+            status:
+              type:
+                - "null"
+                - string
+            year_built:
+              type:
+                - "null"
+                - number
+          additionalProperties: true
+    starlink:
+      type: DeclarativeStream
+      name: starlink
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://api.spacexdata.com/v4/
+          path: /starlink
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          type: object
+          $schema: http://json-schema.org/schema#
+          properties:
+            version:
+              type:
+                - "null"
+                - string
+            height_km:
+              type:
+                - "null"
+                - number
+            id:
+              type:
+                - "null"
+                - string
+            latitude:
+              type:
+                - "null"
+                - number
+            launch:
+              type:
+                - "null"
+                - string
+            longitude:
+              type:
+                - "null"
+                - number
+            spaceTrack:
+              type: object
+              properties:
+                APOAPSIS:
+                  type: number
+                ARG_OF_PERICENTER:
+                  type: number
+                BSTAR:
+                  type: number
+                CCSDS_OMM_VERS:
+                  type:
+                    - "null"
+                    - string
+                CENTER_NAME:
+                  type:
+                    - "null"
+                    - string
+                CLASSIFICATION_TYPE:
+                  type:
+                    - "null"
+                    - string
+                COMMENT:
+                  type:
+                    - "null"
+                    - string
+                COUNTRY_CODE:
+                  type:
+                    - "null"
+                    - string
+                CREATION_DATE:
+                  type:
+                    - "null"
+                    - string
+                DECAYED:
+                  type: number
+                DECAY_DATE:
+                  type:
+                    - "null"
+                    - string
+                ECCENTRICITY:
+                  type: number
+                ELEMENT_SET_NO:
+                  type: number
+                EPHEMERIS_TYPE:
+                  type: number
+                EPOCH:
+                  type:
+                    - "null"
+                    - string
+                FILE:
+                  type: number
+                GP_ID:
+                  type: number
+                INCLINATION:
+                  type: number
+                LAUNCH_DATE:
+                  type:
+                    - "null"
+                    - string
+                MEAN_ANOMALY:
+                  type: number
+                MEAN_ELEMENT_THEORY:
+                  type:
+                    - "null"
+                    - string
+                MEAN_MOTION:
+                  type: number
+                MEAN_MOTION_DDOT:
+                  type: number
+                MEAN_MOTION_DOT:
+                  type: number
+                NORAD_CAT_ID:
+                  type: number
+                OBJECT_ID:
+                  type:
+                    - "null"
+                    - string
+                OBJECT_NAME:
+                  type:
+                    - "null"
+                    - string
+                OBJECT_TYPE:
+                  type:
+                    - "null"
+                    - string
+                ORIGINATOR:
+                  type:
+                    - "null"
+                    - string
+                PERIAPSIS:
+                  type: number
+                PERIOD:
+                  type: number
+                RA_OF_ASC_NODE:
+                  type: number
+                RCS_SIZE:
+                  type:
+                    - "null"
+                    - string
+                REF_FRAME:
+                  type:
+                    - "null"
+                    - string
+                REV_AT_EPOCH:
+                  type: number
+                SEMIMAJOR_AXIS:
+                  type: number
+                SITE:
+                  type:
+                    - "null"
+                    - string
+                TIME_SYSTEM:
+                  type:
+                    - "null"
+                    - string
+                TLE_LINE0:
+                  type:
+                    - "null"
+                    - string
+                TLE_LINE1:
+                  type:
+                    - "null"
+                    - string
+                TLE_LINE2:
+                  type:
+                    - "null"
+                    - string
+            velocity_kms:
+              type:
+                - "null"
+                - number
+          additionalProperties: true
+  base_requester:
+    type: HttpRequester
+    url_base: https://api.spacexdata.com/v4/
+streams:
+  - type: DeclarativeStream
+    name: launches
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /launches/{{config['options'] or config['id'] or 'latest'}}
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          auto_update:
+            type: boolean
+          capsules:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          cores:
+            type: array
+            items:
+              type: object
+              properties:
+                core:
+                  type:
+                    - "null"
+                    - string
+                flight:
+                  type: number
+                gridfins:
+                  type: boolean
+                landing_attempt:
+                  type: boolean
+                landing_success:
+                  type: boolean
+                landing_type:
+                  type:
+                    - "null"
+                    - string
+                landpad:
+                  type:
+                    - "null"
+                    - string
+                legs:
+                  type: boolean
+                reused:
+                  type: boolean
+          crew:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          date_local:
+            type:
+              - "null"
+              - string
+          date_precision:
+            type:
+              - "null"
+              - string
+          date_unix:
+            type: number
+          date_utc:
+            type:
+              - "null"
+              - string
+          details:
+            type: string
+          failures:
+            type: array
+          fairings:
+            type: object
+            properties:
+              recovered:
+                type: boolean
+              recovery_attempt:
+                type: boolean
+              reused:
+                type: boolean
+              ships:
+                type: array
+                items:
+                  type:
+                    - "null"
+                    - string
+          flight_number:
+            type: number
+          id:
+            type:
+              - "null"
+              - string
+          launch_library_id:
+            type:
+              - "null"
+              - string
+          launchpad:
+            type:
+              - "null"
+              - string
+          links:
+            type: object
+            properties:
+              article:
+                type:
+                  - "null"
+                  - string
+              flickr:
+                type: object
+                properties:
+                  original:
+                    type: array
+                    items:
+                      type:
+                        - "null"
+                        - string
+                  small:
+                    type: array
+              patch:
+                type: object
+                properties:
+                  large:
+                    type:
+                      - "null"
+                      - string
+                  small:
+                    type:
+                      - "null"
+                      - string
+              reddit:
+                type: object
+                properties:
+                  launch:
+                    type:
+                      - "null"
+                      - string
+              webcast:
+                type:
+                  - "null"
+                  - string
+              wikipedia:
+                type:
+                  - "null"
+                  - string
+              youtube_id:
+                type:
+                  - "null"
+                  - string
+          name:
+            type:
+              - "null"
+              - string
+          net:
+            type: boolean
+          payloads:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          rocket:
+            type:
+              - "null"
+              - string
+          ships:
+            type: array
+          static_fire_date_unix:
+            type:
+              - "null"
+              - number
+          static_fire_date_utc:
+            type:
+              - "null"
+              - string
+          success:
+            type: boolean
+          tbd:
+            type: boolean
+          upcoming:
+            type: boolean
+          window:
+            type:
+              - "null"
+              - number
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: capsules
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /capsules
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          type:
+            type:
+              - "null"
+              - string
+          id:
+            type:
+              - "null"
+              - string
+          land_landings:
+            type: number
+          last_update:
+            type:
+              - "null"
+              - string
+          launches:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          reuse_count:
+            type: number
+          serial:
+            type:
+              - "null"
+              - string
+          status:
+            type:
+              - "null"
+              - string
+          water_landings:
+            type: number
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: company
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /company
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          ceo:
+            type:
+              - "null"
+              - string
+          coo:
+            type:
+              - "null"
+              - string
+          cto:
+            type:
+              - "null"
+              - string
+          cto_propulsion:
+            type:
+              - "null"
+              - string
+          employees:
+            type: number
+          founded:
+            type: number
+          founder:
+            type:
+              - "null"
+              - string
+          headquarters:
+            type: object
+            properties:
+              address:
+                type:
+                  - "null"
+                  - string
+              city:
+                type:
+                  - "null"
+                  - string
+              state:
+                type:
+                  - "null"
+                  - string
+          id:
+            type:
+              - "null"
+              - string
+          launch_sites:
+            type: number
+          links:
+            type: object
+            properties:
+              elon_twitter:
+                type:
+                  - "null"
+                  - string
+              flickr:
+                type:
+                  - "null"
+                  - string
+              twitter:
+                type:
+                  - "null"
+                  - string
+              website:
+                type:
+                  - "null"
+                  - string
+          name:
+            type:
+              - "null"
+              - string
+          summary:
+            type:
+              - "null"
+              - string
+          test_sites:
+            type: number
+          valuation:
+            type: number
+          vehicles:
+            type: number
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: crew
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /crew
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          agency:
+            type:
+              - "null"
+              - string
+          id:
+            type:
+              - "null"
+              - string
+          image:
+            type:
+              - "null"
+              - string
+          launches:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          name:
+            type:
+              - "null"
+              - string
+          status:
+            type:
+              - "null"
+              - string
+          wikipedia:
+            type:
+              - "null"
+              - string
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: cores
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /cores
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          asds_attempts:
+            type: number
+          asds_landings:
+            type: number
+          block:
+            type:
+              - "null"
+              - number
+          id:
+            type:
+              - "null"
+              - string
+          last_update:
+            type:
+              - "null"
+              - string
+          launches:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          reuse_count:
+            type: number
+          rtls_attempts:
+            type: number
+          rtls_landings:
+            type: number
+          serial:
+            type:
+              - "null"
+              - string
+          status:
+            type:
+              - "null"
+              - string
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: dragons
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /dragons
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          type:
+            type:
+              - "null"
+              - string
+          active:
+            type: boolean
+          crew_capacity:
+            type: number
+          description:
+            type:
+              - "null"
+              - string
+          diameter:
+            type: object
+            properties:
+              feet:
+                type: number
+              meters:
+                type: number
+          dry_mass_kg:
+            type: number
+          dry_mass_lb:
+            type: number
+          first_flight:
+            type:
+              - "null"
+              - string
+          flickr_images:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          heat_shield:
+            type: object
+            properties:
+              dev_partner:
+                type:
+                  - "null"
+                  - string
+              material:
+                type:
+                  - "null"
+                  - string
+              size_meters:
+                type: number
+              temp_degrees:
+                type: number
+          height_w_trunk:
+            type: object
+            properties:
+              feet:
+                type: number
+              meters:
+                type: number
+          id:
+            type:
+              - "null"
+              - string
+          launch_payload_mass:
+            type: object
+            properties:
+              kg:
+                type: number
+              lb:
+                type: number
+          launch_payload_vol:
+            type: object
+            properties:
+              cubic_feet:
+                type: number
+              cubic_meters:
+                type: number
+          name:
+            type:
+              - "null"
+              - string
+          orbit_duration_yr:
+            type: number
+          pressurized_capsule:
+            type: object
+            properties:
+              payload_volume:
+                type: object
+                properties:
+                  cubic_feet:
+                    type: number
+                  cubic_meters:
+                    type: number
+          return_payload_mass:
+            type: object
+            properties:
+              kg:
+                type: number
+              lb:
+                type: number
+          return_payload_vol:
+            type: object
+            properties:
+              cubic_feet:
+                type: number
+              cubic_meters:
+                type: number
+          sidewall_angle_deg:
+            type: number
+          thrusters:
+            type: array
+            items:
+              type: object
+              properties:
+                type:
+                  type:
+                    - "null"
+                    - string
+                amount:
+                  type: number
+                fuel_1:
+                  type:
+                    - "null"
+                    - string
+                fuel_2:
+                  type:
+                    - "null"
+                    - string
+                isp:
+                  type: number
+                pods:
+                  type: number
+                thrust:
+                  type: object
+                  properties:
+                    kN:
+                      type: number
+                    lbf:
+                      type: number
+          trunk:
+            type: object
+            properties:
+              cargo:
+                type: object
+                properties:
+                  solar_array:
+                    type: number
+                  unpressurized_cargo:
+                    type: boolean
+              trunk_volume:
+                type: object
+                properties:
+                  cubic_feet:
+                    type: number
+                  cubic_meters:
+                    type: number
+          wikipedia:
+            type:
+              - "null"
+              - string
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: landpads
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /landpads
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          type:
+            type:
+              - "null"
+              - string
+          details:
+            type:
+              - "null"
+              - string
+          full_name:
+            type:
+              - "null"
+              - string
+          id:
+            type:
+              - "null"
+              - string
+          images:
+            type: object
+            properties:
+              large:
+                type: array
+                items:
+                  type:
+                    - "null"
+                    - string
+          landing_attempts:
+            type: number
+          landing_successes:
+            type: number
+          latitude:
+            type: number
+          launches:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          locality:
+            type:
+              - "null"
+              - string
+          longitude:
+            type: number
+          name:
+            type:
+              - "null"
+              - string
+          region:
+            type:
+              - "null"
+              - string
+          status:
+            type:
+              - "null"
+              - string
+          wikipedia:
+            type:
+              - "null"
+              - string
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: payloads
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /payloads
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          type:
+            type:
+              - "null"
+              - string
+          apoapsis_km:
+            type:
+              - "null"
+              - number
+          arg_of_pericenter:
+            type:
+              - "null"
+              - number
+          customers:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          dragon:
+            type: object
+            properties:
+              capsule:
+                type:
+                  - "null"
+                  - string
+              flight_time_sec:
+                type:
+                  - "null"
+                  - number
+              land_landing:
+                type:
+                  - boolean
+                  - "null"
+              manifest:
+                type:
+                  - "null"
+                  - string
+              mass_returned_kg:
+                type:
+                  - "null"
+                  - number
+              mass_returned_lbs:
+                type:
+                  - "null"
+                  - number
+              water_landing:
+                type:
+                  - boolean
+                  - "null"
+          eccentricity:
+            type:
+              - "null"
+              - number
+          epoch:
+            type:
+              - "null"
+              - string
+          id:
+            type:
+              - "null"
+              - string
+          inclination_deg:
+            type:
+              - "null"
+              - number
+          launch:
+            type:
+              - "null"
+              - string
+          lifespan_years:
+            type:
+              - "null"
+              - number
+          longitude:
+            type:
+              - "null"
+              - number
+          manufacturers:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          mass_kg:
+            type:
+              - "null"
+              - number
+          mass_lbs:
+            type:
+              - "null"
+              - number
+          mean_anomaly:
+            type:
+              - "null"
+              - number
+          mean_motion:
+            type:
+              - "null"
+              - number
+          name:
+            type:
+              - "null"
+              - string
+          nationalities:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          norad_ids:
+            type: array
+            items:
+              type: number
+          orbit:
+            type:
+              - "null"
+              - string
+          periapsis_km:
+            type:
+              - "null"
+              - number
+          period_min:
+            type:
+              - "null"
+              - number
+          raan:
+            type:
+              - "null"
+              - number
+          reference_system:
+            type:
+              - "null"
+              - string
+          regime:
+            type:
+              - "null"
+              - string
+          reused:
+            type: boolean
+          semi_major_axis_km:
+            type:
+              - "null"
+              - number
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: history
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /history
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          details:
+            type:
+              - "null"
+              - string
+          event_date_unix:
+            type: number
+          event_date_utc:
+            type:
+              - "null"
+              - string
+          id:
+            type:
+              - "null"
+              - string
+          links:
+            type: object
+            properties:
+              article:
+                type:
+                  - "null"
+                  - string
+          title:
+            type:
+              - "null"
+              - string
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: rockets
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /rockets
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          type:
+            type:
+              - "null"
+              - string
+          active:
+            type: boolean
+          boosters:
+            type: number
+          company:
+            type:
+              - "null"
+              - string
+          cost_per_launch:
+            type: number
+          country:
+            type:
+              - "null"
+              - string
+          description:
+            type:
+              - "null"
+              - string
+          diameter:
+            type: object
+            properties:
+              feet:
+                type: number
+              meters:
+                type: number
+          engines:
+            type: object
+            properties:
+              version:
+                type:
+                  - "null"
+                  - string
+              type:
+                type:
+                  - "null"
+                  - string
+              engine_loss_max:
+                type:
+                  - "null"
+                  - number
+              isp:
+                type: object
+                properties:
+                  sea_level:
+                    type: number
+                  vacuum:
+                    type: number
+              layout:
+                type:
+                  - "null"
+                  - string
+              number:
+                type: number
+              propellant_1:
+                type:
+                  - "null"
+                  - string
+              propellant_2:
+                type:
+                  - "null"
+                  - string
+              thrust_sea_level:
+                type: object
+                properties:
+                  kN:
+                    type: number
+                  lbf:
+                    type: number
+              thrust_to_weight:
+                type: number
+              thrust_vacuum:
+                type: object
+                properties:
+                  kN:
+                    type: number
+                  lbf:
+                    type: number
+          first_flight:
+            type:
+              - "null"
+              - string
+          first_stage:
+            type: object
+            properties:
+              burn_time_sec:
+                type:
+                  - "null"
+                  - number
+              engines:
+                type: number
+              fuel_amount_tons:
+                type: number
+              reusable:
+                type: boolean
+              thrust_sea_level:
+                type: object
+                properties:
+                  kN:
+                    type: number
+                  lbf:
+                    type: number
+              thrust_vacuum:
+                type: object
+                properties:
+                  kN:
+                    type: number
+                  lbf:
+                    type: number
+          flickr_images:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          height:
+            type: object
+            properties:
+              feet:
+                type: number
+              meters:
+                type: number
+          id:
+            type:
+              - "null"
+              - string
+          landing_legs:
+            type: object
+            properties:
+              material:
+                type:
+                  - "null"
+                  - string
+              number:
+                type: number
+          mass:
+            type: object
+            properties:
+              kg:
+                type: number
+              lb:
+                type: number
+          name:
+            type:
+              - "null"
+              - string
+          payload_weights:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type:
+                    - "null"
+                    - string
+                kg:
+                  type: number
+                lb:
+                  type: number
+                name:
+                  type:
+                    - "null"
+                    - string
+          second_stage:
+            type: object
+            properties:
+              burn_time_sec:
+                type:
+                  - "null"
+                  - number
+              engines:
+                type: number
+              fuel_amount_tons:
+                type: number
+              payloads:
+                type: object
+                properties:
+                  composite_fairing:
+                    type: object
+                    properties:
+                      diameter:
+                        type: object
+                        properties:
+                          feet:
+                            type:
+                              - "null"
+                              - number
+                          meters:
+                            type:
+                              - "null"
+                              - number
+                      height:
+                        type: object
+                        properties:
+                          feet:
+                            type:
+                              - "null"
+                              - number
+                          meters:
+                            type:
+                              - "null"
+                              - number
+                  option_1:
+                    type:
+                      - "null"
+                      - string
+              reusable:
+                type: boolean
+              thrust:
+                type: object
+                properties:
+                  kN:
+                    type: number
+                  lbf:
+                    type: number
+          stages:
+            type: number
+          success_rate_pct:
+            type: number
+          wikipedia:
+            type:
+              - "null"
+              - string
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: roadster
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /roadster
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          apoapsis_au:
+            type: number
+          details:
+            type:
+              - "null"
+              - string
+          earth_distance_km:
+            type: number
+          earth_distance_mi:
+            type: number
+          eccentricity:
+            type: number
+          epoch_jd:
+            type: number
+          flickr_images:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          id:
+            type:
+              - "null"
+              - string
+          inclination:
+            type: number
+          launch_date_unix:
+            type: number
+          launch_date_utc:
+            type:
+              - "null"
+              - string
+          launch_mass_kg:
+            type: number
+          launch_mass_lbs:
+            type: number
+          longitude:
+            type: number
+          mars_distance_km:
+            type: number
+          mars_distance_mi:
+            type: number
+          name:
+            type:
+              - "null"
+              - string
+          norad_id:
+            type: number
+          orbit_type:
+            type:
+              - "null"
+              - string
+          periapsis_arg:
+            type: number
+          periapsis_au:
+            type: number
+          period_days:
+            type: number
+          semi_major_axis_au:
+            type: number
+          speed_kph:
+            type: number
+          speed_mph:
+            type: number
+          video:
+            type:
+              - "null"
+              - string
+          wikipedia:
+            type:
+              - "null"
+              - string
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: ships
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /ships
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          type:
+            type:
+              - "null"
+              - string
+          abs:
+            type:
+              - "null"
+              - number
+          active:
+            type: boolean
+          class:
+            type:
+              - "null"
+              - number
+          course_deg:
+            type:
+              - "null"
+              - number
+          home_port:
+            type:
+              - "null"
+              - string
+          id:
+            type:
+              - "null"
+              - string
+          image:
+            type:
+              - "null"
+              - string
+          imo:
+            type:
+              - "null"
+              - number
+          last_ais_update:
+            type:
+              - "null"
+              - string
+          latitude:
+            type:
+              - "null"
+              - number
+          launches:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          legacy_id:
+            type:
+              - "null"
+              - string
+          link:
+            type:
+              - "null"
+              - string
+          longitude:
+            type:
+              - "null"
+              - number
+          mass_kg:
+            type:
+              - "null"
+              - number
+          mass_lbs:
+            type:
+              - "null"
+              - number
+          mmsi:
+            type:
+              - "null"
+              - number
+          model:
+            type:
+              - "null"
+              - string
+          name:
+            type:
+              - "null"
+              - string
+          roles:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+          speed_kn:
+            type:
+              - "null"
+              - number
+          status:
+            type:
+              - "null"
+              - string
+          year_built:
+            type:
+              - "null"
+              - number
+        additionalProperties: true
+  - type: DeclarativeStream
+    name: starlink
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://api.spacexdata.com/v4/
+        path: /starlink
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          version:
+            type:
+              - "null"
+              - string
+          height_km:
+            type:
+              - "null"
+              - number
+          id:
+            type:
+              - "null"
+              - string
+          latitude:
+            type:
+              - "null"
+              - number
+          launch:
+            type:
+              - "null"
+              - string
+          longitude:
+            type:
+              - "null"
+              - number
+          spaceTrack:
+            type: object
+            properties:
+              APOAPSIS:
+                type: number
+              ARG_OF_PERICENTER:
+                type: number
+              BSTAR:
+                type: number
+              CCSDS_OMM_VERS:
+                type:
+                  - "null"
+                  - string
+              CENTER_NAME:
+                type:
+                  - "null"
+                  - string
+              CLASSIFICATION_TYPE:
+                type:
+                  - "null"
+                  - string
+              COMMENT:
+                type:
+                  - "null"
+                  - string
+              COUNTRY_CODE:
+                type:
+                  - "null"
+                  - string
+              CREATION_DATE:
+                type:
+                  - "null"
+                  - string
+              DECAYED:
+                type: number
+              DECAY_DATE:
+                type:
+                  - "null"
+                  - string
+              ECCENTRICITY:
+                type: number
+              ELEMENT_SET_NO:
+                type: number
+              EPHEMERIS_TYPE:
+                type: number
+              EPOCH:
+                type:
+                  - "null"
+                  - string
+              FILE:
+                type: number
+              GP_ID:
+                type: number
+              INCLINATION:
+                type: number
+              LAUNCH_DATE:
+                type:
+                  - "null"
+                  - string
+              MEAN_ANOMALY:
+                type: number
+              MEAN_ELEMENT_THEORY:
+                type:
+                  - "null"
+                  - string
+              MEAN_MOTION:
+                type: number
+              MEAN_MOTION_DDOT:
+                type: number
+              MEAN_MOTION_DOT:
+                type: number
+              NORAD_CAT_ID:
+                type: number
+              OBJECT_ID:
+                type:
+                  - "null"
+                  - string
+              OBJECT_NAME:
+                type:
+                  - "null"
+                  - string
+              OBJECT_TYPE:
+                type:
+                  - "null"
+                  - string
+              ORIGINATOR:
+                type:
+                  - "null"
+                  - string
+              PERIAPSIS:
+                type: number
+              PERIOD:
+                type: number
+              RA_OF_ASC_NODE:
+                type: number
+              RCS_SIZE:
+                type:
+                  - "null"
+                  - string
+              REF_FRAME:
+                type:
+                  - "null"
+                  - string
+              REV_AT_EPOCH:
+                type: number
+              SEMIMAJOR_AXIS:
+                type: number
+              SITE:
+                type:
+                  - "null"
+                  - string
+              TIME_SYSTEM:
+                type:
+                  - "null"
+                  - string
+              TLE_LINE0:
+                type:
+                  - "null"
+                  - string
+              TLE_LINE1:
+                type:
+                  - "null"
+                  - string
+              TLE_LINE2:
+                type:
+                  - "null"
+                  - string
+          velocity_kms:
+            type:
+              - "null"
+              - number
+        additionalProperties: true
+spec:
+  type: Spec
+  connection_specification:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    required: []
+    properties:
+      id:
+        type: string
+        title: Unique ID for specific source target
+        desciption: Optional, For a specific ID
+        order: 0
+      options:
+        type: string
+        title: Configuration options for endpoints
+        desciption: >-
+          Optional, Possible values for an endpoint. Example values for
+          launches-latest, upcoming, past
+        order: 1
+    additionalProperties: true
+metadata:
+  autoImportSchema:
+    launches: false
+    capsules: false
+    company: false
+    crew: false
+    cores: false
+    dragons: false
+    landpads: false
+    payloads: false
+    history: false
+    rockets: false
+    roadster: false
+    ships: false
+    starlink: false
+schemas:
+  launches:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      auto_update:
+        type: boolean
+      capsules:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      cores:
+        type: array
+        items:
+          type: object
+          properties:
+            core:
+              type:
+                - "null"
+                - string
+            flight:
+              type: number
+            gridfins:
+              type: boolean
+            landing_attempt:
+              type: boolean
+            landing_success:
+              type: boolean
+            landing_type:
+              type:
+                - "null"
+                - string
+            landpad:
+              type:
+                - "null"
+                - string
+            legs:
+              type: boolean
+            reused:
+              type: boolean
+      crew:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      date_local:
+        type:
+          - "null"
+          - string
+      date_precision:
+        type:
+          - "null"
+          - string
+      date_unix:
+        type: number
+      date_utc:
+        type:
+          - "null"
+          - string
+      details:
+        type: string
+      failures:
+        type: array
+      fairings:
+        type: object
+        properties:
+          recovered:
+            type: boolean
+          recovery_attempt:
+            type: boolean
+          reused:
+            type: boolean
+          ships:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+      flight_number:
+        type: number
+      id:
+        type:
+          - "null"
+          - string
+      launch_library_id:
+        type:
+          - "null"
+          - string
+      launchpad:
+        type:
+          - "null"
+          - string
+      links:
+        type: object
+        properties:
+          article:
+            type:
+              - "null"
+              - string
+          flickr:
+            type: object
+            properties:
+              original:
+                type: array
+                items:
+                  type:
+                    - "null"
+                    - string
+              small:
+                type: array
+          patch:
+            type: object
+            properties:
+              large:
+                type:
+                  - "null"
+                  - string
+              small:
+                type:
+                  - "null"
+                  - string
+          reddit:
+            type: object
+            properties:
+              launch:
+                type:
+                  - "null"
+                  - string
+          webcast:
+            type:
+              - "null"
+              - string
+          wikipedia:
+            type:
+              - "null"
+              - string
+          youtube_id:
+            type:
+              - "null"
+              - string
+      name:
+        type:
+          - "null"
+          - string
+      net:
+        type: boolean
+      payloads:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      rocket:
+        type:
+          - "null"
+          - string
+      ships:
+        type: array
+      static_fire_date_unix:
+        type:
+          - "null"
+          - number
+      static_fire_date_utc:
+        type:
+          - "null"
+          - string
+      success:
+        type: boolean
+      tbd:
+        type: boolean
+      upcoming:
+        type: boolean
+      window:
+        type:
+          - "null"
+          - number
+    additionalProperties: true
+  capsules:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      type:
+        type:
+          - "null"
+          - string
+      id:
+        type:
+          - "null"
+          - string
+      land_landings:
+        type: number
+      last_update:
+        type:
+          - "null"
+          - string
+      launches:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      reuse_count:
+        type: number
+      serial:
+        type:
+          - "null"
+          - string
+      status:
+        type:
+          - "null"
+          - string
+      water_landings:
+        type: number
+    additionalProperties: true
+  company:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      ceo:
+        type:
+          - "null"
+          - string
+      coo:
+        type:
+          - "null"
+          - string
+      cto:
+        type:
+          - "null"
+          - string
+      cto_propulsion:
+        type:
+          - "null"
+          - string
+      employees:
+        type: number
+      founded:
+        type: number
+      founder:
+        type:
+          - "null"
+          - string
+      headquarters:
+        type: object
+        properties:
+          address:
+            type:
+              - "null"
+              - string
+          city:
+            type:
+              - "null"
+              - string
+          state:
+            type:
+              - "null"
+              - string
+      id:
+        type:
+          - "null"
+          - string
+      launch_sites:
+        type: number
+      links:
+        type: object
+        properties:
+          elon_twitter:
+            type:
+              - "null"
+              - string
+          flickr:
+            type:
+              - "null"
+              - string
+          twitter:
+            type:
+              - "null"
+              - string
+          website:
+            type:
+              - "null"
+              - string
+      name:
+        type:
+          - "null"
+          - string
+      summary:
+        type:
+          - "null"
+          - string
+      test_sites:
+        type: number
+      valuation:
+        type: number
+      vehicles:
+        type: number
+    additionalProperties: true
+  crew:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      agency:
+        type:
+          - "null"
+          - string
+      id:
+        type:
+          - "null"
+          - string
+      image:
+        type:
+          - "null"
+          - string
+      launches:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      name:
+        type:
+          - "null"
+          - string
+      status:
+        type:
+          - "null"
+          - string
+      wikipedia:
+        type:
+          - "null"
+          - string
+    additionalProperties: true
+  cores:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      asds_attempts:
+        type: number
+      asds_landings:
+        type: number
+      block:
+        type:
+          - "null"
+          - number
+      id:
+        type:
+          - "null"
+          - string
+      last_update:
+        type:
+          - "null"
+          - string
+      launches:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      reuse_count:
+        type: number
+      rtls_attempts:
+        type: number
+      rtls_landings:
+        type: number
+      serial:
+        type:
+          - "null"
+          - string
+      status:
+        type:
+          - "null"
+          - string
+    additionalProperties: true
+  dragons:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      type:
+        type:
+          - "null"
+          - string
+      active:
+        type: boolean
+      crew_capacity:
+        type: number
+      description:
+        type:
+          - "null"
+          - string
+      diameter:
+        type: object
+        properties:
+          feet:
+            type: number
+          meters:
+            type: number
+      dry_mass_kg:
+        type: number
+      dry_mass_lb:
+        type: number
+      first_flight:
+        type:
+          - "null"
+          - string
+      flickr_images:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      heat_shield:
+        type: object
+        properties:
+          dev_partner:
+            type:
+              - "null"
+              - string
+          material:
+            type:
+              - "null"
+              - string
+          size_meters:
+            type: number
+          temp_degrees:
+            type: number
+      height_w_trunk:
+        type: object
+        properties:
+          feet:
+            type: number
+          meters:
+            type: number
+      id:
+        type:
+          - "null"
+          - string
+      launch_payload_mass:
+        type: object
+        properties:
+          kg:
+            type: number
+          lb:
+            type: number
+      launch_payload_vol:
+        type: object
+        properties:
+          cubic_feet:
+            type: number
+          cubic_meters:
+            type: number
+      name:
+        type:
+          - "null"
+          - string
+      orbit_duration_yr:
+        type: number
+      pressurized_capsule:
+        type: object
+        properties:
+          payload_volume:
+            type: object
+            properties:
+              cubic_feet:
+                type: number
+              cubic_meters:
+                type: number
+      return_payload_mass:
+        type: object
+        properties:
+          kg:
+            type: number
+          lb:
+            type: number
+      return_payload_vol:
+        type: object
+        properties:
+          cubic_feet:
+            type: number
+          cubic_meters:
+            type: number
+      sidewall_angle_deg:
+        type: number
+      thrusters:
+        type: array
+        items:
+          type: object
+          properties:
+            type:
+              type:
+                - "null"
+                - string
+            amount:
+              type: number
+            fuel_1:
+              type:
+                - "null"
+                - string
+            fuel_2:
+              type:
+                - "null"
+                - string
+            isp:
+              type: number
+            pods:
+              type: number
+            thrust:
+              type: object
+              properties:
+                kN:
+                  type: number
+                lbf:
+                  type: number
+      trunk:
+        type: object
+        properties:
+          cargo:
+            type: object
+            properties:
+              solar_array:
+                type: number
+              unpressurized_cargo:
+                type: boolean
+          trunk_volume:
+            type: object
+            properties:
+              cubic_feet:
+                type: number
+              cubic_meters:
+                type: number
+      wikipedia:
+        type:
+          - "null"
+          - string
+    additionalProperties: true
+  landpads:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      type:
+        type:
+          - "null"
+          - string
+      details:
+        type:
+          - "null"
+          - string
+      full_name:
+        type:
+          - "null"
+          - string
+      id:
+        type:
+          - "null"
+          - string
+      images:
+        type: object
+        properties:
+          large:
+            type: array
+            items:
+              type:
+                - "null"
+                - string
+      landing_attempts:
+        type: number
+      landing_successes:
+        type: number
+      latitude:
+        type: number
+      launches:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      locality:
+        type:
+          - "null"
+          - string
+      longitude:
+        type: number
+      name:
+        type:
+          - "null"
+          - string
+      region:
+        type:
+          - "null"
+          - string
+      status:
+        type:
+          - "null"
+          - string
+      wikipedia:
+        type:
+          - "null"
+          - string
+    additionalProperties: true
+  payloads:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      type:
+        type:
+          - "null"
+          - string
+      apoapsis_km:
+        type:
+          - "null"
+          - number
+      arg_of_pericenter:
+        type:
+          - "null"
+          - number
+      customers:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      dragon:
+        type: object
+        properties:
+          capsule:
+            type:
+              - "null"
+              - string
+          flight_time_sec:
+            type:
+              - "null"
+              - number
+          land_landing:
+            type:
+              - boolean
+              - "null"
+          manifest:
+            type:
+              - "null"
+              - string
+          mass_returned_kg:
+            type:
+              - "null"
+              - number
+          mass_returned_lbs:
+            type:
+              - "null"
+              - number
+          water_landing:
+            type:
+              - boolean
+              - "null"
+      eccentricity:
+        type:
+          - "null"
+          - number
+      epoch:
+        type:
+          - "null"
+          - string
+      id:
+        type:
+          - "null"
+          - string
+      inclination_deg:
+        type:
+          - "null"
+          - number
+      launch:
+        type:
+          - "null"
+          - string
+      lifespan_years:
+        type:
+          - "null"
+          - number
+      longitude:
+        type:
+          - "null"
+          - number
+      manufacturers:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      mass_kg:
+        type:
+          - "null"
+          - number
+      mass_lbs:
+        type:
+          - "null"
+          - number
+      mean_anomaly:
+        type:
+          - "null"
+          - number
+      mean_motion:
+        type:
+          - "null"
+          - number
+      name:
+        type:
+          - "null"
+          - string
+      nationalities:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      norad_ids:
+        type: array
+        items:
+          type: number
+      orbit:
+        type:
+          - "null"
+          - string
+      periapsis_km:
+        type:
+          - "null"
+          - number
+      period_min:
+        type:
+          - "null"
+          - number
+      raan:
+        type:
+          - "null"
+          - number
+      reference_system:
+        type:
+          - "null"
+          - string
+      regime:
+        type:
+          - "null"
+          - string
+      reused:
+        type: boolean
+      semi_major_axis_km:
+        type:
+          - "null"
+          - number
+    additionalProperties: true
+  history:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      details:
+        type:
+          - "null"
+          - string
+      event_date_unix:
+        type: number
+      event_date_utc:
+        type:
+          - "null"
+          - string
+      id:
+        type:
+          - "null"
+          - string
+      links:
+        type: object
+        properties:
+          article:
+            type:
+              - "null"
+              - string
+      title:
+        type:
+          - "null"
+          - string
+    additionalProperties: true
+  rockets:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      type:
+        type:
+          - "null"
+          - string
+      active:
+        type: boolean
+      boosters:
+        type: number
+      company:
+        type:
+          - "null"
+          - string
+      cost_per_launch:
+        type: number
+      country:
+        type:
+          - "null"
+          - string
+      description:
+        type:
+          - "null"
+          - string
+      diameter:
+        type: object
+        properties:
+          feet:
+            type: number
+          meters:
+            type: number
+      engines:
+        type: object
+        properties:
+          version:
+            type:
+              - "null"
+              - string
+          type:
+            type:
+              - "null"
+              - string
+          engine_loss_max:
+            type:
+              - "null"
+              - number
+          isp:
+            type: object
+            properties:
+              sea_level:
+                type: number
+              vacuum:
+                type: number
+          layout:
+            type:
+              - "null"
+              - string
+          number:
+            type: number
+          propellant_1:
+            type:
+              - "null"
+              - string
+          propellant_2:
+            type:
+              - "null"
+              - string
+          thrust_sea_level:
+            type: object
+            properties:
+              kN:
+                type: number
+              lbf:
+                type: number
+          thrust_to_weight:
+            type: number
+          thrust_vacuum:
+            type: object
+            properties:
+              kN:
+                type: number
+              lbf:
+                type: number
+      first_flight:
+        type:
+          - "null"
+          - string
+      first_stage:
+        type: object
+        properties:
+          burn_time_sec:
+            type:
+              - "null"
+              - number
+          engines:
+            type: number
+          fuel_amount_tons:
+            type: number
+          reusable:
+            type: boolean
+          thrust_sea_level:
+            type: object
+            properties:
+              kN:
+                type: number
+              lbf:
+                type: number
+          thrust_vacuum:
+            type: object
+            properties:
+              kN:
+                type: number
+              lbf:
+                type: number
+      flickr_images:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      height:
+        type: object
+        properties:
+          feet:
+            type: number
+          meters:
+            type: number
+      id:
+        type:
+          - "null"
+          - string
+      landing_legs:
+        type: object
+        properties:
+          material:
+            type:
+              - "null"
+              - string
+          number:
+            type: number
+      mass:
+        type: object
+        properties:
+          kg:
+            type: number
+          lb:
+            type: number
+      name:
+        type:
+          - "null"
+          - string
+      payload_weights:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type:
+                - "null"
+                - string
+            kg:
+              type: number
+            lb:
+              type: number
+            name:
+              type:
+                - "null"
+                - string
+      second_stage:
+        type: object
+        properties:
+          burn_time_sec:
+            type:
+              - "null"
+              - number
+          engines:
+            type: number
+          fuel_amount_tons:
+            type: number
+          payloads:
+            type: object
+            properties:
+              composite_fairing:
+                type: object
+                properties:
+                  diameter:
+                    type: object
+                    properties:
+                      feet:
+                        type:
+                          - "null"
+                          - number
+                      meters:
+                        type:
+                          - "null"
+                          - number
+                  height:
+                    type: object
+                    properties:
+                      feet:
+                        type:
+                          - "null"
+                          - number
+                      meters:
+                        type:
+                          - "null"
+                          - number
+              option_1:
+                type:
+                  - "null"
+                  - string
+          reusable:
+            type: boolean
+          thrust:
+            type: object
+            properties:
+              kN:
+                type: number
+              lbf:
+                type: number
+      stages:
+        type: number
+      success_rate_pct:
+        type: number
+      wikipedia:
+        type:
+          - "null"
+          - string
+    additionalProperties: true
+  roadster:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      apoapsis_au:
+        type: number
+      details:
+        type:
+          - "null"
+          - string
+      earth_distance_km:
+        type: number
+      earth_distance_mi:
+        type: number
+      eccentricity:
+        type: number
+      epoch_jd:
+        type: number
+      flickr_images:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      id:
+        type:
+          - "null"
+          - string
+      inclination:
+        type: number
+      launch_date_unix:
+        type: number
+      launch_date_utc:
+        type:
+          - "null"
+          - string
+      launch_mass_kg:
+        type: number
+      launch_mass_lbs:
+        type: number
+      longitude:
+        type: number
+      mars_distance_km:
+        type: number
+      mars_distance_mi:
+        type: number
+      name:
+        type:
+          - "null"
+          - string
+      norad_id:
+        type: number
+      orbit_type:
+        type:
+          - "null"
+          - string
+      periapsis_arg:
+        type: number
+      periapsis_au:
+        type: number
+      period_days:
+        type: number
+      semi_major_axis_au:
+        type: number
+      speed_kph:
+        type: number
+      speed_mph:
+        type: number
+      video:
+        type:
+          - "null"
+          - string
+      wikipedia:
+        type:
+          - "null"
+          - string
+    additionalProperties: true
+  ships:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      type:
+        type:
+          - "null"
+          - string
+      abs:
+        type:
+          - "null"
+          - number
+      active:
+        type: boolean
+      class:
+        type:
+          - "null"
+          - number
+      course_deg:
+        type:
+          - "null"
+          - number
+      home_port:
+        type:
+          - "null"
+          - string
+      id:
+        type:
+          - "null"
+          - string
+      image:
+        type:
+          - "null"
+          - string
+      imo:
+        type:
+          - "null"
+          - number
+      last_ais_update:
+        type:
+          - "null"
+          - string
+      latitude:
+        type:
+          - "null"
+          - number
+      launches:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      legacy_id:
+        type:
+          - "null"
+          - string
+      link:
+        type:
+          - "null"
+          - string
+      longitude:
+        type:
+          - "null"
+          - number
+      mass_kg:
+        type:
+          - "null"
+          - number
+      mass_lbs:
+        type:
+          - "null"
+          - number
+      mmsi:
+        type:
+          - "null"
+          - number
+      model:
+        type:
+          - "null"
+          - string
+      name:
+        type:
+          - "null"
+          - string
+      roles:
+        type: array
+        items:
+          type:
+            - "null"
+            - string
+      speed_kn:
+        type:
+          - "null"
+          - number
+      status:
+        type:
+          - "null"
+          - string
+      year_built:
+        type:
+          - "null"
+          - number
+    additionalProperties: true
+  starlink:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      version:
+        type:
+          - "null"
+          - string
+      height_km:
+        type:
+          - "null"
+          - number
+      id:
+        type:
+          - "null"
+          - string
+      latitude:
+        type:
+          - "null"
+          - number
+      launch:
+        type:
+          - "null"
+          - string
+      longitude:
+        type:
+          - "null"
+          - number
+      spaceTrack:
+        type: object
+        properties:
+          APOAPSIS:
+            type: number
+          ARG_OF_PERICENTER:
+            type: number
+          BSTAR:
+            type: number
+          CCSDS_OMM_VERS:
+            type:
+              - "null"
+              - string
+          CENTER_NAME:
+            type:
+              - "null"
+              - string
+          CLASSIFICATION_TYPE:
+            type:
+              - "null"
+              - string
+          COMMENT:
+            type:
+              - "null"
+              - string
+          COUNTRY_CODE:
+            type:
+              - "null"
+              - string
+          CREATION_DATE:
+            type:
+              - "null"
+              - string
+          DECAYED:
+            type: number
+          DECAY_DATE:
+            type:
+              - "null"
+              - string
+          ECCENTRICITY:
+            type: number
+          ELEMENT_SET_NO:
+            type: number
+          EPHEMERIS_TYPE:
+            type: number
+          EPOCH:
+            type:
+              - "null"
+              - string
+          FILE:
+            type: number
+          GP_ID:
+            type: number
+          INCLINATION:
+            type: number
+          LAUNCH_DATE:
+            type:
+              - "null"
+              - string
+          MEAN_ANOMALY:
+            type: number
+          MEAN_ELEMENT_THEORY:
+            type:
+              - "null"
+              - string
+          MEAN_MOTION:
+            type: number
+          MEAN_MOTION_DDOT:
+            type: number
+          MEAN_MOTION_DOT:
+            type: number
+          NORAD_CAT_ID:
+            type: number
+          OBJECT_ID:
+            type:
+              - "null"
+              - string
+          OBJECT_NAME:
+            type:
+              - "null"
+              - string
+          OBJECT_TYPE:
+            type:
+              - "null"
+              - string
+          ORIGINATOR:
+            type:
+              - "null"
+              - string
+          PERIAPSIS:
+            type: number
+          PERIOD:
+            type: number
+          RA_OF_ASC_NODE:
+            type: number
+          RCS_SIZE:
+            type:
+              - "null"
+              - string
+          REF_FRAME:
+            type:
+              - "null"
+              - string
+          REV_AT_EPOCH:
+            type: number
+          SEMIMAJOR_AXIS:
+            type: number
+          SITE:
+            type:
+              - "null"
+              - string
+          TIME_SYSTEM:
+            type:
+              - "null"
+              - string
+          TLE_LINE0:
+            type:
+              - "null"
+              - string
+          TLE_LINE1:
+            type:
+              - "null"
+              - string
+          TLE_LINE2:
+            type:
+              - "null"
+              - string
+      velocity_kms:
+        type:
+          - "null"
+          - number
+    additionalProperties: true

--- a/airbyte-integrations/connectors/source-spacex-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-spacex-api/metadata.yaml
@@ -6,11 +6,11 @@ data:
     # Please update to the latest version of the connector base image.
     # https://hub.docker.com/r/airbyte/python-connector-base
     # Please use the full address with sha256 hash to guarantee build reproducibility.
-    baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
+    baseImage: docker.io/airbyte/source-declarative-manifest:4.3.3@sha256:8586ff17ed9584435d0e946a5d0ec393435c81d08da2d8e2913f7984836ce452
   connectorSubtype: api
   connectorType: source
   definitionId: 62235e65-af7a-4138-9130-0bda954eb6a8
-  dockerImageTag: 0.1.13
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-spacex-api
   githubIssueLabel: source-spacex-api
   icon: spacex.svg
@@ -18,7 +18,7 @@ data:
   name: SpaceX API
   remoteRegistries:
     pypi:
-      enabled: true
+      enabled: false
       packageName: airbyte-source-spacex-api
   registries:
     cloud:
@@ -29,8 +29,8 @@ data:
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/spacex-api
   tags:
-    - language:python
     - cdk:low-code
+    - language:manifest-only
   ab_internal:
     sl: 100
     ql: 100

--- a/docs/integrations/sources/spacex-api.md
+++ b/docs/integrations/sources/spacex-api.md
@@ -75,6 +75,7 @@ The SpaceX API has both v4 and v5 for [launches](https://github.com/r-spacex/Spa
 
 | Version | Date       | Pull Request                                             | Subject                                           |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------|
+| 0.2.0 | 2024-08-09 | [43424](https://github.com/airbytehq/airbyte/pull/43424) | Refactor connector to manifest-only format |
 | 0.1.13 | 2024-08-03 | [43176](https://github.com/airbytehq/airbyte/pull/43176) | Update dependencies |
 | 0.1.12 | 2024-07-27 | [42792](https://github.com/airbytehq/airbyte/pull/42792) | Update dependencies |
 | 0.1.11 | 2024-07-20 | [42261](https://github.com/airbytehq/airbyte/pull/42261) | Update dependencies |


### PR DESCRIPTION
## What
Migrates source-spacex-api to manifest-only format

## How
Ran the airbyte-ci commands `migrate-to-manifest-only`, `bump-version`, `format fix` and `pull-request`.

## Review Guide
1. manifest.yaml: should be at the root level of the folder, list version `4.3.0` and contain an inline spec
2. metadata.py: should list the correct `manifest-only` language tag and point to a recent version of `source-declarative-manifest`
3. acceptance-test-config.yml: should correctly point to `manifest.yaml` for the spec test
4. readme.md: Should be updated with correct references to the connector (this has historically been a sticking point with our READMEs)
5. Pretty much everything else should be nuked

## User Impact
Hopefully none!