### PR TITLE
docs: fix n8n typo

### DIFF
--- a/docs/integrations/sources/n8n.md
+++ b/docs/integrations/sources/n8n.md
@@ -6,7 +6,7 @@ This source can sync data from [N8n](https://docs.n8n.io/api/). At present this 
 
 ## This Source Supports the Following Streams
 
-- [execitions](https://docs.n8n.io/api/api-reference/#tag/Execution/paths/~1executions/get)
+- [executions](https://docs.n8n.io/api/api-reference/#tag/Execution/paths/~1executions/get)
 
 ### Features
 


### PR DESCRIPTION
Fixed a typo in n8n docs.

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Fixed typo in n8n docs

## How
<!--
* Describe how code changes achieve the solution.
-->
Fixed typo

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
Review spelling 

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
n/a

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
