### PR TITLE
Source PostHog: Fix events stream pagination

### DIFF
--- a/airbyte-integrations/connectors/source-posthog/README.md
+++ b/airbyte-integrations/connectors/source-posthog/README.md
@@ -7,32 +7,17 @@ For information about how to use this connector within Airbyte, see [the documen
 
 ### Prerequisites
 
-**To iterate on this connector, make sure to complete this prerequisites section.**
+* Python (`^3.9`)
+* Poetry (`^1.7`) - installation instructions [here](https://python-poetry.org/docs/#installation)
 
-#### Build & Activate Virtual Environment and install dependencies
+### Installing the connector
 
-From this connector directory, create a virtual environment:
-
-```
-python -m venv .venv
-```
-
-This will generate a virtualenv for this module in `.venv/`. Make sure this venv is active in your
-development environment of choice. To activate it from the terminal, run:
-
-```
-source .venv/bin/activate
-pip install -r requirements.txt
+From this connector directory, run:
+```bash
+poetry install --with dev
 ```
 
-If you are in an IDE, follow your IDE's instructions to activate the virtualenv.
-
-Note that while we are installing dependencies from `requirements.txt`, you should only edit `setup.py` for your dependencies. `requirements.txt` is
-used for editable installs (`pip install -e`) to pull in Python dependencies from the monorepo and will call `setup.py`.
-If this is mumbo jumbo to you, don't worry about it, just put your deps in `setup.py` but install using `pip install -r requirements.txt` and everything
-should work as you expect.
-
-#### Create credentials
+### Create credentials
 
 **If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.io/integrations/sources/posthog)
 to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `source_posthog/spec.json` file.
@@ -45,31 +30,23 @@ and place them into `secrets/config.json`.
 ### Locally running the connector
 
 ```
-python main.py spec
-python main.py check --config secrets/config.json
-python main.py discover --config secrets/config.json
-python main.py read --config secrets/config.json --catalog sample_files/configured_catalog.json
+poetry run source-posthog spec
+poetry run source-posthog check --config secrets/config.json
+poetry run source-posthog discover --config secrets/config.json
+poetry run source-posthog read --config secrets/config.json --catalog sample_files/configured_catalog.json
 ```
 
-### Locally running the connector docker image
+### Building the docker image
 
-#### Build
-
-**Via [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md) (recommended):**
-
+1. Install [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md)
+2. Run the following command to build the docker image:
 ```bash
 airbyte-ci connectors --name=source-posthog build
 ```
 
-An image will be built with the tag `airbyte/source-posthog:dev`.
+An image will be available on your host with the tag `airbyte/source-posthog:dev`.
 
-**Via `docker build`:**
-
-```bash
-docker build -t airbyte/source-posthog:dev .
-```
-
-#### Run
+### Running as a docker container
 
 Then run any of the connector commands as follows:
 
@@ -80,10 +57,9 @@ docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-posthog:dev discover -
 docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/sample_files:/sample_files airbyte/source-posthog:dev read --config /secrets/config.json --catalog /sample_files/configured_catalog.json
 ```
 
-## Testing
+### Running our CI test suite
 
 You can run our full test suite locally using [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md):
-
 ```bash
 airbyte-ci connectors --name=source-posthog test
 ```

--- a/airbyte-integrations/connectors/source-posthog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-posthog/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: af6d50ee-dddf-4126-a8ee-7faee990774f
-  dockerImageTag: 1.1.5
+  dockerImageTag: 1.1.6
   dockerRepository: airbyte/source-posthog
   documentationUrl: https://docs.airbyte.com/integrations/sources/posthog
   githubIssueLabel: source-posthog

--- a/airbyte-integrations/connectors/source-posthog/pyproject.toml
+++ b/airbyte-integrations/connectors/source-posthog/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.1.5"
+version = "1.1.6"
 name = "source-posthog"
 description = "Source implementation for Posthog."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
@@ -152,13 +152,12 @@ definitions:
           inject_into: "request_parameter"
           field_name: "limit"
         pagination_strategy:
-          type: "CursorPagination"
-          cursor_value: "{{ response['next'] }}"
+          type: "OffsetIncrement"
           page_size: 10000
         page_token_option:
-          type: RequestPath
-        $parameters:
-          url_base: "#/definitions/requester/url_base"
+          type: RequestOption
+          field_name: "offset"
+          inject_into: "request_parameter"
 
 streams:
   - "#/definitions/projects_stream"

--- a/docs/integrations/sources/posthog.md
+++ b/docs/integrations/sources/posthog.md
@@ -69,31 +69,31 @@ Want to use the PostHog API beyond these limits? Email Posthog at `customers@pos
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                             | Subject                                                                                                            |
-| :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
-| 1.1.5 | 2024-08-10 | [43488](https://github.com/airbytehq/airbyte/pull/43488) | Update dependencies |
-| 1.1.4 | 2024-08-03 | [43232](https://github.com/airbytehq/airbyte/pull/43232) | Update dependencies |
-| 1.1.3 | 2024-07-27 | [42769](https://github.com/airbytehq/airbyte/pull/42769) | Update dependencies |
-| 1.1.2 | 2024-07-20 | [42151](https://github.com/airbytehq/airbyte/pull/42151) | Update dependencies |
-| 1.1.1 | 2024-07-13 | [41823](https://github.com/airbytehq/airbyte/pull/41823) | Update dependencies |
-| 1.1.0   | 2024-06-20 | [39763](https://github.com/airbytehq/airbyte/pull/39763) | Add `properties` and `uuid` 
-attributes to persons stream |
-| 1.0.0   | 2023-12-04 | [28593](https://github.com/airbytehq/airbyte/pull/28593) | Fix events.event type                                                                                              |
-| 0.1.15  | 2023-10-28 | [31265](https://github.com/airbytehq/airbyte/pull/31265) | Fix Events stream datetime format                                                                                  |
-| 0.1.14  | 2023-08-29 | [29947](https://github.com/airbytehq/airbyte/pull/29947) | Add optional field to spec: `events_time_step`                                                                     |
-| 0.1.13  | 2023-07-19 | [28461](https://github.com/airbytehq/airbyte/pull/28461) | Fixed EventsSimpleRetriever declaration                                                                            |
-| 0.1.12  | 2023-06-28 | [27764](https://github.com/airbytehq/airbyte/pull/27764) | Update following state breaking changes                                                                            |
-| 0.1.11  | 2023-06-09 | [27135](https://github.com/airbytehq/airbyte/pull/27135) | Fix custom EventsSimpleRetriever                                                                                   |
-| 0.1.10  | 2023-04-15 | [24084](https://github.com/airbytehq/airbyte/pull/24084) | Increase `events` streams batch size                                                                               |
-| 0.1.9   | 2023-02-13 | [22906](https://github.com/airbytehq/airbyte/pull/22906) | Specified date formatting in specification                                                                         |
-| 0.1.8   | 2022-11-11 | [18993](https://github.com/airbytehq/airbyte/pull/18993) | connector migrated to low-code, added projects,insights streams, added project based slicing for all other streams |
-| 0.1.7   | 2022-07-26 | [14585](https://github.com/airbytehq/airbyte/pull/14585) | Add missing 'properties' field to event attributes                                                                 |
-| 0.1.6   | 2022-01-20 | [8617](https://github.com/airbytehq/airbyte/pull/8617)   | Update connector fields title/description                                                                          |
-| 0.1.5   | 2021-12-24 | [9082](https://github.com/airbytehq/airbyte/pull/9082)   | Remove obsolete session_events and insights streams                                                                |
-| 0.1.4   | 2021-09-14 | [6058](https://github.com/airbytehq/airbyte/pull/6058)   | Support self-hosted posthog instances                                                                              |
-| 0.1.3   | 2021-07-20 | [4001](https://github.com/airbytehq/airbyte/pull/4001)   | Incremental streams read only relevant pages                                                                       |
-| 0.1.2   | 2021-07-15 | [4692](https://github.com/airbytehq/airbyte/pull/4692)   | Use account information for checking the connection                                                                |
-| 0.1.1   | 2021-07-05 | [4539](https://github.com/airbytehq/airbyte/pull/4539)   | Add `AIRBYTE_ENTRYPOINT` env variable for kubernetes support                                                       |
-| 0.1.0   | 2021-06-08 | [3768](https://github.com/airbytehq/airbyte/pull/3768)   | Initial Release                                                                                                    |
+| Version | Date       | Pull Request                                             | Subject                                                                                                                 |
+| :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| 1.1.6   | 2024-08-13 | [44012](https://github.com/airbytehq/airbyte/pull/44012) | Fix `events` stream pagniator to workaround PostHog API issue [#13508](https://github.com/PostHog/posthog/issues/13508) |
+| 1.1.5   | 2024-08-10 | [43488](https://github.com/airbytehq/airbyte/pull/43488) | Update dependencies                                                                                                     |
+| 1.1.4   | 2024-08-03 | [43232](https://github.com/airbytehq/airbyte/pull/43232) | Update dependencies                                                                                                     |
+| 1.1.3   | 2024-07-27 | [42769](https://github.com/airbytehq/airbyte/pull/42769) | Update dependencies                                                                                                     |
+| 1.1.2   | 2024-07-20 | [42151](https://github.com/airbytehq/airbyte/pull/42151) | Update dependencies                                                                                                     |
+| 1.1.1   | 2024-07-13 | [41823](https://github.com/airbytehq/airbyte/pull/41823) | Update dependencies                                                                                                     |
+| 1.1.0   | 2024-06-20 | [39763](https://github.com/airbytehq/airbyte/pull/39763) | Add `properties` and `uuid` attributes to persons stream                                                                |
+| 1.0.0   | 2023-12-04 | [28593](https://github.com/airbytehq/airbyte/pull/28593) | Fix events.event type                                                                                                   |
+| 0.1.15  | 2023-10-28 | [31265](https://github.com/airbytehq/airbyte/pull/31265) | Fix Events stream datetime format                                                                                       |
+| 0.1.14  | 2023-08-29 | [29947](https://github.com/airbytehq/airbyte/pull/29947) | Add optional field to spec: `events_time_step`                                                                          |
+| 0.1.13  | 2023-07-19 | [28461](https://github.com/airbytehq/airbyte/pull/28461) | Fixed EventsSimpleRetriever declaration                                                                                 |
+| 0.1.12  | 2023-06-28 | [27764](https://github.com/airbytehq/airbyte/pull/27764) | Update following state breaking changes                                                                                 |
+| 0.1.11  | 2023-06-09 | [27135](https://github.com/airbytehq/airbyte/pull/27135) | Fix custom EventsSimpleRetriever                                                                                        |
+| 0.1.10  | 2023-04-15 | [24084](https://github.com/airbytehq/airbyte/pull/24084) | Increase `events` streams batch size                                                                                    |
+| 0.1.9   | 2023-02-13 | [22906](https://github.com/airbytehq/airbyte/pull/22906) | Specified date formatting in specification                                                                              |
+| 0.1.8   | 2022-11-11 | [18993](https://github.com/airbytehq/airbyte/pull/18993) | connector migrated to low-code, added projects,insights streams, added project based slicing for all other streams      |
+| 0.1.7   | 2022-07-26 | [14585](https://github.com/airbytehq/airbyte/pull/14585) | Add missing 'properties' field to event attributes                                                                      |
+| 0.1.6   | 2022-01-20 | [8617](https://github.com/airbytehq/airbyte/pull/8617)   | Update connector fields title/description                                                                               |
+| 0.1.5   | 2021-12-24 | [9082](https://github.com/airbytehq/airbyte/pull/9082)   | Remove obsolete session_events and insights streams                                                                     |
+| 0.1.4   | 2021-09-14 | [6058](https://github.com/airbytehq/airbyte/pull/6058)   | Support self-hosted posthog instances                                                                                   |
+| 0.1.3   | 2021-07-20 | [4001](https://github.com/airbytehq/airbyte/pull/4001)   | Incremental streams read only relevant pages                                                                            |
+| 0.1.2   | 2021-07-15 | [4692](https://github.com/airbytehq/airbyte/pull/4692)   | Use account information for checking the connection                                                                     |
+| 0.1.1   | 2021-07-05 | [4539](https://github.com/airbytehq/airbyte/pull/4539)   | Add `AIRBYTE_ENTRYPOINT` env variable for kubernetes support                                                            |
+| 0.1.0   | 2021-06-08 | [3768](https://github.com/airbytehq/airbyte/pull/3768)   | Initial Release                                                                                                         |
 
 </details>

--- a/docs/integrations/sources/posthog.md
+++ b/docs/integrations/sources/posthog.md
@@ -71,7 +71,7 @@ Want to use the PostHog API beyond these limits? Email Posthog at `customers@pos
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                 |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- |
-| 1.1.6   | 2024-08-13 | [44012](https://github.com/airbytehq/airbyte/pull/44012) | Fix `events` stream pagniator to workaround PostHog API issue [#13508](https://github.com/PostHog/posthog/issues/13508) |
+| 1.1.6   | 2024-08-13 | [44016](https://github.com/airbytehq/airbyte/pull/44016) | Fix `events` stream pagniator to workaround PostHog API issue [#13508](https://github.com/PostHog/posthog/issues/13508) |
 | 1.1.5   | 2024-08-10 | [43488](https://github.com/airbytehq/airbyte/pull/43488) | Update dependencies                                                                                                     |
 | 1.1.4   | 2024-08-03 | [43232](https://github.com/airbytehq/airbyte/pull/43232) | Update dependencies                                                                                                     |
 | 1.1.3   | 2024-07-27 | [42769](https://github.com/airbytehq/airbyte/pull/42769) | Update dependencies                                                                                                     |


### PR DESCRIPTION
## What

This PR contains two changes:
1. It solves PostHog source pagination bug on stream `events`, that was raised through issue #33915. Indeed, the stream was using a cursor based pagination. However, the pagination in PostHog API is broken (see [issue](https://github.com/PostHog/posthog/issues/13508)): the cursor (field `next` in API response) returns the same URL that was called, causing Airbyte stream to loop infinitely over the same page. There is no plan on PostHog end to fix this as the API endpoint is deprecated and kept only for backward compatibility (see [documentation](https://posthog.com/docs/api/events)).
2. It updates the connector `README.md` according to the poetry update.

## How

For the issue on the `events` stream, there is a possible workaround, by using an offset based pagination. PostHog's API has `limit` and `offset` query parameters that are working. Once the pagination returns no results, the result is `null`.

Therefore I updated the `manifest.yaml` key `definitions.events_stream.retriever.paginator.pagination_strategy` to an `OffsetIncrement`.

## Review guide
1. `airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml`
2. `airbyte-integrations/connectors/source-posthog/README.md`
3. `docs/integrations/sources/posthog.md`

## User Impact
Instead of an infinite loop and a failing stream, the user will get all events.

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [ ] NO ❌
