### PR TITLE
source-google-analytics-v4-service-account-only: re-deprecate

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4-service-account-only/metadata.yaml
@@ -9,11 +9,11 @@ data:
       - analyticsdata.googleapis.com
       - analyticsreporting.googleapis.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
+    baseImage: docker.io/airbyte/python-connector-base:1.2.0@sha256:c22a9d97464b69d6ef01898edf3f8612dc11614f05a84984451dde195f337db9
   connectorSubtype: api
   connectorType: source
   definitionId: 9e28a926-8f3c-4911-982d-a2e1c378b59c
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.0
   dockerRepository: airbyte/source-google-analytics-v4-service-account-only
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-v4-service-account-only
   githubIssueLabel: source-google-analytics-v4-service-account-only

--- a/docs/integrations/sources/google-analytics-v4-service-account-only.md
+++ b/docs/integrations/sources/google-analytics-v4-service-account-only.md
@@ -274,8 +274,7 @@ The Google Analytics connector should not run into the "requests per 100 seconds
 
 | Version | Date       | Pull Request                                             | Subject                                  |
 |:--------|:-----------| :------------------------------------------------------- |:-----------------------------------------|
-| 0.1.1 | 2024-08-12 | [43930](https://github.com/airbytehq/airbyte/pull/43930) | Update dependencies |
-| 0.1.0 | 2024-07-01 | [40244](https://github.com/airbytehq/airbyte/pull/40244) | Deprecate the connector |
+| 0.1.0   | 2024-07-01 | [40244](https://github.com/airbytehq/airbyte/pull/40244) | Deprecate the connector                  |
 | 0.0.2   | 2024-04-19 | [37432](https://github.com/airbytehq/airbyte/pull/36267) | Fix empty response error for test stream |
 | 0.0.1   | 2024-01-29 | [34323](https://github.com/airbytehq/airbyte/pull/34323) | Initial Release                          |
 


### PR DESCRIPTION
## What
Our `up-to-date` pipeline abusively updated an archived connectors.
Archived connectors do not get published so this change had no effect.
As this connector is archived it should not receive additional updates.

Changes to the `up-to-date` flow to ignore archived connectors have been shipped since then.

We should just revert the latest update of this connector as it was not released.
