### PR TITLE
metadata-service: rename registries to registryOverrides

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
@@ -577,7 +577,7 @@ class Connector:
         Returns:
             bool: True if the connector is enabled, False otherwise.
         """
-        registries = self.metadata.get("registries")
+        registries = self.metadata.get("registryOverrides")
         if not registries:
             return False
 

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/insights.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/insights.py
@@ -56,8 +56,8 @@ def get_metadata_inferred_insights(connector: Connector) -> Dict:
         "connector_support_level": connector.metadata.get("supportLevel"),
         "ab_internal_sl": connector.metadata.get("ab_internal", {}).get("sl"),
         "ab_internal_ql": connector.metadata.get("ab_internal", {}).get("ql"),
-        "is_cloud_enabled": connector.metadata.get("registries", {}).get("cloud", {}).get("enabled", False),
-        "is_oss_enabled": connector.metadata.get("registries", {}).get("oss", {}).get("enabled", False),
+        "is_cloud_enabled": connector.metadata.get("registryOverrides", {}).get("cloud", {}).get("enabled", False),
+        "is_oss_enabled": connector.metadata.get("registryOverrides", {}).get("oss", {}).get("enabled", False),
     }
 
 

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -182,10 +182,10 @@ def _apply_prerelease_overrides(metadata_dict: dict, validator_opts: ValidatorOp
         return metadata_dict
 
     # replace any dockerImageTag references with the actual tag
-    # this includes metadata.data.dockerImageTag, metadata.data.registries[].dockerImageTag
+    # this includes metadata.data.dockerImageTag, metadata.data.registryOverrides[].dockerImageTag
     # where registries is a dictionary of registry name to registry object
     metadata_dict["data"]["dockerImageTag"] = validator_opts.prerelease_tag
-    for registry in get(metadata_dict, "data.registries", {}).values():
+    for registry in get(metadata_dict, "data.registryOverrides", {}).values():
         if "dockerImageTag" in registry:
             registry["dockerImageTag"] = validator_opts.prerelease_tag
 

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
@@ -255,7 +255,7 @@ class ConnectorBreakingChanges(BaseModel):
     )
 
 
-class Registry(BaseModel):
+class RegistryOverride(BaseModel):
     class Config:
         extra = Extra.forbid
 
@@ -302,7 +302,7 @@ class Data(BaseModel):
     tags: Optional[List[str]] = Field(
         [], description="An array of tags that describe the connector. E.g: language:python, keyword:rds, etc."
     )
-    registries: Optional[Registry] = None
+    registryOverrides: Optional[RegistryOverride] = None
     allowedHosts: Optional[AllowedHosts] = None
     releases: Optional[ConnectorReleases] = None
     normalizationConfig: Optional[NormalizationDestinationDefinitionConfig] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml
@@ -91,7 +91,7 @@ properties:
         items:
           type: string
         default: []
-      registries:
+      registryOverrides:
         anyOf:
           - type: object
             additionalProperties: false

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/validators/metadata_validator.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/validators/metadata_validator.py
@@ -33,11 +33,11 @@ def validate_metadata_images_in_dockerhub(
     base_docker_image = get(metadata_definition_dict, "data.dockerRepository")
     base_docker_version = get(metadata_definition_dict, "data.dockerImageTag")
 
-    oss_docker_image = get(metadata_definition_dict, "data.registries.oss.dockerRepository", base_docker_image)
-    oss_docker_version = get(metadata_definition_dict, "data.registries.oss.dockerImageTag", base_docker_version)
+    oss_docker_image = get(metadata_definition_dict, "data.registryOverrides.oss.dockerRepository", base_docker_image)
+    oss_docker_version = get(metadata_definition_dict, "data.registryOverrides.oss.dockerImageTag", base_docker_version)
 
-    cloud_docker_image = get(metadata_definition_dict, "data.registries.cloud.dockerRepository", base_docker_image)
-    cloud_docker_version = get(metadata_definition_dict, "data.registries.cloud.dockerImageTag", base_docker_version)
+    cloud_docker_image = get(metadata_definition_dict, "data.registryOverrides.cloud.dockerRepository", base_docker_image)
+    cloud_docker_version = get(metadata_definition_dict, "data.registryOverrides.cloud.dockerImageTag", base_docker_version)
 
     normalization_docker_image = get(metadata_definition_dict, "data.normalizationConfig.normalizationRepository", None)
     normalization_docker_version = get(metadata_definition_dict, "data.normalizationConfig.normalizationTag", None)

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/repo_nonexistent/metadata_cloud_repo_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/repo_nonexistent/metadata_cloud_repo_does_not_exist.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/exists-2
     normalizationTag: 0.0.1
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
       dockerRepository: airbyte/does-not-exist-4

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/repo_nonexistent/metadata_main_repo_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/repo_nonexistent/metadata_main_repo_does_not_exist.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/exists-2
     normalizationTag: 0.0.1
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/repo_nonexistent/metadata_normalization_repo_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/repo_nonexistent/metadata_normalization_repo_does_not_exist.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/does-not-exist-2
     normalizationTag: 0.0.1
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
       dockerRepository: airbyte/exists-3

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/repo_nonexistent/metadata_oss_repo_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/repo_nonexistent/metadata_oss_repo_does_not_exist.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/exists-2
     normalizationTag: 0.0.1
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
       dockerRepository: airbyte/exists-3

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/tag_nonexistent/metadata_breaking_change_image_tag_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/tag_nonexistent/metadata_breaking_change_image_tag_does_not_exist.yaml
@@ -8,7 +8,7 @@ data:
   icon: onesignal.svg
   license: MIT
   name: OneSignal
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/tag_nonexistent/metadata_cloud_image_tag_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/tag_nonexistent/metadata_cloud_image_tag_does_not_exist.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/exists-2
     normalizationTag: 0.0.1
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
       dockerRepository: airbyte/exists-3

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/tag_nonexistent/metadata_main_image_tag_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/tag_nonexistent/metadata_main_image_tag_does_not_exist.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/exists-2
     normalizationTag: 0.0.1
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/tag_nonexistent/metadata_normalization_image_tag_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/tag_nonexistent/metadata_normalization_image_tag_does_not_exist.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/exists-2
     normalizationTag: 99.99.99 # tag does not exist
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
       dockerRepository: airbyte/exists-3

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/tag_nonexistent/metadata_oss_repo_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/tag_nonexistent/metadata_oss_repo_does_not_exist.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/exists-2
     normalizationTag: 0.0.1
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
       dockerRepository: airbyte/exists-3

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/valid_overrides_but_image_nonexistent/metadata_main_image_tag_does_not_exist_but_is_overrode.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/valid_overrides_but_image_nonexistent/metadata_main_image_tag_does_not_exist_but_is_overrode.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/exists-2
     normalizationTag: 0.0.1
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
       dockerRepository: airbyte/exists-3

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/valid_overrides_but_image_nonexistent/metadata_main_repo_does_not_exist_but_is_overrode.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/referenced_image_not_in_dockerhub/valid_overrides_but_image_nonexistent/metadata_main_repo_does_not_exist_but_is_overrode.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/exists-2
     normalizationTag: 0.0.1
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
       dockerRepository: airbyte/exists-3

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/referenced_image_in_dockerhub/metadata_all_images_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/referenced_image_in_dockerhub/metadata_all_images_exist.yaml
@@ -14,7 +14,7 @@ data:
     normalizationIntegrationType: postgres
     normalizationRepository: airbyte/exists-2
     normalizationTag: 0.0.1
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
       dockerRepository: airbyte/exists-3

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/referenced_image_in_dockerhub/metadata_base_image_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/referenced_image_in_dockerhub/metadata_base_image_exists.yaml
@@ -17,7 +17,7 @@ data:
   icon: alloy-db.svg
   license: MIT
   name: AlloyDB for PostgreSQL
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/connector_build_options_invalid/metadata_base_image_digest_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/connector_build_options_invalid/metadata_base_image_digest_does_not_exists.yaml
@@ -17,7 +17,7 @@ data:
   icon: alloy-db.svg
   license: MIT
   name: AlloyDB for PostgreSQL
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/connector_build_options_invalid/metadata_base_image_name_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/connector_build_options_invalid/metadata_base_image_name_does_not_exists.yaml
@@ -17,7 +17,7 @@ data:
   icon: alloy-db.svg
   license: MIT
   name: AlloyDB for PostgreSQL
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/connector_build_options_invalid/metadata_base_image_tag_does_not_exists.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/connector_build_options_invalid/metadata_base_image_tag_does_not_exists.yaml
@@ -17,7 +17,7 @@ data:
   icon: alloy-db.svg
   license: MIT
   name: AlloyDB for PostgreSQL
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/connector_build_options_invalid/metadata_build_base_image_wrong_type.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/connector_build_options_invalid/metadata_build_base_image_wrong_type.yaml
@@ -13,7 +13,7 @@ data:
   icon: google-sheets.svg
   license: Elv2
   name: Google Sheets
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/overrides_invalid/metadata_registry_no_id_override.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/overrides_invalid/metadata_registry_no_id_override.yaml
@@ -14,7 +14,7 @@ data:
     hosts:
       - "${host}"
       - "${tunnel_method.tunnel_host}"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
       definitionId: woohoo

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/overrides_invalid/metadata_registry_no_type_override.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/overrides_invalid/metadata_registry_no_type_override.yaml
@@ -14,7 +14,7 @@ data:
     hosts:
       - "${host}"
       - "${tunnel_method.tunnel_host}"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
       connectorType: destination

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/overrides_invalid/metadata_registry_unknown_override.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/overrides_invalid/metadata_registry_unknown_override.yaml
@@ -14,7 +14,7 @@ data:
     hosts:
       - "${host}"
       - "${tunnel_method.tunnel_host}"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
       what: is this?

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/releases_invalid/metadata_major_version_no_breaking_change_entry_for_version.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/releases_invalid/metadata_major_version_no_breaking_change_entry_for_version.yaml
@@ -9,7 +9,7 @@ data:
   icon: onesignal.svg
   license: MIT
   name: OneSignal
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/releases_invalid/metadata_major_version_no_releases.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/optional_top_level_property_invalid/releases_invalid/metadata_major_version_no_releases.yaml
@@ -9,7 +9,7 @@ data:
   icon: onesignal.svg
   license: MIT
   name: OneSignal
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/metadata_build_base_image.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/metadata_build_base_image.yaml
@@ -13,7 +13,7 @@ data:
   icon: google-sheets.svg
   license: Elv2
   name: Google Sheets
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/with_overrides/metadata_registry_complex_override.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/with_overrides/metadata_registry_complex_override.yaml
@@ -14,7 +14,7 @@ data:
     hosts:
       - "${host}"
       - "${tunnel_method.tunnel_host}"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/with_overrides/metadata_registry_enabled.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/with_overrides/metadata_registry_enabled.yaml
@@ -14,7 +14,7 @@ data:
     hosts:
       - "${host}"
       - "${tunnel_method.tunnel_host}"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
   tags:

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_gcs_upload.py
@@ -433,6 +433,6 @@ def test_upload_metadata_to_gcs_with_prerelease(mocker, valid_metadata_upload_fi
         tmp_metadata, error = gcs_upload.validate_and_load(tmp_metadata_file_path, [], validator_opts=ValidatorOptions(docs_path=DOCS_PATH))
         tmp_metadata_dict = to_json_sanitized_dict(tmp_metadata, exclude_none=True)
         assert tmp_metadata_dict["data"]["dockerImageTag"] == prerelease_image_tag
-        for registry in get(tmp_metadata_dict, "data.registries", {}).values():
+        for registry in get(tmp_metadata_dict, "data.registryOverrides", {}).values():
             if "dockerImageTag" in registry:
                 assert registry["dockerImageTag"] == prerelease_image_tag

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
@@ -11,9 +11,7 @@ from metadata_service.validators import metadata_validator
 
 @pytest.fixture
 def metadata_definition():
-    metadata_file_url = (
-        "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations/connectors/source-faker/metadata.yaml"
-    )
+    metadata_file_url = "https://raw.githubusercontent.com/airbytehq/airbyte/8f0a6afe41cd1f9e70e954255749b7867592f863/airbyte-integrations/connectors/source-faker/metadata.yaml"
     response = requests.get(metadata_file_url)
     response.raise_for_status()
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -371,8 +371,8 @@ def get_registry_status_lists(registry_entry: LatestMetadataEntry) -> Tuple[List
     """
     metadata_data_dict = registry_entry.metadata_definition.dict()
 
