### PR TITLE
extract-jdbc: cursor incremental query includes lb

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StreamPartitionsCreatorUtilsTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StreamPartitionsCreatorUtilsTest.kt
@@ -147,6 +147,7 @@ class StreamPartitionsCreatorUtilsTest {
             StreamPartitionReader.CursorIncrementalInput(
                 cursor = k,
                 cursorLowerBound = Jsons.numberNode(1),
+                isLowerBoundIncluded = false,
                 cursorUpperBound = Jsons.numberNode(4),
             )
         val splits: List<Pair<List<JsonNode>?, List<JsonNode>?>> =

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/StreamPartitionsCreator.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/StreamPartitionsCreator.kt
@@ -95,6 +95,7 @@ class StreamPartitionsCreator(
                 StreamPartitionReader.CursorIncrementalInput(
                         cursor = cursor,
                         cursorLowerBound = cursorLowerBound,
+                        isLowerBoundIncluded = true,
                         cursorUpperBound = utils.computeCursorUpperBound(cursor) ?: return listOf(),
                     )
                     .split()
@@ -118,6 +119,7 @@ class StreamPartitionsCreator(
                 StreamPartitionReader.CursorIncrementalInput(
                         cursor = cursor,
                         cursorLowerBound = cursorLowerBound,
+                        isLowerBoundIncluded = true,
                         cursorUpperBound = cursorUpperBound,
                     )
                     .split()
@@ -137,8 +139,14 @@ class StreamPartitionsCreator(
 
     fun StreamPartitionReader.CursorIncrementalInput.split():
         List<StreamPartitionReader.CursorIncrementalInput> =
-        utils.split(this, listOf(cursorLowerBound), listOf(cursorUpperBound)).map { (lb, ub) ->
-            copy(cursorLowerBound = lb!!.first(), cursorUpperBound = ub!!.first())
+        utils.split(this, listOf(cursorLowerBound), listOf(cursorUpperBound)).mapIndexed {
+            idx: Int,
+            (lb, ub) ->
+            copy(
+                cursorLowerBound = lb!!.first(),
+                isLowerBoundIncluded = idx == 0,
+                cursorUpperBound = ub!!.first(),
+            )
         }
 
     private val utils = StreamPartitionsCreatorUtils(ctx, parameters)


### PR DESCRIPTION
Uses the previously-introduced `GreaterOrEqual` to fix cursor-based incremental sync queries.

The cursor's lower bound value needs to be included in the WHERE clause because the cursor column values may be not unique; right now we're facing data loss for example if the cursor column is of type DATE DEFAULT NOW() and rows get inserted after a daily sync but on the same day.