### PR TITLE
publish-pipelines: increase retry delay

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -45,6 +45,7 @@ jobs:
           subcommand: "connectors --concurrency=1 --execute-timeout=3600 --metadata-changes-only publish --main-release"
           python_registry_token: ${{ secrets.PYPI_TOKEN }}
           max_attempts: 2
+          retry_wait_seconds: 600 # 10 minutes
 
       - name: Publish connectors [manual]
         id: publish-connectors


### PR DESCRIPTION
## What
Even with retries in place we still face some transient publish failures:
* On DockerHub login (rate limiting)
* On Dagger Engine start up

https://github.com/airbytehq/airbyte/actions/runs/10335559052
https://github.com/airbytehq/airbyte/actions/runs/10335542757
https://github.com/airbytehq/airbyte/actions/runs/10335567216

## How
I suggest giving a 10mn delay between attempts to check if it reduces the flakyness.
