### PR TITLE
fix(connector-insights): ignore CI report if it does not exist

### DIFF
--- a/airbyte-ci/connectors/connectors_insights/README.md
+++ b/airbyte-ci/connectors/connectors_insights/README.md
@@ -56,6 +56,9 @@ This CLI is currently running nightly in GitHub Actions. The workflow can be fou
 
 ## Changelog
 
+### 0.3.2
+Bugfix: Ignore CI on master report if it's not accessible.
+
 ### 0.3.1
 Skip manifest inferred insights when the connector does not have a `manifest.yaml` file.
 

--- a/airbyte-ci/connectors/connectors_insights/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_insights/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-insights"
-version = "0.3.1"
+version = "0.3.2"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/hacks.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/hacks.py
@@ -56,10 +56,13 @@ def get_ci_on_master_report(connector: Connector) -> Dict | None:
             except (IndexError, KeyError, TypeError):
                 continue
             json_report_url = report_url.replace(".html", ".json")
-            # The first table entry is the latest report
-            json_report = get_ci_json_report(json_report_url)
-            if json_report["connector_version"] == connector.version:
-                return json_report
+            # The first table entry is the latest report, but sometimes it's not there questionmark
+            try:
+                json_report = get_ci_json_report(json_report_url)
+                if json_report["connector_version"] == connector.version:
+                    return json_report
+            except Exception as e:
+                continue
             return None
 
     return None

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/insights.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/insights.py
@@ -8,13 +8,12 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
-from typing_extensions import Mapping
-
 from connectors_insights.hacks import get_ci_on_master_report
 from connectors_insights.models import ConnectorInsights
 from connectors_insights.pylint import get_pylint_output
 from connectors_insights.result_backends import FileToPersist, ResultBackend
 from connectors_insights.sbom import get_json_sbom
+from typing_extensions import Mapping
 
 if TYPE_CHECKING:
     from typing import Dict, List, Tuple

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/insights.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/insights.py
@@ -8,12 +8,13 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
+from typing_extensions import Mapping
+
 from connectors_insights.hacks import get_ci_on_master_report
 from connectors_insights.models import ConnectorInsights
 from connectors_insights.pylint import get_pylint_output
 from connectors_insights.result_backends import FileToPersist, ResultBackend
 from connectors_insights.sbom import get_json_sbom
-from typing_extensions import Mapping
 
 if TYPE_CHECKING:
     from typing import Dict, List, Tuple


### PR DESCRIPTION
## What

Fixes a bug in connector insights not generating for a bunch of connectors when the CI report for their test run does not exist: https://github.com/airbytehq/airbyte/actions/workflows/connectors_insights.yml

Not that we assumed those JSON reports are there, but for some reason they are not. I'm not sure if it's a bug and the report path assumed previous version of the connector, or if we stopped putting the reports there.

## How

Wrapped accessing the report in a try-catch block. This is a band-aid, and a better fix would be preferred.

@alafanechere would have to remove SBOM generation from connector-insights anyway, so perhaps it's worth making a better fix? 

## User Impact
None.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
