### PR TITLE
Rename registries to registryOverrides in connector metadata

### DIFF
--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: awssqs.svg
   license: MIT
   name: Amazon SQS
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-astra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-astra/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - "*.apps.astra.datastax.com"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/destination-aws-datalake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-aws-datalake/metadata.yaml
@@ -10,7 +10,7 @@ data:
   icon: awsdatalake.svg
   license: MIT
   name: AWS Datalake
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: azureblobstorage.svg
   license: MIT
   name: Azure Blob Storage
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: bigquery.svg
   license: ELv2
   name: BigQuery (denormalized typed struct)
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -12,7 +12,7 @@ data:
   icon: bigquery.svg
   license: ELv2
   name: BigQuery
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: cassandra.svg
   license: MIT
   name: Cassandra
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-chroma/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-chroma/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: clickhouse.svg
   license: MIT
   name: Clickhouse
-  registries:
+  registryOverrides:
     cloud:
       dockerRepository: airbyte/destination-clickhouse-strict-encrypt
       enabled: true

--- a/airbyte-integrations/connectors/destination-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-convex/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: convex.svg
   license: MIT
   name: Convex
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-csv/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-csv/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: file-csv.svg
   license: MIT
   name: Local CSV
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-cumulio/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cumulio/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: cumulio.svg
   license: MIT
   name: Cumul.io
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-databend/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databend/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: databend.svg
   license: MIT
   name: Databend
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-databricks/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databricks/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: databricks.svg
   license: ELv2
   name: Databricks Lakehouse
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: airbyte.svg
   license: MIT
   name: End-to-End Testing (/dev/null)
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-doris/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-doris/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: apachedoris.svg
   license: MIT
   name: Apache Doris
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-duckdb/metadata.yaml
@@ -10,7 +10,7 @@ data:
   icon: duckdb.svg
   license: MIT
   name: DuckDB
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: dynamodb.svg
   license: MIT
   name: DynamoDB
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-e2e-test/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: airbyte.svg
   license: MIT
   name: E2E Testing
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:

--- a/airbyte-integrations/connectors/destination-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: elasticsearch.svg
   license: MIT
   name: ElasticSearch
-  registries:
+  registryOverrides:
     cloud:
       dockerRepository: airbyte/destination-elasticsearch-strict-encrypt
       enabled: true

--- a/airbyte-integrations/connectors/destination-exasol/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-exasol/metadata.yaml
@@ -7,7 +7,7 @@ data:
   githubIssueLabel: destination-exasol
   license: MIT
   name: Exasol
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
@@ -10,7 +10,7 @@ data:
   icon: firebolt.svg
   license: MIT
   name: Firebolt
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-firestore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firestore/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: firestore.svg
   license: MIT
   name: Google Firestore
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: googlecloudstorage.svg
   license: ELv2
   name: Google Cloud Storage (GCS)
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: google-sheets.svg
   license: ELv2
   name: Google Sheets
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
@@ -7,7 +7,7 @@ data:
   githubIssueLabel: destination-iceberg
   license: MIT
   name: Apache Iceberg
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kafka/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: kafka.svg
   license: MIT
   name: Kafka
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # hide Kafka Destination https://github.com/airbytehq/airbyte-cloud/issues/2610
     oss:

--- a/airbyte-integrations/connectors/destination-keen/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-keen/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: chargify.svg
   license: MIT
   name: Chargify (Keen)
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-kinesis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kinesis/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: kinesis.svg
   license: MIT
   name: Kinesis
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-kvdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kvdb/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-langchain/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-langchain/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-local-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-local-json/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: file-json.svg
   license: MIT
   name: Local JSON
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: mariadb.svg
   license: MIT
   name: MariaDB ColumnStore
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: meilisearch.svg
   license: MIT
   name: MeiliSearch
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-milvus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-milvus/metadata.yaml
@@ -5,7 +5,7 @@ data:
       - api.openai.com
       - api.cohere.ai
       - "${embedding.api_base}"
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:

--- a/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: mongodb.svg
   license: ELv2
   name: MongoDB
-  registries:
+  registryOverrides:
     cloud:
       dockerRepository: airbyte/destination-mongodb-strict-encrypt
       enabled: true

--- a/airbyte-integrations/connectors/destination-mqtt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mqtt/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: mqtt.svg
   license: MIT
   name: MQTT
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-mssql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql-strict-encrypt/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: mssql.svg
   license: ELv2
   name: MS SQL Server
-  registries:
+  registryOverrides:
     cloud:
       dockerRepository: airbyte/destination-mssql-strict-encrypt
       enabled: true

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:

--- a/airbyte-integrations/connectors/destination-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: mysql.svg
   license: ELv2
   name: MySQL
-  registries:
+  registryOverrides:
     cloud:
       dockerRepository: airbyte/destination-mysql-strict-encrypt
       enabled: true

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: oracle.svg
   license: ELv2
   name: Oracle
