### PR TITLE
Destination weaviate: set support level to 300

### DIFF
--- a/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-weaviate/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   ab_internal:
     ql: 300
-    sl: 200
+    sl: 300
   allowedHosts:
     hosts:
       - ${indexing.host}


### PR DESCRIPTION
## What
Set support level to 300 so alerts are routed to the Python team

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
