### PR TITLE
Docs: troubleshooting get email from org not user table

### DIFF
--- a/docs/using-airbyte/getting-started/oss-quickstart.md
+++ b/docs/using-airbyte/getting-started/oss-quickstart.md
@@ -5,13 +5,11 @@ products: oss-community
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-
-
 # Quickstart
 
 Airbyte Open Source is a reliable and extensible open source data pipeline.
 
-If you're getting started with Airbyte Cloud, you can skip ahead to moving data by [adding your first source](add-a-source.md). 
+If you're getting started with Airbyte Cloud, you can skip ahead to moving data by [adding your first source](add-a-source.md).
 
 This quickstart guides you through creating a locally deployed instance of Airbyte in just minutes using `abctl` ([Airbyte Command Line Tool](https://github.com/airbytehq/abctl)). You'll be able to move data with minimal setup while you're exploring what Airbyte can do!
 
@@ -20,7 +18,7 @@ If you've already set up an Airbyte instance using Docker Compose and want to mo
 :::tip
 **When you're ready to put an Airbyte instance into production, you'll want to review our guides on deployment.**
 
-For the best experience, we recommend [Deploying Airbyte on Kubernetes via Helm](../../deploying-airbyte/deploying-airbyte.md). 
+For the best experience, we recommend [Deploying Airbyte on Kubernetes via Helm](../../deploying-airbyte/deploying-airbyte.md).
 
 On a local deployment, Airbyte's default behavior is to store connector secrets in your configured database. These secrets are stored in plain text and are not encrypted. Refer to the [Secret Management documentation](../../deploying-airbyte/integrations/secrets.md) to set up an external secrets manager.
 :::
@@ -29,7 +27,7 @@ If setting up an Airbyte server does not fit your use case needs (i.e. you're us
 
 ## Prerequisites
 
-- To use `abctl`, you'll need to have **Docker Desktop** installed. See Docker's instructions for installation: [Mac](https://docs.docker.com/desktop/install/mac-install/), [Windows](https://docs.docker.com/desktop/install/windows-install/), [Linux](https://docs.docker.com/desktop/install/linux-install/) 
+- To use `abctl`, you'll need to have **Docker Desktop** installed. See Docker's instructions for installation: [Mac](https://docs.docker.com/desktop/install/mac-install/), [Windows](https://docs.docker.com/desktop/install/windows-install/), [Linux](https://docs.docker.com/desktop/install/linux-install/)
 
 ## 1: Install `abctl`
 
@@ -45,7 +43,7 @@ If you would rather install `abctl` yourself, follow the instructions for your o
 defaultValue="abctl-mac">
 <TabItem value="abctl-mac" label="Mac">
 
-We recommend that Mac users use Brew to install the `abctl` command. 
+We recommend that Mac users use Brew to install the `abctl` command.
 
 ```bash
 brew tap airbytehq/tap
@@ -53,21 +51,23 @@ brew install abctl
 ```
 
 With Brew, you can keep abctl up to date easily, by running:
+
 ```bash
 brew upgrade abctl
-``` 
+```
 
 </TabItem>
 <TabItem value="abctl-linux" label="Linux" default>
 
 **1: Download the latest release of `abctl`.**
 
-<a class="abctl-download button button--primary" data-architecture="linux-amd64" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" style={{ marginRight: '10px' }} download>Latest linux-amd64 Release</a>
+<a class="abctl-download button button--primary" data-architecture="linux-amd64" href="https://github.com/airbytehq/abctl/releases/latest" target="\_blank" style={{ marginRight: '10px' }} download>Latest linux-amd64 Release</a>
 <a class="abctl-download button button--primary" data-architecture="linux-arm64" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" download>Latest linux-arm64 Release</a>
 <br/>
 <br/>
 
 :::info
+
 <details>
 <summary>Be sure to download the file that is compatible with your machine's processor architecture.</summary>
 
@@ -85,7 +85,7 @@ uname -m
 
 **2: Extract the archive**
 
-This will create a directory named abctl which contains the executable along with other needed files. 
+This will create a directory named abctl which contains the executable along with other needed files.
 
 ```bash
 tar -xvzf {name-of-file-downloaded.linux-*.tar.gz}
@@ -101,11 +101,12 @@ chmod +x abctl/abctl
 
 **4: Add `abctl` to your PATH**
 
-This will allow you to run `abctl` from any directory in your terminal. 
+This will allow you to run `abctl` from any directory in your terminal.
 
 ```bash
 sudo mv abctl /usr/local/bin
 ```
+
 **5: Verify the installation**
 
 ```bash
@@ -113,7 +114,6 @@ abctl --version
 ```
 
 If this command prints the installed version of the Airbyte Command Line Tool, it confirm that you are now ready to manage a local Airbyte instance using `abctl`.
-
 
 </TabItem>
 <TabItem value="abctl-windows" label="Windows" default>
@@ -125,19 +125,21 @@ If this command prints the installed version of the Airbyte Command Line Tool, i
 <br/>
 
 **2: Extract the archive**
-- Right click the zip file you've downloaded and select `Extract All...`, then choose a destination folder. 
 
-This creates a folder called abctl containing the abctl executable and other reqired files. 
+- Right click the zip file you've downloaded and select `Extract All...`, then choose a destination folder.
+
+This creates a folder called abctl containing the abctl executable and other reqired files.
 
 **3: Add the executable to your PATH**
+
 - In the "System Properties" window (you can find this by searching for "enviornment variables" in the Start menu), click the `Environment Variables` button
 - Under System variables, find the path and click to `Edit`
-- Click `New` and add the path to the folder you extracted the abctl files to in the previous step. 
-- Click `OK` to save these changes. 
+- Click `New` and add the path to the folder you extracted the abctl files to in the previous step.
+- Click `OK` to save these changes.
 
 **4: Open a new Command Prompt or PowerShell window**
 
-This is important because changes to your PATH will only take effect in a newly opened window. 
+This is important because changes to your PATH will only take effect in a newly opened window.
 
 **5: Verify the installation**
 
@@ -146,7 +148,6 @@ abctl version
 ```
 
 If this command prints the installed version of the Airbyte Command Line Tool, it confirm that you are now ready to manage a local Airbyte instance using `abctl`.
-
 
 </TabItem>
 
@@ -186,13 +187,13 @@ Which should output something similar to:
 }
 ```
 
-Use the value in the password field to authenticate to your new Airbyte instance. If you wish to configure 
-authentication follow the documentation on the [Authentication Integration](../../deploying-airbyte/integrations/authentication) 
+Use the value in the password field to authenticate to your new Airbyte instance. If you wish to configure
+authentication follow the documentation on the [Authentication Integration](../../deploying-airbyte/integrations/authentication)
 page.
 
-As long as your Docker Desktop daemon is running in the background, you can use Airbyte by returning to [http://localhost:8000](http://localhost:8000). 
+As long as your Docker Desktop daemon is running in the background, you can use Airbyte by returning to [http://localhost:8000](http://localhost:8000).
 
-If you quit Docker Desktop and want to return to your local Airbyte workspace, just start Docker Desktop again. Once Docker finishes restarting, you'll be able to access Airbyte's local installation as normal. 
+If you quit Docker Desktop and want to return to your local Airbyte workspace, just start Docker Desktop again. Once Docker finishes restarting, you'll be able to access Airbyte's local installation as normal.
 
 ## 3: Move Data
 
@@ -227,6 +228,7 @@ If you have data that you would like to migrate from an existing docker compose 
 ```
 docker compose stop
 ```
+
 2. Make sure that you have the latest version of abctl by running the following command:
 
 ```
@@ -234,13 +236,14 @@ curl -LsfS https://get.airbyte.com | bash -
 ```
 
 3. Run abctl with the migrate flag set with the following command:
+
 ```
 abctl local install --migrate
 ```
 
 :::note
 
-If you're using a version of Airbyte that you've installed with `abctl`, you can find instructions on upgrading your Airbyte installation [here](../../operator-guides/upgrading-airbyte.md#upgrading-with-abctl). 
+If you're using a version of Airbyte that you've installed with `abctl`, you can find instructions on upgrading your Airbyte installation [here](../../operator-guides/upgrading-airbyte.md#upgrading-with-abctl).
 
 :::
 
@@ -281,11 +284,11 @@ curl -LsfS https://get.airbyte.com | bash -
 ```
 
 6. Run the `abctl` command and install Airbyte:
-:::tip
-By default, `abctl` only configures an ingress rule for the host `localhost`. In order to ensure that Airbyte can be accessed outside of the EC2 instance, you will need to specify the `--host` flag to the `local install` command, providing the FQDN of the host which is hosting Airbyte. For example, `abctl local install --host airbyte.company.example`.
-:::
-:::tip
-By default, `abctl` will listen on port 8000. If port 8000 is already in used or you require a different port, you can specify this by passing the `--port` flag to the `local install` command. For example, `abctl local install --port 6598`
+   :::tip
+   By default, `abctl` only configures an ingress rule for the host `localhost`. In order to ensure that Airbyte can be accessed outside of the EC2 instance, you will need to specify the `--host` flag to the `local install` command, providing the FQDN of the host which is hosting Airbyte. For example, `abctl local install --host airbyte.company.example`.
+   :::
+   :::tip
+   By default, `abctl` will listen on port 8000. If port 8000 is already in used or you require a different port, you can specify this by passing the `--port` flag to the `local install` command. For example, `abctl local install --port 6598`
 
 Ensure the security group configured for the EC2 Instance allows traffic in on the port (8000 by default, or whatever port was passed to `--port`) that you deploy Airbyte on. See the [Control traffic to your AWS resources using security groups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html) documentation for more information.
 :::
@@ -315,10 +318,9 @@ host Airbyte at, for example: `airbyte.company.example`.
 
 ## Uninstalling
 
+If you want to remove Airbyte from your system, consider which of the following two options you would like to use.
 
-If you want to remove Airbyte from your system, consider which of the following two options you would like to use. 
-
-1: Run the following command to stop all running containers that `abctl` has created **while preserving any data you've created**: 
+1: Run the following command to stop all running containers that `abctl` has created **while preserving any data you've created**:
 
 ```shell
 abctl local uninstall
@@ -349,30 +351,33 @@ If you want to interact with the pods or resources inside the cluster you can us
 For more advanced interactions (e.g. loading custom docker containers), read more in [developing locally](../../contributing-to-airbyte/developing-locally#using-abctl-for-airbyte-development).
 
 ### Unable To Locate User Email
-:::note
-In `abctl` [v0.11.0](https://github.com/airbytehq/abctl/releases/tag/v0.11.0), support for basic-auth was removed (as basic-auth support was removed from the `Airbyte Platform` in [v0.63.11](https://github.com/airbytehq/airbyte-platform/releases/tag/v0.63.11), and replaced with a more secure randomly generated password.  When logging into Airbyte, the email (provided during registration) should be automatically populated and the randomly generated password can be fetched by running `abctl local credentials`.
 
-Airbyte is aware of situations where the email is not be automatically populated and we are working on addressing this within the `abctl` tool.  In the interim, some manually steps are required to retrieve the authentication email address when it is unknown.
+:::note
+In `abctl` [v0.11.0](https://github.com/airbytehq/abctl/releases/tag/v0.11.0), support for basic-auth was removed (as basic-auth support was removed from the `Airbyte Platform` in [v0.63.11](https://github.com/airbytehq/airbyte-platform/releases/tag/v0.63.11), and replaced with a more secure randomly generated password. When logging into Airbyte, the email (provided during registration) should be automatically populated and the randomly generated password can be fetched by running `abctl local credentials`.
+
+Airbyte is aware of situations where the email is not be automatically populated and we are working on addressing this within the `abctl` tool. In the interim, some manually steps are required to retrieve the authentication email address when it is unknown.
 :::
 
-If the email address for authenticating is not automatically populated, and you are unsure what the login email should be, the email can be retrieved from the database used by Airbyte. If using an external database, you will need to connect to the database and execute the query `SELECT "email" FROM "user"`.  If using the database automatically included with the `abctl local install` command, you will need to install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and execute the following command:
+If the email address for authenticating is not automatically populated, and you are unsure what the login email should be, the email can be retrieved from the database used by Airbyte. If using an external database, you will need to connect to the database and execute the query `SELECT "email" FROM "organization"`. If using the database automatically included with the `abctl local install` command, you will need to install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and execute the following command:
+
 ```
-kubectl exec --kubeconfig ~/.airbyte/abctl/abctl.kubeconfig --namespace airbyte-abctl -it airbyte-db-0 -- psql -U airbyte -d db-airbyte -t -A -c 'SELECT "email" FROM "user"'
+kubectl exec --kubeconfig ~/.airbyte/abctl/abctl.kubeconfig --namespace airbyte-abctl -it airbyte-db-0 -- psql -U airbyte -d db-airbyte -t -A -c 'SELECT "email" FROM "organization"'
 ```
 
 The password for this user can be retrieved by running `abctl local credentials`.
 
 ### Additional Resources
 
-There are several channels for community support of local setup and deployment. 
+There are several channels for community support of local setup and deployment.
 
 **GitHub Airbyte Forum's Getting Started FAQ:**<br/>Search the questions others have asked or ask a new question of your own in the [GitHub forum](https://github.com/airbytehq/airbyte/discussions/categories/questions).
 
 **Airbyte Knowledge Base:**<br/>While support services are limited to Cloud and Enterprise customers, anyone may search the support team's [Help Center](https://support.airbyte.com/hc).
 
 **Community Slack:**<br/>Helpful channels for troubleshooting include:<br/>
-- [#ask-community-for-troubleshooting](https://airbytehq.slack.com/archives/C021JANJ6TY): Where members of the Airbyte community can ask and answer questions. 
-- [#ask-ai](https://airbytehq.slack.com/archives/C01AHCD885S): For quick answers sourced from documentation and open support channels, you can have a chat with our virtual Airbyte assistant.  
+
+- [#ask-community-for-troubleshooting](https://airbytehq.slack.com/archives/C021JANJ6TY): Where members of the Airbyte community can ask and answer questions.
+- [#ask-ai](https://airbytehq.slack.com/archives/C01AHCD885S): For quick answers sourced from documentation and open support channels, you can have a chat with our virtual Airbyte assistant.
 
 **Introductory Course:**<br/>
 On Udemy, [The Complete Hands-on Introduction to Airbyte](https://www.udemy.com/course/the-complete-hands-on-introduction-to-airbyte/) is a convenient and hands-on introduction to Airbyte that includes setting up example source and destination configurations. You'll also go on to use it in conjunction with Apache Airflow, Snowflake, dbt, and more.

--- a/docs/using-airbyte/getting-started/oss-quickstart.md
+++ b/docs/using-airbyte/getting-started/oss-quickstart.md
@@ -5,11 +5,13 @@ products: oss-community
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+
+
 # Quickstart
 
 Airbyte Open Source is a reliable and extensible open source data pipeline.
 
-If you're getting started with Airbyte Cloud, you can skip ahead to moving data by [adding your first source](add-a-source.md).
+If you're getting started with Airbyte Cloud, you can skip ahead to moving data by [adding your first source](add-a-source.md). 
 
 This quickstart guides you through creating a locally deployed instance of Airbyte in just minutes using `abctl` ([Airbyte Command Line Tool](https://github.com/airbytehq/abctl)). You'll be able to move data with minimal setup while you're exploring what Airbyte can do!
 
@@ -18,7 +20,7 @@ If you've already set up an Airbyte instance using Docker Compose and want to mo
 :::tip
 **When you're ready to put an Airbyte instance into production, you'll want to review our guides on deployment.**
 
-For the best experience, we recommend [Deploying Airbyte on Kubernetes via Helm](../../deploying-airbyte/deploying-airbyte.md).
+For the best experience, we recommend [Deploying Airbyte on Kubernetes via Helm](../../deploying-airbyte/deploying-airbyte.md). 
 
 On a local deployment, Airbyte's default behavior is to store connector secrets in your configured database. These secrets are stored in plain text and are not encrypted. Refer to the [Secret Management documentation](../../deploying-airbyte/integrations/secrets.md) to set up an external secrets manager.
 :::
@@ -27,7 +29,7 @@ If setting up an Airbyte server does not fit your use case needs (i.e. you're us
 
 ## Prerequisites
 
-- To use `abctl`, you'll need to have **Docker Desktop** installed. See Docker's instructions for installation: [Mac](https://docs.docker.com/desktop/install/mac-install/), [Windows](https://docs.docker.com/desktop/install/windows-install/), [Linux](https://docs.docker.com/desktop/install/linux-install/)
+- To use `abctl`, you'll need to have **Docker Desktop** installed. See Docker's instructions for installation: [Mac](https://docs.docker.com/desktop/install/mac-install/), [Windows](https://docs.docker.com/desktop/install/windows-install/), [Linux](https://docs.docker.com/desktop/install/linux-install/) 
 
 ## 1: Install `abctl`
 
@@ -43,7 +45,7 @@ If you would rather install `abctl` yourself, follow the instructions for your o
 defaultValue="abctl-mac">
 <TabItem value="abctl-mac" label="Mac">
 
-We recommend that Mac users use Brew to install the `abctl` command.
+We recommend that Mac users use Brew to install the `abctl` command. 
 
 ```bash
 brew tap airbytehq/tap
@@ -51,23 +53,21 @@ brew install abctl
 ```
 
 With Brew, you can keep abctl up to date easily, by running:
-
 ```bash
 brew upgrade abctl
-```
+``` 
 
 </TabItem>
 <TabItem value="abctl-linux" label="Linux" default>
 
 **1: Download the latest release of `abctl`.**
 
-<a class="abctl-download button button--primary" data-architecture="linux-amd64" href="https://github.com/airbytehq/abctl/releases/latest" target="\_blank" style={{ marginRight: '10px' }} download>Latest linux-amd64 Release</a>
+<a class="abctl-download button button--primary" data-architecture="linux-amd64" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" style={{ marginRight: '10px' }} download>Latest linux-amd64 Release</a>
 <a class="abctl-download button button--primary" data-architecture="linux-arm64" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" download>Latest linux-arm64 Release</a>
 <br/>
 <br/>
 
 :::info
-
 <details>
 <summary>Be sure to download the file that is compatible with your machine's processor architecture.</summary>
 
@@ -85,7 +85,7 @@ uname -m
 
 **2: Extract the archive**
 
-This will create a directory named abctl which contains the executable along with other needed files.
+This will create a directory named abctl which contains the executable along with other needed files. 
 
 ```bash
 tar -xvzf {name-of-file-downloaded.linux-*.tar.gz}
@@ -101,12 +101,11 @@ chmod +x abctl/abctl
 
 **4: Add `abctl` to your PATH**
 
-This will allow you to run `abctl` from any directory in your terminal.
+This will allow you to run `abctl` from any directory in your terminal. 
 
 ```bash
 sudo mv abctl /usr/local/bin
 ```
-
 **5: Verify the installation**
 
 ```bash
@@ -114,6 +113,7 @@ abctl --version
 ```
 
 If this command prints the installed version of the Airbyte Command Line Tool, it confirm that you are now ready to manage a local Airbyte instance using `abctl`.
+
 
 </TabItem>
 <TabItem value="abctl-windows" label="Windows" default>
@@ -125,21 +125,19 @@ If this command prints the installed version of the Airbyte Command Line Tool, i
 <br/>
 
 **2: Extract the archive**
+- Right click the zip file you've downloaded and select `Extract All...`, then choose a destination folder. 
 
-- Right click the zip file you've downloaded and select `Extract All...`, then choose a destination folder.
-
-This creates a folder called abctl containing the abctl executable and other reqired files.
+This creates a folder called abctl containing the abctl executable and other reqired files. 
 
 **3: Add the executable to your PATH**
-
 - In the "System Properties" window (you can find this by searching for "enviornment variables" in the Start menu), click the `Environment Variables` button
 - Under System variables, find the path and click to `Edit`
-- Click `New` and add the path to the folder you extracted the abctl files to in the previous step.
-- Click `OK` to save these changes.
+- Click `New` and add the path to the folder you extracted the abctl files to in the previous step. 
+- Click `OK` to save these changes. 
 
 **4: Open a new Command Prompt or PowerShell window**
 
-This is important because changes to your PATH will only take effect in a newly opened window.
+This is important because changes to your PATH will only take effect in a newly opened window. 
 
 **5: Verify the installation**
 
@@ -148,6 +146,7 @@ abctl version
 ```
 
 If this command prints the installed version of the Airbyte Command Line Tool, it confirm that you are now ready to manage a local Airbyte instance using `abctl`.
+
 
 </TabItem>
 
@@ -187,13 +186,13 @@ Which should output something similar to:
 }
 ```
 
-Use the value in the password field to authenticate to your new Airbyte instance. If you wish to configure
-authentication follow the documentation on the [Authentication Integration](../../deploying-airbyte/integrations/authentication)
+Use the value in the password field to authenticate to your new Airbyte instance. If you wish to configure 
+authentication follow the documentation on the [Authentication Integration](../../deploying-airbyte/integrations/authentication) 
 page.
 
-As long as your Docker Desktop daemon is running in the background, you can use Airbyte by returning to [http://localhost:8000](http://localhost:8000).
+As long as your Docker Desktop daemon is running in the background, you can use Airbyte by returning to [http://localhost:8000](http://localhost:8000). 
 
-If you quit Docker Desktop and want to return to your local Airbyte workspace, just start Docker Desktop again. Once Docker finishes restarting, you'll be able to access Airbyte's local installation as normal.
+If you quit Docker Desktop and want to return to your local Airbyte workspace, just start Docker Desktop again. Once Docker finishes restarting, you'll be able to access Airbyte's local installation as normal. 
 
 ## 3: Move Data
 
@@ -228,7 +227,6 @@ If you have data that you would like to migrate from an existing docker compose 
 ```
 docker compose stop
 ```
-
 2. Make sure that you have the latest version of abctl by running the following command:
 
 ```
@@ -236,14 +234,13 @@ curl -LsfS https://get.airbyte.com | bash -
 ```
 
 3. Run abctl with the migrate flag set with the following command:
-
 ```
 abctl local install --migrate
 ```
 
 :::note
 
-If you're using a version of Airbyte that you've installed with `abctl`, you can find instructions on upgrading your Airbyte installation [here](../../operator-guides/upgrading-airbyte.md#upgrading-with-abctl).
+If you're using a version of Airbyte that you've installed with `abctl`, you can find instructions on upgrading your Airbyte installation [here](../../operator-guides/upgrading-airbyte.md#upgrading-with-abctl). 
 
 :::
 
@@ -284,11 +281,11 @@ curl -LsfS https://get.airbyte.com | bash -
 ```
 
 6. Run the `abctl` command and install Airbyte:
-   :::tip
-   By default, `abctl` only configures an ingress rule for the host `localhost`. In order to ensure that Airbyte can be accessed outside of the EC2 instance, you will need to specify the `--host` flag to the `local install` command, providing the FQDN of the host which is hosting Airbyte. For example, `abctl local install --host airbyte.company.example`.
-   :::
-   :::tip
-   By default, `abctl` will listen on port 8000. If port 8000 is already in used or you require a different port, you can specify this by passing the `--port` flag to the `local install` command. For example, `abctl local install --port 6598`
+:::tip
+By default, `abctl` only configures an ingress rule for the host `localhost`. In order to ensure that Airbyte can be accessed outside of the EC2 instance, you will need to specify the `--host` flag to the `local install` command, providing the FQDN of the host which is hosting Airbyte. For example, `abctl local install --host airbyte.company.example`.
+:::
+:::tip
+By default, `abctl` will listen on port 8000. If port 8000 is already in used or you require a different port, you can specify this by passing the `--port` flag to the `local install` command. For example, `abctl local install --port 6598`
 
 Ensure the security group configured for the EC2 Instance allows traffic in on the port (8000 by default, or whatever port was passed to `--port`) that you deploy Airbyte on. See the [Control traffic to your AWS resources using security groups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html) documentation for more information.
 :::
@@ -318,9 +315,10 @@ host Airbyte at, for example: `airbyte.company.example`.
 
 ## Uninstalling
 
-If you want to remove Airbyte from your system, consider which of the following two options you would like to use.
 
-1: Run the following command to stop all running containers that `abctl` has created **while preserving any data you've created**:
+If you want to remove Airbyte from your system, consider which of the following two options you would like to use. 
+
+1: Run the following command to stop all running containers that `abctl` has created **while preserving any data you've created**: 
 
 ```shell
 abctl local uninstall
@@ -351,15 +349,13 @@ If you want to interact with the pods or resources inside the cluster you can us
 For more advanced interactions (e.g. loading custom docker containers), read more in [developing locally](../../contributing-to-airbyte/developing-locally#using-abctl-for-airbyte-development).
 
 ### Unable To Locate User Email
-
 :::note
-In `abctl` [v0.11.0](https://github.com/airbytehq/abctl/releases/tag/v0.11.0), support for basic-auth was removed (as basic-auth support was removed from the `Airbyte Platform` in [v0.63.11](https://github.com/airbytehq/airbyte-platform/releases/tag/v0.63.11), and replaced with a more secure randomly generated password. When logging into Airbyte, the email (provided during registration) should be automatically populated and the randomly generated password can be fetched by running `abctl local credentials`.
+In `abctl` [v0.11.0](https://github.com/airbytehq/abctl/releases/tag/v0.11.0), support for basic-auth was removed (as basic-auth support was removed from the `Airbyte Platform` in [v0.63.11](https://github.com/airbytehq/airbyte-platform/releases/tag/v0.63.11), and replaced with a more secure randomly generated password.  When logging into Airbyte, the email (provided during registration) should be automatically populated and the randomly generated password can be fetched by running `abctl local credentials`.
 
-Airbyte is aware of situations where the email is not be automatically populated and we are working on addressing this within the `abctl` tool. In the interim, some manually steps are required to retrieve the authentication email address when it is unknown.
+Airbyte is aware of situations where the email is not be automatically populated and we are working on addressing this within the `abctl` tool.  In the interim, some manually steps are required to retrieve the authentication email address when it is unknown.
 :::
 
-If the email address for authenticating is not automatically populated, and you are unsure what the login email should be, the email can be retrieved from the database used by Airbyte. If using an external database, you will need to connect to the database and execute the query `SELECT "email" FROM "organization"`. If using the database automatically included with the `abctl local install` command, you will need to install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and execute the following command:
-
+If the email address for authenticating is not automatically populated, and you are unsure what the login email should be, the email can be retrieved from the database used by Airbyte. If using an external database, you will need to connect to the database and execute the query `SELECT "email" FROM "organization"`.  If using the database automatically included with the `abctl local install` command, you will need to install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and execute the following command:
 ```
 kubectl exec --kubeconfig ~/.airbyte/abctl/abctl.kubeconfig --namespace airbyte-abctl -it airbyte-db-0 -- psql -U airbyte -d db-airbyte -t -A -c 'SELECT "email" FROM "organization"'
 ```
@@ -368,16 +364,15 @@ The password for this user can be retrieved by running `abctl local credentials`
 
 ### Additional Resources
 
-There are several channels for community support of local setup and deployment.
+There are several channels for community support of local setup and deployment. 
 
 **GitHub Airbyte Forum's Getting Started FAQ:**<br/>Search the questions others have asked or ask a new question of your own in the [GitHub forum](https://github.com/airbytehq/airbyte/discussions/categories/questions).
 
 **Airbyte Knowledge Base:**<br/>While support services are limited to Cloud and Enterprise customers, anyone may search the support team's [Help Center](https://support.airbyte.com/hc).
 
 **Community Slack:**<br/>Helpful channels for troubleshooting include:<br/>
-
-- [#ask-community-for-troubleshooting](https://airbytehq.slack.com/archives/C021JANJ6TY): Where members of the Airbyte community can ask and answer questions.
-- [#ask-ai](https://airbytehq.slack.com/archives/C01AHCD885S): For quick answers sourced from documentation and open support channels, you can have a chat with our virtual Airbyte assistant.
+- [#ask-community-for-troubleshooting](https://airbytehq.slack.com/archives/C021JANJ6TY): Where members of the Airbyte community can ask and answer questions. 
+- [#ask-ai](https://airbytehq.slack.com/archives/C01AHCD885S): For quick answers sourced from documentation and open support channels, you can have a chat with our virtual Airbyte assistant.  
 
 **Introductory Course:**<br/>
 On Udemy, [The Complete Hands-on Introduction to Airbyte](https://www.udemy.com/course/the-complete-hands-on-introduction-to-airbyte/) is a convenient and hands-on introduction to Airbyte that includes setting up example source and destination configurations. You'll also go on to use it in conjunction with Apache Airflow, Snowflake, dbt, and more.


### PR DESCRIPTION
To login into Airbyte the email used isn't the one in `user` table but `organization`.
As we have couple of users having problem with this it is better have the docs pointing to the right place.

Querying the `user` table probably can help most users as they won't change the org / user email.
I ran some tests updating the Profile email and updating the `user` table directly to check if that could help users having trouble accessing the UI but I figured out the `email` in `user` isn't the correct value.