### PR TITLE
metadata-service [orchestrator]: fix typo preventing correct stale metadata detection

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/github.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/github.py
@@ -122,7 +122,7 @@ def stale_gcs_latest_metadata_file(context, github_metadata_definitions: list, m
         if metadata_entry.metadata_definition.data.supportLevel
         != "archived"  # We give a 2 hour grace period for the metadata to be updated
         and datetime.datetime.strptime(metadata_entry.last_modified, "%a, %d %b %Y %H:%M:%S %Z").replace(tzinfo=datetime.timezone.utc)
-        > now - PUBLISH_GRACE_PERIOD
+        < now - PUBLISH_GRACE_PERIOD
     }
 
     stale_connectors = []

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.2.3"
+version = "0.2.4"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
## What
We want to get the github connectors modified more than 6 hours ago, not the opposite 🤦 
