### PR TITLE
Source Monday: Add Boards name to `items` stream

### DIFF
--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 80a54ea2-9959-4040-aac1-eee42423ec9b
-  dockerImageTag: 2.1.3
+  dockerImageTag: 2.1.4
   releases:
     breakingChanges:
       2.0.0:

--- a/airbyte-integrations/connectors/source-monday/pyproject.toml
+++ b/airbyte-integrations/connectors/source-monday/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.1.3"
+version = "2.1.4"
 name = "source-monday"
 description = "Source implementation for Monday."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-monday/source_monday/schemas/items.json
+++ b/airbyte-integrations/connectors/source-monday/source_monday/schemas/items.json
@@ -31,7 +31,8 @@
     "board": {
       "type": ["null", "object"],
       "properties": {
-        "id": { "type": ["null", "string"] }
+        "id": { "type": ["null", "string"] },
+        "name": { "type": ["null", "string"] }
       }
     },
     "column_values": {

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -77,7 +77,7 @@ The Monday connector should not run into Monday API limitations under normal usa
 
 | Version | Date       | Pull Request                                              | Subject                                                                                           |
 | :------ | :--------- | :-------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
-| 2.1.4 | 2024-08-17 | [44200](https://github.com/airbytehq/airbyte/pull/44200) | Add boards name to the `items` stream |
+| 2.1.4 | 2024-08-17 | [44201](https://github.com/airbytehq/airbyte/pull/44201) | Add boards name to the `items` stream |
 | 2.1.3 | 2024-06-04 | [38958](https://github.com/airbytehq/airbyte/pull/38958) | [autopull] Upgrade base image to v1.2.1 |
 | 2.1.2 | 2024-04-30 | [37722](https://github.com/airbytehq/airbyte/pull/37722) | Fetch `display_value` field for column values of `Mirror`, `Dependency` and `Connect Board` types |
 | 2.1.1 | 2024-04-05 | [36717](https://github.com/airbytehq/airbyte/pull/36717) | Add handling of complexityBudgetExhausted error. |

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -77,6 +77,7 @@ The Monday connector should not run into Monday API limitations under normal usa
 
 | Version | Date       | Pull Request                                              | Subject                                                                                           |
 | :------ | :--------- | :-------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
+| 2.1.4 | 2024-08-17 | [44200](https://github.com/airbytehq/airbyte/pull/44200) | Add boards name to the `items` stream |
 | 2.1.3 | 2024-06-04 | [38958](https://github.com/airbytehq/airbyte/pull/38958) | [autopull] Upgrade base image to v1.2.1 |
 | 2.1.2 | 2024-04-30 | [37722](https://github.com/airbytehq/airbyte/pull/37722) | Fetch `display_value` field for column values of `Mirror`, `Dependency` and `Connect Board` types |
 | 2.1.1 | 2024-04-05 | [36717](https://github.com/airbytehq/airbyte/pull/36717) | Add handling of complexityBudgetExhausted error. |


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/44199

## How
Added name to the board's column in the `items` stream
The GraphQL query would automatically fetch the columns for retrieval

Ref documentation:
https://developer.monday.com/api-reference/reference/boards#fields

Board has field `name` - string
![image](https://github.com/user-attachments/assets/98e65ea5-8bbe-4f84-a8ee-2e198750925d)