-  registries:
+  registryOverrides:
     cloud:
       dockerRepository: airbyte/destination-oracle-strict-encrypt
       enabled: true

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -24,7 +24,7 @@ data:
     pypi:
       enabled: false # TODO: enable once the CLI is working
       packageName: airbyte-destination-pinecone
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -9,7 +9,7 @@ data:
   icon: postgresql.svg
   license: ELv2
   name: Postgres
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -12,7 +12,7 @@ data:
   icon: postgresql.svg
   license: ELv2
   name: Postgres
-  registries:
+  registryOverrides:
     cloud:
       dockerRepository: airbyte/destination-postgres-strict-encrypt
       enabled: true

--- a/airbyte-integrations/connectors/destination-pubsub/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pubsub/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: googlepubsub.svg
   license: MIT
   name: Google PubSub
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: pulsar.svg
   license: MIT
   name: Pulsar
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-qdrant/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-r2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-r2/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: cloudflare-r2.svg
   license: MIT
   name: Cloudflare R2
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: pulsar.svg
   license: MIT
   name: RabbitMQ
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # hide RabbitMQ Destination https://github.com/airbytehq/airbyte/issues/16315
     oss:

--- a/airbyte-integrations/connectors/destination-redis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redis/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: redis.svg
   license: MIT
   name: Redis
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-redpanda/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redpanda/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: redpanda.svg
   license: MIT
   name: Redpanda
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -12,7 +12,7 @@ data:
   icon: redshift.svg
   license: MIT
   name: Redshift
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-rockset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rockset/metadata.yaml
@@ -7,7 +7,7 @@ data:
   githubIssueLabel: destination-rockset
   license: MIT
   name: Rockset
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: s3-glue.svg
   license: MIT
   name: S3 Glue
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: s3.svg
   license: ELv2
   name: S3
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-scylla/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-scylla/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: scylla.svg
   license: MIT
   name: Scylla
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-selectdb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-selectdb/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: selectdb.svg
   license: MIT
   name: SelectDB
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-sftp-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-sftp-json/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: sftp.svg
   license: MIT
   name: SFTP-JSON
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake-cortex/metadata.yaml
@@ -24,7 +24,7 @@ data:
     pypi:
       enabled: false
       packageName: airbyte-destination-snowflake-cortex
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -12,7 +12,7 @@ data:
   icon: snowflake.svg
   license: ELv2
   name: Snowflake
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-sqlite/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-sqlite/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: sqlite.svg
   license: MIT
   name: Local SQLite
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: starburst-galaxy.svg
   license: MIT
   name: Starburst Galaxy
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-teradata/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: teradata.svg
   license: MIT
   name: Teradata Vantage
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-tidb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-tidb/metadata.yaml
@@ -12,7 +12,7 @@ data:
     normalizationIntegrationType: tidb
     normalizationRepository: airbyte/normalization-tidb
     normalizationTag: 0.4.3
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: timeplus.svg
   license: MIT
   name: Timeplus
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-typesense/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-typesense/metadata.yaml
@@ -10,7 +10,7 @@ data:
   icon: typesense.svg
   license: MIT
   name: Typesense
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-vectara/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-vectara/metadata.yaml
@@ -3,7 +3,7 @@ data:
     hosts:
       - api.vectara.io
       - "vectara-prod-${self.customer_id}.auth.us-west-2.amazoncognito.com"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/destination-vertica/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-vertica/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -20,7 +20,7 @@ data:
   icon: weaviate.svg
   license: MIT
   name: Weaviate
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-xata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-xata/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
@@ -12,7 +12,7 @@ data:
   icon: yellowbrick.svg
   license: ELv2
   name: Yellowbrick
-  registries:
+  registryOverrides:
     cloud:
       dockerRepository: airbyte/destination-yellowbrick
       enabled: true

--- a/airbyte-integrations/connectors/destination-yugabytedb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yugabytedb/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: yugabytedb.svg
   license: MIT
   name: YugabyteDB
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - "*.api-us1.com"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-adjust/metadata.yaml
+++ b/airbyte-integrations/connectors/source-adjust/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-adjust
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-aha/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aha/metadata.yaml
@@ -2,7 +2,7 @@ data:
   ab_internal:
     ql: 200
     sl: 100
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-aircall/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aircall/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-aircall
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -23,7 +23,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-airtable
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-alpha-vantage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-alpha-vantage/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-alpha-vantage
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -25,7 +25,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-amazon-ads
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -27,7 +27,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-amazon-seller-partner
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-sqs/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-amazon-sqs
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -23,7 +23,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-amplitude
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-apify-dataset/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apify-dataset/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: apify.svg
   license: MIT
   name: Apify Dataset
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-appfollow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appfollow/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-appfollow
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-apple-search-ads
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-appsflyer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appsflyer/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-appsflyer
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-appstore-singer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appstore-singer/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: false
       # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
       packageName: airbyte-source-appstore-singer
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-asana/metadata.yaml
+++ b/airbyte-integrations/connectors/source-asana/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - app.asana.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-ashby/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ashby/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-ashby
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-auth0/metadata.yaml
+++ b/airbyte-integrations/connectors/source-auth0/metadata.yaml
@@ -21,7 +21,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-auth0
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-avni/metadata.yaml
+++ b/airbyte-integrations/connectors/source-avni/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - "*"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-aws-cloudtrail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aws-cloudtrail/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - "cloudtrail.*.amazonaws.com"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
@@ -24,7 +24,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-azure-blob-storage
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-azure-table/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-table/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-azure-table
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-babelforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-babelforce/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: false
       packageName: airbyte-source-babelforce
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-bamboo-hr/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bamboo-hr/metadata.yaml
@@ -18,7 +18,7 @@ data:
   license: MIT
   releaseDate: 2021-08-27
   name: BambooHR
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-bigcommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigcommerce/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-bigcommerce
-  registries:
+  registryOverrides:
     oss:
       enabled: false
     cloud:

--- a/airbyte-integrations/connectors/source-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigquery/metadata.yaml
@@ -12,7 +12,7 @@ data:
   icon: bigquery.svg
   license: ELv2
   name: BigQuery
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -28,7 +28,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-bing-ads
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-braintree/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braintree/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-braintree
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-braze/metadata.yaml
+++ b/airbyte-integrations/connectors/source-braze/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-braze
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-breezometer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-breezometer/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-breezometer
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-callrail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-callrail/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-callrail
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-captain-data/metadata.yaml
+++ b/airbyte-integrations/connectors/source-captain-data/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-captain-data
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-cart/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cart/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: cart.svg
   license: MIT
   name: Cart.com
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-chargebee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-chargebee
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-chargify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargify/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-chargify
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-chartmogul/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chartmogul/metadata.yaml
@@ -5,7 +5,7 @@ data:
   allowedHosts:
     hosts:
       - api.chartmogul.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-clazar/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clazar/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - api.clazar.io
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
@@ -3,7 +3,7 @@ data:
     hosts:
       - ${host}
       - ${tunnel_method.tunnel_host}
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:

--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -16,7 +16,7 @@ data:
   icon: clickhouse.svg
   license: MIT
   name: ClickHouse
-  registries:
+  registryOverrides:
     cloud:
       dockerImageTag: 0.2.2
       dockerRepository: airbyte/source-clickhouse-strict-encrypt

--- a/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
@@ -15,7 +15,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-clickup-api
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-clockify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clockify/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: clockify.svg
   license: MIT
   name: Clockify
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-close-com/metadata.yaml
+++ b/airbyte-integrations/connectors/source-close-com/metadata.yaml
@@ -19,7 +19,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-close-com
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
@@ -11,7 +11,7 @@ data:
   icon: cockroachdb.svg
   license: MIT
   name: Cockroachdb
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # Can not be in cloud until security is handled via DEPLOYMENT_MODE=cloud.
     oss:

--- a/airbyte-integrations/connectors/source-coda/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coda/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: coda.svg
   license: MIT
   name: Coda
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-coin-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coin-api/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: coinapi.svg
   license: MIT
   name: Coin API
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
@@ -14,7 +14,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-coingecko-coins
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # Did not pass acceptance tests
     oss:

--- a/airbyte-integrations/connectors/source-coinmarketcap/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coinmarketcap/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - pro-api.coinmarketcap.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-commcare/metadata.yaml
+++ b/airbyte-integrations/connectors/source-commcare/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-commcare
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-commercetools/metadata.yaml
+++ b/airbyte-integrations/connectors/source-commercetools/metadata.yaml
@@ -7,7 +7,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-commercetools
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-configcat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-configcat/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-configcat
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-confluence/metadata.yaml
+++ b/airbyte-integrations/connectors/source-confluence/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: confluence.svg
   license: MIT
   name: Confluence
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-convertkit/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convertkit/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-convertkit
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convex/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-convex
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-copper/metadata.yaml
+++ b/airbyte-integrations/connectors/source-copper/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: copper.svg
   license: MIT
   name: Copper
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-courier/metadata.yaml
+++ b/airbyte-integrations/connectors/source-courier/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-courier
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/source-customer-io/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-customer-io
-  registries:
+  registryOverrides:
     oss:
       enabled: false
     cloud:

--- a/airbyte-integrations/connectors/source-datadog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datadog/metadata.yaml
@@ -10,7 +10,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-datadog
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-datascope/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datascope/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-datascope
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-db2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-db2/metadata.yaml
@@ -11,7 +11,7 @@ data:
   icon: db2.svg
   license: MIT
   name: IBM Db2
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # Would require DEPLOYMENT_MODE=cloud handling to release to cloud again
     oss:

--- a/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
@@ -15,7 +15,7 @@ data:
   githubIssueLabel: source-declarative-manifest
   license: MIT
   name: Low-Code Source
-  registries:
+  registryOverrides:
     # The path for using this source in the Airbyte UI is still with the connector builder for now.
     cloud:
       enabled: false