-    # get data.registries fiield, handling the case where it is not present or none
-    registries_field = get(metadata_data_dict, "data.registries") or {}
+    # get data.registryOverrides fiield, handling the case where it is not present or none
+    registries_field = get(metadata_data_dict, "data.registryOverrides") or {}
 
     # registries is a dict of registry_name -> {enabled: bool}
     all_enabled_registries = [

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -122,7 +122,7 @@ def apply_overrides_from_registry(metadata_data: dict, override_registry_key: st
     Returns:
         dict: The metadata data field with the overrides applied.
     """
-    override_registry = metadata_data["registries"][override_registry_key]
+    override_registry = metadata_data["registryOverrides"][override_registry_key]
     del override_registry["enabled"]
 
     # remove any None values from the override registry
@@ -222,7 +222,7 @@ def metadata_to_registry_entry(metadata_entry: LatestMetadataEntry, override_reg
     overridden_metadata_data = apply_overrides_from_registry(metadata_data, override_registry_key)
 
     # remove fields that are not needed in the registry
-    del overridden_metadata_data["registries"]
+    del overridden_metadata_data["registryOverrides"]
     del overridden_metadata_data["connectorType"]
 
     # rename field connectorSubtype to sourceType

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -215,7 +215,9 @@ def test_definition_id_conversion(registry_type, connector_type, expected_id_fie
     Test if the definitionId in the metadata is successfully converted to
     destinationDefinitionId or sourceDefinitionId in the registry entry.
     """
-    metadata = {"data": {"connectorType": connector_type, "definitionId": "test-id", "registryOverrides": {registry_type: {"enabled": True}}}}
+    metadata = {
+        "data": {"connectorType": connector_type, "definitionId": "test-id", "registryOverrides": {registry_type: {"enabled": True}}}
+    }
 
     mock_metadata_entry = mock.Mock()
     mock_metadata_entry.metadata_definition.dict.return_value = metadata

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -44,7 +44,7 @@ VALID_METADATA_DICT = {
         "connectorSubtype": "api",
         "supportLevel": "community",
         "releaseStage": "alpha",
-        "registries": {"oss": {"enabled": True}, "cloud": {"enabled": True}},
+        "registryOverrides": {"oss": {"enabled": True}, "cloud": {"enabled": True}},
     },
 }
 INVALID_METADATA_DICT = {"invalid": "metadata"}
@@ -131,7 +131,7 @@ def test_get_registry_status_lists(registries_data, expected_enabled, expected_d
             "connectorSubtype": "api",
             "releaseStage": "alpha",
             "supportLevel": "community",
-            "registries": registries_data,
+            "registryOverrides": registries_data,
         },
     }
     metadata_definition = MetadataDefinition.parse_obj(metadata_dict)
