### PR TITLE
airbyte-ci: generate SBOM on publish

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -789,7 +789,8 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 ## Changelog
 
 | Version | PR                                                         | Description                                                                                                                  |
-|---------| ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
+| ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.33.0  | [#44377](https://github.com/airbytehq/airbyte/pull/44377)  | Upload connector SBOM to metadata service bucket on publish.                                                                 |
 | 4.32.5  | [#44173](https://github.com/airbytehq/airbyte/pull/44173)  | Bug fix for live tests' --should-read-with-state handling.                                                                   |
 | 4.32.4  | [#44025](https://github.com/airbytehq/airbyte/pull/44025)  | Ignore third party connectors on `publish`.                                                                                  |
 | 4.32.3  | [#44118](https://github.com/airbytehq/airbyte/pull/44118)  | Improve error handling in live tests.                                                                                        |

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.32.5"
+version = "4.33.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_publish.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_publish.py
@@ -155,6 +155,7 @@ STEPS_TO_PATCH = [
     (publish_pipeline, "PullConnectorImageFromRegistry"),
     (publish_pipeline.steps, "run_connector_build"),
     (publish_pipeline, "CheckPythonRegistryPackageDoesNotExist"),
+    (publish_pipeline, "UploadSbom"),
 ]
 
 
@@ -203,9 +204,11 @@ async def test_run_connector_publish_pipeline_when_image_exists_or_failed(mocker
     run_metadata_validation = publish_pipeline.MetadataValidation.return_value.run
     run_metadata_validation.return_value = mocker.Mock(status=StepStatus.SUCCESS)
 
-    # ensure spec always succeeds
+    # ensure spec and sbom upload always succeeds
     run_upload_spec_to_cache = publish_pipeline.UploadSpecToCache.return_value.run
     run_upload_spec_to_cache.return_value = mocker.Mock(status=StepStatus.SUCCESS)
+    run_upload_sbom = publish_pipeline.UploadSbom.return_value.run
+    run_upload_sbom.return_value = mocker.Mock(status=StepStatus.SUCCESS)
 
     run_check_connector_image_does_not_exist = publish_pipeline.CheckConnectorImageDoesNotExist.return_value.run
     run_check_connector_image_does_not_exist.return_value = mocker.Mock(status=check_image_exists_status)
@@ -219,7 +222,7 @@ async def test_run_connector_publish_pipeline_when_image_exists_or_failed(mocker
 
     # Check that nothing else is called
     for module, to_mock in STEPS_TO_PATCH:
-        if to_mock not in ["MetadataValidation", "MetadataUpload", "CheckConnectorImageDoesNotExist", "UploadSpecToCache"]:
+        if to_mock not in ["MetadataValidation", "MetadataUpload", "CheckConnectorImageDoesNotExist", "UploadSpecToCache", "UploadSbom"]:
             getattr(module, to_mock).return_value.run.assert_not_called()
 
     if check_image_exists_status is StepStatus.SKIPPED:
@@ -231,6 +234,7 @@ async def test_run_connector_publish_pipeline_when_image_exists_or_failed(mocker
                 run_metadata_validation.return_value,
                 run_check_connector_image_does_not_exist.return_value,
                 run_upload_spec_to_cache.return_value,
+                run_upload_sbom.return_value,
                 run_metadata_upload.return_value,
             ]
         )


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/8989
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/8990

We want to expose an url to our connector SBOM in our connector registry.
But we first have to generate them, and the publish is the right place as this can be considered as a connector release artifact.

## How
Update our publish pipeline to:
* Generate an SBOM from the published docker image, in SPDX JSON format using `syft`
* Upload the generated SBOM file to our metadata-service bucket

NB: If the connector was already published we still perform the SBOM generation/upload, this will allow a simple backfill for already published connector version.

## Example
I pre-released `source-faker` from this branch, it uploaded the following SBOM to our metadata service bucket (which has the `connectors.airbyte.com` CDN):

[https://connectors.airbyte.com/files/sbom/airbyte/source-faker/6.2.9-dev.e955ad82c7.spdx.json](https://connectors.airbyte.com/files/sbom/airbyte/source-faker/6.2.9-dev.e955ad82c7.spdx.json)

## User Impact
None, this should be transparent to developers.