--- a/airbyte-integrations/connectors/source-delighted/metadata.yaml
+++ b/airbyte-integrations/connectors/source-delighted/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: delighted.svg
   license: MIT
   name: Delighted
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-dixa/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dixa/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-dixa
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-dockerhub/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dockerhub/metadata.yaml
@@ -18,7 +18,7 @@ data:
   icon: dockerhub.svg
   license: MIT
   name: Dockerhub
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-dremio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dremio/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-dremio
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-drift/metadata.yaml
+++ b/airbyte-integrations/connectors/source-drift/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: drift.svg
   license: MIT
   name: Drift
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-dv-360/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dv-360/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-dv-360
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dynamodb/metadata.yaml
@@ -12,7 +12,7 @@ data:
   icon: dynamodb.svg
   license: MIT
   name: DynamoDB
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: airbyte.svg
   license: MIT
   name: End-to-End Testing (Mock API)
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: airbyte.svg
   license: MIT
   name: E2E Testing
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: elasticsearch.svg
   license: MIT
   name: Elasticsearch
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-emailoctopus/metadata.yaml
+++ b/airbyte-integrations/connectors/source-emailoctopus/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: emailoctopus.svg
   license: MIT
   name: EmailOctopus
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-everhour/metadata.yaml
+++ b/airbyte-integrations/connectors/source-everhour/metadata.yaml
@@ -5,7 +5,7 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
@@ -7,7 +7,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-exchange-rates
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-facebook-marketing
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: facebook.svg
   license: ELv2
   name: Facebook Pages
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -16,7 +16,7 @@ data:
   icon: faker.svg
   license: MIT
   name: Sample Data (Faker)
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-fastbill/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fastbill/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: fastbill.svg
   license: MIT
   name: Fastbill
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-fauna/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fauna/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-fauna
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-file
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-firebase-realtime-database/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firebase-realtime-database/metadata.yaml
@@ -14,7 +14,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-firebase-realtime-database
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firebolt/metadata.yaml
@@ -14,7 +14,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-firebolt
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-fleetio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fleetio/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-flexport/metadata.yaml
+++ b/airbyte-integrations/connectors/source-flexport/metadata.yaml
@@ -7,7 +7,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-flexport
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
@@ -26,7 +26,7 @@ data:
   icon: freshcaller.svg
   license: MIT
   name: Freshcaller
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-freshdesk
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-freshsales/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshsales/metadata.yaml
@@ -5,7 +5,7 @@ data:
   allowedHosts:
     hosts:
       - "*.myfreshworks.com"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-freshservice/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshservice/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: freshservice.svg
   license: MIT
   name: Freshservice
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-fullstory/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fullstory/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-fullstory
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-gainsight-px/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gainsight-px/metadata.yaml
@@ -8,7 +8,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-gainsight-px
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gcs/metadata.yaml
@@ -18,7 +18,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-gcs
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-genesys/metadata.yaml
+++ b/airbyte-integrations/connectors/source-genesys/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-genesys
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-getlago/metadata.yaml
+++ b/airbyte-integrations/connectors/source-getlago/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-getlago
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-github
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-gitlab
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-glassfrog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-glassfrog/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: glassfrog.svg
   license: MIT
   name: Glassfrog
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-gnews/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gnews/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-gnews
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-gocardless/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gocardless/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-gocardless
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-goldcast/metadata.yaml
+++ b/airbyte-integrations/connectors/source-goldcast/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - customapi.goldcast.io
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: gong.svg
   license: MIT
   name: Gong
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -23,7 +23,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-google-ads
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -24,7 +24,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-google-analytics-data-api
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
@@ -20,7 +20,7 @@ data:
   icon: google-analytics.svg
   license: Elv2
   name: Google Analytics (Universal Analytics)
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -25,7 +25,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-google-analytics-v4
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-google-directory/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-directory/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-google-directory
-  registries:
+  registryOverrides:
     cloud:
       dockerImageTag: 0.2.12
       enabled: true

--- a/airbyte-integrations/connectors/source-google-drive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-drive/metadata.yaml
@@ -17,7 +17,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-google-drive
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: google-pagespeed-insights.svg
   license: MIT
   name: Google PageSpeed Insights
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-google-search-console
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-google-sheets
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-google-webfonts/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-webfonts/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: googleworkpace.svg
   license: MIT
   name: Google Webfonts
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-google-workspace-admin-reports/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-workspace-admin-reports/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: false
       # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
       packageName: airbyte-source-google-workspace-admin-reports
