### PR TITLE
Docs: update connector test documentation

### DIFF
--- a/docs/connector-development/testing-connectors/README.md
+++ b/docs/connector-development/testing-connectors/README.md
@@ -4,10 +4,10 @@ Multiple tests suites compose the Airbyte connector testing pyramid
 
 ## Tests run by our CI pipeline
 
-- [Connectors QA checks](https://docs.airbyte.com/contributing-to-airbyte/resources/qa-checks): Static asset checks that validate that a connector is correctly packaged to be successfully released to production.
-- Unit tests: Connector-specific tests written by the connector developer which don’t require access to the source/destination.
-- Integration tests: Connector-specific tests written by the connector developer which _may_ require access to the source/destination.
-- [Connector Acceptance tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/): Connector-agnostic tests that verify that a connector adheres to the Airbyte protocol. Credentials to a source/destination sandbox account are **required**.
+- [Connector QA Checks](https://docs.airbyte.com/contributing-to-airbyte/resources/qa-checks): Static asset checks that validate that a connector is correctly packaged to be successfully released to production.
+- Unit Tests: Connector-specific tests written by the connector developer which don’t require access to the source/destination.
+- Integration Tests: Connector-specific tests written by the connector developer which _may_ require access to the source/destination.
+- [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/): Connector-agnostic tests that verify that a connector adheres to the [Airbyte protocol](https://docs.airbyte.com/understanding-airbyte/airbyte-protocol). Credentials to a source/destination sandbox account are **required**.
 - [Regression Tests](https://github.com/airbytehq/airbyte/tree/master/airbyte-ci/connectors/live-tests): Connector-agnostic tests that verify that the behavior of a connector hasn’t changed unexpectedly between connector versions. A sandbox cloud connection is required. Currently only available for API source connectors.
 
 
@@ -19,7 +19,7 @@ If you want to run the global test suite, exactly like what is run in CI, you sh
 airbyte-ci connectors --name=<connector_name> test
 ```
 
-CI will run all the tests that are available for a connector. This can include all of the tests listed above, if we have the appropriate credentials. At a minimum, it will include the static asset checks and any tests that exist in a connector's `unit_tests` and `integration_tests` directories.
+CI will run all the tests that are available for a connector. This can include all of the tests listed above, if we have the appropriate credentials. At a minimum, it will include the Connector QA checks and any tests that exist in a connector's `unit_tests` and `integration_tests` directories.
 To run Connector Acceptance tests locally, you must provide connector configuration as a `config.json` file in a `.secrets` folder in the connector code directory.
 Regression tests may only be run locally with authorization to our cloud resources.
 

--- a/docs/connector-development/testing-connectors/README.md
+++ b/docs/connector-development/testing-connectors/README.md
@@ -2,10 +2,14 @@
 
 Multiple tests suites compose the Airbyte connector testing pyramid
 
-## Common to all connectors
+## Tests run by our CI pipeline
 
-- [Connectors QA checks](https://docs.airbyte.com/contributing-to-airbyte/resources/qa-checks)
-- [Connector Acceptance tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/)
+- [Connectors QA checks](https://docs.airbyte.com/contributing-to-airbyte/resources/qa-checks): Static assets checks that validate that the connector is correctly packaged to be successfully released to production.
+- Unit tests: Connector-specific tests written by the connector developer and which don’t require access to the source/destination.
+- Integration tests: Connector-specific tests written by the connector developer which may require access to the source/destination.
+- [Connector Acceptance tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/): Connector-agnostic tests that verify that the connector adheres to the Airbyte protocol. Credentials to a source/destination sandbox account are required.
+- [Regression tests](https://github.com/airbytehq/airbyte/tree/master/airbyte-ci/connectors/live-tests): Connector-agnostic tests that verify that the behavior of the connector hasn’t changed unexpectedly between connector versions. A sandbox cloud connection is required. Currently only available for API source connectors.
+
 
 ## 🤖 CI
 
@@ -15,8 +19,9 @@ If you want to run the global test suite, exactly like what is run in CI, you sh
 airbyte-ci connectors --name=<connector_name> test
 ```
 
-This will run all the tests for the connector, including the QA checks and the Connector Acceptance tests.
-Connector Acceptance tests require connector configuration to be provided as a `config.json` file in a `.secrets` folder in the connector code directory.
+This will run all the tests that are available for the connector. This can include all of the tests listed above, if we have the appropriate credentials; at a minimum it will include the static asset checks and any tests that exist in a connector's `unit_tests` and `integration_tests` directories.
+To run Connector Acceptance tests locally, you must provide connector configuration as a `config.json` file in a `.secrets` folder in the connector code directory.
+Regression tests may only be run locally with authorization to our cloud resources.
 
 Our CI infrastructure runs the connector tests with [`airbyte-ci` CLI](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md). Connectors tests are automatically and remotely triggered on your branch according to the changes made in your branch.
 **Passing tests are required to merge a connector pull request.**

--- a/docs/connector-development/testing-connectors/README.md
+++ b/docs/connector-development/testing-connectors/README.md
@@ -4,11 +4,11 @@ Multiple tests suites compose the Airbyte connector testing pyramid
 
 ## Tests run by our CI pipeline
 
-- [Connectors QA checks](https://docs.airbyte.com/contributing-to-airbyte/resources/qa-checks): Static assets checks that validate that the connector is correctly packaged to be successfully released to production.
-- Unit tests: Connector-specific tests written by the connector developer and which don’t require access to the source/destination.
-- Integration tests: Connector-specific tests written by the connector developer which may require access to the source/destination.
-- [Connector Acceptance tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/): Connector-agnostic tests that verify that the connector adheres to the Airbyte protocol. Credentials to a source/destination sandbox account are required.
-- [Regression tests](https://github.com/airbytehq/airbyte/tree/master/airbyte-ci/connectors/live-tests): Connector-agnostic tests that verify that the behavior of the connector hasn’t changed unexpectedly between connector versions. A sandbox cloud connection is required. Currently only available for API source connectors.
+- [Connectors QA checks](https://docs.airbyte.com/contributing-to-airbyte/resources/qa-checks): Static asset checks that validate that a connector is correctly packaged to be successfully released to production.
+- Unit tests: Connector-specific tests written by the connector developer which don’t require access to the source/destination.
+- Integration tests: Connector-specific tests written by the connector developer which _may_ require access to the source/destination.
+- [Connector Acceptance tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/): Connector-agnostic tests that verify that a connector adheres to the Airbyte protocol. Credentials to a source/destination sandbox account are **required**.
+- [Regression Tests](https://github.com/airbytehq/airbyte/tree/master/airbyte-ci/connectors/live-tests): Connector-agnostic tests that verify that the behavior of a connector hasn’t changed unexpectedly between connector versions. A sandbox cloud connection is required. Currently only available for API source connectors.
 
 
 ## 🤖 CI
@@ -19,7 +19,7 @@ If you want to run the global test suite, exactly like what is run in CI, you sh
 airbyte-ci connectors --name=<connector_name> test
 ```
 
-This will run all the tests that are available for the connector. This can include all of the tests listed above, if we have the appropriate credentials; at a minimum it will include the static asset checks and any tests that exist in a connector's `unit_tests` and `integration_tests` directories.
+CI will run all the tests that are available for a connector. This can include all of the tests listed above, if we have the appropriate credentials. At a minimum, it will include the static asset checks and any tests that exist in a connector's `unit_tests` and `integration_tests` directories.
 To run Connector Acceptance tests locally, you must provide connector configuration as a `config.json` file in a `.secrets` folder in the connector code directory.
 Regression tests may only be run locally with authorization to our cloud resources.
 


### PR DESCRIPTION
Updates the docs page for [connector tests](https://docs.airbyte.com/connector-development/testing-connectors/) to include additional info on unit, integration, and regression tests.