### PR TITLE
Source Aha: Migrate to manifest-only

### DIFF
--- a/airbyte-integrations/connectors/source-aha/README.md
+++ b/airbyte-integrations/connectors/source-aha/README.md
@@ -1,101 +1,63 @@
-# Aha Source
+# Aha source connector
 
-This is the repository for the Aha configuration based source connector.
-For information about how to use this connector within Airbyte, see [the documentation](https://docs.airbyte.com/integrations/sources/aha).
+This directory contains the manifest-only connector for `source-aha`.
+This _manifest-only_ connector is not a Python package on its own, as it runs inside of the base `source-declarative-manifest` image.
+
+For information about how to configure and use this connector within Airbyte, see [the connector's full documentation](https://docs.airbyte.com/integrations/sources/aha).
 
 ## Local development
 
-### Prerequisites
+We recommend using the Connector Builder to edit this connector.
+Using either Airbyte Cloud or your local Airbyte OSS instance, navigate to the **Builder** tab and select **Import a YAML**.
+Then select the connector's `manifest.yaml` file to load the connector into the Builder. You're now ready to make changes to the connector!
 
-* Python (`^3.9`)
-* Poetry (`^1.7`) - installation instructions [here](https://python-poetry.org/docs/#installation)
-
-
-
-### Installing the connector
-
-From this connector directory, run:
-```bash
-poetry install --with dev
-```
-
-
-### Create credentials
-
-**If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.com/integrations/sources/aha)
-to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `src/source_aha/spec.yaml` file.
-Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
-See `sample_files/sample_config.json` for a sample config file.
-
-
-### Locally running the connector
-
-```
-poetry run source-aha spec
-poetry run source-aha check --config secrets/config.json
-poetry run source-aha discover --config secrets/config.json
-poetry run source-aha read --config secrets/config.json --catalog integration_tests/configured_catalog.json
-```
-
-### Running tests
-
-To run tests locally, from the connector directory run:
-
-```
-poetry run pytest tests
-```
+If you prefer to develop locally, you can follow the instructions below.
 
 ### Building the docker image
 
+You can build any manifest-only connector with `airbyte-ci`:
+
 1. Install [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md)
 2. Run the following command to build the docker image:
+
 ```bash
 airbyte-ci connectors --name=source-aha build
 ```
 
 An image will be available on your host with the tag `airbyte/source-aha:dev`.
 
+### Creating credentials
+
+**If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.com/integrations/sources/aha)
+to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `spec` object in the connector's `manifest.yaml` file.
+Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
 
 ### Running as a docker container
 
-Then run any of the connector commands as follows:
-```
+Then run any of the standard source connector commands:
+
+```bash
 docker run --rm airbyte/source-aha:dev spec
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-aha:dev check --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-aha:dev discover --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/source-aha:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
 ```
 
-### Running our CI test suite
+### Running the CI test suite
 
 You can run our full test suite locally using [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md):
+
 ```bash
 airbyte-ci connectors --name=source-aha test
 ```
 
-### Customizing acceptance Tests
-
-Customize `acceptance-test-config.yml` file to configure acceptance tests. See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference) for more information.
-If your connector requires to create or destroy resources for use during acceptance tests create fixtures for it and place them inside integration_tests/acceptance.py.
-
-### Dependency Management
-
-All of your dependencies should be managed via Poetry. 
-To add a new dependency, run:
-```bash
-poetry add <package-name>
-```
-
-Please commit the changes to `pyproject.toml` and `poetry.lock` files.
-
 ## Publishing a new version of the connector
 
-You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
-1. Make sure your changes are passing our test suite: `airbyte-ci connectors --name=source-aha test`
-2. Bump the connector version (please follow [semantic versioning for connectors](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#semantic-versioning-for-connectors)): 
+If you want to contribute changes to `source-aha`, here's how you can do that:
+1. Make your changes locally, or load the connector's manifest into Connector Builder and make changes there.
+2. Make sure your changes are passing our test suite with `airbyte-ci connectors --name=source-aha test`
+3. Bump the connector version (please follow [semantic versioning for connectors](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#semantic-versioning-for-connectors)):
     - bump the `dockerImageTag` value in in `metadata.yaml`
-    - bump the `version` value in `pyproject.toml`
-3. Make sure the `metadata.yaml` content is up to date.
 4. Make sure the connector documentation and its changelog is up to date (`docs/integrations/sources/aha.md`).
 5. Create a Pull Request: use [our PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#pull-request-title-convention).
 6. Pat yourself on the back for being an awesome contributor.

--- a/airbyte-integrations/connectors/source-aha/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-aha/acceptance-test-config.yml
@@ -4,7 +4,7 @@ connector_image: airbyte/source-aha:dev
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_aha/spec.yaml"
+      - spec_path: "manifest.yaml"
   connection:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-aha/manifest.yaml
+++ b/airbyte-integrations/connectors/source-aha/manifest.yaml
@@ -1,0 +1,2935 @@
+version: 4.3.0
+type: DeclarativeSource
+check:
+  type: CheckStream
+  stream_names:
+    - products_stream
+definitions:
+  streams:
+    features_stream:
+      type: DeclarativeStream
+      name: features_stream
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: "{{ config['url'] }}/api/v1"
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config['api_key'] }}"
+          path: /features
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - features
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: page
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: per_page
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 5
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: "http://json-schema.org/draft-07/schema#"
+          type: "object"
+          additionalProperties: true
+          properties:
+            id:
+              type:
+                - "null"
+                - "string"
+            reference_num:
+              type:
+                - "null"
+                - "string"
+            name:
+              type:
+                - "null"
+                - "string"
+            created_at:
+              type:
+                - "null"
+                - "string"
+            url:
+              type:
+                - "null"
+                - "string"
+            resource:
+              type:
+                - "null"
+                - "string"
+            product_id:
+              type:
+                - "null"
+                - "string"
+    products_stream:
+      type: DeclarativeStream
+      name: products_stream
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: "{{ config['url'] }}/api/v1"
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config['api_key'] }}"
+          path: /products
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - products
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: page
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: per_page
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 5
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: "http://json-schema.org/draft-07/schema#"
+          type: "object"
+          additionalProperties: true
+          properties:
+            id:
+              type:
+                - "null"
+                - "string"
+            reference_prefix:
+              type:
+                - "null"
+                - "string"
+            name:
+              type:
+                - "null"
+                - "string"
+            product_line:
+              type:
+                - "null"
+                - "boolean"
+            created_at:
+              type:
+                - "null"
+                - "string"
+            workspace_type:
+              type:
+                - "null"
+                - "string"
+    idea_categories_stream:
+      type: DeclarativeStream
+      name: idea_categories_stream
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: "{{ config['url'] }}/api/v1"
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config['api_key'] }}"
+          path: /products/{{ stream_partition.id }}/idea_categories
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - idea_categories
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: page
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: per_page
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 5
+        partition_router:
+          - type: SubstreamPartitionRouter
+            parent_stream_configs:
+              - type: ParentStreamConfig
+                parent_key: id
+                partition_field: id
+                stream:
+                  type: DeclarativeStream
+                  name: products_stream
+                  retriever:
+                    type: SimpleRetriever
+                    requester:
+                      type: HttpRequester
+                      url_base: "{{ config['url'] }}/api/v1"
+                      authenticator:
+                        type: BearerAuthenticator
+                        api_token: "{{ config['api_key'] }}"
+                      path: /products
+                      http_method: GET
+                    record_selector:
+                      type: RecordSelector
+                      extractor:
+                        type: DpathExtractor
+                        field_path:
+                          - products
+                    paginator:
+                      type: DefaultPaginator
+                      page_token_option:
+                        type: RequestOption
+                        inject_into: request_parameter
+                        field_name: page
+                      page_size_option:
+                        type: RequestOption
+                        inject_into: request_parameter
+                        field_name: per_page
+                      pagination_strategy:
+                        type: PageIncrement
+                        page_size: 5
+                  schema_loader:
+                    type: InlineSchemaLoader
+                    schema:
+                      $schema: "http://json-schema.org/draft-07/schema#"
+                      type: "object"
+                      additionalProperties: true
+                      properties:
+                        id:
+                          type:
+                            - "null"
+                            - "string"
+                        reference_prefix:
+                          type:
+                            - "null"
+                            - "string"
+                        name:
+                          type:
+                            - "null"
+                            - "string"
+                        product_line:
+                          type:
+                            - "null"
+                            - "boolean"
+                        created_at:
+                          type:
+                            - "null"
+                            - "string"
+                        workspace_type:
+                          type:
+                            - "null"
+                            - "string"
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: "http://json-schema.org/draft-07/schema#"
+          type: "object"
+          properties:
+            id:
+              type:
+                - "null"
+                - "string"
+            name:
+              type:
+                - "null"
+                - "string"
+            parent_id:
+              type:
+                - "null"
+                - "string"
+            created_at:
+              type:
+                - "null"
+                - "string"
+    ideas_stream:
+      type: DeclarativeStream
+      name: ideas_stream
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: "{{ config['url'] }}/api/v1"
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config['api_key'] }}"
+          path: ideas
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - ideas
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: page
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: per_page
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 5
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: "http://json-schema.org/draft-07/schema#"
+          type: "object"
+          additionalProperties: true
+          properties:
+            id:
+              type:
+                - "null"
+                - "string"
+            name:
+              type:
+                - "null"
+                - "string"
+            reference_num:
+              type:
+                - "null"
+                - "string"
+            created_at:
+              type:
+                - "null"
+                - "string"
+            updated_at:
+              type:
+                - "null"
+                - "string"
+            workflow_status:
+              type:
+                - "null"
+                - "object"
+              properties:
+                id:
+                  type:
+                    - "null"
+                    - "string"
+                name:
+                  type:
+                    - "null"
+                    - "string"
+                position:
+                  type:
+                    - "null"
+                    - "integer"
+                complete:
+                  type:
+                    - "null"
+                    - "boolean"
+                color:
+                  type:
+                    - "null"
+                    - "string"
+            description:
+              type:
+                - "null"
+                - "object"
+              properties:
+                id:
+                  type:
+                    - "null"
+                    - "string"
+                body:
+                  type:
+                    - "null"
+                    - "string"
+                created_at:
+                  type:
+                    - "null"
+                    - "string"
+                attachments:
+                  type:
+                    - "null"
+                    - "array"
+            url:
+              type:
+                - "null"
+                - "string"
+            resource:
+              type:
+                - "null"
+                - "string"
+    idea_endorsements_stream:
+      type: DeclarativeStream
+      name: idea_endorsements_stream
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: "{{ config['url'] }}/api/v1"
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config['api_key'] }}"
+          path: /ideas/{{ stream_partition.id }}/endorsements
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - idea_endorsements
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: page
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: per_page
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 5
+        partition_router:
+          - type: SubstreamPartitionRouter
+            parent_stream_configs:
+              - type: ParentStreamConfig
+                parent_key: id
+                partition_field: id
+                stream:
+                  type: DeclarativeStream
+                  name: ideas_stream
+                  retriever:
+                    type: SimpleRetriever
+                    requester:
+                      type: HttpRequester
+                      url_base: "{{ config['url'] }}/api/v1"
+                      authenticator:
+                        type: BearerAuthenticator
+                        api_token: "{{ config['api_key'] }}"
+                      path: ideas
+                      http_method: GET
+                    record_selector:
+                      type: RecordSelector
+                      extractor:
+                        type: DpathExtractor
+                        field_path:
+                          - ideas
+                    paginator:
+                      type: DefaultPaginator
+                      page_token_option:
+                        type: RequestOption
+                        inject_into: request_parameter
+                        field_name: page
+                      page_size_option:
+                        type: RequestOption
+                        inject_into: request_parameter
+                        field_name: per_page
+                      pagination_strategy:
+                        type: PageIncrement
+                        page_size: 5
+                  schema_loader:
+                    type: InlineSchemaLoader
+                    schema:
+                      $schema: "http://json-schema.org/draft-07/schema#"
+                      type: "object"
+                      additionalProperties: true
+                      properties:
+                        id:
+                          type:
+                            - "null"
+                            - "string"
+                        name:
+                          type:
+                            - "null"
+                            - "string"
+                        reference_num:
+                          type:
+                            - "null"
+                            - "string"
+                        created_at:
+                          type:
+                            - "null"
+                            - "string"
+                        updated_at:
+                          type:
+                            - "null"
+                            - "string"
+                        workflow_status:
+                          type:
+                            - "null"
+                            - "object"
+                          properties:
+                            id:
+                              type:
+                                - "null"
+                                - "string"
+                            name:
+                              type:
+                                - "null"
+                                - "string"
+                            position:
+                              type:
+                                - "null"
+                                - "integer"
+                            complete:
+                              type:
+                                - "null"
+                                - "boolean"
+                            color:
+                              type:
+                                - "null"
+                                - "string"
+                        description:
+                          type:
+                            - "null"
+                            - "object"
+                          properties:
+                            id:
+                              type:
+                                - "null"
+                                - "string"
+                            body:
+                              type:
+                                - "null"
+                                - "string"
+                            created_at:
+                              type:
+                                - "null"
+                                - "string"
+                            attachments:
+                              type:
+                                - "null"
+                                - "array"
+                        url:
+                          type:
+                            - "null"
+                            - "string"
+                        resource:
+                          type:
+                            - "null"
+                            - "string"
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: "http://json-schema.org/draft-07/schema#"
+          type: "object"
+          properties:
+            id:
+              type:
+                - "null"
+                - "string"
+            idea_id:
+              type:
+                - "null"
+                - "string"
+            created_at:
+              type:
+                - "null"
+                - "string"
+            updated_at:
+              type:
+                - "null"
+                - "string"
+            value:
+              type:
+                - "null"
+                - "string"
+            link:
+              type:
+                - "null"
+                - "string"
+            weight:
+              type:
+                - "null"
+                - "integer"
+            endorsed_by_portal_user:
+              type: "object"
+              properties:
+                id:
+                  type:
+                    - "null"
+                    - "string"
+                name:
+                  type:
+                    - "null"
+                    - "string"
+                email:
+                  type:
+                    - "null"
+                    - "string"
+                created_at:
+                  type:
+                    - "null"
+                    - "string"
+            endorsed_by_idea_user:
+              type: "object"
+              properties:
+                id:
+                  type:
+                    - "null"
+                    - "string"
+                name:
+                  type:
+                    - "null"
+                    - "string"
+                email:
+                  type:
+                    - "null"
+                    - "string"
+                created_at:
+                  type:
+                    - "null"
+                    - "string"
+            endorsed_by_idea_organization:
+              type: "object"
+              properties:
+                id:
+                  type:
+                    - "null"
+                    - "string"
+                name:
+                  type:
+                    - "null"
+                    - "string"
+                created_at:
+                  type:
+                    - "null"
+                    - "string"
+                url:
+                  type:
+                    - "null"
+                    - "string"
+                resource:
+                  type:
+                    - "null"
+                    - "string"
+            endorsed_by_user:
+              type: "object"
+              properties:
+                id:
+                  type:
+                    - "null"
+                    - "string"
+                name:
+                  type:
+                    - "null"
+                    - "string"
+                email:
+                  type:
+                    - "null"
+                    - "string"
+                created_at:
+                  type:
+                    - "null"
+                    - "string"
+                updated_at:
+                  type:
+                    - "null"
+                    - "string"
+    idea_comments_stream:
+      type: DeclarativeStream
+      name: idea_comments_stream
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: "{{ config['url'] }}/api/v1"
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config['api_key'] }}"
+          path: /ideas/{{ stream_partition.id }}/idea_comments
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - idea_comments
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: page
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: per_page
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 5
+        partition_router:
+          - type: SubstreamPartitionRouter
+            parent_stream_configs:
+              - type: ParentStreamConfig
+                parent_key: id
+                partition_field: id
+                stream:
+                  type: DeclarativeStream
+                  name: ideas_stream
+                  retriever:
+                    type: SimpleRetriever
+                    requester:
+                      type: HttpRequester
+                      url_base: "{{ config['url'] }}/api/v1"
+                      authenticator:
+                        type: BearerAuthenticator
+                        api_token: "{{ config['api_key'] }}"
+                      path: ideas
+                      http_method: GET
+                    record_selector:
+                      type: RecordSelector
+                      extractor:
+                        type: DpathExtractor
+                        field_path:
+                          - ideas
+                    paginator:
+                      type: DefaultPaginator
+                      page_token_option:
+                        type: RequestOption
+                        inject_into: request_parameter
+                        field_name: page
+                      page_size_option:
+                        type: RequestOption
+                        inject_into: request_parameter
+                        field_name: per_page
+                      pagination_strategy:
+                        type: PageIncrement
+                        page_size: 5
+                  schema_loader:
+                    type: InlineSchemaLoader
+                    schema:
+                      $schema: "http://json-schema.org/draft-07/schema#"
+                      type: "object"
+                      additionalProperties: true
+                      properties:
+                        id:
+                          type:
+                            - "null"
+                            - "string"
+                        name:
+                          type:
+                            - "null"
+                            - "string"
+                        reference_num:
+                          type:
+                            - "null"
+                            - "string"
+                        created_at:
+                          type:
+                            - "null"
+                            - "string"
+                        updated_at:
+                          type:
+                            - "null"
+                            - "string"
+                        workflow_status:
+                          type:
+                            - "null"
+                            - "object"
+                          properties:
+                            id:
+                              type:
+                                - "null"
+                                - "string"
+                            name:
+                              type:
+                                - "null"
+                                - "string"
+                            position:
+                              type:
+                                - "null"
+                                - "integer"
+                            complete:
+                              type:
+                                - "null"
+                                - "boolean"
+                            color:
+                              type:
+                                - "null"
+                                - "string"
+                        description:
+                          type:
+                            - "null"
+                            - "object"
+                          properties:
+                            id:
+                              type:
+                                - "null"
+                                - "string"
+                            body:
+                              type:
+                                - "null"
+                                - "string"
+                            created_at:
+                              type:
+                                - "null"
+                                - "string"
+                            attachments:
+                              type:
+                                - "null"
+                                - "array"
+                        url:
+                          type:
+                            - "null"
+                            - "string"
+                        resource:
+                          type:
+                            - "null"
+                            - "string"
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: "http://json-schema.org/draft-07/schema#"
+          type: "object"
+          properties:
+            id:
+              type:
+                - "null"
+                - "string"
+            idea_id:
+              type:
+                - "null"
+                - "string"
+            body:
+              type:
+                - "null"
+                - "string"
+            created_at:
+              type:
+                - "null"
+                - "string"
+            visibility:
+              type:
+                - "null"
+                - "string"
+            parent_idea_comment_id:
+              type:
+                - "null"
+                - "string"
+            idea_commenter_user:
+              type: "object"
+              properties:
+                id:
+                  type:
+                    - "null"
+                    - "string"
+                name_id:
+                  type:
+                    - "null"
+                    - "string"
+                email:
+                  type:
+                    - "null"
+                    - "string"
+                created_at:
+                  type:
+                    - "null"
+                    - "string"
+                updated_at:
+                  type:
+                    - "null"
+                    - "string"
+            idea:
+              type: "object"
+              properties:
+                id:
+                  type:
+                    - "null"
+                    - "string"
+                reference_num:
+                  type:
+                    - "null"
+                    - "string"
+                name:
+                  type:
+                    - "null"
+                    - "string"
+                created_at:
+                  type:
+                    - "null"
+                    - "string"
+                updated_at:
+                  type:
+                    - "null"
+                    - "string"
+                workflow_status:
+                  type: "object"
+                  properties:
+                    id:
+                      type:
+                        - "null"
+                        - "string"
+                    name:
+                      type:
+                        - "null"
+                        - "string"
+                    position:
+                      type:
+                        - "null"
+                        - "integer"
+                    complete:
+                      type:
+                        - "null"
+                        - "boolean"
+                    color:
+                      type:
+                        - "null"
+                        - "string"
+                description:
+                  type: "object"
+                  properties:
+                    id:
+                      type:
+                        - "null"
+                        - "string"
+                    body:
+                      type:
+                        - "null"
+                        - "string"
+                    created_at:
+                      type:
+                        - "null"
+                        - "string"
+                    attachments:
+                      type:
+                        - "null"
+                        - "array"
+                  url:
+                    type:
+                      - "null"
+                      - "string"
+                  resource:
+                    type:
+                      - "null"
+                      - "string"
+              attachments:
+                type:
+                  - "null"
+                  - "array"
+            attachments:
+              type:
+                - "null"
+                - "array"
+    users_stream:
+      type: DeclarativeStream
+      name: users_stream
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: "{{ config['url'] }}/api/v1"
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config['api_key'] }}"
+          path: users
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - users
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: page
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: per_page
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 5
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: "http://json-schema.org/draft-07/schema#"
+          type: "object"
+          additionalProperties: true
+          properties:
+            id:
+              type:
+                - "null"
+                - "string"
+            name:
+              type:
+                - "null"
+                - "string"
+            email:
+              type:
+                - "null"
+                - "string"
+            created_at:
+              type:
+                - "null"
+                - "string"
+            updated_at:
+              type:
+                - "null"
+                - "string"
+            accessed_at:
+              type:
+                - "null"
+                - "string"
+            product_roles:
+              type:
+                - "null"
+                - "array"
+            enabled:
+              type:
+                - "null"
+                - "boolean"
+            paid_seat:
+              type:
+                - "null"
+                - "boolean"
+            administrator:
+              type:
+                - "null"
+                - "boolean"
+            administrator_roles:
+              type:
+                - "null"
+                - "object"
+            identity_provider:
+              type:
+                - "null"
+                - "object"
+    goals_stream:
+      type: DeclarativeStream
+      name: goals_stream
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: "{{ config['url'] }}/api/v1"
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config['api_key'] }}"
+          path: goals
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - goals
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: page
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: per_page
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 5
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: "http://json-schema.org/draft-07/schema#"
+          type: "object"
+          additionalProperties: true
+          properties:
+            id:
+              type:
+                - "null"
+                - "string"
+            name:
+              type:
+                - "null"
+                - "string"
+            reference_num:
+              type:
+                - "null"
+                - "string"
+            effort:
+              type:
+                - "null"
+                - "number"
+            value:
+              type:
+                - "null"
+                - "number"
+            position:
+              type:
+                - "null"
+                - "number"
+            created_at:
+              type:
+                - "null"
+                - "string"
+            updated_at:
+              type:
+                - "null"
+                - "string"
+            product_id:
+              type:
+                - "null"
+                - "string"
+            progress:
+              type:
+                - "null"
+                - "number"
+            progress_source:
+              type:
+                - "null"
+                - "string"
+            url:
+              type:
+                - "null"
+                - "string"
+            resource:
+              type:
+                - "null"
+                - "string"
+            description:
+              type:
+                - "null"
+                - "object"
+            success_metric:
+              type:
+                - "null"
+                - "object"
+            project:
+              type:
+                - "null"
+                - "object"
+            timeframe:
+              type:
+                - "null"
+                - "object"
+            initiatives:
+              type:
+                - "null"
+                - "array"
+              items:
+                type:
+                  - "null"
+                  - "object"
+                additionalProperties: true
+            comments_count:
+              type:
+                - "null"
+                - "integer"
+            features:
+              type:
+                - "null"
+                - "array"
+              items:
+                type:
+                  - "null"
+                  - "object"
+                additionalProperties: true
+            releases:
+              type:
+                - "null"
+                - "array"
+            custom_fields:
+              type:
+                - "null"
+                - "array"
+            parent:
+              type:
+                - "null"
+                - "object"
+              additionalProperties: true
+            parents:
+              type:
+                - "null"
+                - "array"
+              items:
+                type:
+                  - "null"
+                  - "object"
+                additionalProperties: true
+  base_requester:
+    type: HttpRequester
+    url_base: "{{ config['url'] }}/api/v1"
+    authenticator:
+      type: BearerAuthenticator
+      api_token: "{{ config['api_key'] }}"
+streams:
+  - type: DeclarativeStream
+    name: features_stream
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['url'] }}/api/v1"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['api_key'] }}"
+        path: /features
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - features
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        page_size_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: per_page
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 5
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: "http://json-schema.org/draft-07/schema#"
+        type: "object"
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          reference_num:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          url:
+            type:
+              - "null"
+              - "string"
+          resource:
+            type:
+              - "null"
+              - "string"
+          product_id:
+            type:
+              - "null"
+              - "string"
+  - type: DeclarativeStream
+    name: products_stream
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['url'] }}/api/v1"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['api_key'] }}"
+        path: /products
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - products
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        page_size_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: per_page
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 5
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: "http://json-schema.org/draft-07/schema#"
+        type: "object"
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          reference_prefix:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          product_line:
+            type:
+              - "null"
+              - "boolean"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          workspace_type:
+            type:
+              - "null"
+              - "string"
+  - type: DeclarativeStream
+    name: idea_categories_stream
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['url'] }}/api/v1"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['api_key'] }}"
+        path: /products/{{ stream_partition.id }}/idea_categories
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - idea_categories
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        page_size_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: per_page
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 5
+      partition_router:
+        - type: SubstreamPartitionRouter
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              parent_key: id
+              partition_field: id
+              stream:
+                type: DeclarativeStream
+                name: products_stream
+                retriever:
+                  type: SimpleRetriever
+                  requester:
+                    type: HttpRequester
+                    url_base: "{{ config['url'] }}/api/v1"
+                    authenticator:
+                      type: BearerAuthenticator
+                      api_token: "{{ config['api_key'] }}"
+                    path: /products
+                    http_method: GET
+                  record_selector:
+                    type: RecordSelector
+                    extractor:
+                      type: DpathExtractor
+                      field_path:
+                        - products
+                  paginator:
+                    type: DefaultPaginator
+                    page_token_option:
+                      type: RequestOption
+                      inject_into: request_parameter
+                      field_name: page
+                    page_size_option:
+                      type: RequestOption
+                      inject_into: request_parameter
+                      field_name: per_page
+                    pagination_strategy:
+                      type: PageIncrement
+                      page_size: 5
+                schema_loader:
+                  type: InlineSchemaLoader
+                  schema:
+                    $schema: "http://json-schema.org/draft-07/schema#"
+                    type: "object"
+                    additionalProperties: true
+                    properties:
+                      id:
+                        type:
+                          - "null"
+                          - "string"
+                      reference_prefix:
+                        type:
+                          - "null"
+                          - "string"
+                      name:
+                        type:
+                          - "null"
+                          - "string"
+                      product_line:
+                        type:
+                          - "null"
+                          - "boolean"
+                      created_at:
+                        type:
+                          - "null"
+                          - "string"
+                      workspace_type:
+                        type:
+                          - "null"
+                          - "string"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: "http://json-schema.org/draft-07/schema#"
+        type: "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          parent_id:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+  - type: DeclarativeStream
+    name: ideas_stream
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['url'] }}/api/v1"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['api_key'] }}"
+        path: ideas
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - ideas
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        page_size_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: per_page
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 5
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: "http://json-schema.org/draft-07/schema#"
+        type: "object"
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          reference_num:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          updated_at:
+            type:
+              - "null"
+              - "string"
+          workflow_status:
+            type:
+              - "null"
+              - "object"
+            properties:
+              id:
+                type:
+                  - "null"
+                  - "string"
+              name:
+                type:
+                  - "null"
+                  - "string"
+              position:
+                type:
+                  - "null"
+                  - "integer"
+              complete:
+                type:
+                  - "null"
+                  - "boolean"
+              color:
+                type:
+                  - "null"
+                  - "string"
+          description:
+            type:
+              - "null"
+              - "object"
+            properties:
+              id:
+                type:
+                  - "null"
+                  - "string"
+              body:
+                type:
+                  - "null"
+                  - "string"
+              created_at:
+                type:
+                  - "null"
+                  - "string"
+              attachments:
+                type:
+                  - "null"
+                  - "array"
+          url:
+            type:
+              - "null"
+              - "string"
+          resource:
+            type:
+              - "null"
+              - "string"
+  - type: DeclarativeStream
+    name: idea_endorsements_stream
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['url'] }}/api/v1"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['api_key'] }}"
+        path: /ideas/{{ stream_partition.id }}/endorsements
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - idea_endorsements
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        page_size_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: per_page
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 5
+      partition_router:
+        - type: SubstreamPartitionRouter
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              parent_key: id
+              partition_field: id
+              stream:
+                type: DeclarativeStream
+                name: ideas_stream
+                retriever:
+                  type: SimpleRetriever
+                  requester:
+                    type: HttpRequester
+                    url_base: "{{ config['url'] }}/api/v1"
+                    authenticator:
+                      type: BearerAuthenticator
+                      api_token: "{{ config['api_key'] }}"
+                    path: ideas
+                    http_method: GET
+                  record_selector:
+                    type: RecordSelector
+                    extractor:
+                      type: DpathExtractor
+                      field_path:
+                        - ideas
+                  paginator:
+                    type: DefaultPaginator
+                    page_token_option:
+                      type: RequestOption
+                      inject_into: request_parameter
+                      field_name: page
+                    page_size_option:
+                      type: RequestOption
+                      inject_into: request_parameter
+                      field_name: per_page
+                    pagination_strategy:
+                      type: PageIncrement
+                      page_size: 5
+                schema_loader:
+                  type: InlineSchemaLoader
+                  schema:
+                    $schema: "http://json-schema.org/draft-07/schema#"
+                    type: "object"
+                    additionalProperties: true
+                    properties:
+                      id:
+                        type:
+                          - "null"
+                          - "string"
+                      name:
+                        type:
+                          - "null"
+                          - "string"
+                      reference_num:
+                        type:
+                          - "null"
+                          - "string"
+                      created_at:
+                        type:
+                          - "null"
+                          - "string"
+                      updated_at:
+                        type:
+                          - "null"
+                          - "string"
+                      workflow_status:
+                        type:
+                          - "null"
+                          - "object"
+                        properties:
+                          id:
+                            type:
+                              - "null"
+                              - "string"
+                          name:
+                            type:
+                              - "null"
+                              - "string"
+                          position:
+                            type:
+                              - "null"
+                              - "integer"
+                          complete:
+                            type:
+                              - "null"
+                              - "boolean"
+                          color:
+                            type:
+                              - "null"
+                              - "string"
+                      description:
+                        type:
+                          - "null"
+                          - "object"
+                        properties:
+                          id:
+                            type:
+                              - "null"
+                              - "string"
+                          body:
+                            type:
+                              - "null"
+                              - "string"
+                          created_at:
+                            type:
+                              - "null"
+                              - "string"
+                          attachments:
+                            type:
+                              - "null"
+                              - "array"
+                      url:
+                        type:
+                          - "null"
+                          - "string"
+                      resource:
+                        type:
+                          - "null"
+                          - "string"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: "http://json-schema.org/draft-07/schema#"
+        type: "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          idea_id:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          updated_at:
+            type:
+              - "null"
+              - "string"
+          value:
+            type:
+              - "null"
+              - "string"
+          link:
+            type:
+              - "null"
+              - "string"
+          weight:
+            type:
+              - "null"
+              - "integer"
+          endorsed_by_portal_user:
+            type: "object"
+            properties:
+              id:
+                type:
+                  - "null"
+                  - "string"
+              name:
+                type:
+                  - "null"
+                  - "string"
+              email:
+                type:
+                  - "null"
+                  - "string"
+              created_at:
+                type:
+                  - "null"
+                  - "string"
+          endorsed_by_idea_user:
+            type: "object"
+            properties:
+              id:
+                type:
+                  - "null"
+                  - "string"
+              name:
+                type:
+                  - "null"
+                  - "string"
+              email:
+                type:
+                  - "null"
+                  - "string"
+              created_at:
+                type:
+                  - "null"
+                  - "string"
+          endorsed_by_idea_organization:
+            type: "object"
+            properties:
+              id:
+                type:
+                  - "null"
+                  - "string"
+              name:
+                type:
+                  - "null"
+                  - "string"
+              created_at:
+                type:
+                  - "null"
+                  - "string"
+              url:
+                type:
+                  - "null"
+                  - "string"
+              resource:
+                type:
+                  - "null"
+                  - "string"
+          endorsed_by_user:
+            type: "object"
+            properties:
+              id:
+                type:
+                  - "null"
+                  - "string"
+              name:
+                type:
+                  - "null"
+                  - "string"
+              email:
+                type:
+                  - "null"
+                  - "string"
+              created_at:
+                type:
+                  - "null"
+                  - "string"
+              updated_at:
+                type:
+                  - "null"
+                  - "string"
+  - type: DeclarativeStream
+    name: idea_comments_stream
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['url'] }}/api/v1"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['api_key'] }}"
+        path: /ideas/{{ stream_partition.id }}/idea_comments
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - idea_comments
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        page_size_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: per_page
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 5
+      partition_router:
+        - type: SubstreamPartitionRouter
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              parent_key: id
+              partition_field: id
+              stream:
+                type: DeclarativeStream
+                name: ideas_stream
+                retriever:
+                  type: SimpleRetriever
+                  requester:
+                    type: HttpRequester
+                    url_base: "{{ config['url'] }}/api/v1"
+                    authenticator:
+                      type: BearerAuthenticator
+                      api_token: "{{ config['api_key'] }}"
+                    path: ideas
+                    http_method: GET
+                  record_selector:
+                    type: RecordSelector
+                    extractor:
+                      type: DpathExtractor
+                      field_path:
+                        - ideas
+                  paginator:
+                    type: DefaultPaginator
+                    page_token_option:
+                      type: RequestOption
+                      inject_into: request_parameter
+                      field_name: page
+                    page_size_option:
+                      type: RequestOption
+                      inject_into: request_parameter
+                      field_name: per_page
+                    pagination_strategy:
+                      type: PageIncrement
+                      page_size: 5
+                schema_loader:
+                  type: InlineSchemaLoader
+                  schema:
+                    $schema: "http://json-schema.org/draft-07/schema#"
+                    type: "object"
+                    additionalProperties: true
+                    properties:
+                      id:
+                        type:
+                          - "null"
+                          - "string"
+                      name:
+                        type:
+                          - "null"
+                          - "string"
+                      reference_num:
+                        type:
+                          - "null"
+                          - "string"
+                      created_at:
+                        type:
+                          - "null"
+                          - "string"
+                      updated_at:
+                        type:
+                          - "null"
+                          - "string"
+                      workflow_status:
+                        type:
+                          - "null"
+                          - "object"
+                        properties:
+                          id:
+                            type:
+                              - "null"
+                              - "string"
+                          name:
+                            type:
+                              - "null"
+                              - "string"
+                          position:
+                            type:
+                              - "null"
+                              - "integer"
+                          complete:
+                            type:
+                              - "null"
+                              - "boolean"
+                          color:
+                            type:
+                              - "null"
+                              - "string"
+                      description:
+                        type:
+                          - "null"
+                          - "object"
+                        properties:
+                          id:
+                            type:
+                              - "null"
+                              - "string"
+                          body:
+                            type:
+                              - "null"
+                              - "string"
+                          created_at:
+                            type:
+                              - "null"
+                              - "string"
+                          attachments:
+                            type:
+                              - "null"
+                              - "array"
+                      url:
+                        type:
+                          - "null"
+                          - "string"
+                      resource:
+                        type:
+                          - "null"
+                          - "string"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: "http://json-schema.org/draft-07/schema#"
+        type: "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          idea_id:
+            type:
+              - "null"
+              - "string"
+          body:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          visibility:
+            type:
+              - "null"
+              - "string"
+          parent_idea_comment_id:
+            type:
+              - "null"
+              - "string"
+          idea_commenter_user:
+            type: "object"
+            properties:
+              id:
+                type:
+                  - "null"
+                  - "string"
+              name_id:
+                type:
+                  - "null"
+                  - "string"
+              email:
+                type:
+                  - "null"
+                  - "string"
+              created_at:
+                type:
+                  - "null"
+                  - "string"
+              updated_at:
+                type:
+                  - "null"
+                  - "string"
+          idea:
+            type: "object"
+            properties:
+              id:
+                type:
+                  - "null"
+                  - "string"
+              reference_num:
+                type:
+                  - "null"
+                  - "string"
+              name:
+                type:
+                  - "null"
+                  - "string"
+              created_at:
+                type:
+                  - "null"
+                  - "string"
+              updated_at:
+                type:
+                  - "null"
+                  - "string"
+              workflow_status:
+                type: "object"
+                properties:
+                  id:
+                    type:
+                      - "null"
+                      - "string"
+                  name:
+                    type:
+                      - "null"
+                      - "string"
+                  position:
+                    type:
+                      - "null"
+                      - "integer"
+                  complete:
+                    type:
+                      - "null"
+                      - "boolean"
+                  color:
+                    type:
+                      - "null"
+                      - "string"
+              description:
+                type: "object"
+                properties:
+                  id:
+                    type:
+                      - "null"
+                      - "string"
+                  body:
+                    type:
+                      - "null"
+                      - "string"
+                  created_at:
+                    type:
+                      - "null"
+                      - "string"
+                  attachments:
+                    type:
+                      - "null"
+                      - "array"
+                url:
+                  type:
+                    - "null"
+                    - "string"
+                resource:
+                  type:
+                    - "null"
+                    - "string"
+            attachments:
+              type:
+                - "null"
+                - "array"
+          attachments:
+            type:
+              - "null"
+              - "array"
+  - type: DeclarativeStream
+    name: users_stream
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['url'] }}/api/v1"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['api_key'] }}"
+        path: users
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - users
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        page_size_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: per_page
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 5
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: "http://json-schema.org/draft-07/schema#"
+        type: "object"
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          email:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          updated_at:
+            type:
+              - "null"
+              - "string"
+          accessed_at:
+            type:
+              - "null"
+              - "string"
+          product_roles:
+            type:
+              - "null"
+              - "array"
+          enabled:
+            type:
+              - "null"
+              - "boolean"
+          paid_seat:
+            type:
+              - "null"
+              - "boolean"
+          administrator:
+            type:
+              - "null"
+              - "boolean"
+          administrator_roles:
+            type:
+              - "null"
+              - "object"
+          identity_provider:
+            type:
+              - "null"
+              - "object"
+  - type: DeclarativeStream
+    name: goals_stream
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['url'] }}/api/v1"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['api_key'] }}"
+        path: goals
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - goals
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: page
+        page_size_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: per_page
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 5
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: "http://json-schema.org/draft-07/schema#"
+        type: "object"
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          reference_num:
+            type:
+              - "null"
+              - "string"
+          effort:
+            type:
+              - "null"
+              - "number"
+          value:
+            type:
+              - "null"
+              - "number"
+          position:
+            type:
+              - "null"
+              - "number"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          updated_at:
+            type:
+              - "null"
+              - "string"
+          product_id:
+            type:
+              - "null"
+              - "string"
+          progress:
+            type:
+              - "null"
+              - "number"
+          progress_source:
+            type:
+              - "null"
+              - "string"
+          url:
+            type:
+              - "null"
+              - "string"
+          resource:
+            type:
+              - "null"
+              - "string"
+          description:
+            type:
+              - "null"
+              - "object"
+          success_metric:
+            type:
+              - "null"
+              - "object"
+          project:
+            type:
+              - "null"
+              - "object"
+          timeframe:
+            type:
+              - "null"
+              - "object"
+          initiatives:
+            type:
+              - "null"
+              - "array"
+            items:
+              type:
+                - "null"
+                - "object"
+              additionalProperties: true
+          comments_count:
+            type:
+              - "null"
+              - "integer"
+          features:
+            type:
+              - "null"
+              - "array"
+            items:
+              type:
+                - "null"
+                - "object"
+              additionalProperties: true
+          releases:
+            type:
+              - "null"
+              - "array"
+          custom_fields:
+            type:
+              - "null"
+              - "array"
+          parent:
+            type:
+              - "null"
+              - "object"
+            additionalProperties: true
+          parents:
+            type:
+              - "null"
+              - "array"
+            items:
+              type:
+                - "null"
+                - "object"
+              additionalProperties: true
+spec:
+  type: Spec
+  documentation_url: https://docs.airbyte.com/integrations/sources/aha
+  connection_specification:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    required:
+      - api_key
+      - url
+    properties:
+      api_key:
+        type: string
+        title: API Bearer Token
+        airbyte_secret: true
+        description: API Key
+        order: 0
+      url:
+        type: string
+        description: URL
+        title: Aha Url Instance
+        order: 1
+    additionalProperties: true
+metadata:
+  autoImportSchema:
+    features_stream: false
+    products_stream: false
+    idea_categories_stream: false
+    ideas_stream: false
+    idea_endorsements_stream: false
+    idea_comments_stream: false
+    users_stream: false
+    goals_stream: false
+schemas:
+  features_stream:
+    $schema: "http://json-schema.org/draft-07/schema#"
+    type: "object"
+    additionalProperties: true
+    properties:
+      id:
+        type:
+          - "null"
+          - "string"
+      reference_num:
+        type:
+          - "null"
+          - "string"
+      name:
+        type:
+          - "null"
+          - "string"
+      created_at:
+        type:
+          - "null"
+          - "string"
+      url:
+        type:
+          - "null"
+          - "string"
+      resource:
+        type:
+          - "null"
+          - "string"
+      product_id:
+        type:
+          - "null"
+          - "string"
+  products_stream:
+    $schema: "http://json-schema.org/draft-07/schema#"
+    type: "object"
+    additionalProperties: true
+    properties:
+      id:
+        type:
+          - "null"
+          - "string"
+      reference_prefix:
+        type:
+          - "null"
+          - "string"
+      name:
+        type:
+          - "null"
+          - "string"
+      product_line:
+        type:
+          - "null"
+          - "boolean"
+      created_at:
+        type:
+          - "null"
+          - "string"
+      workspace_type:
+        type:
+          - "null"
+          - "string"
+  idea_categories_stream:
+    $schema: "http://json-schema.org/draft-07/schema#"
+    type: "object"
+    properties:
+      id:
+        type:
+          - "null"
+          - "string"
+      name:
+        type:
+          - "null"
+          - "string"
+      parent_id:
+        type:
+          - "null"
+          - "string"
+      created_at:
+        type:
+          - "null"
+          - "string"
+  ideas_stream:
+    $schema: "http://json-schema.org/draft-07/schema#"
+    type: "object"
+    additionalProperties: true
+    properties:
+      id:
+        type:
+          - "null"
+          - "string"
+      name:
+        type:
+          - "null"
+          - "string"
+      reference_num:
+        type:
+          - "null"
+          - "string"
+      created_at:
+        type:
+          - "null"
+          - "string"
+      updated_at:
+        type:
+          - "null"
+          - "string"
+      workflow_status:
+        type:
+          - "null"
+          - "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          position:
+            type:
+              - "null"
+              - "integer"
+          complete:
+            type:
+              - "null"
+              - "boolean"
+          color:
+            type:
+              - "null"
+              - "string"
+      description:
+        type:
+          - "null"
+          - "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          body:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          attachments:
+            type:
+              - "null"
+              - "array"
+      url:
+        type:
+          - "null"
+          - "string"
+      resource:
+        type:
+          - "null"
+          - "string"
+  idea_endorsements_stream:
+    $schema: "http://json-schema.org/draft-07/schema#"
+    type: "object"
+    properties:
+      id:
+        type:
+          - "null"
+          - "string"
+      idea_id:
+        type:
+          - "null"
+          - "string"
+      created_at:
+        type:
+          - "null"
+          - "string"
+      updated_at:
+        type:
+          - "null"
+          - "string"
+      value:
+        type:
+          - "null"
+          - "string"
+      link:
+        type:
+          - "null"
+          - "string"
+      weight:
+        type:
+          - "null"
+          - "integer"
+      endorsed_by_portal_user:
+        type: "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          email:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+      endorsed_by_idea_user:
+        type: "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          email:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+      endorsed_by_idea_organization:
+        type: "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          url:
+            type:
+              - "null"
+              - "string"
+          resource:
+            type:
+              - "null"
+              - "string"
+      endorsed_by_user:
+        type: "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          email:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          updated_at:
+            type:
+              - "null"
+              - "string"
+  idea_comments_stream:
+    $schema: "http://json-schema.org/draft-07/schema#"
+    type: "object"
+    properties:
+      id:
+        type:
+          - "null"
+          - "string"
+      idea_id:
+        type:
+          - "null"
+          - "string"
+      body:
+        type:
+          - "null"
+          - "string"
+      created_at:
+        type:
+          - "null"
+          - "string"
+      visibility:
+        type:
+          - "null"
+          - "string"
+      parent_idea_comment_id:
+        type:
+          - "null"
+          - "string"
+      idea_commenter_user:
+        type: "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          name_id:
+            type:
+              - "null"
+              - "string"
+          email:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          updated_at:
+            type:
+              - "null"
+              - "string"
+      idea:
+        type: "object"
+        properties:
+          id:
+            type:
+              - "null"
+              - "string"
+          reference_num:
+            type:
+              - "null"
+              - "string"
+          name:
+            type:
+              - "null"
+              - "string"
+          created_at:
+            type:
+              - "null"
+              - "string"
+          updated_at:
+            type:
+              - "null"
+              - "string"
+          workflow_status:
+            type: "object"
+            properties:
+              id:
+                type:
+                  - "null"
+                  - "string"
+              name:
+                type:
+                  - "null"
+                  - "string"
+              position:
+                type:
+                  - "null"
+                  - "integer"
+              complete:
+                type:
+                  - "null"
+                  - "boolean"
+              color:
+                type:
+                  - "null"
+                  - "string"
+          description:
+            type: "object"
+            properties:
+              id:
+                type:
+                  - "null"
+                  - "string"
+              body:
+                type:
+                  - "null"
+                  - "string"
+              created_at:
+                type:
+                  - "null"
+                  - "string"
+              attachments:
+                type:
+                  - "null"
+                  - "array"
+            url:
+              type:
+                - "null"
+                - "string"
+            resource:
+              type:
+                - "null"
+                - "string"
+        attachments:
+          type:
+            - "null"
+            - "array"
+      attachments:
+        type:
+          - "null"
+          - "array"
+  users_stream:
+    $schema: "http://json-schema.org/draft-07/schema#"
+    type: "object"
+    additionalProperties: true
+    properties:
+      id:
+        type:
+          - "null"
+          - "string"
+      name:
+        type:
+          - "null"
+          - "string"
+      email:
+        type:
+          - "null"
+          - "string"
+      created_at:
+        type:
+          - "null"
+          - "string"
+      updated_at:
+        type:
+          - "null"
+          - "string"
+      accessed_at:
+        type:
+          - "null"
+          - "string"
+      product_roles:
+        type:
+          - "null"
+          - "array"
+      enabled:
+        type:
+          - "null"
+          - "boolean"
+      paid_seat:
+        type:
+          - "null"
+          - "boolean"
+      administrator:
+        type:
+          - "null"
+          - "boolean"
+      administrator_roles:
+        type:
+          - "null"
+          - "object"
+      identity_provider:
+        type:
+          - "null"
+          - "object"
+  goals_stream:
+    $schema: "http://json-schema.org/draft-07/schema#"
+    type: "object"
+    additionalProperties: true
+    properties:
+      id:
+        type:
+          - "null"
+          - "string"
+      name:
+        type:
+          - "null"
+          - "string"
+      reference_num:
+        type:
+          - "null"
+          - "string"
+      effort:
+        type:
+          - "null"
+          - "number"
+      value:
+        type:
+          - "null"
+          - "number"
+      position:
+        type:
+          - "null"
+          - "number"
+      created_at:
+        type:
+          - "null"
+          - "string"
+      updated_at:
+        type:
+          - "null"
+          - "string"
+      product_id:
+        type:
+          - "null"
+          - "string"
+      progress:
+        type:
+          - "null"
+          - "number"
+      progress_source:
+        type:
+          - "null"
+          - "string"
+      url:
+        type:
+          - "null"
+          - "string"
+      resource:
+        type:
+          - "null"
+          - "string"
+      description:
+        type:
+          - "null"
+          - "object"
+      success_metric:
+        type:
+          - "null"
+          - "object"
+      project:
+        type:
+          - "null"
+          - "object"
+      timeframe:
+        type:
+          - "null"
+          - "object"
+      initiatives:
+        type:
+          - "null"
+          - "array"
+        items:
+          type:
+            - "null"
+            - "object"
+          additionalProperties: true
+      comments_count:
+        type:
+          - "null"
+          - "integer"
+      features:
+        type:
+          - "null"
+          - "array"
+        items:
+          type:
+            - "null"
+            - "object"
+          additionalProperties: true
+      releases:
+        type:
+          - "null"
+          - "array"
+      custom_fields:
+        type:
+          - "null"
+          - "array"
+      parent:
+        type:
+          - "null"
+          - "object"
+        additionalProperties: true
+      parents:
+        type:
+          - "null"
+          - "array"
+        items:
+          type:
+            - "null"
+            - "object"
+          additionalProperties: true

--- a/airbyte-integrations/connectors/source-aha/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aha/metadata.yaml
@@ -9,17 +9,17 @@ data:
       enabled: true
   remoteRegistries:
     pypi:
-      enabled: true
+      enabled: false
       packageName: airbyte-source-aha
   connectorBuildOptions:
     # Please update to the latest version of the connector base image.
     # https://hub.docker.com/r/airbyte/python-connector-base
     # Please use the full address with sha256 hash to guarantee build reproducibility.
-    baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
+    baseImage: docker.io/airbyte/source-declarative-manifest:4.3.3@sha256:8586ff17ed9584435d0e946a5d0ec393435c81d08da2d8e2913f7984836ce452
   connectorSubtype: api
   connectorType: source
   definitionId: 81ca39dc-4534-4dd2-b848-b0cfd2c11fce
-  dockerImageTag: 0.3.12
+  dockerImageTag: 0.4.0
   dockerRepository: airbyte/source-aha
   documentationUrl: https://docs.airbyte.com/integrations/sources/aha
   githubIssueLabel: source-aha
@@ -29,8 +29,8 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-    - language:python
     - cdk:low-code
+    - language:manifest-only
   connectorTestSuitesOptions:
     - suite: liveTests
       testConnections:

--- a/docs/integrations/sources/aha.md
+++ b/docs/integrations/sources/aha.md
@@ -42,6 +42,7 @@ Rate Limiting information is updated [here](https://www.aha.io/api#rate-limiting
 
 | Version | Date       | Pull Request                                             | Subject                                                                 |
 |:--------|:-----------| :------------------------------------------------------- |:------------------------------------------------------------------------|
+| 0.4.0 | 2024-08-09 | [43425](https://github.com/airbytehq/airbyte/pull/43425) | Refactor connector manifest-only format |
 | 0.3.12 | 2024-08-03 | [43186](https://github.com/airbytehq/airbyte/pull/43186) | Update dependencies |
 | 0.3.11 | 2024-07-27 | [42737](https://github.com/airbytehq/airbyte/pull/42737) | Update dependencies |
 | 0.3.10 | 2024-07-20 | [42306](https://github.com/airbytehq/airbyte/pull/42306) | Update dependencies |


### PR DESCRIPTION
## What
Migrates source <name> to manifest-only format

## How
Ran the airbyte-ci commands: [`migrate-to-manifest-only`, `bump-version`, `format fix` and `pull-request`].

## Review Guide
1. manifest.yaml: should be at the root level of the folder, list version `4.3.0` and contain an inline spec
2. metadata.py: should list the correct `manifest-only` language tag and point to a recent version of `source-declarative-manifest`
3. acceptance-test-config.yml: should correctly point to `manifest.yaml` for the spec test
4. readme.md: Should be updated with correct references to the connector (this has historically been a sticking point with our READMEs)
5. Pretty much everything else should be nuked

## User Impact
None
