### PR TITLE
docs: update stream statuses in docs

### DIFF
--- a/docs/cloud/managing-airbyte-cloud/review-connection-status.md
+++ b/docs/cloud/managing-airbyte-cloud/review-connection-status.md
@@ -33,15 +33,12 @@ The stream status allows you to monitor an individual stream's latest status. Co
 
 |   | Status                   | Description                                                                                     |
 | - | ------------------------ | ----------------------------------------------------------------------------------------------- |
-|![On time](./assets/connection_synced.png) | **On time**              | The stream is operating within the expected timeframe expectations set by the replication frequency |
+|![Synced](./assets/connection_synced.png) | **Synced**              | The stream's last sync was successful. |
 |![Syncing](./assets/connection_syncing.png) | **Syncing**              | The stream is currently actively syncing. The stream will also be highlighted in grey to indicate the sync is actively extracting or loading data.    |
 |![Queued](./assets/connection_not_yet_synced.png) | **Queued**               | The stream has not synced yet, and is scheduled to be synced in the current ongoing sync            |
 |![Queued for next sync](./assets/connection_not_yet_synced.png) | **Queued for next sync** | The stream has not synced yet, and is scheduled to be synced in the next scheduled sync             |
-|![On track](./assets/connection_synced.png) | **On track**             | The connection is slightly delayed but is expected to catch up before the next sync. This can occur when a transient sync error occurs.    |
-|![Late](./assets/connection_incomplete.png) | **Late**               | The connection has not loaded data within the scheduled replication frequency. For example, if the replication frequency is 1 hour, the connection has not loaded data for more than 1 hour                                     |
-|![Error](./assets/connection_incomplete.png) | **Error**              | The connection has not loaded data in more than two times the scheduled replication frequency. For example, if the replication frequency is 1 hour, the connection has not loaded data for more than 2 hours                    |
+|![Error](./assets/connection_incomplete.png) | **Error**              | The connection did not succeed on its most recent sync, but is expected to recover on the next one                    |
 |![Action Required](./assets/connection_action_required.png) | **Action Required**    | A breaking change related to the source or destination requires attention to resolve                |
-|![Pending](./assets/connection_disabled.png) | **Pending**            | The stream has not been synced yet, so not status exists                   
 
 Once the sync is complete, each stream displays the time since the last record was loaded to the destination. You can click **Last record loaded** in the header to optionally display the exact datetime the last record was loaded.
 


### PR DESCRIPTION
## What
Some stream statuses have been changed from being schedule-related to being last-sync-related.  This updates the docs to reflect that.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
