### PR TITLE
docs: add SBOM url to metadata state in connector documentation

### DIFF
--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -55,6 +55,7 @@ export default function ConnectorRegistry({ type }) {
             <th>OSS</th>
             <th>Cloud</th>
             <th>Docker Image</th>
+            <th>SBOM</th>
           </tr>
         </thead>
         <tbody>
@@ -97,6 +98,13 @@ export default function ConnectorRegistry({ type }) {
                       {connector.dockerRepository_oss}:
                       {connector.dockerImageTag_oss}
                     </code>
+                  </small>
+                </td>
+                <td>
+                  <small>
+                    {connector.generated_oss?.sbomUrl ? (
+                      <a target="_blank" href={connector.generated_oss.sbomUrl}>SPDX JSON</a>
+                    ) : "No SBOM"}
                   </small>
                 </td>
               </tr>

--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -236,6 +236,7 @@ const ConnectorMetadataCallout = ({
   syncSuccessRate,
   usageRate,
   lastUpdated,
+  sbomUrl,
 }) => (
   <Callout className={styles.connectorMetadataCallout}>
     <dl className={styles.connectorMetadata}>
@@ -281,6 +282,7 @@ const ConnectorMetadataCallout = ({
               lastUpdated
             ).fromNow()})`}</span>
           )}
+
         </MetadataStat>
       )}
       {cdkVersion && (
@@ -291,6 +293,13 @@ const ConnectorMetadataCallout = ({
           {isLatestCDK && (
             <span className={styles.deemphasizeText}>{"(Latest)"}</span>
           )}
+        </MetadataStat>
+      )}
+      {sbomUrl && (
+        <MetadataStat label="SBOM">
+          <a target="_blank" href={sbomUrl}>
+            SPDX JSON
+          </a>
         </MetadataStat>
       )}
       {syncSuccessRate && (
@@ -339,6 +348,7 @@ export const HeaderDecoration = ({
   syncSuccessRate,
   usageRate,
   lastUpdated,
+  sbomUrl,
 }) => {
   const isOss = boolStringToBool(isOssString);
   const isCloud = boolStringToBool(isCloudString);
@@ -369,6 +379,7 @@ export const HeaderDecoration = ({
         syncSuccessRate={syncSuccessRate}
         usageRate={usageRate}
         lastUpdated={lastUpdated}
+        sbomUrl={sbomUrl}
       />
     </>
   );

--- a/docusaurus/src/remark/docsHeaderDecoration.js
+++ b/docusaurus/src/remark/docsHeaderDecoration.js
@@ -48,6 +48,11 @@ const plugin = () => {
           "generated_[oss|cloud].source_file_info.metadata_last_modified"
         );
 
+        const sbomUrl = getFromPaths(
+          registryEntry,
+          "generated_[oss|cloud].sbomUrl"
+        )
+
         const { version, isLatest, url } = parseCDKVersion(
           rawCDKVersion,
           latestPythonCdkVersion
@@ -70,6 +75,7 @@ const plugin = () => {
           syncSuccessRate,
           usageRate,
           lastUpdated,
+          sbomUrl,
         };
 
         firstHeading = false;


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/44385

We want to expose the SBOM url in the connector documentation

## How
Pass the `sbomUrl` from the registry entry down to a metadata stat component

## Example
From the Vercel preview

<img width="992" alt="Screenshot 2024-08-20 at 10 37 36" src="https://github.com/user-attachments/assets/111c573b-2b2b-4139-8c73-479af728f516">
<img width="1002" alt="Screenshot 2024-08-20 at 10 58 36" src="https://github.com/user-attachments/assets/32b7e78d-5c53-43a4-a40a-23d6f0d4c656">
