### PR TITLE
source-declarative-manifest: clean 4.3.3 cut

### DIFF
--- a/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: source
   definitionId: 64a2f99c-542f-4af8-9a6f-355f1217b436
   # This version should not be updated manually - it is updated by the CDK release workflow.
-  dockerImageTag: 4.3.2
+  dockerImageTag: 4.3.3
   dockerRepository: airbyte/source-declarative-manifest
   # This page is hidden from the docs for now, since the connector is not in any Airbyte registries.
   documentationUrl: https://docs.airbyte.com/integrations/sources/low-code

--- a/airbyte-integrations/connectors/source-declarative-manifest/poetry.lock
+++ b/airbyte-integrations/connectors/source-declarative-manifest/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "airbyte-cdk"
-version = "4.3.2"
+version = "4.3.3"
 description = "A framework for writing Airbyte Connectors."
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "airbyte_cdk-4.3.2-py3-none-any.whl", hash = "sha256:1dd92de77e2212b13ed6f1e9c4b2559baa905eff6db5bf14b0fbaf1149e60e4c"},
-    {file = "airbyte_cdk-4.3.2.tar.gz", hash = "sha256:89db68167e214e5b55d5ef5f821f017ee64bf859f44c60bc0169071fa376e9af"},
+    {file = "airbyte_cdk-4.3.3-py3-none-any.whl", hash = "sha256:94db877276c77b5fc6a370e540538c2711cbd3323e75f239b90996d1938b4b64"},
+    {file = "airbyte_cdk-4.3.3.tar.gz", hash = "sha256:dd93cae009cbae97cf243ed681137ee26b2cca7bec6d1e4039020bb5dbc8dfa3"},
 ]
 
 [package.dependencies]
@@ -1383,4 +1383,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10,<3.12"
-content-hash = "21a04e74592c17ce845a2516e3bd1837576a8da760b495fc5d4a58bc02ebf408"
+content-hash = "76ce57c9d64456a8940c0250bd5b681eb59cdd594c2b8f4a40c5b47703de654d"

--- a/airbyte-integrations/connectors/source-declarative-manifest/pyproject.toml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.3.2"
+version = "4.3.3"
 name = "source-declarative-manifest"
 description = "Base source implementation for low-code sources."
 authors = ["Airbyte <contact@airbyte.io>"]
@@ -17,7 +17,7 @@ include = "source_declarative_manifest"
 
 [tool.poetry.dependencies]
 python = "^3.10,<3.12"
-airbyte-cdk = "4.3.2"
+airbyte-cdk = "4.3.3"
 
 [tool.poetry.scripts]
 source-declarative-manifest = "source_declarative_manifest.run:run"

--- a/docs/integrations/sources/low-code.md
+++ b/docs/integrations/sources/low-code.md
@@ -9,6 +9,7 @@ The changelog below is automatically updated by the `bump_version` command as pa
 
 | Version | Date       | Pull Request                                             | Subject                                                              |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------- |
+| 4.3.3 | 2024-08-13 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 4.3.3 |
 | 4.3.2 | 2024-08-05 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 4.3.2 |
 | 4.3.1 | 2024-08-03 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 4.3.1 |
 | 4.3.0 | 2024-08-02 | [42969](https://github.com/airbytehq/airbyte/pull/42969) | Manually Bump own version version to 4.3.0 |


### PR DESCRIPTION
## What
See https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1723532078973299

## Pre-requisites:
Delete tags 4.3.2, 4.3.3, 4.3.4, 4.3.5 in [DockerHub](https://hub.docker.com/r/airbyte/source-declarative-manifest/tags)