-  registries:
+  registryOverrides:
     cloud:
       dockerImageTag: 0.1.4
       enabled: false

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-greenhouse
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-gridly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gridly/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-gridly
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-gutendex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gutendex/metadata.yaml
@@ -11,7 +11,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-gutendex
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-hardcoded-records/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hardcoded-records/metadata.yaml
@@ -16,7 +16,7 @@ data:
   icon: faker.svg
   license: MIT
   name: Hardcoded Records
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-harness/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harness/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-harness
-  registries:
+  registryOverrides:
     oss:
       enabled: false
     cloud:

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-harvest
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-hellobaton/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hellobaton/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-hellobaton
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-hibob/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hibob/metadata.yaml
@@ -3,7 +3,7 @@ data:
     hosts:
       - app.sandbox.hibob.com
       - app.hibob.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-hubplanner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubplanner/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-hubplanner
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-hubspot
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-insightly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-insightly/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: insightly.svg
   license: MIT
   name: Insightly
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
       dockerImageTag: 0.2.16

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -18,7 +18,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-instagram
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-instatus/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instatus/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-instatus
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-intercom
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-intruder/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intruder/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-intruder
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-ip2whois/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ip2whois/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: ip2whois.svg
   license: MIT
   name: IP2Whois
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-iterable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-iterable/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-iterable
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-jina-ai-reader/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jina-ai-reader/metadata.yaml
@@ -3,7 +3,7 @@ data:
     hosts:
       - "https://s.jina.ai"
       - "https://r.jina.ai"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-jira
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-k6-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-k6-cloud/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: k6cloud.svg
   license: MIT
   name: K6 Cloud
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kafka/metadata.yaml
@@ -8,7 +8,7 @@ data:
   icon: kafka.svg
   license: MIT
   name: Kafka
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-klarna/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klarna/metadata.yaml
@@ -20,7 +20,7 @@ data:
   icon: klarna.svg
   license: MIT
   name: Klarna
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-klaus-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaus-api/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-klaus-api
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -19,7 +19,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-klaviyo
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-kustomer-singer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kustomer-singer/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: false
       # TODO: Set enabled=true after `airbyte-lib-validate-source` is passing.
       packageName: airbyte-source-kustomer-singer
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-kyriba/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kyriba/metadata.yaml
@@ -18,7 +18,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-kyriba
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-kyve/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kyve/metadata.yaml
@@ -13,7 +13,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-kyve
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-launchdarkly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-launchdarkly/metadata.yaml
@@ -20,7 +20,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-launchdarkly
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-lemlist/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lemlist/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-lemlist
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-lever-hiring/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lever-hiring/metadata.yaml
@@ -5,7 +5,7 @@ data:
       - api.sandbox.lever.co
       - api.lever.co
       - auth.lever.co
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -23,7 +23,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-linkedin-ads
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-linkedin-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-pages/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - api.linkedin.com
       - www.linkedin.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-linnworks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linnworks/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: linnworks.svg
   license: MIT
   name: Linnworks
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-lokalise/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lokalise/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-lokalise
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-looker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-looker/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-looker
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -23,7 +23,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-mailchimp
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-mailerlite/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailerlite/metadata.yaml
@@ -31,7 +31,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-mailerlite
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-mailersend/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailersend/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-mailersend
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-mailgun/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailgun/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: mailgun.svg
   license: MIT
   name: Mailgun
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-mailjet-mail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailjet-mail/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-mailjet-mail
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-mailjet-sms/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailjet-sms/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: mailjetsms.svg
   license: MIT
   name: Mailjet SMS
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-marketo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-marketo/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-marketo
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-merge/metadata.yaml
+++ b/airbyte-integrations/connectors/source-merge/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-merge
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-metabase/metadata.yaml
+++ b/airbyte-integrations/connectors/source-metabase/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: metabase.svg
   license: MIT
   name: Metabase
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-microsoft-dataverse
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-microsoft-onedrive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-onedrive/metadata.yaml
@@ -10,7 +10,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-microsoft-onedrive
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
@@ -10,7 +10,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-microsoft-sharepoint
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-microsoft-teams/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-teams/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - graph.microsoft.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -23,7 +23,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-mixpanel
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -39,7 +39,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-monday
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -16,7 +16,7 @@ data:
   license: ELv2
   maxSecondsBetweenMessages: 7200
   name: MongoDb
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -17,7 +17,7 @@ data:
   license: ELv2
   maxSecondsBetweenMessages: 7200
   name: Microsoft SQL Server (MSSQL)
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-my-hours/metadata.yaml
+++ b/airbyte-integrations/connectors/source-my-hours/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-my-hours
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -17,7 +17,7 @@ data:
   license: ELv2
   maxSecondsBetweenMessages: 7200
   name: MySQL
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-n8n/metadata.yaml
+++ b/airbyte-integrations/connectors/source-n8n/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-n8n
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-nasa/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nasa/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-nasa
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-netsuite/metadata.yaml
+++ b/airbyte-integrations/connectors/source-netsuite/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-netsuite
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-news-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-news-api/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-newsdata/metadata.yaml
+++ b/airbyte-integrations/connectors/source-newsdata/metadata.yaml
@@ -13,7 +13,7 @@ data:
   githubIssueLabel: source-newsdata
   license: MIT
   name: Newsdata
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-northpass-lms/metadata.yaml
+++ b/airbyte-integrations/connectors/source-northpass-lms/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - api.northpass.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-notion
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-nytimes/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nytimes/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: nytimes.svg
   license: MIT
   name: New York Times
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-okta/metadata.yaml
+++ b/airbyte-integrations/connectors/source-okta/metadata.yaml
@@ -2,7 +2,7 @@ data:
   ab_internal:
     ql: 200
     sl: 100
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-omnisend/metadata.yaml
+++ b/airbyte-integrations/connectors/source-omnisend/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-onesignal/metadata.yaml
+++ b/airbyte-integrations/connectors/source-onesignal/metadata.yaml
@@ -26,7 +26,7 @@ data:
   icon: onesignal.svg
   license: MIT
   name: OneSignal
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: open-exchange-rates.svg
   license: MIT
   name: Open Exchange Rates
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: openweather.svg
   license: MIT
   name: Openweather
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-opsgenie/metadata.yaml
+++ b/airbyte-integrations/connectors/source-opsgenie/metadata.yaml
@@ -13,7 +13,7 @@ data:
   githubIssueLabel: source-opsgenie
   license: MIT
   name: Opsgenie
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/metadata.yaml
@@ -3,7 +3,7 @@ data:
     hosts:
       - ${host}
       - ${tunnel_method.tunnel_host}
