### PR TITLE
Add erd_url to registry in metadata service

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
@@ -296,6 +296,7 @@ class Data(BaseModel):
     )
     releaseDate: Optional[date] = Field(None, description="The date when this connector was first released, in yyyy-mm-dd format.")
     protocolVersion: Optional[str] = Field(None, description="the Airbyte Protocol version supported by the connector")
+    erdUrl: Optional[str] = Field(None, description="The URL where you can visualize the ERD")
     connectorSubtype: Literal["api", "database", "datalake", "file", "custom", "message_queue", "unknown", "vectorstore"]
     releaseStage: ReleaseStage
     supportLevel: Optional[SupportLevel] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
@@ -205,6 +205,7 @@ class ConnectorRegistrySourceDefinition(BaseModel):
     maxSecondsBetweenMessages: Optional[int] = Field(
         None, description="Number of seconds allowed between 2 airbyte protocol messages. The source will timeout if this delay is reach"
     )
+    erdUrl: Optional[str] = Field(None, description="The URL where you can visualize the ERD")
     releases: Optional[ConnectorReleases] = None
     ab_internal: Optional[AirbyteInternal] = None
     generated: Optional[GeneratedFields] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
@@ -219,6 +219,7 @@ class ConnectorRegistrySourceDefinition(BaseModel):
     maxSecondsBetweenMessages: Optional[int] = Field(
         None, description="Number of seconds allowed between 2 airbyte protocol messages. The source will timeout if this delay is reach"
     )
+    erdUrl: Optional[str] = Field(None, description="The URL where you can visualize the ERD")
     releases: Optional[ConnectorReleases] = None
     ab_internal: Optional[AirbyteInternal] = None
     generated: Optional[GeneratedFields] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorMetadataDefinitionV0.yaml
@@ -70,6 +70,9 @@ properties:
       protocolVersion:
         type: string
         description: the Airbyte Protocol version supported by the connector
+      erdUrl:
+        type: string
+        description: The URL where you can visualize the ERD
       connectorSubtype:
         type: string
         enum:

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorRegistrySourceDefinition.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorRegistrySourceDefinition.yaml
@@ -70,6 +70,9 @@ properties:
   maxSecondsBetweenMessages:
     description: Number of seconds allowed between 2 airbyte protocol messages. The source will timeout if this delay is reach
     type: integer
+  erdUrl:
+    type: string
+    description: The URL where you can visualize the ERD
   releases:
     "$ref": ConnectorReleases.yaml
   ab_internal:

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.10.0"
+version = "0.10.1"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
@@ -11,7 +11,9 @@ from metadata_service.validators import metadata_validator
 
 @pytest.fixture
 def metadata_definition():
-    metadata_file_url = "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations/connectors/source-faker/metadata.yaml"
+    metadata_file_url = (
+        "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations/connectors/source-faker/metadata.yaml"
+    )
     response = requests.get(metadata_file_url)
     response.raise_for_status()
 

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
@@ -11,7 +11,7 @@ from metadata_service.validators import metadata_validator
 
 @pytest.fixture
 def metadata_definition():
