### PR TITLE
Destination pinecode: Set support level to 300

### DIFF
--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   ab_internal:
     ql: 300
-    sl: 200
+    sl: 300
   allowedHosts:
     hosts:
       - "*.${indexing.pinecone_environment}.pinecone.io"


### PR DESCRIPTION
## What
Set support level to 300 so alerts are routed to the Python team

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