-  registries:
+  registryOverrides:
     cloud:
       enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
     oss:

--- a/airbyte-integrations/connectors/source-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle/metadata.yaml
@@ -16,7 +16,7 @@ data:
   icon: oracle.svg
   license: ELv2
   name: Oracle DB
-  registries:
+  registryOverrides:
     cloud:
       dockerImageTag: 0.5.2
       dockerRepository: airbyte/source-oracle-strict-encrypt

--- a/airbyte-integrations/connectors/source-orb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orb/metadata.yaml
@@ -14,7 +14,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-orb
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-orbit/metadata.yaml
+++ b/airbyte-integrations/connectors/source-orbit/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: orbit.svg
   license: MIT
   name: Orbit
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-oura/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oura/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-outbrain-amplify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-outbrain-amplify/metadata.yaml
@@ -23,7 +23,7 @@ data:
   icon: icon.svg
   license: MIT
   name: Outbrain Amplify
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-outreach/metadata.yaml
+++ b/airbyte-integrations/connectors/source-outreach/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - api.outreach.io
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-pagerduty/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pagerduty/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-pagerduty
-  registries:
+  registryOverrides:
     oss:
       enabled: false
     cloud:

--- a/airbyte-integrations/connectors/source-pardot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pardot/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-pardot
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-partnerstack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-partnerstack/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-partnerstack
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -23,7 +23,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-paypal-transaction
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-paystack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paystack/metadata.yaml
@@ -21,7 +21,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-paystack
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-pendo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pendo/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: pendo.svg
   license: MIT
   name: Pendo
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-persistiq/metadata.yaml
+++ b/airbyte-integrations/connectors/source-persistiq/metadata.yaml
@@ -8,7 +8,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-persistiq
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-pexels-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pexels-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-pexels-api
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-pinterest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pinterest/metadata.yaml
@@ -18,7 +18,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-pinterest
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pipedrive/metadata.yaml
@@ -9,7 +9,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-pipedrive
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-pivotal-tracker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pivotal-tracker/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - www.pivotaltracker.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-plaid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-plaid/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-plaid
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-plausible/metadata.yaml
+++ b/airbyte-integrations/connectors/source-plausible/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-pocket/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pocket/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: pocket.svg
   license: MIT
   name: Pocket
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - "*"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-polygon-stock-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-polygon-stock-api/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: polygon.svg
   license: MIT
   name: Polygon Stock API
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -17,7 +17,7 @@ data:
   license: ELv2
   maxSecondsBetweenMessages: 7200
   name: Postgres
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-posthog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-posthog/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-posthog
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-postmarkapp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postmarkapp/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: postmark.svg
   license: MIT
   name: Postmark App
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-prestashop/metadata.yaml
+++ b/airbyte-integrations/connectors/source-prestashop/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: prestashop.svg
   license: MIT
   name: PrestaShop
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-primetric/metadata.yaml
+++ b/airbyte-integrations/connectors/source-primetric/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - api.primetric.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-public-apis/metadata.yaml
+++ b/airbyte-integrations/connectors/source-public-apis/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-public-apis
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-punk-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-punk-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-punk-api
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-pypi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pypi/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: pypi.svg
   license: MIT
   name: PyPI
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-qualaroo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-qualaroo/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-qualaroo
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -19,7 +19,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-quickbooks
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-railz/metadata.yaml
+++ b/airbyte-integrations/connectors/source-railz/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-railz
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-rd-station-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rd-station-marketing/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-rd-station-marketing
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-recharge/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recharge/metadata.yaml
@@ -18,7 +18,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-recharge
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-recreation/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recreation/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: recreation.svg
   license: MIT
   name: Recreation
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-recruitee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recruitee/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-recruitee
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-recurly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recurly/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: recurly.svg
   license: MIT
   name: Recurly
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/source-redshift/metadata.yaml
@@ -12,7 +12,7 @@ data:
   icon: redshift.svg
   license: ELv2
   name: Redshift
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-reply-io/metadata.yaml
+++ b/airbyte-integrations/connectors/source-reply-io/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-retently/metadata.yaml
+++ b/airbyte-integrations/connectors/source-retently/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: retently.svg
   license: MIT
   name: Retently
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-ringcentral/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ringcentral/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-ringcentral
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-rki-covid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rki-covid/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-rki-covid
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-rocket-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rocket-chat/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-rocket-chat
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-rss/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rss/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - "*"
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-s3
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-salesforce
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-salesloft/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesloft/metadata.yaml
@@ -5,7 +5,7 @@ data:
   allowedHosts:
     hosts:
       - api.salesloft.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-sap-fieldglass/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sap-fieldglass/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-sap-fieldglass
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-scaffold-java-jdbc/metadata.yaml
+++ b/airbyte-integrations/connectors/source-scaffold-java-jdbc/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - TODO # Please change to the hostname of the source.
-  registries:
+  registryOverrides:
     oss:
       enabled: false
     cloud:

