### PR TITLE
Destination milvus: Set support level to 300

### DIFF
--- a/airbyte-integrations/connectors/destination-milvus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-milvus/metadata.yaml
@@ -35,7 +35,7 @@ data:
     - language:python
     - cdk:python
   ab_internal:
-    sl: 200
+    sl: 300
     ql: 300
   supportLevel: certified
   connectorTestSuitesOptions:


### PR DESCRIPTION
## What
Setting support level to 300 so alerts get routed to the python team

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
