### PR TITLE
airbyte-ci: ignore source-declarative-manifest in up-to-date

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -39,4 +39,4 @@ jobs:
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: "connectors  ${{ github.event.inputs.connectors-options || '--concurrency=10 --language=python --language=low-code' }} up-to-date --create-prs ${{ github.event.inputs.auto-merge == 'false' && '' || '--auto-merge' }}"
+          subcommand: "connectors  ${{ github.event.inputs.connectors-options || '--concurrency=10 --language=python --language=low-code' }} up-to-date --ignore-connector=source-declarative-manifest --create-prs ${{ github.event.inputs.auto-merge == 'false' && '' || '--auto-merge' }}"

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -523,6 +523,7 @@ Options:
   --open-reports    Auto open reports in the browser.
   --create-prs      Create pull requests for each updated connector.
   --auto-merge    Set the auto-merge label on created PRs.
+  --ignore-connector TEXT  Ignore a connector by its technical name (can be used multiple times).
   --help      Show this message and exit.
 ```
 
@@ -789,6 +790,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.32.0  | [#43969](https://github.com/airbytehq/airbyte/pull/43969)  | Add an `--ignore-connector` option to `up-to-date`                                                                           |
 | 4.31.5  | [#43934](https://github.com/airbytehq/airbyte/pull/43934)  | Track deleted files when generating pull-request                                                                             |
 | 4.31.4  | [#43724](https://github.com/airbytehq/airbyte/pull/43724)  | Do not send slack message on connector pre-release.                                                                          |
 | 4.31.3  | [#43426](https://github.com/airbytehq/airbyte/pull/43426)  | Ignore archived connectors on connector selection from modified files.                                                       |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/commands.py
@@ -49,6 +49,12 @@ from pipelines.helpers.connectors.command import run_connector_pipeline
     default=False,
     help="Auto open reports in browser",
 )
+@click.option(
+    "--ignore-connector",
+    type=str,
+    multiple=True,
+    help="Connector technical name to ignore in the pipeline",
+)
 @click.pass_context
 async def up_to_date(
     ctx: click.Context,
@@ -57,6 +63,7 @@ async def up_to_date(
     auto_merge: bool,
     no_bump: bool,
     open_reports: bool,
+    ignore_connector: List[str],
 ) -> bool:
 
     if create_prs and not ctx.obj["ci_github_access_token"]:
@@ -64,6 +71,9 @@ async def up_to_date(
             "GitHub access token is required to create or simulate a pull request. Set the CI_GITHUB_ACCESS_TOKEN environment variable."
         )
 
+    ctx.obj["selected_connectors_with_modified_files"] = [
+        connector for connector in ctx.obj["selected_connectors_with_modified_files"] if connector.technical_name not in ignore_connector
+    ]
     return await run_connector_pipeline(
         ctx,
         "Get Python connector up to date",

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.31.5"
+version = "4.32.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
We don't want `up-to-date` to cut new `source-declarative-manifest` versions to respect coupling of this connector version to the CDK version.
More details here: https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1723532078973299

## How
* airbyte-ci: Add an `--ignore-connector` option to `up-to-date` command
* `up-to-date` GHA workflow: Pass `--ignore-connector=source-declarative-manifest` to the `up-to-date` command.

