### PR TITLE
docs: Add ERDs to connector docs

### DIFF
--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -146,6 +146,10 @@ The Amazon Seller Partner source connector supports the following [sync modes](h
 - [Vendor Traffic Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(only available in OSS, incremental\)
 <!-- /env:oss -->
 
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships)
+
 ## Report options
 
 Report options can be assigned on a per-stream basis that alter the behavior when generating a report.

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -146,9 +146,11 @@ The Amazon Seller Partner source connector supports the following [sync modes](h
 - [Vendor Traffic Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(only available in OSS, incremental\)
 <!-- /env:oss -->
 
+<HideInUI>
 ### Entity-Relationship Diagram (ERD)
 To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships)
+</HideInUI>
 
 ## Report options
 

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -210,9 +210,13 @@ Account Impression Performance Report: composite pk - [AccountName, AccountNumbe
 
 Note: These are just examples, and you should consider your own data and needs in order to correctly define the primary key.
 
-See more info about user-defined pk [here](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped#user-defined-primary-key).
+See more info about user-defined primary key [here](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append-deduped#user-defined-primary-key).
 
 :::
+
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-bing-ads?view=relationships)
 
 ### Custom Reports
 

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -214,9 +214,11 @@ See more info about user-defined primary key [here](https://docs.airbyte.com/und
 
 :::
 
+<HideInUI>
 ### Entity-Relationship Diagram (ERD)
 To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-bing-ads?view=relationships)
+</HideInUI>
 
 ### Custom Reports
 

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -189,9 +189,11 @@ You can segment the Ad Insights table into parts based on the following informat
 
 For more information, see the [Facebook Insights API documentation.](https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/)
 
+<HideInUI>
 ### Entity-Relationship Diagram (ERD)
 To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
+</HideInUI>
 
 <!-- Christo: the note below was commented out as its accuracy could not be verified. If it can be verified and clarified for users, it should be added back in.
 

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -189,7 +189,7 @@ You can segment the Ad Insights table into parts based on the following informat
 
 For more information, see the [Facebook Insights API documentation.](https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/)
 
-[![Alt Text](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21])]([Link URL](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships))
+[![Image](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://www.google.com)
 
 ![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)[(Diagram)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -191,7 +191,7 @@ For more information, see the [Facebook Insights API documentation.](https://dev
 
 ![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)[(Diagram)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
-[<img src="https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21">](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
+![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)(Diagram)(https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
 <!-- Christo: the note below was commented out as its accuracy could not be verified. If it can be verified and clarified for users, it should be added back in.
 

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -189,6 +189,8 @@ You can segment the Ad Insights table into parts based on the following informat
 
 For more information, see the [Facebook Insights API documentation.](https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/)
 
+[![Alt Text](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21])]([Link URL](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships))
+
 ![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)[(Diagram)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
 ![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)(Diagram)(https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -193,6 +193,10 @@ For more information, see the [Facebook Insights API documentation.](https://dev
 
 ![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)(Diagram)(https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
+<a href=“https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships”>
+<img src="https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21" alt="ERD" />
+</a>
+
 <!-- Christo: the note below was commented out as its accuracy could not be verified. If it can be verified and clarified for users, it should be added back in.
 
 :::note

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -191,7 +191,7 @@ For more information, see the [Facebook Insights API documentation.](https://dev
 
 ![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)[(Diagram)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
-![image search api](https://user-images.githubusercontent.com/110724391/184472398-c590b47c-e1f2-41f8-87e6-2a1f68e8850d.png)[(Youtube)](https://www.youtube.com/watch?v=3HIr0imLgxM)
+[<img src="https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21">](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
 <!-- Christo: the note below was commented out as its accuracy could not be verified. If it can be verified and clarified for users, it should be added back in.
 

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -189,8 +189,11 @@ You can segment the Ad Insights table into parts based on the following informat
 
 For more information, see the [Facebook Insights API documentation.](https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/)
 
-[![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)]([link to your URL](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships))
+![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
+![image search api](https://user-images.githubusercontent.com/110724391/184472398-c590b47c-e1f2-41f8-87e6-2a1f68e8850d.png)[(Youtube)](https://www.youtube.com/watch?v=3HIr0imLgxM)
+
+[<img src="https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21">](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 <!-- Christo: the note below was commented out as its accuracy could not be verified. If it can be verified and clarified for users, it should be added back in.
 
 :::note

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -189,6 +189,8 @@ You can segment the Ad Insights table into parts based on the following informat
 
 For more information, see the [Facebook Insights API documentation.](https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/)
 
+[![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)]([link to your URL](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships))
+
 <!-- Christo: the note below was commented out as its accuracy could not be verified. If it can be verified and clarified for users, it should be added back in.
 
 :::note

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -189,11 +189,10 @@ You can segment the Ad Insights table into parts based on the following informat
 
 For more information, see the [Facebook Insights API documentation.](https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/)
 
-![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
+![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)[(Diagram)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
 ![image search api](https://user-images.githubusercontent.com/110724391/184472398-c590b47c-e1f2-41f8-87e6-2a1f68e8850d.png)[(Youtube)](https://www.youtube.com/watch?v=3HIr0imLgxM)
 
-[<img src="https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21">](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 <!-- Christo: the note below was commented out as its accuracy could not be verified. If it can be verified and clarified for users, it should be added back in.
 
 :::note

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -189,11 +189,7 @@ You can segment the Ad Insights table into parts based on the following informat
 
 For more information, see the [Facebook Insights API documentation.](https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/)
 
-[![Image](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://www.google.com)
-
-![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)[(Diagram)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
-
-![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)(Diagram)(https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
 <!-- Christo: the note below was commented out as its accuracy could not be verified. If it can be verified and clarified for users, it should be added back in.
 

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -189,6 +189,8 @@ You can segment the Ad Insights table into parts based on the following informat
 
 For more information, see the [Facebook Insights API documentation.](https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/)
 
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
 <!-- Christo: the note below was commented out as its accuracy could not be verified. If it can be verified and clarified for users, it should be added back in.

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -195,10 +195,6 @@ For more information, see the [Facebook Insights API documentation.](https://dev
 
 ![Entity Relationship Diagram](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)(Diagram)(https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships)
 
-<a href=“https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships”>
-<img src="https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21" alt="ERD" />
-</a>
-
 <!-- Christo: the note below was commented out as its accuracy could not be verified. If it can be verified and clarified for users, it should be added back in.
 
 :::note

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -138,6 +138,10 @@ This connector outputs the following incremental streams:
 - [WorkflowRuns](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository)
 - [Workflows](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#list-repository-workflows)
 
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-github?view=relationships)
+
 ### Notes
 
 1. Only 4 streams \(`comments`, `commits`, `issues` and `review comments`\) from the listed above streams are pure incremental meaning that they:

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -138,9 +138,11 @@ This connector outputs the following incremental streams:
 - [WorkflowRuns](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository)
 - [Workflows](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#list-repository-workflows)
 
+<HideInUI>
 ### Entity-Relationship Diagram (ERD)
 To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-github?view=relationships)
+</HideInUI>
 
 ### Notes
 

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -247,10 +247,6 @@ For incremental streams, data is synced up to the previous day using your Google
 
 Primary keys are chosen to uniquely identify records within streams. In this selection, we considered the scope of ID uniqueness as detailed in [the Google Ads API structure documentation](https://developers.google.com/google-ads/api/docs/concepts/api-structure#object_ids). This approach guarantees that each record remains unique across various scopes and contexts. Moreover, in the Google Ads API, segmentation is crucial for dissecting performance data. As pointed out in [the Google Ads support documentation](https://developers.google.com/google-ads/api/docs/reporting/segmentation), segments offer a granular insight into data based on specific criteria, like device type or click interactions.
 
-### Entity-Relationship Diagram (ERD)
-To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
-[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-google-ads?view=relationships)
-
 ## Custom Query: Understanding Google Ads Query Language
 
 Additional streams for Google Ads can be dynamically created using custom queries.

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -247,6 +247,10 @@ For incremental streams, data is synced up to the previous day using your Google
 
 Primary keys are chosen to uniquely identify records within streams. In this selection, we considered the scope of ID uniqueness as detailed in [the Google Ads API structure documentation](https://developers.google.com/google-ads/api/docs/concepts/api-structure#object_ids). This approach guarantees that each record remains unique across various scopes and contexts. Moreover, in the Google Ads API, segmentation is crucial for dissecting performance data. As pointed out in [the Google Ads support documentation](https://developers.google.com/google-ads/api/docs/reporting/segmentation), segments offer a granular insight into data based on specific criteria, like device type or click interactions.
 
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-google-ads?view=relationships)
+
 ## Custom Query: Understanding Google Ads Query Language
 
 Additional streams for Google Ads can be dynamically created using custom queries.

--- a/docs/integrations/sources/google-search-console.md
+++ b/docs/integrations/sources/google-search-console.md
@@ -148,9 +148,11 @@ The granularity for the cursor is 1 day, so Incremental Sync in Append mode may 
 - [Analytics site report by site](https://developers.google.com/webmaster-tools/search-console-api-original/v3/searchanalytics/query)
 - Analytics report by custom dimensions
 
+<HideInUI>
 ### Entity-Relationship Diagram (ERD)
 To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-google-search-console?view=relationships)
+</HideInUI>
 
 ## Connector-specific configurations
 

--- a/docs/integrations/sources/google-search-console.md
+++ b/docs/integrations/sources/google-search-console.md
@@ -148,6 +148,10 @@ The granularity for the cursor is 1 day, so Incremental Sync in Append mode may 
 - [Analytics site report by site](https://developers.google.com/webmaster-tools/search-console-api-original/v3/searchanalytics/query)
 - Analytics report by custom dimensions
 
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-google-search-console?view=relationships)
+
 ## Connector-specific configurations
 
 ### Custom reports

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -200,6 +200,10 @@ The HubSpot source connector supports the following streams:
 - [LineItemsWebAnalytics](https://developers.hubspot.com/docs/api/events/web-analytics) \(Incremental\)
 - [ProductsWebAnalytics](https://developers.hubspot.com/docs/api/events/web-analytics) \(Incremental\)
 
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-hubspot?view=relationships)
+
 ### Notes on the `property_history` streams
 
 `Property_history` streams can be synced using an `Incremental` sync mode, which uses a cursor timestamp to determine which records have been updated since the previous sync. Within these streams, some fields types (ex. `CALCULATED` type) will always have a cursor timstamp that mirrors the time of the latest sync. This results in each sync including many more records than were necessarily changed since the previous sync.

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -200,9 +200,11 @@ The HubSpot source connector supports the following streams:
 - [LineItemsWebAnalytics](https://developers.hubspot.com/docs/api/events/web-analytics) \(Incremental\)
 - [ProductsWebAnalytics](https://developers.hubspot.com/docs/api/events/web-analytics) \(Incremental\)
 
+<HideInUI>
 ### Entity-Relationship Diagram (ERD)
 To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-hubspot?view=relationships)
+</HideInUI>
 
 ### Notes on the `property_history` streams
 

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -102,6 +102,10 @@ the [Instagram Graph API](https://developers.facebook.com/docs/instagram-api/). 
 related to Instagram Ads, use the Facebook Marketing source.
 :::
 
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-instagram?view=relationships)
+
 ## Data type map
 
 AirbyteRecords are required to conform to

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -102,9 +102,11 @@ the [Instagram Graph API](https://developers.facebook.com/docs/instagram-api/). 
 related to Instagram Ads, use the Facebook Marketing source.
 :::
 
+<HideInUI>
 ### Entity-Relationship Diagram (ERD)
 To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-instagram?view=relationships)
+</HideInUI>
 
 ## Data type map
 

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -124,9 +124,11 @@ This connector outputs the following incremental streams:
 - [Sprint issues](https://developer.atlassian.com/cloud/jira/software/rest/api-group-sprint/#api-rest-agile-1-0-sprint-sprintid-issue-get)
 - [PullRequests](https://docs.airbyte.com/integrations/sources/jira#experimental-tables)
 
+<HideInUI>
 ### Entity-Relationship Diagram (ERD)
 To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-jira?view=relationships)
+</HideInUI>
 
 ## Experimental Tables
 

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -124,7 +124,9 @@ This connector outputs the following incremental streams:
 - [Sprint issues](https://developer.atlassian.com/cloud/jira/software/rest/api-group-sprint/#api-rest-agile-1-0-sprint-sprintid-issue-get)
 - [PullRequests](https://docs.airbyte.com/integrations/sources/jira#experimental-tables)
 
-If there are more endpoints you'd like Airbyte to support, please [create an issue.](https://github.com/airbytehq/airbyte/issues/new/choose)
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-jira?view=relationships)
 
 ## Experimental Tables
 

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -167,9 +167,11 @@ This source can sync data for the [Shopify REST API](https://shopify.dev/api/adm
 - [Transactions (GraphQL)](https://shopify.dev/docs/api/admin-graphql/2024-04/objects/OrderTransaction)
 - [Tender Transactions](https://shopify.dev/api/admin-rest/2024-04/resources/tendertransaction)
 
+<HideInUI>
 ### Entity-Relationship Diagram (ERD)
 To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-shopify?view=relationships)
+</HideInUI>
 
 ## Capturing deleted records
 

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -167,6 +167,10 @@ This source can sync data for the [Shopify REST API](https://shopify.dev/api/adm
 - [Transactions (GraphQL)](https://shopify.dev/docs/api/admin-graphql/2024-04/objects/OrderTransaction)
 - [Tender Transactions](https://shopify.dev/api/admin-rest/2024-04/resources/tendertransaction)
 
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-shopify?view=relationships)
+
 ## Capturing deleted records
 
 The connector captures deletions for records in the `Articles`, `Blogs`, `CustomCollections`, `Orders`, `Pages`, `PriceRules` and `Products` streams.

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -129,6 +129,10 @@ The Stripe source connector supports the following streams:
 - [Transfer Reversals](https://stripe.com/docs/api/transfer_reversals/list)
 - [Usage Records](https://stripe.com/docs/api/usage_records/subscription_item_summary_list)
 
+### Entity-Relationship Diagram (ERD)
+To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
+[![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-stripe?view=relationships)
+
 ### Data type map
 
 The [Stripe API](https://stripe.com/docs/api) uses the same [JSON Schema](https://json-schema.org/understanding-json-schema) types that Airbyte uses internally \(`string`, `date-time`, `object`, `array`, `boolean`, `integer`, and `number`\), so no type conversions are performed for the Stripe connector.

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -129,9 +129,11 @@ The Stripe source connector supports the following streams:
 - [Transfer Reversals](https://stripe.com/docs/api/transfer_reversals/list)
 - [Usage Records](https://stripe.com/docs/api/usage_records/subscription_item_summary_list)
 
+<HideInUI>
 ### Entity-Relationship Diagram (ERD)
 To view the relationships between our supported streams, visit our Entity-Relationship Diagram. This will open a new window. 
 [![ERD](https://github.com/user-attachments/assets/b5ca62de-8d45-4f2f-a07b-34c9ea357b21)](https://dbdocs.io/airbyteio/source-stripe?view=relationships)
+</HideInUI>
 
 ### Data type map
 


### PR DESCRIPTION
## What
Adds ERD to the docs for connectors under "Supported Streams". Brute forces this for now.

- Instagram
- Google Search Console
- Amazon Seller Partner
- JIRA
- Bing Ads
- Shopify
- GitHub
- Hubspot
- Stripe
- Facebook Marketing
