### PR TITLE
Revert "Temporarily disable required reviews on Community manifest-only connectors"

### DIFF
--- a/airbyte-ci/connectors/connector_ops/README.md
+++ b/airbyte-ci/connectors/connector_ops/README.md
@@ -37,8 +37,6 @@ poetry run pytest
 ```
 
 ## Changelog
-
-- 0.7.1: Temporarily disable required reviewers for community manifest-only connectors.
 - 0.7.0: Added required reviewers for manifest-only connector changes/additions.
 - 0.6.1: Simplified gradle dependency discovery logic.
 - 0.6.0: Added manifest-only build.

--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -44,14 +44,11 @@ def find_mandatory_reviewers() -> List[Dict[str, Union[str, Dict[str, List]]]]:
             "teams": list(CERTIFIED_MANIFEST_ONLY_CONNECTOR_REVIEWERS),
             "is_required": find_changed_manifest_only_connectors(support_level="certified"),
         },
-        # TODO: We are disabling this requirement to unblock automerging of the manifest-only migrations.
-        # We should re-enable this requirement when we have migrated our existing connectors to manifest-only
-        # and are ready to enforce reviews for community connectors again.
-        # {
-        #     "name": "Manifest-only community connectors",
-        #     "teams": list(COMMUNITY_MANIFEST_ONLY_CONNECTOR_REVIEWERS),
-        #     "is_required": find_changed_manifest_only_connectors(support_level="community"),
-        # },
+        {
+            "name": "Manifest-only community connectors",
+            "teams": list(COMMUNITY_MANIFEST_ONLY_CONNECTOR_REVIEWERS),
+            "is_required": find_changed_manifest_only_connectors(support_level="community"),
+        },
     ]
 
     return [{"name": r["name"], "teams": r["teams"]} for r in requirements if r["is_required"]]

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector_ops"
-version = "0.7.1"
+version = "0.7.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/connector_ops/tests/test_required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/tests/test_required_reviewer_checks.py
@@ -113,9 +113,8 @@ def test_find_mandatory_reviewers_no_tracked_changed(capsys, not_tracked_change_
     check_review_requirements_file(capsys, not_tracked_change_expected_team)
 
 
-# TODO: Re-enable this test when we have migrated our existing connectors to manifest-only and no longer need to automerge
-# def test_find_reviewers_manifest_only_community_connector(capsys, test_community_manifest_only_connector_expected_team):
-#     check_review_requirements_file(capsys, test_community_manifest_only_connector_expected_team)
+def test_find_reviewers_manifest_only_community_connector(capsys, test_community_manifest_only_connector_expected_team):
+    check_review_requirements_file(capsys, test_community_manifest_only_connector_expected_team)
 
 
 def test_find_reviewers_manifest_only_certified_connector(capsys, test_certified_manifest_only_connector_expected_team):


### PR DESCRIPTION
Reverts airbytehq/airbyte#44004 so we can test running auto-merge manually with a required review.