### PR TITLE
extract-jdbc: rename PartitionsCreator and PartitionReader impls

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/fakesource/FakeSourcePartitionsCreatorFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/fakesource/FakeSourcePartitionsCreatorFactory.kt
@@ -5,13 +5,13 @@ import io.airbyte.cdk.command.OpaqueStateValue
 import io.airbyte.cdk.read.CreateNoPartitions
 import io.airbyte.cdk.read.Feed
 import io.airbyte.cdk.read.Global
+import io.airbyte.cdk.read.JdbcSequentialPartitionsCreator
 import io.airbyte.cdk.read.JdbcStreamState
 import io.airbyte.cdk.read.PartitionsCreator
 import io.airbyte.cdk.read.PartitionsCreatorFactory
 import io.airbyte.cdk.read.StateQuerier
 import io.airbyte.cdk.read.Stream
 import io.airbyte.cdk.read.StreamReadContextManager
-import io.airbyte.cdk.read.StreamSequentialPartitionsCreator
 import io.airbyte.cdk.read.streamPartitionsCreatorInput
 import jakarta.inject.Singleton
 
@@ -28,7 +28,7 @@ class FakeSourcePartitionsCreatorFactory(
             is Global -> CreateNoPartitions
             is Stream -> {
                 val streamState: JdbcStreamState<*> = streamReadContextManager[feed]
-                StreamSequentialPartitionsCreator(
+                JdbcSequentialPartitionsCreator(
                     streamReadContextManager.selectQueryGenerator,
                     streamState,
                     opaqueStateValue.streamPartitionsCreatorInput(

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/DefaultJdbcSharedState.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/DefaultJdbcSharedState.kt
@@ -67,16 +67,16 @@ class DefaultJdbcSharedState(
 
     internal val semaphore = Semaphore(configuration.maxConcurrency)
 
-    override fun tryAcquireResourcesForCreator(): StreamPartitionsCreator.AcquiredResources? =
+    override fun tryAcquireResourcesForCreator(): JdbcPartitionsCreator.AcquiredResources? =
         if (semaphore.tryAcquire()) {
-            StreamPartitionsCreator.AcquiredResources { semaphore.release() }
+            JdbcPartitionsCreator.AcquiredResources { semaphore.release() }
         } else {
             null
         }
 
-    override fun tryAcquireResourcesForReader(): StreamPartitionReader.AcquiredResources? =
+    override fun tryAcquireResourcesForReader(): JdbcPartitionReader.AcquiredResources? =
         if (semaphore.tryAcquire()) {
-            StreamPartitionReader.AcquiredResources { semaphore.release() }
+            JdbcPartitionReader.AcquiredResources { semaphore.release() }
         } else {
             null
         }

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/JdbcSharedState.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/JdbcSharedState.kt
@@ -52,8 +52,8 @@ interface JdbcSharedState {
     }
 
     /** Tries to acquire global resources for [JdbcPartitionsCreator]. */
-    fun tryAcquireResourcesForCreator(): StreamPartitionsCreator.AcquiredResources?
+    fun tryAcquireResourcesForCreator(): JdbcPartitionsCreator.AcquiredResources?
 
     /** Tries to acquire global resources for [JdbcPartitionReader]. */
-    fun tryAcquireResourcesForReader(): StreamPartitionReader.AcquiredResources?
+    fun tryAcquireResourcesForReader(): JdbcPartitionReader.AcquiredResources?
 }


### PR DESCRIPTION
Replaces https://github.com/airbytehq/airbyte/pull/44398 (in part)

This is a purely mechanical change that renames `StreamPartitionsCreator` into `JdbcPartitionsCreator` and `StreamPartitionReader` into `JdbcPartitionReader`. This makes the next PR's diff easier to read.