### PR TITLE
gradle: fix annoying ksp error, bump CDK dependencies

### DIFF
--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -12,26 +12,26 @@ allprojects {
     }
 
     dependencies {
-        api platform('org.jetbrains.kotlin:kotlin-bom:2.0.0')
+        api platform('org.jetbrains.kotlin:kotlin-bom:2.0.10')
         api platform('org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1')
-        api platform('com.fasterxml.jackson:jackson-bom:2.16.1')
-        api platform('io.micronaut:micronaut-core-bom:4.3.13')
+        api platform('com.fasterxml.jackson:jackson-bom:2.17.2')
+        api platform('io.micronaut:micronaut-core-bom:4.6.1')
         api platform('org.junit:junit-bom:5.10.2')
         api platform('org.slf4j:slf4j-bom:2.0.13')
         api platform('org.apache.logging.log4j:log4j-bom:2.21.1')
-        api platform('org.testcontainers:testcontainers-bom:1.19.8')
+        api platform('org.testcontainers:testcontainers-bom:1.20.1')
 
         api 'org.jetbrains.kotlin:kotlin-stdlib'
-        api 'com.google.dagger:dagger-compiler:2.51.1'
-        ksp 'com.google.dagger:dagger-compiler:2.51.1'
+        api 'com.google.dagger:dagger:2.51.1'
+        ksp 'com.google.dagger:dagger-compiler:2.52'
 
-        annotationProcessor platform('io.micronaut:micronaut-core-bom:4.3.13')
-        annotationProcessor 'info.picocli:picocli-codegen:4.7.5'
+        annotationProcessor platform('io.micronaut:micronaut-core-bom:4.6.1')
+        annotationProcessor 'info.picocli:picocli-codegen:4.7.6'
         annotationProcessor 'io.micronaut:micronaut-inject-kotlin'
 
-        ksp platform('io.micronaut:micronaut-core-bom:4.3.13')
+        ksp platform('io.micronaut:micronaut-core-bom:4.6.1')
         ksp 'io.micronaut:micronaut-inject-kotlin'
-        kspTest platform('io.micronaut:micronaut-core-bom:4.3.13')
+        kspTest platform('io.micronaut:micronaut-core-bom:4.6.1')
         kspTest 'io.micronaut:micronaut-inject-kotlin'
     }
 

--- a/airbyte-cdk/bulk/core/base/build.gradle
+++ b/airbyte-cdk/bulk/core/base/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-afterburner'
     implementation 'com.networknt:json-schema-validator:1.4.0'
     implementation 'info.picocli:picocli:4.7.6'
-    implementation 'io.micronaut.picocli:micronaut-picocli:5.2.0'
+    implementation 'io.micronaut.picocli:micronaut-picocli:5.5.0'
     implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
     implementation 'org.apache.commons:commons-lang3:3.14.0'
     implementation 'org.apache.logging.log4j:log4j-api'
@@ -32,9 +32,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
     implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
     implementation 'org.apache.logging.log4j:log4j-layout-template-json:2.17.2'
-    implementation 'org.bouncycastle:bcpkix-jdk18on:1.77'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
-    implementation 'org.bouncycastle:bctls-jdk18on:1.77'
 
     runtimeOnly 'com.google.guava:guava:33.2.0-jre'
     runtimeOnly 'org.apache.commons:commons-compress:1.26.1'
@@ -47,8 +45,8 @@ dependencies {
     testFixturesApi('org.testcontainers:testcontainers') {
         exclude group: 'org.apache.commons', module: 'commons-compress'
     }
-    testFixturesApi 'io.micronaut.test:micronaut-test-core:4.2.1'
-    testFixturesApi 'io.micronaut.test:micronaut-test-junit5:4.2.1'
+    testFixturesApi 'io.micronaut.test:micronaut-test-core:4.5.0'
+    testFixturesApi 'io.micronaut.test:micronaut-test-junit5:4.5.0'
     testFixturesApi 'com.h2database:h2:2.2.224'
     testFixturesApi 'io.github.deblockt:json-diff:1.0.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     id 'base'
-    id 'com.github.spotbugs' version '6.0.7' apply false
-    id 'org.jetbrains.kotlin.jvm' version '2.0.0' apply false
-    id 'com.google.devtools.ksp' version '2.0.0-1.0.24' apply false
+    id 'com.github.spotbugs' version '6.0.7'
+    id 'org.jetbrains.kotlin.jvm' version '2.0.0'
+    id 'com.google.devtools.ksp' version '2.0.0-1.0.24'
 }
 
 allprojects {
@@ -103,6 +103,12 @@ allprojects {
         }
         dependsOn {
             tasks.matching { it.name == 'generate' }
+        }
+    }
+
+    configurations.all {
+        resolutionStrategy {
+            preferProjectModules()
         }
     }
 


### PR DESCRIPTION
Presently, gradle barfs exception stack traces when building the Bulk CDK. This is due to problems resolving dependency conflicts in the ksp annotation processor classpath. This is just a code generator so these errors turn out to be just noise. This PR fixes this.

Since we're already messing with dependencies, this PR also bumps dependency versions in the Bulk CDK.
