### PR TITLE
metadata-service[lib]: add sbom_url to generated registry fields

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
@@ -185,6 +185,7 @@ class GeneratedFields(BaseModel):
     git: Optional[GitInfo] = None
     source_file_info: Optional[SourceFileInfo] = None
     metrics: Optional[ConnectorMetrics] = None
+    sbomUrl: Optional[str] = Field(None, description="URL to the SBOM file")
 
 
 class ConnectorTestSuiteOptions(BaseModel):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryDestinationDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryDestinationDefinition.py
@@ -132,6 +132,7 @@ class GeneratedFields(BaseModel):
     git: Optional[GitInfo] = None
     source_file_info: Optional[SourceFileInfo] = None
     metrics: Optional[ConnectorMetrics] = None
+    sbomUrl: Optional[str] = Field(None, description="URL to the SBOM file")
 
 
 class ActorDefinitionResourceRequirements(BaseModel):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
@@ -128,6 +128,7 @@ class GeneratedFields(BaseModel):
     git: Optional[GitInfo] = None
     source_file_info: Optional[SourceFileInfo] = None
     metrics: Optional[ConnectorMetrics] = None
+    sbomUrl: Optional[str] = Field(None, description="URL to the SBOM file")
 
 
 class ActorDefinitionResourceRequirements(BaseModel):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
@@ -142,6 +142,7 @@ class GeneratedFields(BaseModel):
     git: Optional[GitInfo] = None
     source_file_info: Optional[SourceFileInfo] = None
     metrics: Optional[ConnectorMetrics] = None
+    sbomUrl: Optional[str] = Field(None, description="URL to the SBOM file")
 
 
 class ActorDefinitionResourceRequirements(BaseModel):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/GeneratedFields.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/GeneratedFields.py
@@ -47,3 +47,4 @@ class GeneratedFields(BaseModel):
     git: Optional[GitInfo] = None
     source_file_info: Optional[SourceFileInfo] = None
     metrics: Optional[ConnectorMetrics] = None
+    sbomUrl: Optional[str] = Field(None, description="URL to the SBOM file")

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/GeneratedFields.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/GeneratedFields.yaml
@@ -11,3 +11,6 @@ properties:
     "$ref": SourceFileInfo.yaml
   metrics:
     "$ref": ConnectorMetrics.yaml
+  sbomUrl:
+    type: string
+    description: URL to the SBOM file

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.10.1"
+version = "0.10.2"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
## What
We want to expose an optional `sbomUrl` generated field in our metadata and registry entries models.

## How
Update metadata service lib models with the new field.