### PR TITLE
connectors-insights: fix generation for non manifest connector

### DIFF
--- a/airbyte-ci/connectors/connectors_insights/README.md
+++ b/airbyte-ci/connectors/connectors_insights/README.md
@@ -56,6 +56,9 @@ This CLI is currently running nightly in GitHub Actions. The workflow can be fou
 
 ## Changelog
 
+### 0.3.1
+Skip manifest inferred insights when the connector does not have a `manifest.yaml` file.
+
 ### 0.3.0
 Adding `manifest_uses_parameters`, `manifest_uses_custom_components`, and `manifest_custom_components_classes` insights.
 

--- a/airbyte-ci/connectors/connectors_insights/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_insights/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-insights"
-version = "0.3.0"
+version = "0.3.1"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/insights.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/insights.py
@@ -24,9 +24,12 @@ if TYPE_CHECKING:
 
 
 def get_manifest_inferred_insights(connector: Connector) -> dict:
+    if connector.manifest_path is None or not connector.manifest_path.exists():
+        return {}
+
     manifest = connector.manifest_path.read_text()
 
-    schemas_directory = connector.code_path / connector.technical_name.replace("-", "_") / "schemas"
+    schemas_directory = connector.code_directory / connector.technical_name.replace("-", "_") / "schemas"
 
     return {
         "manifest_uses_parameters": manifest.find("$parameters") != -1,

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/models.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/models.py
@@ -34,10 +34,10 @@ class ConnectorInsights(BaseModel):
     deprecated_classes_in_use: list[str] | None
     deprecated_modules_in_use: list[str] | None
     forbidden_method_names_in_use: list[str] | None
-    manifest_uses_parameters: StrictBool
-    manifest_uses_custom_components: StrictBool
+    manifest_uses_parameters: StrictBool | None
+    manifest_uses_custom_components: StrictBool | None
     manifest_custom_component_classes: list[str] | None
-    has_json_schemas: StrictBool
+    has_json_schemas: StrictBool | None
 
     class Config:
         json_encoders = {dict: lambda v: json.dumps(v, default=pydantic_encoder)}


### PR DESCRIPTION
## What
Insights generation is broken:
* for non low-code connectors: a function tried to read the manifest file but it does not always exists.
* access to schema directory was not working as the `Connector.code_path` attribute does not exists.

[Connector insights generation now works again.](https://github.com/airbytehq/airbyte/actions/runs/10321951142/job/28576029190)