### PR TITLE
metadata-service [orchestrator]: get commit last modified timestamp

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.2.2"
+version = "0.2.3"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
## What
The last modified timestamp we used was not the latest connector commit timestamp but the latest branch modification timestamp. 
