### PR TITLE
fix(source-declarative-manifest): use absolute path to manifest.yaml

### DIFF
--- a/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: source
   definitionId: 64a2f99c-542f-4af8-9a6f-355f1217b436
   # This version should not be updated manually - it is updated by the CDK release workflow.
-  dockerImageTag: 4.4.2
+  dockerImageTag: 4.4.3
   dockerRepository: airbyte/source-declarative-manifest
   # This page is hidden from the docs for now, since the connector is not in any Airbyte registries.
   documentationUrl: https://docs.airbyte.com/integrations/sources/low-code

--- a/airbyte-integrations/connectors/source-declarative-manifest/pyproject.toml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.4.2"
+version = "4.4.3"
 name = "source-declarative-manifest"
 description = "Base source implementation for low-code sources."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-declarative-manifest/source_declarative_manifest/run.py
+++ b/airbyte-integrations/connectors/source-declarative-manifest/source_declarative_manifest/run.py
@@ -1,10 +1,13 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
+from __future__ import annotations
+
 import json
 import os
 import pkgutil
 import sys
+from pathlib import Path
 from typing import List
 
 from airbyte_cdk.connector import BaseConnector
@@ -36,7 +39,7 @@ class SourceLocalYaml(YamlDeclarativeSource):
 
 def _is_local_manifest_command(args: List[str]) -> bool:
     # Check for a local manifest.yaml file
-    return os.path.isfile("source_declarative_manifest/manifest.yaml")
+    return Path("/airbyte/integration_code/source_declarative_manifest/manifest.yaml").exists()
 
 
 def handle_command(args: List[str]) -> None:


### PR DESCRIPTION
## What

Fixes a problem where in K8s env manifest-only connectors would fail to start properly because `os.path.isfile` does not see the relative path to connector manifest. Using absolute path is a hotfix, we should figure out why the path would behave differently.

## Context

P0 internal Slack https://airbytehq-team.slack.com/archives/C07HAPHUKMY

## Caveats

Source declarative manifest is used in manifest-only connectors as base image, AND in custom builder connectors. Custom builder connectors come without the yaml file and use config manifest injection, so this change does not affect them, it's safe.