--- a/airbyte-integrations/connectors/source-search-metrics/metadata.yaml
+++ b/airbyte-integrations/connectors/source-search-metrics/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-search-metrics
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-secoda/metadata.yaml
+++ b/airbyte-integrations/connectors/source-secoda/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-secoda
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -27,7 +27,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-sendgrid
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-sendinblue/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendinblue/metadata.yaml
@@ -25,7 +25,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-sendinblue
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-senseforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-senseforce/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-senseforce
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -26,7 +26,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-sentry
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-serpstat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-serpstat/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-serpstat
-  registries:
+  registryOverrides:
     oss:
       enabled: true
   connectorBuildOptions:

--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -18,7 +18,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-sftp-bulk
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-sftp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp/metadata.yaml
@@ -12,7 +12,7 @@ data:
   icon: sftp.svg
   license: MIT
   name: SFTP
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -23,7 +23,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-shopify
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-shortio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shortio/metadata.yaml
@@ -9,7 +9,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-shortio
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-singlestore/metadata.yaml
+++ b/airbyte-integrations/connectors/source-singlestore/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - ${host}
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-slack
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-smaily/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smaily/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-smaily
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-smartengage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smartengage/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: smartengage.svg
   license: MIT
   name: SmartEngage
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-smartsheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smartsheets/metadata.yaml
@@ -20,7 +20,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-smartsheets
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -19,7 +19,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-snapchat-marketing
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -15,7 +15,7 @@ data:
   icon: snowflake.svg
   license: ELv2
   name: Snowflake
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-sonar-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sonar-cloud/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: sonarcloud.svg
   license: MIT
   name: Sonar Cloud
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-spacex-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-spacex-api/metadata.yaml
@@ -20,7 +20,7 @@ data:
     pypi:
       enabled: false
       packageName: airbyte-source-spacex-api
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-square/metadata.yaml
+++ b/airbyte-integrations/connectors/source-square/metadata.yaml
@@ -18,7 +18,7 @@ data:
   icon: square.svg
   license: MIT
   name: Square
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-statuspage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-statuspage/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-strava/metadata.yaml
+++ b/airbyte-integrations/connectors/source-strava/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: strava.svg
   license: MIT
   name: Strava
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-stripe
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-survey-sparrow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-survey-sparrow/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: surveysparrow.svg
   license: MIT
   name: SurveySparrow
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-surveycto/metadata.yaml
+++ b/airbyte-integrations/connectors/source-surveycto/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-surveycto
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-surveymonkey/metadata.yaml
+++ b/airbyte-integrations/connectors/source-surveymonkey/metadata.yaml
@@ -18,7 +18,7 @@ data:
   license: MIT
   maxSecondsBetweenMessages: 86400
   name: SurveyMonkey
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-talkdesk-explore/metadata.yaml
+++ b/airbyte-integrations/connectors/source-talkdesk-explore/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-talkdesk-explore
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-tempo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tempo/metadata.yaml
@@ -20,7 +20,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-tempo
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/source-teradata/metadata.yaml
@@ -11,7 +11,7 @@ data:
   icon: teradata.svg
   license: MIT
   name: Teradata
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-the-guardian-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-the-guardian-api/metadata.yaml
@@ -26,7 +26,7 @@ data:
   icon: theguardian.svg
   license: MIT
   name: The Guardian API
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-tidb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tidb/metadata.yaml
@@ -12,7 +12,7 @@ data:
   icon: tidb.svg
   license: MIT
   name: TiDB
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -19,7 +19,7 @@ data:
   license: MIT
   maxSecondsBetweenMessages: 86400
   name: TikTok Marketing
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-timely/metadata.yaml
+++ b/airbyte-integrations/connectors/source-timely/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: timely.svg
   license: MIT
   name: Timely
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-tmdb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tmdb/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-tmdb
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-todoist/metadata.yaml
+++ b/airbyte-integrations/connectors/source-todoist/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-todoist
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-toggl/metadata.yaml
+++ b/airbyte-integrations/connectors/source-toggl/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-tplcentral/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tplcentral/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-tplcentral
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-trello/metadata.yaml
+++ b/airbyte-integrations/connectors/source-trello/metadata.yaml
@@ -11,7 +11,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-trello
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-trustpilot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-trustpilot/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-trustpilot
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-tvmaze-schedule/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tvmaze-schedule/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-tvmaze-schedule
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-twilio-taskrouter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio-taskrouter/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: twilio.svg
   license: MIT
   name: Twilio Taskrouter
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -25,7 +25,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-twilio
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-twitter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twitter/metadata.yaml
@@ -19,7 +19,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-twitter
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-tyntec-sms/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tyntec-sms/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-tyntec-sms
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-typeform
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-unleash/metadata.yaml
+++ b/airbyte-integrations/connectors/source-unleash/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-unleash
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-us-census/metadata.yaml
+++ b/airbyte-integrations/connectors/source-us-census/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-us-census
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-vantage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-vantage/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-vantage
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-visma-economic/metadata.yaml
+++ b/airbyte-integrations/connectors/source-visma-economic/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: visma-economic.svg
   license: MIT
   name: Visma Economic
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-vitally/metadata.yaml
+++ b/airbyte-integrations/connectors/source-vitally/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-vitally
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-waiteraid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-waiteraid/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-waiteraid
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-weatherstack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-weatherstack/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-weatherstack
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-webflow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-webflow/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-webflow
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-whisky-hunter/metadata.yaml
+++ b/airbyte-integrations/connectors/source-whisky-hunter/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-whisky-hunter
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-wikipedia-pageviews/metadata.yaml
+++ b/airbyte-integrations/connectors/source-wikipedia-pageviews/metadata.yaml
@@ -21,7 +21,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-wikipedia-pageviews
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
@@ -20,7 +20,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-woocommerce
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-workable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-workable/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-workable
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-workramp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-workramp/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-wrike/metadata.yaml
+++ b/airbyte-integrations/connectors/source-wrike/metadata.yaml
@@ -10,7 +10,7 @@ data:
     pypi:
       enabled: false
       packageName: airbyte-source-wrike
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -2,7 +2,7 @@ data:
   allowedHosts:
     hosts:
       - api.xero.com
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-xkcd/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xkcd/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-xkcd
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-yahoo-finance-price/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yahoo-finance-price/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: yahoo-finance-price.svg
   license: MIT
   name: Yahoo Finance Price
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-yandex-metrica/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yandex-metrica/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: yandexmetrica.svg
   license: MIT
   name: Yandex Metrica
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-yotpo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yotpo/metadata.yaml
@@ -12,7 +12,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-yotpo
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-younium/metadata.yaml
+++ b/airbyte-integrations/connectors/source-younium/metadata.yaml
@@ -3,7 +3,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-younium
-  registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-youtube-analytics/metadata.yaml
+++ b/airbyte-integrations/connectors/source-youtube-analytics/metadata.yaml
@@ -19,7 +19,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-youtube-analytics
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-zapier-supported-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zapier-supported-storage/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: zapiersupportedstorage.svg
   license: MIT
   name: Zapier Supported Storage
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
@@ -22,7 +22,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-zendesk-chat
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-sell/metadata.yaml
@@ -6,7 +6,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-zendesk-sell
-  registries:
+  registryOverrides:
     oss:
       enabled: false
     cloud:

