### PR TITLE
[source-mongodb-v2] Adding permission check on oplog.rs needed by CDC

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
-  dockerImageTag: 1.5.3
+  dockerImageTag: 1.5.4
   dockerRepository: airbyte/source-mongodb-v2
   documentationUrl: https://docs.airbyte.com/integrations/sources/mongodb-v2
   githubIssueLabel: source-mongodb-v2

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSource.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSource.java
@@ -11,6 +11,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoSecurityException;
 import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoDatabase;
 import com.mongodb.connection.ClusterType;
 import io.airbyte.cdk.integrations.BaseConnector;
 import io.airbyte.cdk.integrations.base.AirbyteExceptionHandler;
@@ -59,8 +60,13 @@ public class MongoDbSource extends BaseConnector implements Source {
     try {
       final MongoDbSourceConfig sourceConfig = new MongoDbSourceConfig(config);
       try (final MongoClient mongoClient = createMongoClient(sourceConfig)) {
-        final String databaseName = sourceConfig.getDatabaseName();
+        if (!checkOplogReadAccess(mongoClient)) {
+          return new AirbyteConnectionStatus()
+                  .withMessage("User does not have read access to the oplog.rs collection in database local, which is required by CDC.")
+                  .withStatus(AirbyteConnectionStatus.Status.FAILED);
+        }
 
+        final String databaseName = sourceConfig.getDatabaseName();
         if (MongoUtil.checkDatabaseExists(mongoClient, databaseName)) {
           /*
            * Perform the authorized collections check before the cluster type check. The MongoDB Java driver
@@ -168,6 +174,21 @@ public class MongoDbSource extends BaseConnector implements Source {
 
   protected MongoClient createMongoClient(final MongoDbSourceConfig config) {
     return MongoConnectionUtils.createMongoClient(config);
+  }
+
+  protected boolean checkOplogReadAccess(final MongoClient mongoClient) {
+    try {
+      MongoDatabase localDb = mongoClient.getDatabase("local");
+      localDb.getCollection("oplog.rs").find().first();
+      LOGGER.info("User has read access to the oplog.rs collection.");
+      return true;
+    } catch (MongoCommandException | MongoSecurityException e) {
+      LOGGER.error("User does not have read access to the oplog.rs collection.", e);
+      return false;
+    } catch (Exception e) {
+      LOGGER.error("An error occurred while checking read access to the oplog.rs collection.", e);
+      return false;
+    }
   }
 
   List<AutoCloseableIterator<AirbyteMessage>> createFullRefreshIterators(final MongoDbSourceConfig sourceConfig,

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSource.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSource.java
@@ -62,8 +62,8 @@ public class MongoDbSource extends BaseConnector implements Source {
       try (final MongoClient mongoClient = createMongoClient(sourceConfig)) {
         if (!checkOplogReadAccess(mongoClient)) {
           return new AirbyteConnectionStatus()
-                  .withMessage("User does not have read access to the oplog.rs collection in database local, which is required by CDC.")
-                  .withStatus(AirbyteConnectionStatus.Status.FAILED);
+              .withMessage("User does not have read access to the oplog.rs collection in database local, which is required by CDC.")
+              .withStatus(AirbyteConnectionStatus.Status.FAILED);
         }
 
         final String databaseName = sourceConfig.getDatabaseName();

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoDbSourceTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoDbSourceTest.java
@@ -71,6 +71,7 @@ class MongoDbSourceTest {
     when(mongoDatabase.runCommand(any())).thenReturn(response);
     when(mongoClient.getDatabase(any())).thenReturn(mongoDatabase);
     when(mongoClient.getClusterDescription()).thenReturn(clusterDescription);
+    when(source.checkOplogReadAccess(mongoClient)).thenReturn(true);
 
     final AirbyteConnectionStatus airbyteConnectionStatus = source.check(airbyteSourceConfig);
     assertNotNull(airbyteConnectionStatus);
@@ -125,6 +126,7 @@ class MongoDbSourceTest {
     when(mongoDatabase.runCommand(any())).thenReturn(response);
     when(mongoClient.getDatabase(any())).thenReturn(mongoDatabase);
     when(mongoClient.getClusterDescription()).thenReturn(clusterDescription);
+    when(source.checkOplogReadAccess(mongoClient)).thenReturn(true);
 
     final AirbyteConnectionStatus airbyteConnectionStatus = source.check(airbyteSourceConfig);
     assertNotNull(airbyteConnectionStatus);
@@ -142,6 +144,7 @@ class MongoDbSourceTest {
     when(mongoDatabase.runCommand(any())).thenReturn(response);
     when(mongoClient.getDatabase(any())).thenReturn(mongoDatabase);
     when(mongoClient.getClusterDescription()).thenReturn(clusterDescription);
+    when(source.checkOplogReadAccess(mongoClient)).thenReturn(true);
 
     final AirbyteConnectionStatus airbyteConnectionStatus = source.check(airbyteSourceConfig);
     assertNotNull(airbyteConnectionStatus);
@@ -167,6 +170,7 @@ class MongoDbSourceTest {
   void testCheckOperationUnexpectedException() {
     final String expectedMessage = "This is just a test failure.";
     when(mongoClient.getDatabase(any())).thenThrow(new IllegalArgumentException(expectedMessage));
+    when(source.checkOplogReadAccess(mongoClient)).thenReturn(true);
 
     final AirbyteConnectionStatus airbyteConnectionStatus = source.check(airbyteSourceConfig);
     assertNotNull(airbyteConnectionStatus);

--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -198,10 +198,11 @@ For more information regarding configuration parameters, please see [MongoDb Doc
   <summary>Expand to review</summary>
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                   |
-|:--------| :--------- | :------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------- |
-| 1.5.3   | 2024-08-08 | [43410](https://github.com/airbytehq/airbyte/pull/43410)   | Adopt latest CDK.                                                                                                                                          |
-| 1.5.2   | 2024-08-06 | [42869](https://github.com/airbytehq/airbyte/pull/42869)   | Adopt latest CDK.                                                                                                                                          |
-| 1.5.1   | 2024-08-01 | [42549](https://github.com/airbytehq/airbyte/pull/42549) | Centered the connector icon.                                                     |
+|:--------| :--------- | :------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------|
+| 1.5.4   |  2024-08-20 | [44490](https://github.com/airbytehq/airbyte/pull/44490) | Add read permission check on oplog.rs collection used by CDC.                                             | 
+| 1.5.3   | 2024-08-08 | [43410](https://github.com/airbytehq/airbyte/pull/43410)   | Adopt latest CDK.                                                                                         |
+| 1.5.2   | 2024-08-06 | [42869](https://github.com/airbytehq/airbyte/pull/42869)   | Adopt latest CDK.                                                                                         |
+| 1.5.1   | 2024-08-01 | [42549](https://github.com/airbytehq/airbyte/pull/42549) | Centered the connector icon.                                                                              |
 | 1.5.0   | 2024-07-26 | [42561](https://github.com/airbytehq/airbyte/pull/42561)  | Implement WASS algorithm.                                                                                 |
 | 1.4.3   | 2024-07-22 | [39145](https://github.com/airbytehq/airbyte/pull/39145) | Warn (vs fail) on different \_id types in collection.                                                     |
 | 1.4.2   | 2024-07-01 | [40516](https://github.com/airbytehq/airbyte/pull/40516) | Remove dbz hearbeat.                                                                                      |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Fixes https://github.com/airbytehq/airbyte/issues/44477

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

The user will not be able to set up the connector if his/her airbyte user does not have read access to the oplog.rs collection.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
