### PR TITLE
Update cdc.md

### DIFF
--- a/docs/understanding-airbyte/cdc.md
+++ b/docs/understanding-airbyte/cdc.md
@@ -26,7 +26,7 @@ We add some metadata columns for CDC sources which all begin with the `_ab_cdc_`
 - The modifications you are trying to capture must be made using `DELETE`/`INSERT`/`UPDATE`. For example, changes made from `TRUNCATE`/`ALTER` won't appear in logs and therefore in your destination.
 - There are database-specific limitations. See the documentation pages for individual connectors for more information.
 - The records produced by `DELETE` statements only contain primary keys. All other data fields are unset.
-- For `Incremental | Append + Dedupe` sync modes, records produced by `DELETE` will be removed from the final table during dedupelication. To retain these records in the final table, use `Incremental | Append` sync mode. Records produced by `DELETE` will be still be accessible in the `airbyte_internal` schema.
+- For `Append + Dedupe` destination sync modes, records produced by `DELETE` will be removed from the final table during dedupelication, if the destination supports it. To retain these records in the final table, use `Incremental | Append` sync mode. Records produced by `DELETE` will be still be accessible in the `airbyte_internal` schema.
 
 ## Current Support
 

--- a/docs/understanding-airbyte/cdc.md
+++ b/docs/understanding-airbyte/cdc.md
@@ -26,6 +26,7 @@ We add some metadata columns for CDC sources which all begin with the `_ab_cdc_`
 - The modifications you are trying to capture must be made using `DELETE`/`INSERT`/`UPDATE`. For example, changes made from `TRUNCATE`/`ALTER` won't appear in logs and therefore in your destination.
 - There are database-specific limitations. See the documentation pages for individual connectors for more information.
 - The records produced by `DELETE` statements only contain primary keys. All other data fields are unset.
+- For `Incremental | Append + Dedupe` sync modes, records produced by `DELETE` will be removed from the final table during dedupelication. To retain these records in the final table, use `Incremental | Append` sync mode. Records produced by `DELETE` will be still be accessible in the `airbyte_internal` schema.
 
 ## Current Support
 


### PR DESCRIPTION
Updating to clarify deduplication removes records with NOT NULL values for `_ab_cdc_deleted_at`

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Updating CDC docs to clarify records with NOT NULL `_ab_cdc_deletedat` are removed from final table during deduplication. 

Suggests users should switch to `Incremental | Append` if they want these to be retained in the final table

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
