### PR TITLE
add missing ES text type `match_only_text` #21479

### DIFF
--- a/airbyte-integrations/connectors/source-elasticsearch/src/main/java/io/airbyte/integrations/source/elasticsearch/typemapper/ElasticsearchTypeMapper.java
+++ b/airbyte-integrations/connectors/source-elasticsearch/src/main/java/io/airbyte/integrations/source/elasticsearch/typemapper/ElasticsearchTypeMapper.java
@@ -84,6 +84,7 @@ public class ElasticsearchTypeMapper {
 
       // TEXT SEARCH TYPES
       put("text", Arrays.asList("string", "array"));
+      put("match_only_text", Arrays.asList("string", "array"));
       put("alias", Arrays.asList("string", "array"));
       put("search_as_you_type", Arrays.asList("string", "array"));
       put("token_count", Arrays.asList("integer", "array"));


### PR DESCRIPTION
## What
The elasticsearch source errors when it encounters an index using the `match_only_text` field type, which should map to Airbyte's string type.  

## How
Updated the elastic type mapper to map `match_only_text` to AirByte's `string`.

## Review guide
1. `airbyte-integrations/connectors/source-elasticsearch/src/main/java/io/airbyte/integrations/source/elasticsearch/typemapper/ElasticsearchTypeMapper.java`

## User Impact
This will allow users to more easily connect to Elastic without having to use workaround.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
