### PR TITLE
metadata-service[orchestrator]: set SBOM url in registry

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.10.2"
+version = "0.10.3"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.2.4"
+version = "0.3.0"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -339,6 +339,28 @@ def test_erd_url():
     assert result["erdUrl"] == "https://an-erd.com"
 
 
+def test_sbom_url():
+    """
+    Test that if when defined in the metadata, the sbom url will be populated in the registry
+    """
+    mock_metadata_entry = mock.Mock()
+    mock_metadata_entry.metadata_definition.dict.return_value = {
+        "data": {
+            "connectorType": "source",
+            "definitionId": "test-id",
+            "registryOverrides": {"oss": {"enabled": True}},
+            "dockerRepository": "test-connector",
+            "dockerImageTag": "test-tag",
+            "generated": {"sbomUrl": "test-sbom-url"},
+        }
+    }
+    mock_metadata_entry.icon_url = "test-icon-url"
+    mock_metadata_entry.dependency_file_url = "test-dependency-file-url"
+
+    result = metadata_to_registry_entry(mock_metadata_entry, "oss")
+    assert result["generated"]["sbomUrl"] == "test-sbom-url"
+
+
 def test_support_level_default():
     """
     Test if supportLevel is defaulted to alpha in the registry entry.


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/8991
We want to populate the `generated` field of connector a registry entry with an URL to its SBOM.

## How
* Check if an SBOM is available at the expected URL with an `HEAD` request.
* Update the metadata `generated` fields with the `sbomUrl`.