--- a/airbyte-integrations/connectors/source-zendesk-sunshine/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-sunshine/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: zendesk-sunshine.svg
   license: MIT
   name: Zendesk Sunshine
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -23,7 +23,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-zendesk-support
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -23,7 +23,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-zendesk-talk
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-zenefits/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenefits/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: icon.svg
   license: MIT
   name: Zenefits
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/source-zenloop/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/metadata.yaml
@@ -17,7 +17,7 @@ data:
   icon: zenloop.svg
   license: MIT
   name: Zenloop
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-zoho-crm
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-zoom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoom/metadata.yaml
@@ -14,7 +14,7 @@ data:
   icon: zoom.svg
   license: MIT
   name: Zoom
-  registries:
+  registryOverrides:
     cloud:
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/source-zuora/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zuora/metadata.yaml
@@ -16,7 +16,7 @@ data:
     pypi:
       enabled: true
       packageName: airbyte-source-zuora
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/third-party/farosai/airbyte-harness-source/metadata.yaml
+++ b/airbyte-integrations/connectors/third-party/farosai/airbyte-harness-source/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/third-party/farosai/airbyte-jenkins-source/metadata.yaml
+++ b/airbyte-integrations/connectors/third-party/farosai/airbyte-jenkins-source/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/third-party/farosai/airbyte-pagerduty-source/metadata.yaml
+++ b/airbyte-integrations/connectors/third-party/farosai/airbyte-pagerduty-source/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/third-party/farosai/airbyte-victorops-source/metadata.yaml
+++ b/airbyte-integrations/connectors/third-party/farosai/airbyte-victorops-source/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:

--- a/airbyte-integrations/connectors/third-party/ghcr/streamr-airbyte-connector/metadata.yaml
+++ b/airbyte-integrations/connectors/third-party/ghcr/streamr-airbyte-connector/metadata.yaml
@@ -1,5 +1,5 @@
 data:
-  registries:
+  registryOverrides:
     cloud:
       enabled: false
     oss:


### PR DESCRIPTION
## What
Rename `registries` to `registryOverrides` in connector metadata.yaml.
Skipping CI to not trigger tests on all connectors

Manual testing on `destination-postgres`: https://github.com/airbytehq/airbyte/actions/runs/10353121102