@@ -215,7 +215,7 @@ def test_definition_id_conversion(registry_type, connector_type, expected_id_fie
     Test if the definitionId in the metadata is successfully converted to
     destinationDefinitionId or sourceDefinitionId in the registry entry.
     """
-    metadata = {"data": {"connectorType": connector_type, "definitionId": "test-id", "registries": {registry_type: {"enabled": True}}}}
+    metadata = {"data": {"connectorType": connector_type, "definitionId": "test-id", "registryOverrides": {registry_type: {"enabled": True}}}}
 
     mock_metadata_entry = mock.Mock()
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
@@ -230,7 +230,7 @@ def test_tombstone_custom_public_set():
     """
     Test if tombstone, custom and public are set correctly in the registry entry.
     """
-    metadata = {"data": {"connectorType": "source", "definitionId": "test-id", "registries": {"oss": {"enabled": True}}}}
+    metadata = {"data": {"connectorType": "source", "definitionId": "test-id", "registryOverrides": {"oss": {"enabled": True}}}}
 
     mock_metadata_entry = mock.Mock()
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
@@ -247,7 +247,7 @@ def test_fields_deletion():
     """
     Test if registries, connectorType, and definitionId fields were deleted from the registry entry.
     """
-    metadata = {"data": {"connectorType": "source", "definitionId": "test-id", "registries": {"oss": {"enabled": True}}}}
+    metadata = {"data": {"connectorType": "source", "definitionId": "test-id", "registryOverrides": {"oss": {"enabled": True}}}}
 
     mock_metadata_entry = mock.Mock()
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
@@ -255,7 +255,7 @@ def test_fields_deletion():
     mock_metadata_entry.dependency_file_url = "test-dependency-file-url"
 
     result = metadata_to_registry_entry(mock_metadata_entry, "oss")
-    assert "registries" not in result
+    assert "registryOverrides" not in result
     assert "connectorType" not in result
     assert "definitionId" not in result
 
@@ -274,7 +274,7 @@ def test_overrides_application(registry_type, expected_docker_image_tag, expecte
             "connectorType": "source",
             "definitionId": "test-id",
             "dockerImageTag": "base_tag",
-            "registries": {
+            "registryOverrides": {
                 "oss": {"enabled": True, "dockerImageTag": "oss_tag", "additionalField": "oss_value"},
                 "cloud": {"enabled": True, "dockerImageTag": "cloud_tag", "additionalField": "cloud_value"},
             },
@@ -304,7 +304,7 @@ def test_source_type_extraction():
             "connectorType": "source",
             "connectorSubtype": "database",
             "definitionId": "test-id",
-            "registries": {"oss": {"enabled": True}},
+            "registryOverrides": {"oss": {"enabled": True}},
         }
     }
 
@@ -321,7 +321,7 @@ def test_support_level_default():
     """
     Test if supportLevel is defaulted to alpha in the registry entry.
     """
-    metadata = {"data": {"connectorType": "source", "definitionId": "test-id", "registries": {"oss": {"enabled": True}}}}
+    metadata = {"data": {"connectorType": "source", "definitionId": "test-id", "registryOverrides": {"oss": {"enabled": True}}}}
 
     mock_metadata_entry = mock.Mock()
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
@@ -341,7 +341,7 @@ def test_migration_documentation_url_default():
             "connectorType": "source",
             "definitionId": "test-id",
             "documentationUrl": "test-doc-url",
-            "registries": {"oss": {"enabled": True}},
+            "registryOverrides": {"oss": {"enabled": True}},
             "releases": {"migrationDocumentationUrl": None, "breakingChanges": {"1.0.0": {"migrationDocumentationUrl": None}}},
         }
     }
@@ -368,7 +368,7 @@ def test_breaking_changes_migration_documentation_url():
             "connectorType": "source",
             "definitionId": "test-id",
             "documentationUrl": "test-doc-url",
-            "registries": {"oss": {"enabled": True}},
+            "registryOverrides": {"oss": {"enabled": True}},
             "releases": {
                 "migrationDocumentationUrl": "test-migration-doc-url",
                 "breakingChanges": {"1.0.0": {"migrationDocumentationUrl": "test-migration-doc-url-version"}},
@@ -390,7 +390,7 @@ def test_icon_url():
     """
     Test if the iconUrl in the metadata entry is correctly set in the registry entry.
     """
-    metadata = {"data": {"connectorType": "source", "definitionId": "test-id", "registries": {"oss": {"enabled": True}}}}
+    metadata = {"data": {"connectorType": "source", "definitionId": "test-id", "registryOverrides": {"oss": {"enabled": True}}}}
 
     mock_metadata_entry = mock.Mock()
     mock_metadata_entry.metadata_definition.dict.return_value = metadata


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/8997
We want to rename the `registries` metadata field to `registryOverrides`.
This is to make this field's role more explicit for connector version pinning on Airbyte OSS or Cloud.

Connector specific renaming is in https://github.com/airbytehq/airbyte/pull/43757