### PR TITLE
S3 Destination: Descreased thread allocation & memory ratio for AsyncConsumer

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.44.4
+version=0.44.9

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/BaseS3Destination.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/BaseS3Destination.kt
@@ -21,7 +21,9 @@ private val LOGGER = KotlinLogging.logger {}
 abstract class BaseS3Destination
 protected constructor(
     protected val configFactory: S3DestinationConfigFactory = S3DestinationConfigFactory(),
-    protected val environment: Map<String, String> = System.getenv()
+    protected val environment: Map<String, String> = System.getenv(),
+    private val memoryRatio: Double = 0.5,
+    private val nThreads: Int = 5
 ) : BaseConnector(), Destination {
     private val nameTransformer: NamingConventionTransformer = S3NameTransformer()
 
@@ -74,7 +76,9 @@ protected constructor(
                 outputRecordCollector,
                 S3StorageOperations(nameTransformer, s3Config.getS3Client(), s3Config),
                 s3Config,
-                catalog
+                catalog,
+                memoryRatio,
+                nThreads
             )
     }
 

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -4,9 +4,9 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.44.0'
+    cdkVersionRequired = '0.44.9'
     features = ['db-destinations', 's3-destinations']
-    useLocalCdk = true // TODO: Version CDK, bump required version, and set this to false
+    useLocalCdk = false // TODO: Version CDK, bump required version, and set this to false
 }
 
 airbyteJavaConnector.addCdkDependencies()

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 0.6.6
+  dockerImageTag: 0.6.7
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/main/kotlin/io/airbyte/integrations/destination/s3/S3Destination.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/main/kotlin/io/airbyte/integrations/destination/s3/S3Destination.kt
@@ -10,7 +10,7 @@ import io.airbyte.cdk.integrations.destination.s3.S3DestinationConfigFactory
 import io.airbyte.cdk.integrations.destination.s3.StorageProvider
 
 open class S3Destination : BaseS3Destination {
-    constructor()
+    constructor() : super(nThreads = 1, memoryRatio = 0.5)
 
     @VisibleForTesting
     constructor(

--- a/airbyte-integrations/connectors/destination-s3/src/main/kotlin/io/airbyte/integrations/destination/s3/S3Destination.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/main/kotlin/io/airbyte/integrations/destination/s3/S3Destination.kt
@@ -10,7 +10,7 @@ import io.airbyte.cdk.integrations.destination.s3.S3DestinationConfigFactory
 import io.airbyte.cdk.integrations.destination.s3.StorageProvider
 
 open class S3Destination : BaseS3Destination {
-    constructor() : super(nThreads = 1, memoryRatio = 0.5)
+    constructor() : super(nThreads = 2, memoryRatio = 0.5)
 
     @VisibleForTesting
     constructor(

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -514,14 +514,15 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.6.6 | 2024-08-06 | [43343](https://github.com/airbytehq/airbyte/pull/43343) | Use Kotlin 2.0.0 |
-| 0.6.5 | 2024-08-01 | [42405](https://github.com/airbytehq/airbyte/pull/42405) | S3 parallelizes workloads, checkpoints, submits counts, support for generationId in metadata for refreshes. |
-| 0.6.4 | 2024-04-16 | [42006](https://github.com/airbytehq/airbyte/pull/42006) | remove unnecessary zookeeper dependency |
-| 0.6.3 | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204) | convert all production code to kotlin |
-| 0.6.2 | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204) | add assume role auth |
-| 0.6.1 | 2024-04-08 | [37546](https://github.com/airbytehq/airbyte/pull/37546) | Adapt to CDK 0.30.8; |
-| 0.6.0 | 2024-04-08 | [36869](https://github.com/airbytehq/airbyte/pull/36869) | Adapt to CDK 0.29.8; Kotlin converted code. |
-| 0.5.9 | 2024-02-22 | [35569](https://github.com/airbytehq/airbyte/pull/35569) | Fix logging bug. |
+| 0.6.7   | 2024-08-11 | [43713](https://github.com/airbytehq/airbyte/issues/43713) | Decreased memory ratio (0.7 -> 0.5) and thread allocation (5 -> 1) for async S3 uploads.                                                             |
+| 0.6.6   | 2024-08-06 | [43343](https://github.com/airbytehq/airbyte/pull/43343)   | Use Kotlin 2.0.0                                                                                                                                     |
+| 0.6.5   | 2024-08-01 | [42405](https://github.com/airbytehq/airbyte/pull/42405)   | S3 parallelizes workloads, checkpoints, submits counts, support for generationId in metadata for refreshes.                                          |
+| 0.6.4   | 2024-04-16 | [42006](https://github.com/airbytehq/airbyte/pull/42006)   | remove unnecessary zookeeper dependency                                                                                                              |
+| 0.6.3   | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204)   | convert all production code to kotlin                                                                                                                |
+| 0.6.2   | 2024-04-15 | [38204](https://github.com/airbytehq/airbyte/pull/38204)   | add assume role auth                                                                                                                                 |
+| 0.6.1   | 2024-04-08 | [37546](https://github.com/airbytehq/airbyte/pull/37546)   | Adapt to CDK 0.30.8;                                                                                                                                 |
+| 0.6.0   | 2024-04-08 | [36869](https://github.com/airbytehq/airbyte/pull/36869)   | Adapt to CDK 0.29.8; Kotlin converted code.                                                                                                          |
+| 0.5.9   | 2024-02-22 | [35569](https://github.com/airbytehq/airbyte/pull/35569)   | Fix logging bug.                                                                                                                                     |
 | 0.5.8   | 2024-01-03 | [#33924](https://github.com/airbytehq/airbyte/pull/33924)  | Add new ap-southeast-3 AWS region                                                                                                                    |
 | 0.5.7   | 2023-12-28 | [#33788](https://github.com/airbytehq/airbyte/pull/33788)  | Thread-safe fix for file part names                                                                                                                  |
 | 0.5.6   | 2023-12-08 | [#33263](https://github.com/airbytehq/airbyte/pull/33263)  | (incorrect filename format, do not use) Adopt java CDK version 0.7.0.                                                                                |


### PR DESCRIPTION
[This issue ](https://github.com/airbytehq/airbyte-internal-issues/issues/9407)

Some configurations OOM consistently in the cloud. I can't find evidence this is affecting customers, but bumping memory to 2G (same as other async destinations) seems to enable it to succeed.

There are three changes here:

* increase memory requirements to 2G
* reduce the memory ratio to 0.5
* additional changes to make it possible to tweak memory ratio and concurrency entirely with a connector release (no CDK)

I built a dev connector off this, and it allows even the most demanding loads to make steady progress.