### PR TITLE
extract-jdbc: better handling of NULL cursor values

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/StreamPartitionsCreatorUtils.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/StreamPartitionsCreatorUtils.kt
@@ -4,7 +4,6 @@ package io.airbyte.cdk.read
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
-import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.discover.Field
 import io.airbyte.cdk.util.Jsons
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -105,7 +104,9 @@ class StreamPartitionsCreatorUtils(
             ctx.selectQuerier.executeQuery(q).use { if (it.hasNext()) it.next() else return null }
         val value: JsonNode = record[cursor.id] ?: Jsons.nullNode()
         if (value.isNull) {
-            throw ConfigErrorException("NULL value found for cursor ${cursor.id}")
+            // Either the table is empty, or its cursor column values are all NULL.
+            // In both cases, there is nothing to be done.
+            return null
         }
         return ctx.transientCursorUpperBoundState.update { value }
     }


### PR DESCRIPTION
In source-oracle, empty tables incorrectly trigger a ConfigErrorException because SELECT MAX(...) will return NULL even when the table is empty.