-    metadata_file_url = "https://raw.githubusercontent.com/airbytehq/airbyte/8f0a6afe41cd1f9e70e954255749b7867592f863/airbyte-integrations/connectors/source-faker/metadata.yaml"
+    metadata_file_url = "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations/connectors/source-faker/metadata.yaml"
     response = requests.get(metadata_file_url)
     response.raise_for_status()
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -207,8 +207,7 @@ def metadata_to_registry_entry(metadata_entry: LatestMetadataEntry, override_reg
     """Convert the metadata definition to a registry entry.
 
     Args:
-        metadata_definition (dict): The metadata definition.
-        connector_type (str): One of "source" or "destination".
+        metadata_entry (LatestMetadataEntry): The metadata definition.
         override_registry_key (str): The key of the registry to override the metadata with.
 
     Returns:

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.2.0"
+version = "0.2.1"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/cloud_registry.json
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/cloud_registry.json
@@ -9109,7 +9109,7 @@
       "custom": false,
       "releaseStage": "generally_available",
       "protocolVersion": "0.2.0",
-      "erd_url": "https://dbdocs.io/maximec5e237b90b/source-facebook-marketing",
+      "erdUrl": "https://dbdocs.io/maximec5e237b90b/source-facebook-marketing",
       "allowedHosts": {
         "hosts": ["graph.facebook.com"]
       }

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/cloud_registry.json
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/cloud_registry.json
@@ -9109,6 +9109,7 @@
       "custom": false,
       "releaseStage": "generally_available",
       "protocolVersion": "0.2.0",
+      "erd_url": "https://dbdocs.io/maximec5e237b90b/source-facebook-marketing",
       "allowedHosts": {
         "hosts": ["graph.facebook.com"]
       }

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/oss_registry.json
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/oss_registry.json
@@ -13544,6 +13544,7 @@
       "public": true,
       "custom": false,
       "releaseStage": "generally_available",
+      "erd_url": "https://dbdocs.io/maximec5e237b90b/source-facebook-marketing",
       "allowedHosts": {
         "hosts": ["graph.facebook.com"]
       }

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/oss_registry.json
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/oss_registry.json
@@ -13544,7 +13544,7 @@
       "public": true,
       "custom": false,
       "releaseStage": "generally_available",
-      "erd_url": "https://dbdocs.io/maximec5e237b90b/source-facebook-marketing",
+      "erdUrl": "https://dbdocs.io/maximec5e237b90b/source-facebook-marketing",
       "allowedHosts": {
         "hosts": ["graph.facebook.com"]
       }

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -328,7 +328,7 @@ def test_erd_url():
         "data": {
             "connectorType": "source",
             "definitionId": "test-id",
-            "registries": {"oss": {"enabled": True}},
+            "registryOverrides": {"oss": {"enabled": True}},
             "erdUrl": "https://an-erd.com",
         }
     }

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -317,6 +317,26 @@ def test_source_type_extraction():
     assert result["sourceType"] == "database"
 
 
+def test_erd_url():
+    """
+    Test that if when defined in the metadata, the erd_url will be populated in the registry
+    """
+    mock_metadata_entry = mock.Mock()
+    mock_metadata_entry.metadata_definition.dict.return_value = {
+        "data": {
+            "connectorType": "source",
+            "definitionId": "test-id",
+            "registries": {"oss": {"enabled": True}},
+            "erd_url": "https://an-erd.com",
+        }
+    }
+    mock_metadata_entry.icon_url = "test-icon-url"
+    mock_metadata_entry.dependency_file_url = "test-dependency-file-url"
+
+    result = metadata_to_registry_entry(mock_metadata_entry, "oss")
+    assert result["erd_url"] == "https://an-erd.com"
+
+
 def test_support_level_default():
     """
     Test if supportLevel is defaulted to alpha in the registry entry.

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -327,14 +327,14 @@ def test_erd_url():
             "connectorType": "source",
             "definitionId": "test-id",
             "registries": {"oss": {"enabled": True}},
-            "erd_url": "https://an-erd.com",
+            "erdUrl": "https://an-erd.com",
         }
     }
     mock_metadata_entry.icon_url = "test-icon-url"
     mock_metadata_entry.dependency_file_url = "test-dependency-file-url"
 
     result = metadata_to_registry_entry(mock_metadata_entry, "oss")
-    assert result["erd_url"] == "https://an-erd.com"
+    assert result["erdUrl"] == "https://an-erd.com"
 
 
 def test_support_level_default():


### PR DESCRIPTION
## What
Addresses the first part of https://github.com/airbytehq/airbyte-internal-issues/issues/9171 where we want to add the erd_url to the registry so that we can show it in the public doc

## How
* Adding the field to the metadata.yaml model (see airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py)
* Adding the field to the registry model for sources (see airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorRegistrySourceDefinition.yaml)

The rest should trickle automatically to the registry

## User Impact
The field will now be available to be written in the public doc.


## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌

## Questions
* Will we need to re-releases the sources to make it available? My guess is that if the only change in a connector is the metadata.yaml file, the connector won't be re-released and the new field `erd_url` will be pushed to the registry
