### PR TITLE
bulk-cdk-toolkit-extract-jdbc: fix cursor-related bugs

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/fakesource/FakeSourceOperations.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/fakesource/FakeSourceOperations.kt
@@ -34,6 +34,7 @@ import io.airbyte.cdk.read.From
 import io.airbyte.cdk.read.FromNode
 import io.airbyte.cdk.read.FromSample
 import io.airbyte.cdk.read.Greater
+import io.airbyte.cdk.read.GreaterOrEqual
 import io.airbyte.cdk.read.Lesser
 import io.airbyte.cdk.read.LesserOrEqual
 import io.airbyte.cdk.read.Limit
@@ -148,6 +149,7 @@ class FakeSourceOperations : JdbcMetadataQuerier.FieldTypeMapper, SelectQueryGen
             is And -> conj.map { it.sql() }.joinToString(") AND (", "(", ")")
             is Or -> disj.map { it.sql() }.joinToString(") OR (", "(", ")")
             is Equal -> "${column.id} = ?"
+            is GreaterOrEqual -> "${column.id} >= ?"
             is Greater -> "${column.id} > ?"
             is LesserOrEqual -> "${column.id} <= ?"
             is Lesser -> "${column.id} < ?"

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StreamPartitionsCreatorUtilsTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StreamPartitionsCreatorUtilsTest.kt
@@ -147,6 +147,7 @@ class StreamPartitionsCreatorUtilsTest {
             StreamPartitionReader.CursorIncrementalInput(
                 cursor = k,
                 cursorLowerBound = Jsons.numberNode(1),
+                isLowerBoundIncluded = false,
                 cursorUpperBound = Jsons.numberNode(4),
             )
         val splits: List<Pair<List<JsonNode>?, List<JsonNode>?>> =

--- a/airbyte-cdk/bulk/core/extract/src/test/resources/fakesource/expected-messages-stream-warm-start.json
+++ b/airbyte-cdk/bulk/core/extract/src/test/resources/fakesource/expected-messages-stream-warm-start.json
@@ -28,6 +28,40 @@
     }
   },
   {
+    "type": "RECORD",
+    "record": {
+      "namespace": "PUBLIC",
+      "stream": "EVENTS",
+      "data": {
+        "ID": "3VWqE0Hrb7TV5BOEP2wN+g==",
+        "TS": "2024-04-30T00:00:00.000000-04:00",
+        "MSG": null
+      },
+      "emitted_at": 3133641600000
+    }
+  },
+  {
+    "type": "STATE",
+    "state": {
+      "type": "STREAM",
+      "stream": {
+        "stream_descriptor": {
+          "name": "EVENTS",
+          "namespace": "PUBLIC"
+        },
+        "stream_state": {
+          "primary_key": {},
+          "cursors": {
+            "TS": "2024-04-30T00:00:00.000000-04:00"
+          }
+        }
+      },
+      "sourceStats": {
+        "recordCount": 2.0
+      }
+    }
+  },
+  {
     "type": "TRACE",
     "trace": {
       "type": "STREAM_STATUS",

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerySpec.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerySpec.kt
@@ -26,7 +26,9 @@ sealed interface SelectNode {
 
 data class SelectColumns(
     override val columns: List<Field>,
-) : SelectNode
+) : SelectNode {
+    constructor(vararg columns: Field) : this(columns.toList())
+}
 
 data class SelectColumnMaxValue(
     val column: Field,
@@ -87,6 +89,11 @@ sealed interface WhereClauseLeafNode : WhereClauseNode {
     val bindingValue: JsonNode
 }
 
+data class GreaterOrEqual(
+    override val column: Field,
+    override val bindingValue: JsonNode,
+) : WhereClauseLeafNode
+
 data class Greater(
     override val column: Field,
     override val bindingValue: JsonNode,
@@ -97,12 +104,12 @@ data class LesserOrEqual(
     override val bindingValue: JsonNode,
 ) : WhereClauseLeafNode
 
-data class Equal(
+data class Lesser(
     override val column: Field,
     override val bindingValue: JsonNode,
 ) : WhereClauseLeafNode
 
-data class Lesser(
+data class Equal(
     override val column: Field,
     override val bindingValue: JsonNode,
 ) : WhereClauseLeafNode
@@ -111,7 +118,9 @@ sealed interface OrderByNode
 
 data class OrderBy(
     val columns: List<Field>,
-) : OrderByNode
+) : OrderByNode {
+    constructor(vararg columns: Field) : this(columns.toList())
+}
 
 data object NoOrderBy : OrderByNode
 

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/StreamPartitionsCreator.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/StreamPartitionsCreator.kt
@@ -95,6 +95,7 @@ class StreamPartitionsCreator(
                 StreamPartitionReader.CursorIncrementalInput(
                         cursor = cursor,
                         cursorLowerBound = cursorLowerBound,
+                        isLowerBoundIncluded = true,
                         cursorUpperBound = utils.computeCursorUpperBound(cursor) ?: return listOf(),
                     )
                     .split()
@@ -118,6 +119,7 @@ class StreamPartitionsCreator(
                 StreamPartitionReader.CursorIncrementalInput(
                         cursor = cursor,
                         cursorLowerBound = cursorLowerBound,
+                        isLowerBoundIncluded = true,
                         cursorUpperBound = cursorUpperBound,
                     )
                     .split()
@@ -137,8 +139,14 @@ class StreamPartitionsCreator(
 
     fun StreamPartitionReader.CursorIncrementalInput.split():
         List<StreamPartitionReader.CursorIncrementalInput> =
-        utils.split(this, listOf(cursorLowerBound), listOf(cursorUpperBound)).map { (lb, ub) ->
-            copy(cursorLowerBound = lb!!.first(), cursorUpperBound = ub!!.first())
+        utils.split(this, listOf(cursorLowerBound), listOf(cursorUpperBound)).mapIndexed {
+            idx: Int,
+            (lb, ub) ->
+            copy(
+                cursorLowerBound = lb!!.first(),
+                isLowerBoundIncluded = idx == 0,
+                cursorUpperBound = ub!!.first(),
+            )
         }
 
     private val utils = StreamPartitionsCreatorUtils(ctx, parameters)

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/StreamPartitionsCreatorUtils.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/StreamPartitionsCreatorUtils.kt
@@ -4,7 +4,6 @@ package io.airbyte.cdk.read
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
-import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.discover.Field
 import io.airbyte.cdk.util.Jsons
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -105,7 +104,9 @@ class StreamPartitionsCreatorUtils(
             ctx.selectQuerier.executeQuery(q).use { if (it.hasNext()) it.next() else return null }
         val value: JsonNode = record[cursor.id] ?: Jsons.nullNode()
         if (value.isNull) {
-            throw ConfigErrorException("NULL value found for cursor ${cursor.id}")
+            // Either the table is empty, or its cursor column values are all NULL.
+            // In both cases, there is nothing to be done.
+            return null
         }
         return ctx.transientCursorUpperBoundState.update { value }
     }


### PR DESCRIPTION
## What
This PR fixes a few bugs related to cursor-based incremental syncs:
1. The cursor's lower bound value needs to be included in the WHERE clause because the cursor column values may be not unique; right now we're facing data loss for example if the cursor column is of type `DATE DEFAULT NOW()` and rows get inserted after a daily sync but on the same day.
2. In source-oracle, empty tables incorrectly trigger a ConfigErrorException because SELECT MAX(...) will return NULL.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
Commit by commit.

## User Impact
None.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
