### PR TITLE
fix: allow review requirements check on forks

### DIFF
--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -76,6 +76,60 @@ jobs:
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           subcommand: "format check all"
           is_fork: "true"
+
+  check-review-requirements:
+    name: Check if a review is required from Connector teams on fork
+    if: github.event.pull_request.head.repo.fork == true
+    environment: community-ci-auto
+    runs-on: community-tooling-test-small
+    needs: fail_on_protected_path_changes
+    timeout-minutes: 10
+    env:
+      MAIN_BRANCH_NAME: "master"
+    permissions:
+      pull-requests: write
+    steps:
+      # This checkouts a fork which can contain untrusted code
+      # It's deemed safe as the review required check is not executing any checked out code
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      # This will sync the .github folder of the main repo with the fork
+      # This allows us to use up to date actions and CI logic from the main repo
+      - name: Pull .github folder from main repository
+        id: pull_github_folder
+        run: |
+          git remote add main https://github.com/airbytehq/airbyte.git
+          git fetch main ${MAIN_BRANCH_NAME}
+          git checkout main/${MAIN_BRANCH_NAME} -- .github
+          git checkout main/${MAIN_BRANCH_NAME} -- airbyte-ci
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install ci-connector-ops package
+        run: |
+          pip install pipx
+          pipx ensurepath
+          pipx install airbyte-ci/connectors/connector_ops
+      - name: Write review requirements file
+        id: write-review-requirements-file
+        run: write-review-requirements-file >> $GITHUB_OUTPUT
+      - name: Get mandatory reviewers
+        id: get-mandatory-reviewers
+        run: print-mandatory-reviewers >> $GITHUB_OUTPUT
+      - name: Check if the review requirements are met
+        if: steps.write-review-requirements-file.outputs.CREATED_REQUIREMENTS_FILE == 'true'
+        uses: Automattic/action-required-review@v3
+        with:
+          status: ${{ steps.get-mandatory-reviewers.outputs.MANDATORY_REVIEWERS  }}
+          token: ${{ secrets.OCTAVIA_4_ROOT_ACCESS }}
+          request-reviews: true
+          requirements-file: .github/connector_org_review_requirements.yaml
+
   connectors_early_ci:
     name: Run connectors early CI on fork
     if: github.event.pull_request.head.repo.fork == true

--- a/.github/workflows/connector_teams_review_requirements.yml
+++ b/.github/workflows/connector_teams_review_requirements.yml
@@ -19,7 +19,7 @@ jobs:
     name: "Check if a review is required from Connector teams"
     runs-on: ubuntu-latest
 
-    if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
@@ -45,6 +45,6 @@ jobs:
         uses: Automattic/action-required-review@v3
         with:
           status: ${{ steps.get-mandatory-reviewers.outputs.MANDATORY_REVIEWERS  }}
-          token: ${{ secrets.OCTAVIA_4_ROOT_ACCESS }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           request-reviews: true
           requirements-file: .github/connector_org_review_requirements.yaml

--- a/.github/workflows/connector_teams_review_requirements.yml
+++ b/.github/workflows/connector_teams_review_requirements.yml
@@ -19,7 +19,7 @@ jobs:
     name: "Check if a review is required from Connector teams"
     runs-on: ubuntu-latest
 
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.draft == false }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
@@ -45,6 +45,6 @@ jobs:
         uses: Automattic/action-required-review@v3
         with:
           status: ${{ steps.get-mandatory-reviewers.outputs.MANDATORY_REVIEWERS  }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.OCTAVIA_4_ROOT_ACCESS }}
           request-reviews: true
           requirements-file: .github/connector_org_review_requirements.yaml


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
[hopefully] fixes an issue where our contribution PRs are not getting auto-requested reviews as we expect: https://github.com/airbytehq/airbyte-internal-issues/issues/9305

## How
<!--
* Describe how code changes achieve the solution.
-->
* Allow running the workflow on forks
* Use GITHUB_TOKEN for this as user forks have access to this token and it has the permissions necessary to perform the check. Implementation suggested [here](https://github.com/airbytehq/airbyte/pull/36370#pullrequestreview-1954271172). Follow up note about the `get-user-teams-membership` action permissions is not relevant to this workflow/action.


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
