### PR TITLE
[ISSUE 9173] add ERD files for source-amazon-seller-partner

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/erd/discovered_catalog.json
@@ -1,0 +1,8074 @@
+{
+  "streams": [
+    {
+      "name": "FBA_CUSTOMER_RETURNS",
+      "json_schema": {
+        "title": "FBA customer returns",
+        "description": "FBA customer returns report Data Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "return-date": {
+            "description": "The date and time when the return was initiated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "order-id": {
+            "description": "The unique identifier of the order associated with the return",
+            "type": ["null", "string"]
+          },
+          "sku": {
+            "description": "Stock Keeping Unit of the product",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "The Amazon Standard Identification Number of the product",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "Fulfillment Network Stock Keeping Unit of the product",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "The name of the product returned by the customer",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "The quantity of the item returned",
+            "type": ["null", "string"]
+          },
+          "fulfillment-center-id": {
+            "description": "Identification of the fulfillment center where the return was processed",
+            "type": ["null", "string"]
+          },
+          "detailed-disposition": {
+            "description": "Detailed description of the disposition of the returned item",
+            "type": ["null", "string"]
+          },
+          "reason": {
+            "description": "The reason provided for the return by the customer",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "The status of the return process",
+            "type": ["null", "string"]
+          },
+          "license-plate-number": {
+            "description": "The unique identifier of the license plate associated with the return",
+            "type": ["null", "string"]
+          },
+          "customer-comments": {
+            "description": "Comments provided by the customer regarding the return",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end date and time of the data record",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_AFN_INVENTORY_DATA",
+      "json_schema": {
+        "title": "FBA Amazon Fulfilled Inventory Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "seller-sku": {
+            "description": "The Seller SKU for the item, which is unique within the seller's inventory.",
+            "type": ["null", "string"]
+          },
+          "fulfillment-channel-sku": {
+            "description": "The SKU assigned to the item by the fulfillment network.",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "The unique identifier for the product in the Amazon catalog.",
+            "type": ["null", "string"]
+          },
+          "condition-type": {
+            "description": "The condition type of the item, such as 'New', 'Used', or 'Refurbished'.",
+            "type": ["null", "string"]
+          },
+          "Warehouse-Condition-code": {
+            "description": "The warehouse code indicating the storage location and condition of the item.",
+            "type": ["null", "string"]
+          },
+          "Quantity Available": {
+            "description": "The total quantity of this item available in the fulfillment center.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time for the data provided, formatted as a date.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_AFN_INVENTORY_DATA_BY_COUNTRY",
+      "json_schema": {
+        "title": "FBA Multi-Country Inventory Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "seller-sku": {
+            "description": "Unique SKU assigned by the seller for the product",
+            "type": ["null", "string"]
+          },
+          "fulfillment-channel-sku": {
+            "description": "Unique SKU assigned by the seller for fulfillment",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "Unique Amazon Standard Identification Number assigned to the product",
+            "type": ["null", "string"]
+          },
+          "condition-type": {
+            "description": "Type of condition (new, used, refurbished, etc.) of the product",
+            "type": ["null", "string"]
+          },
+          "country": {
+            "description": "Country code identifying the country the inventory data pertains to",
+            "type": ["null", "string"]
+          },
+          "quantity-for-local-fulfillment": {
+            "description": "Quantity of the product available for local fulfillment",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "Timestamp indicating when the data was last updated",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "Order detail",
+      "json_schema": {
+        "title": "FBA Fulfillment Removal Order Detail Data",
+        "description": "FBA Fulfillment Removal Order Detail Data Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "request-date": {
+            "description": "The date and time the removal order was requested",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "order-id": {
+            "description": "The unique identifier for the order associated with the removal",
+            "type": ["null", "string"]
+          },
+          "order-type": {
+            "description": "The type of the removal order",
+            "type": ["null", "string"]
+          },
+          "order-status": {
+            "description": "The status of the removal order",
+            "type": ["null", "string"]
+          },
+          "last-updated-date": {
+            "description": "The date and time when the data was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sku": {
+            "description": "The Stock Keeping Unit for the item",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "The Fulfillment Network Stock Keeping Unit for the item",
+            "type": ["null", "string"]
+          },
+          "disposition": {
+            "description": "The method used to dispose of the items",
+            "type": ["null", "string"]
+          },
+          "requested-quantity": {
+            "description": "The quantity of items requested for removal",
+            "type": ["null", "string"]
+          },
+          "cancelled-quantity": {
+            "description": "The quantity of items that were cancelled for removal",
+            "type": ["null", "string"]
+          },
+          "disposed-quantity": {
+            "description": "The quantity of items that were disposed during the removal process",
+            "type": ["null", "string"]
+          },
+          "shipped-quantity": {
+            "description": "The quantity of items that have been shipped for removal",
+            "type": ["null", "string"]
+          },
+          "in-process-quantity": {
+            "description": "The quantity of items currently in the removal process",
+            "type": ["null", "string"]
+          },
+          "removal-fee": {
+            "description": "The fee charged for the removal of items",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency in which the removal fee is charged",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time of the data record",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["last-updated-date"]
+    },
+    {
+      "name": "GET_FBA_FULFILLMENT_REMOVAL_SHIPMENT_DETAIL_DATA",
+      "json_schema": {
+        "title": "FBA Fulfillment Removal Shipment Detail Data",
+        "description": "FBA Fulfillment Removal Shipment Detail Data Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "removal-date": {
+            "description": "The date and time when the removal of the product from fulfillment centers started.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "order-id": {
+            "description": "The unique identification number for the order associated with the shipment.",
+            "type": ["null", "string"]
+          },
+          "shipment-date": {
+            "description": "The date and time when the removal shipment was dispatched.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sku": {
+            "description": "Stock Keeping Unit (SKU) for the product being removed.",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "The Fulfilled Network Stock Keeping Unit (FNSKU) associated with the product.",
+            "type": ["null", "string"]
+          },
+          "disposition": {
+            "description": "The status or action taken on the removal shipment.",
+            "type": ["null", "string"]
+          },
+          "quantity shipped": {
+            "description": "The quantity of products shipped in the removal shipment.",
+            "type": ["null", "string"]
+          },
+          "carrier": {
+            "description": "The carrier responsible for shipping the removal shipment.",
+            "type": ["null", "string"]
+          },
+          "tracking-number": {
+            "description": "The unique tracking number assigned to the removal shipment.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time of the data collection in the requested format.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "FBA_REPLACEMENT",
+      "json_schema": {
+        "title": "FBA Fulfillment Customer Shipment Replacement Data",
+        "description": "FBA Fulfillment Customer Shipment Replacement Data Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "shipment-date": {
+            "description": "Date and time of the free replacement shipment in DD-MON-YYYY format",
+            "title": "Date",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sku": {
+            "description": "Unique identifier of the item used by the seller",
+            "title": "Merchant SKU",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "Amazon Standard Inventory Number",
+            "title": "ASIN",
+            "type": ["null", "string"]
+          },
+          "fulfillment-center-id": {
+            "description": "ID of the fulfillment center shipping this unit",
+            "title": "Warehouse ID",
+            "type": ["null", "string"]
+          },
+          "original-fulfillment-center-id": {
+            "description": "ID of the original fulfillment center shipping the free replaced item",
+            "title": "Original Warehouse ID",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "Number of units shipped in the replacement shipment",
+            "title": "Quantity",
+            "type": ["null", "string"]
+          },
+          "replacement-reason-code": {
+            "description": "Code indicating the reason for the replacement",
+            "title": "Replacement Reason Code",
+            "type": ["null", "string"]
+          },
+          "replacement-customer-order-id": {
+            "description": "Order ID of the replacement order for the original item",
+            "title": "Replacement Customer Order Id",
+            "type": ["null", "string"]
+          },
+          "original-amazon-order-id": {
+            "description": "Order ID of the original shipment for the replacement item",
+            "title": "Original Customer Order ID",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data collection period",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "FEE_CHARGES",
+      "json_schema": {
+        "title": "FBA Storage Fees Report",
+        "description": "FBA Storage Fees Report",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "asin": {
+            "description": "Unique identifier for the Amazon Standard Identification Number.",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "Fulfillment Network Stock Keeping Unit for the item.",
+            "type": ["null", "string"]
+          },
+          "product_name": {
+            "description": "Name of the product or item.",
+            "type": ["null", "string"]
+          },
+          "fulfillment_center": {
+            "description": "Location identifier for the fulfillment center.",
+            "type": ["null", "string"]
+          },
+          "country_code": {
+            "description": "Country code where the data is applicable.",
+            "type": ["null", "string"]
+          },
+          "longest_side": {
+            "description": "Length of the longest side of the item.",
+            "type": ["null", "string"]
+          },
+          "median_side": {
+            "description": "Length of the median side of the item.",
+            "type": ["null", "string"]
+          },
+          "shortest_side": {
+            "description": "Length of the shortest side of the item.",
+            "type": ["null", "string"]
+          },
+          "measurement_units": {
+            "description": "Units used for measurements (e.g., inches, centimeters).",
+            "type": ["null", "string"]
+          },
+          "weight": {
+            "description": "Weight of the item.",
+            "type": ["null", "string"]
+          },
+          "weight_units": {
+            "description": "Units used for weight measurements.",
+            "type": ["null", "string"]
+          },
+          "item_volume": {
+            "description": "Volume occupied by the item.",
+            "type": ["null", "string"]
+          },
+          "volume_units": {
+            "description": "Units used for volume measurements.",
+            "type": ["null", "string"]
+          },
+          "product_size_tier": {
+            "description": "Tier or category based on the size of the product.",
+            "type": ["null", "string"]
+          },
+          "average_quantity_on_hand": {
+            "description": "Average quantity of items available in inventory at hand.",
+            "type": ["null", "string"]
+          },
+          "average_quantity_pending_removal": {
+            "description": "Average quantity of items pending removal from inventory.",
+            "type": ["null", "string"]
+          },
+          "estimated_total_item_volume": {
+            "description": "Estimated total volume occupied by the item.",
+            "type": ["null", "string"]
+          },
+          "month_of_charge": {
+            "description": "Month for which the storage fee is charged.",
+            "type": ["null", "string"]
+          },
+          "storage_rate": {
+            "description": "Rate applied for storage fees.",
+            "type": ["null", "string"]
+          },
+          "estimated_monthly_storage_fee": {
+            "description": "Estimated monthly fee for storage of the item.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "Currency used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "average_quantity_customer_orders": {
+            "description": "Average quantity of items ordered by customers within the specified timeframe.",
+            "type": ["null", "number"]
+          },
+          "base_rate": {
+            "description": "Base rate used for calculating storage fees.",
+            "type": ["null", "number"]
+          },
+          "breakdown_incentive_fee_amount": {
+            "description": "Breakdown of incentive fee amount applied for storage.",
+            "type": ["null", "string"]
+          },
+          "dangerous_goods_storage_type": {
+            "description": "Type of storage for dangerous goods, if applicable.",
+            "type": ["null", "string"]
+          },
+          "eligible_for_inventory_discount": {
+            "description": "Flag indicating if the item is eligible for inventory discount.",
+            "type": ["null", "string"]
+          },
+          "qualifies_for_inventory_discount": {
+            "description": "Flag indicating if the item qualifies for inventory discount.",
+            "type": ["null", "string"]
+          },
+          "storage_utilization_ratio": {
+            "description": "Ratio of storage utilization.",
+            "type": ["null", "number"]
+          },
+          "storage_utilization_ratio_units": {
+            "description": "Units used for storage utilization ratio (e.g., percentage).",
+            "type": ["null", "string"]
+          },
+          "total_incentive_fee_amount": {
+            "description": "Total amount of incentive fees applied.",
+            "type": ["null", "number"]
+          },
+          "utilization_surcharge_rate": {
+            "description": "Rate for utilization surcharge, if applicable.",
+            "type": ["null", "number"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data collection period.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "Fee_charges",
+      "json_schema": {
+        "title": "FBA Storage Fees Report",
+        "description": "FBA Storage Fees Report",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "asin": {
+            "description": "Unique identifier for the Amazon Standard Identification Number.",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "Fulfillment Network Stock Keeping Unit for the item.",
+            "type": ["null", "string"]
+          },
+          "product_name": {
+            "description": "Name of the product or item.",
+            "type": ["null", "string"]
+          },
+          "fulfillment_center": {
+            "description": "Location identifier for the fulfillment center.",
+            "type": ["null", "string"]
+          },
+          "country_code": {
+            "description": "Country code where the data is applicable.",
+            "type": ["null", "string"]
+          },
+          "longest_side": {
+            "description": "Length of the longest side of the item.",
+            "type": ["null", "string"]
+          },
+          "median_side": {
+            "description": "Length of the median side of the item.",
+            "type": ["null", "string"]
+          },
+          "shortest_side": {
+            "description": "Length of the shortest side of the item.",
+            "type": ["null", "string"]
+          },
+          "measurement_units": {
+            "description": "Units used for measurements (e.g., inches, centimeters).",
+            "type": ["null", "string"]
+          },
+          "weight": {
+            "description": "Weight of the item.",
+            "type": ["null", "string"]
+          },
+          "weight_units": {
+            "description": "Units used for weight measurements.",
+            "type": ["null", "string"]
+          },
+          "item_volume": {
+            "description": "Volume occupied by the item.",
+            "type": ["null", "string"]
+          },
+          "volume_units": {
+            "description": "Units used for volume measurements.",
+            "type": ["null", "string"]
+          },
+          "product_size_tier": {
+            "description": "Tier or category based on the size of the product.",
+            "type": ["null", "string"]
+          },
+          "average_quantity_on_hand": {
+            "description": "Average quantity of items available in inventory at hand.",
+            "type": ["null", "string"]
+          },
+          "average_quantity_pending_removal": {
+            "description": "Average quantity of items pending removal from inventory.",
+            "type": ["null", "string"]
+          },
+          "estimated_total_item_volume": {
+            "description": "Estimated total volume occupied by the item.",
+            "type": ["null", "string"]
+          },
+          "month_of_charge": {
+            "description": "Month for which the storage fee is charged.",
+            "type": ["null", "string"]
+          },
+          "storage_rate": {
+            "description": "Rate applied for storage fees.",
+            "type": ["null", "string"]
+          },
+          "estimated_monthly_storage_fee": {
+            "description": "Estimated monthly fee for storage of the item.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "Currency used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "average_quantity_customer_orders": {
+            "description": "Average quantity of items ordered by customers within the specified timeframe.",
+            "type": ["null", "number"]
+          },
+          "base_rate": {
+            "description": "Base rate used for calculating storage fees.",
+            "type": ["null", "number"]
+          },
+          "breakdown_incentive_fee_amount": {
+            "description": "Breakdown of incentive fee amount applied for storage.",
+            "type": ["null", "string"]
+          },
+          "dangerous_goods_storage_type": {
+            "description": "Type of storage for dangerous goods, if applicable.",
+            "type": ["null", "string"]
+          },
+          "eligible_for_inventory_discount": {
+            "description": "Flag indicating if the item is eligible for inventory discount.",
+            "type": ["null", "string"]
+          },
+          "qualifies_for_inventory_discount": {
+            "description": "Flag indicating if the item qualifies for inventory discount.",
+            "type": ["null", "string"]
+          },
+          "storage_utilization_ratio": {
+            "description": "Ratio of storage utilization.",
+            "type": ["null", "number"]
+          },
+          "storage_utilization_ratio_units": {
+            "description": "Units used for storage utilization ratio (e.g., percentage).",
+            "type": ["null", "string"]
+          },
+          "total_incentive_fee_amount": {
+            "description": "Total amount of incentive fees applied.",
+            "type": ["null", "number"]
+          },
+          "utilization_surcharge_rate": {
+            "description": "Rate for utilization surcharge, if applicable.",
+            "type": ["null", "number"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data collection period.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_RESTOCK_INVENTORY_RECOMMENDATIONS_REPORT",
+      "json_schema": {
+        "title": "Restock Inventory Report",
+        "description": "Restock Inventory Report",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "Country": {
+            "description": "Country where the product is located",
+            "type": ["null", "string"]
+          },
+          "Product Name": {
+            "description": "Name of the product",
+            "type": ["null", "string"]
+          },
+          "FNSKU": {
+            "description": "Fulfillment Network Stock Keeping Unit",
+            "type": ["null", "string"]
+          },
+          "Merchant SKU": {
+            "description": "Merchant's Stock Keeping Unit",
+            "type": ["null", "string"]
+          },
+          "ASIN": {
+            "description": "Amazon Standard Identification Number of the product",
+            "type": ["null", "string"]
+          },
+          "Condition": {
+            "description": "Condition of the product",
+            "type": ["null", "string"]
+          },
+          "Supplier": {
+            "description": "Supplier of the product",
+            "type": ["null", "string"]
+          },
+          "Supplier part no.": {
+            "description": "Supplier's part number",
+            "type": ["null", "string"]
+          },
+          "Currency code": {
+            "description": "Currency code used for pricing",
+            "type": ["null", "string"]
+          },
+          "Price": {
+            "description": "Price of the product",
+            "type": ["null", "string"]
+          },
+          "Sales last 30 days": {
+            "description": "Number of units sold in the last 30 days",
+            "type": ["null", "string"]
+          },
+          "Units Sold Last 30 Days": {
+            "description": "Detailed information about units sold in the last 30 days",
+            "type": ["null", "string"]
+          },
+          "Total Units": {
+            "description": "Total number of units available",
+            "type": ["null", "string"]
+          },
+          "Inbound": {
+            "description": "Number of units inbound to Amazon's network",
+            "type": ["null", "string"]
+          },
+          "Available": {
+            "description": "Number of units available for sale",
+            "type": ["null", "string"]
+          },
+          "FC transfer": {
+            "description": "Units transferred between fulfillment centers",
+            "type": ["null", "string"]
+          },
+          "FC Processing": {
+            "description": "Units in processing at fulfillment center",
+            "type": ["null", "string"]
+          },
+          "Customer Order": {
+            "description": "Number of customer orders for the product",
+            "type": ["null", "string"]
+          },
+          "Unfulfillable": {
+            "description": "Number of units that are unfulfillable",
+            "type": ["null", "string"]
+          },
+          "Working": {
+            "description": "Number of units that are in working condition",
+            "type": ["null", "string"]
+          },
+          "Shipped": {
+            "description": "Number of units already shipped",
+            "type": ["null", "string"]
+          },
+          "Receiving": {
+            "description": "Units being received by Amazon",
+            "type": ["null", "string"]
+          },
+          "Fulfilled by": {
+            "description": "Fulfillment method used",
+            "type": ["null", "string"]
+          },
+          "Total Days of Supply (including units from open shipments)": {
+            "description": "Total number of days of supply including units from open shipments",
+            "type": ["null", "string"]
+          },
+          "Days of Supply at Amazon Fulfillment Network": {
+            "description": "Number of days of supply at Amazon's fulfillment network",
+            "type": ["null", "string"]
+          },
+          "Alert": {
+            "description": "Indicates if there is any alert or notification related to the product",
+            "type": ["null", "string"]
+          },
+          "Recommended replenishment qty": {
+            "description": "Recommended quantity for replenishment",
+            "type": ["null", "string"]
+          },
+          "Recommended ship date": {
+            "description": "Date suggested for shipping",
+            "type": ["null", "string"]
+          },
+          "Recommended action": {
+            "description": "Suggested action to take based on the data",
+            "type": ["null", "string"]
+          },
+          "Unit storage size": {
+            "description": "Size of the storage unit",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data collection",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_FLAT_FILE_ACTIONABLE_ORDER_DATA_SHIPPING",
+      "json_schema": {
+        "title": "Flat File All Orders Data Reports (by last update)",
+        "description": "Flat File All Orders Data by Last Update Date General Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "order-id": {
+            "description": "The unique identifier of the order.",
+            "type": "string"
+          },
+          "order-item-id": {
+            "description": "The unique identifier of the order item.",
+            "type": ["null", "string"]
+          },
+          "purchase-date": {
+            "description": "The date and time of the purchase.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "payments-date": {
+            "description": "The date and time of the payment.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "reporting-date": {
+            "description": "The date and time when the data is reported.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "promise-date": {
+            "description": "The promised delivery date and time.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "days-past-promise": {
+            "description": "Number of days past the promised delivery date.",
+            "type": ["null", "string"]
+          },
+          "buyer-email": {
+            "description": "The email address of the buyer.",
+            "type": ["null", "string"]
+          },
+          "buyer-phone-number": {
+            "description": "The phone number of the buyer.",
+            "type": ["null", "string"]
+          },
+          "is-business-order": {
+            "description": "Flag indicating if the order is a business order (true/false).",
+            "type": ["null", "string"]
+          },
+          "quantity-purchased": {
+            "description": "The quantity of the product purchased.",
+            "type": ["null", "string"]
+          },
+          "quantity-shipped": {
+            "description": "The quantity of the product that has been shipped.",
+            "type": ["null", "string"]
+          },
+          "quantity-to-ship": {
+            "description": "The remaining quantity of the product to be shipped.",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "The name of the product in the order.",
+            "type": ["null", "string"]
+          },
+          "purchase-order-number": {
+            "description": "The purchase order number associated with the order.",
+            "type": ["null", "string"]
+          },
+          "recipient-name": {
+            "description": "The name of the recipient of the order.",
+            "type": ["null", "string"]
+          },
+          "ship-city": {
+            "description": "The city where the order is being shipped.",
+            "type": ["null", "string"]
+          },
+          "ship-country": {
+            "description": "The country where the order is being shipped.",
+            "type": ["null", "string"]
+          },
+          "ship-postal-code": {
+            "description": "The postal code of the shipping address.",
+            "type": ["null", "string"]
+          },
+          "ship-promotion-discount": {
+            "description": "Discount applied to shipping.",
+            "type": ["null", "string"]
+          },
+          "ship-service-level": {
+            "description": "The service level of the shipping method.",
+            "type": ["null", "string"]
+          },
+          "ship-state": {
+            "description": "The state where the order is being shipped.",
+            "type": ["null", "string"]
+          },
+          "shipping-price": {
+            "description": "The price of shipping.",
+            "type": ["null", "string"]
+          },
+          "shipping-tax": {
+            "description": "The tax applied to shipping.",
+            "type": ["null", "string"]
+          },
+          "sku": {
+            "description": "The Stock Keeping Unit (SKU) of the product.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time of the data in the specified format (date).",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_FLAT_FILE_OPEN_LISTINGS_DATA",
+      "json_schema": {
+        "title": "Flat File Open Listings Data",
+        "description": "Flat File Open Listings Data Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "sku": {
+            "description": "Stock Keeping Unit code for the product",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "Amazon Standard Identification Number for the product",
+            "type": ["null", "string"]
+          },
+          "price": {
+            "description": "Current price of the product",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "Available quantity of the product",
+            "type": ["null", "string"]
+          },
+          "Business Price": {
+            "description": "The price set by the business for the listing",
+            "type": ["null", "string"]
+          },
+          "Quantity Price Type": {
+            "description": "Type of pricing strategy used for quantity pricing",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 1": {
+            "description": "Minimum quantity threshold for pricing tier 1",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 1": {
+            "description": "Price for products in quantity tier 1",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 2": {
+            "description": "Minimum quantity threshold for pricing tier 2",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 2": {
+            "description": "Price for products in quantity tier 2",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 3": {
+            "description": "Minimum quantity threshold for pricing tier 3",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 3": {
+            "description": "Price for products in quantity tier 3",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 4": {
+            "description": "Minimum quantity threshold for pricing tier 4",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 4": {
+            "description": "Price for products in quantity tier 4",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 5": {
+            "description": "Minimum quantity threshold for pricing tier 5",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 5": {
+            "description": "Price for products in quantity tier 5",
+            "type": ["null", "string"]
+          },
+          "Progressive Price Type": {
+            "description": "Type of pricing strategy used for progressive pricing",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 1": {
+            "description": "Minimum threshold for progressive pricing tier 1",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 1": {
+            "description": "Price for products in progressive tier 1",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 2": {
+            "description": "Minimum threshold for progressive pricing tier 2",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 2": {
+            "description": "Price for products in progressive tier 2",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 3": {
+            "description": "Minimum threshold for progressive pricing tier 3",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 3": {
+            "description": "Price for products in progressive tier 3",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data entry",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "Order_DATE_GENERAL",
+      "json_schema": {
+        "title": "Flat File All Orders Data Reports",
+        "description": "Flat File All Orders Data by Order Date General Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "amazon-order-id": {
+            "description": "Unique identifier for the order on Amazon platform",
+            "type": ["null", "string"]
+          },
+          "merchant-order-id": {
+            "description": "Identifier for the order set by the merchant",
+            "type": ["null", "string"]
+          },
+          "purchase-date": {
+            "description": "Timestamp of the order purchase date",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "last-updated-date": {
+            "description": "Timestamp of the last update for the order",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "order-status": {
+            "description": "Status of the order (e.g., Pending, Shipped)",
+            "type": ["null", "string"]
+          },
+          "fulfillment-channel": {
+            "description": "Channel through which the order is fulfilled (e.g., FBA, Seller Fulfilled)",
+            "type": ["null", "string"]
+          },
+          "sales-channel": {
+            "description": "Channel through which the sale was made",
+            "type": ["null", "string"]
+          },
+          "order-channel": {
+            "description": "Channel through which the order was placed",
+            "type": ["null", "string"]
+          },
+          "ship-service-level": {
+            "description": "Service level of shipping (e.g., Standard, Expedited)",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "Name of the product in the order",
+            "type": ["null", "string"]
+          },
+          "sku": {
+            "description": "Stock Keeping Unit for the product in the order",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "Amazon Standard Identification Number for the product",
+            "type": ["null", "string"]
+          },
+          "item-status": {
+            "description": "Status of the item in the order",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "Number of units ordered",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "Currency used for the order",
+            "type": ["null", "string"]
+          },
+          "item-price": {
+            "description": "Price of each item in the order",
+            "type": ["null", "string"]
+          },
+          "item-tax": {
+            "description": "Tax charged on the item price",
+            "type": ["null", "string"]
+          },
+          "shipping-price": {
+            "description": "Price of shipping for the order",
+            "type": ["null", "string"]
+          },
+          "shipping-tax": {
+            "description": "Tax applied on the shipping price",
+            "type": ["null", "string"]
+          },
+          "gift-wrap-price": {
+            "description": "Price of gift wrapping for the order",
+            "type": ["null", "string"]
+          },
+          "gift-wrap-tax": {
+            "description": "Tax applied on the gift wrapping price",
+            "type": ["null", "string"]
+          },
+          "item-promotion-discount": {
+            "description": "Discount applied on the item price due to promotion",
+            "type": ["null", "string"]
+          },
+          "ship-promotion-discount": {
+            "description": "Discount applied to the shipping cost due to promotions",
+            "type": ["null", "string"]
+          },
+          "ship-city": {
+            "description": "City to which the order is being shipped",
+            "type": ["null", "string"]
+          },
+          "ship-state": {
+            "description": "State to which the order is being shipped",
+            "type": ["null", "string"]
+          },
+          "ship-postal-code": {
+            "description": "Postal code of the shipping address",
+            "type": ["null", "string"]
+          },
+          "ship-country": {
+            "description": "Country to which the order is being shipped",
+            "type": ["null", "string"]
+          },
+          "promotion-ids": {
+            "description": "Identifiers for promotions applied to the order",
+            "type": ["null", "string"]
+          },
+          "cpf": {
+            "description": "Cadastro de Pessoas F\u00edsicas - Brazilian individual taxpayer registry identification number",
+            "type": ["null", "string"]
+          },
+          "is-business-order": {
+            "description": "Indicator if the order is a business order",
+            "type": ["null", "string"]
+          },
+          "purchase-order-number": {
+            "description": "Number associated with the order for purchase tracking",
+            "type": ["null", "string"]
+          },
+          "price-designation": {
+            "description": "Price designation for the order (e.g., Regular price, Discounted price)",
+            "type": ["null", "string"]
+          },
+          "signature-confirmation-recommended": {
+            "description": "Indicator if signature confirmation is recommended for the order",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End timestamp of the data",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["last-updated-date"],
+      "source_defined_primary_key": [["amazon-order-id"]]
+    },
+    {
+      "name": "GET_FLAT_FILE_ALL_ORDERS_DATA_BY_LAST_UPDATE_GENERAL",
+      "json_schema": {
+        "title": "Flat File All Orders Data Reports (by last update)",
+        "description": "Flat File All Orders Data by Last Update Date General Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "amazon-order-id": {
+            "description": "The unique identifier for the Amazon order.",
+            "type": "string"
+          },
+          "merchant-order-id": {
+            "description": "The unique identifier for the merchant's order.",
+            "type": "string"
+          },
+          "purchase-date": {
+            "description": "The date and time of the order purchase.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "last-updated-date": {
+            "description": "The date and time of the last update to the order.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "order-status": {
+            "description": "The status of the order.",
+            "type": ["null", "string"]
+          },
+          "fulfillment-channel": {
+            "description": "The channel through which the order was fulfilled.",
+            "type": ["null", "string"]
+          },
+          "sales-channel": {
+            "description": "The channel through which the sale was made.",
+            "type": ["null", "string"]
+          },
+          "order-channel": {
+            "description": "The channel through which the order was placed.",
+            "type": ["null", "string"]
+          },
+          "ship-service-level": {
+            "description": "The service level of the shipping method.",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "The name of the product in the order.",
+            "type": ["null", "string"]
+          },
+          "sku": {
+            "description": "The Stock Keeping Unit for the product.",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "The Amazon Standard Identification Number for the product.",
+            "type": ["null", "string"]
+          },
+          "item-status": {
+            "description": "The status of the item in the order.",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "The quantity of the product in the order.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency used in the order transaction.",
+            "type": ["null", "string"]
+          },
+          "item-price": {
+            "description": "The price of the item in the order.",
+            "type": ["null", "string"]
+          },
+          "item-tax": {
+            "description": "The tax applied to the item.",
+            "type": ["null", "string"]
+          },
+          "shipping-price": {
+            "description": "The price of shipping for the order.",
+            "type": ["null", "string"]
+          },
+          "shipping-tax": {
+            "description": "The tax applied to shipping.",
+            "type": ["null", "string"]
+          },
+          "gift-wrap-price": {
+            "description": "The price of gift wrapping for the order.",
+            "type": ["null", "string"]
+          },
+          "gift-wrap-tax": {
+            "description": "The tax applied to gift wrapping.",
+            "type": ["null", "string"]
+          },
+          "item-promotion-discount": {
+            "description": "The discount applied to the item.",
+            "type": ["null", "string"]
+          },
+          "ship-promotion-discount": {
+            "description": "The discount applied to the shipping.",
+            "type": ["null", "string"]
+          },
+          "ship-city": {
+            "description": "The city to which the order is being shipped.",
+            "type": ["null", "string"]
+          },
+          "ship-state": {
+            "description": "The state to which the order is being shipped.",
+            "type": ["null", "string"]
+          },
+          "ship-postal-code": {
+            "description": "The postal code of the shipping address.",
+            "type": ["null", "string"]
+          },
+          "ship-country": {
+            "description": "The country to which the order is being shipped.",
+            "type": ["null", "string"]
+          },
+          "promotion-ids": {
+            "description": "The IDs of any promotions applied to the order.",
+            "type": ["null", "string"]
+          },
+          "cpf": {
+            "description": "The taxpayer identification number for the customer.",
+            "type": ["null", "string"]
+          },
+          "is-business-order": {
+            "description": "Indicates if the order is a business order.",
+            "type": ["null", "string"]
+          },
+          "purchase-order-number": {
+            "description": "The purchase order number.",
+            "type": ["null", "string"]
+          },
+          "price-designation": {
+            "description": "The designation of the price.",
+            "type": ["null", "string"]
+          },
+          "signature-confirmation-recommended": {
+            "description": "Indicates if signature confirmation is recommended.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time of the data update.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["last-updated-date"],
+      "source_defined_primary_key": [["amazon-order-id"]]
+    },
+    {
+      "name": "GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE",
+      "json_schema": {
+        "title": "Flat File Settlement Reports",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "settlement-id": {
+            "description": "The unique identifier for a settlement.",
+            "type": ["null", "string"]
+          },
+          "settlement-start-date": {
+            "description": "The start date of the settlement period.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "settlement-end-date": {
+            "description": "The end date of the settlement period.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "deposit-date": {
+            "description": "The date and time when the payment was deposited into the seller's account.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "total-amount": {
+            "description": "The total amount in the settlement.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency in which the financial transactions are recorded.",
+            "type": ["null", "string"]
+          },
+          "transaction-type": {
+            "description": "The type of transaction (e.g., order, refund).",
+            "type": ["null", "string"]
+          },
+          "order-id": {
+            "description": "The unique identifier for an order.",
+            "type": ["null", "string"]
+          },
+          "merchant-order-id": {
+            "description": "The unique identifier for a merchant order.",
+            "type": ["null", "string"]
+          },
+          "adjustment-id": {
+            "description": "The unique identifier for an adjustment made to the settlement.",
+            "type": ["null", "string"]
+          },
+          "shipment-id": {
+            "description": "The unique identifier for a shipment.",
+            "type": ["null", "string"]
+          },
+          "marketplace-name": {
+            "description": "The name of the marketplace where the transaction occurred.",
+            "type": ["null", "string"]
+          },
+          "shipment-fee-type": {
+            "description": "The type of fee related to shipment.",
+            "type": ["null", "string"]
+          },
+          "shipment-fee-amount": {
+            "description": "The amount of fee related to shipment.",
+            "type": ["null", "string"]
+          },
+          "order-fee-type": {
+            "description": "The type of fee associated with an order.",
+            "type": ["null", "string"]
+          },
+          "order-fee-amount": {
+            "description": "The amount of fee associated with an order.",
+            "type": ["null", "string"]
+          },
+          "fulfillment-id": {
+            "description": "The unique identifier for the fulfillment of an order.",
+            "type": ["null", "string"]
+          },
+          "posted-date": {
+            "description": "The date and time when the transaction was posted.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "order-item-code": {
+            "description": "The code assigned to an order item.",
+            "type": ["null", "string"]
+          },
+          "merchant-order-item-id": {
+            "description": "The unique identifier for a specific item in a merchant order.",
+            "type": ["null", "string"]
+          },
+          "merchant-adjustment-item-id": {
+            "description": "The unique identifier for a merchant adjustment item.",
+            "type": ["null", "string"]
+          },
+          "sku": {
+            "description": "The stock keeping unit for a product.",
+            "type": ["null", "string"]
+          },
+          "quantity-purchased": {
+            "description": "The quantity of a product purchased in the order.",
+            "type": ["null", "string"]
+          },
+          "price-type": {
+            "description": "The type of price for a product.",
+            "type": ["null", "string"]
+          },
+          "price-amount": {
+            "description": "The amount of price for a product.",
+            "type": ["null", "string"]
+          },
+          "item-related-fee-type": {
+            "description": "The type of fee related to a specific item in the order.",
+            "type": ["null", "string"]
+          },
+          "item-related-fee-amount": {
+            "description": "The amount of fee related to a specific item in the order.",
+            "type": ["null", "string"]
+          },
+          "misc-fee-amount": {
+            "description": "The amount of miscellaneous fee included in the settlement.",
+            "type": ["null", "string"]
+          },
+          "other-fee-amount": {
+            "description": "The amount of other fees included in the settlement.",
+            "type": ["null", "string"]
+          },
+          "other-fee-reason-description": {
+            "description": "The description of the reason for other fees.",
+            "type": ["null", "string"]
+          },
+          "promotion-id": {
+            "description": "The unique identifier for a promotion.",
+            "type": ["null", "string"]
+          },
+          "promotion-type": {
+            "description": "The type of promotion applied.",
+            "type": ["null", "string"]
+          },
+          "promotion-amount": {
+            "description": "The amount of promotion discount applied.",
+            "type": ["null", "string"]
+          },
+          "direct-payment-type": {
+            "description": "The type of direct payment made to the seller.",
+            "type": ["null", "string"]
+          },
+          "direct-payment-amount": {
+            "description": "The amount of direct payment made to the seller.",
+            "type": ["null", "string"]
+          },
+          "other-amount": {
+            "description": "The amount of other miscellaneous transactions.",
+            "type": ["null", "string"]
+          },
+          "report_id": {
+            "description": "The unique identifier for a settlement report.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time of the data in the report.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_AMAZON_FULFILLED_SHIPMENTS_DATA_GENERAL",
+      "json_schema": {
+        "title": "Amazon Fulfilled Data General",
+        "description": "Amazon Fulfilled Data General Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "amazon-order-id": {
+            "description": "The unique identifier for the Amazon order.",
+            "type": ["null", "string"]
+          },
+          "merchant-order-id": {
+            "description": "The unique identifier for the merchant's order.",
+            "type": ["null", "string"]
+          },
+          "shipment-id": {
+            "description": "The unique identifier for the shipment.",
+            "type": ["null", "string"]
+          },
+          "shipment-item-id": {
+            "description": "The unique identifier for the shipment item.",
+            "type": ["null", "string"]
+          },
+          "amazon-order-item-id": {
+            "description": "The unique identifier for the Amazon order item.",
+            "type": ["null", "string"]
+          },
+          "merchant-order-item-id": {
+            "description": "The unique identifier for the merchant's order item.",
+            "type": ["null", "string"]
+          },
+          "purchase-date": {
+            "description": "The date when the purchase was made.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "payments-date": {
+            "description": "The date when payments were made.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "shipment-date": {
+            "description": "The date when the shipment is made.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "reporting-date": {
+            "description": "The date when the report is generated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "buyer-email": {
+            "description": "The email address of the buyer.",
+            "type": ["null", "string"]
+          },
+          "buyer-name": {
+            "description": "The name of the buyer.",
+            "type": ["null", "string"]
+          },
+          "buyer-phone-number": {
+            "description": "The phone number of the buyer.",
+            "type": ["null", "string"]
+          },
+          "sku": {
+            "description": "The Stock Keeping Unit of the product.",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "The name of the product in the shipment.",
+            "type": ["null", "string"]
+          },
+          "quantity-shipped": {
+            "description": "The quantity of items shipped.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency used for the transaction.",
+            "type": ["null", "string"]
+          },
+          "item-price": {
+            "description": "The price of the item in the shipment.",
+            "type": ["null", "string"]
+          },
+          "item-tax": {
+            "description": "The tax applied to the item's price.",
+            "type": ["null", "string"]
+          },
+          "shipping-price": {
+            "description": "The price of shipping for the shipment.",
+            "type": ["null", "string"]
+          },
+          "shipping-tax": {
+            "description": "The tax applied to the shipping.",
+            "type": ["null", "string"]
+          },
+          "gift-wrap-price": {
+            "description": "The price of gift wrapping for the shipment.",
+            "type": ["null", "string"]
+          },
+          "gift-wrap-tax": {
+            "description": "The tax applied to the gift wrapping.",
+            "type": ["null", "string"]
+          },
+          "ship-service-level": {
+            "description": "The service level of the shipping method.",
+            "type": ["null", "string"]
+          },
+          "recipient-name": {
+            "description": "The name of the recipient of the shipment.",
+            "type": ["null", "string"]
+          },
+          "ship-address-1": {
+            "description": "The first line of the shipping address.",
+            "type": ["null", "string"]
+          },
+          "ship-address-2": {
+            "description": "The second line of the shipping address.",
+            "type": ["null", "string"]
+          },
+          "ship-address-3": {
+            "description": "The third line of the shipping address.",
+            "type": ["null", "string"]
+          },
+          "ship-city": {
+            "description": "The city of the shipping address.",
+            "type": ["null", "string"]
+          },
+          "ship-state": {
+            "description": "The state of the shipping address.",
+            "type": ["null", "string"]
+          },
+          "ship-postal-code": {
+            "description": "The postal code of the shipping address.",
+            "type": ["null", "string"]
+          },
+          "ship-country": {
+            "description": "The country of the shipping address.",
+            "type": ["null", "string"]
+          },
+          "ship-phone-number": {
+            "description": "The phone number of the recipient for shipping.",
+            "type": ["null", "string"]
+          },
+          "bill-address-1": {
+            "description": "The first line of the billing address.",
+            "type": ["null", "string"]
+          },
+          "bill-address-2": {
+            "description": "The second line of the billing address.",
+            "type": ["null", "string"]
+          },
+          "bill-address-3": {
+            "description": "The third line of the billing address.",
+            "type": ["null", "string"]
+          },
+          "bill-city": {
+            "description": "The city of the billing address.",
+            "type": ["null", "string"]
+          },
+          "bill-state": {
+            "description": "The state of the billing address.",
+            "type": ["null", "string"]
+          },
+          "bill-postal-code": {
+            "description": "The postal code of the billing address.",
+            "type": ["null", "string"]
+          },
+          "bill-country": {
+            "description": "The country of the billing address.",
+            "type": ["null", "string"]
+          },
+          "item-promotion-discount": {
+            "description": "Any promotional discount applied to the item.",
+            "type": ["null", "string"]
+          },
+          "ship-promotion-discount": {
+            "description": "Any promotional discount applied to shipping.",
+            "type": ["null", "string"]
+          },
+          "carrier": {
+            "description": "The carrier responsible for shipping the item.",
+            "type": ["null", "string"]
+          },
+          "tracking-number": {
+            "description": "The tracking number for the shipment.",
+            "type": ["null", "string"]
+          },
+          "estimated-arrival-date": {
+            "description": "The estimated arrival date of the shipment.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "fulfillment-center-id": {
+            "description": "The identifier of the fulfillment center.",
+            "type": ["null", "string"]
+          },
+          "fulfillment-channel": {
+            "description": "The channel through which the fulfillment is done.",
+            "type": ["null", "string"]
+          },
+          "sales-channel": {
+            "description": "The channel through which the sale is made.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time for the data represented.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_MERCHANT_LISTINGS_ALL_DATA",
+      "json_schema": {
+        "title": "Get Merchant Listings Reports",
+        "description": "Get Merchant Listings All Data Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "item-name": {
+            "description": "Name of the item listed",
+            "type": ["null", "string"]
+          },
+          "item-description": {
+            "description": "Description of the item",
+            "type": ["null", "string"]
+          },
+          "listing-id": {
+            "description": "Unique ID for the listing",
+            "type": ["null", "string"]
+          },
+          "seller-sku": {
+            "description": "Seller-specific SKU for the item",
+            "type": ["null", "string"]
+          },
+          "price": {
+            "description": "Price of the item",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "Available quantity of the item",
+            "type": ["null", "string"]
+          },
+          "open-date": {
+            "description": "Date and time when the listing was opened",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "image-url": {
+            "description": "URL for the item image",
+            "type": ["null", "string"]
+          },
+          "item-is-marketplace": {
+            "description": "Whether the item is a part of the marketplace",
+            "type": ["null", "string"]
+          },
+          "product-id-type": {
+            "description": "Type of product ID",
+            "type": ["null", "string"]
+          },
+          "zshop-shipping-fee": {
+            "description": "Shipping fee in the shop",
+            "type": ["null", "string"]
+          },
+          "item-note": {
+            "description": "Any additional notes for the item",
+            "type": ["null", "string"]
+          },
+          "item-condition": {
+            "description": "Condition of the item",
+            "type": ["null", "string"]
+          },
+          "zshop-category1": {
+            "description": "Category of the item in the shop",
+            "type": ["null", "string"]
+          },
+          "zshop-browse-path": {
+            "description": "Browse path in the shop",
+            "type": ["null", "string"]
+          },
+          "zshop-storefront-feature": {
+            "description": "Storefront feature status in the shop",
+            "type": ["null", "string"]
+          },
+          "asin1": {
+            "description": "ASIN identifier for the product",
+            "type": ["null", "string"]
+          },
+          "asin2": {
+            "description": "Additional ASIN identifier for the product",
+            "type": ["null", "string"]
+          },
+          "asin3": {
+            "description": "Another ASIN identifier for the product",
+            "type": ["null", "string"]
+          },
+          "will-ship-internationally": {
+            "description": "If the item will be shipped internationally",
+            "type": ["null", "string"]
+          },
+          "expedited-shipping": {
+            "description": "Indicates if expedited shipping is available",
+            "type": ["null", "string"]
+          },
+          "zshop-boldface": {
+            "description": "Indicates if the item is bold-faced in the shop",
+            "type": ["null", "string"]
+          },
+          "product-id": {
+            "description": "ID for the product",
+            "type": ["null", "string"]
+          },
+          "bid-for-featured-placement": {
+            "description": "Whether the item is bid for a featured placement",
+            "type": ["null", "string"]
+          },
+          "add-delete": {
+            "description": "Indicates whether the item is being added or deleted from the listings",
+            "type": ["null", "string"]
+          },
+          "pending-quantity": {
+            "description": "Quantity of items pending",
+            "type": ["null", "string"]
+          },
+          "fulfillment-channel": {
+            "description": "Channel through which fulfillment is done",
+            "type": ["null", "string"]
+          },
+          "merchant-shipping-group": {
+            "description": "Group for merchant shipping",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "Status of the listing",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data in date format",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"],
+      "source_defined_primary_key": [["listing-id"]]
+    },
+    {
+      "name": "VendorDirectFulfillmentShipping",
+      "json_schema": {
+        "title": "Vendor Direct Fulfillment Shipping",
+        "description": "Vendor Direct Fulfillment Shipping",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "purchaseOrderNumber": {
+            "description": "Unique identifier of the purchase order.",
+            "type": ["null", "string"]
+          },
+          "sellingParty": {
+            "description": "Details of the party responsible for selling the goods.",
+            "type": ["null", "object"],
+            "properties": {
+              "partyId": {
+                "description": "Identifier of the selling party.",
+                "type": ["null", "string"]
+              },
+              "address": {
+                "description": "Address details of the selling party.",
+                "type": ["null", "object"],
+                "properties": {
+                  "name": {
+                    "description": "Name of the selling party.",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine1": {
+                    "description": "First line of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine2": {
+                    "description": "Second line of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine3": {
+                    "description": "Third line of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "city": {
+                    "description": "City of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "county": {
+                    "description": "County of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "district": {
+                    "description": "District of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "stateOrRegion": {
+                    "description": "State or region of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "postalCode": {
+                    "description": "Postal code of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "countryCode": {
+                    "description": "Country code of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "phone": {
+                    "description": "Contact phone number of the selling party.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "taxRegistrationDetails": {
+                "description": "Details of tax registration for the selling party.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "taxRegistrationType": {
+                      "description": "Type of tax registration.",
+                      "type": ["null", "string"]
+                    },
+                    "taxRegistrationNumber": {
+                      "description": "Tax registration number of the selling party.",
+                      "type": ["null", "string"]
+                    },
+                    "taxRegistrationAddress": {
+                      "description": "Address details for tax registration.",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "name": { "type": ["null", "string"] },
+                        "addressLine1": { "type": ["null", "string"] },
+                        "addressLine2": { "type": ["null", "string"] },
+                        "addressLine3": { "type": ["null", "string"] },
+                        "city": { "type": ["null", "string"] },
+                        "county": { "type": ["null", "string"] },
+                        "district": { "type": ["null", "string"] },
+                        "stateOrRegion": { "type": ["null", "string"] },
+                        "postalCode": { "type": ["null", "string"] },
+                        "countryCode": { "type": ["null", "string"] },
+                        "phone": { "type": ["null", "string"] }
+                      }
+                    },
+                    "taxRegistrationMessages": {
+                      "description": "Messages related to tax registration.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "shipFromParty": {
+            "description": "Details of the party from which the goods are shipped.",
+            "type": ["null", "object"],
+            "properties": {
+              "partyId": {
+                "description": "Identifier of the shipping party.",
+                "type": ["null", "string"]
+              },
+              "address": {
+                "description": "Address details of the shipping party.",
+                "type": ["null", "object"],
+                "properties": {
+                  "name": {
+                    "description": "Name of the shipping party.",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine1": {
+                    "description": "First line of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine2": {
+                    "description": "Second line of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine3": {
+                    "description": "Third line of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "city": {
+                    "description": "City of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "county": {
+                    "description": "County of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "district": {
+                    "description": "District of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "stateOrRegion": {
+                    "description": "State or region of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "postalCode": {
+                    "description": "Postal code of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "countryCode": {
+                    "description": "Country code of the address.",
+                    "type": ["null", "string"]
+                  },
+                  "phone": {
+                    "description": "Contact phone number of the shipping party.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "taxRegistrationDetails": {
+                "description": "Details of tax registration for the shipping party.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "taxRegistrationType": {
+                      "description": "Type of tax registration.",
+                      "type": ["null", "string"]
+                    },
+                    "taxRegistrationNumber": {
+                      "description": "Tax registration number of the shipping party.",
+                      "type": ["null", "string"]
+                    },
+                    "taxRegistrationAddress": {
+                      "description": "Address details for tax registration.",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "name": { "type": ["null", "string"] },
+                        "addressLine1": { "type": ["null", "string"] },
+                        "addressLine2": { "type": ["null", "string"] },
+                        "addressLine3": { "type": ["null", "string"] },
+                        "city": { "type": ["null", "string"] },
+                        "county": { "type": ["null", "string"] },
+                        "district": { "type": ["null", "string"] },
+                        "stateOrRegion": { "type": ["null", "string"] },
+                        "postalCode": { "type": ["null", "string"] },
+                        "countryCode": { "type": ["null", "string"] },
+                        "phone": { "type": ["null", "string"] }
+                      }
+                    },
+                    "taxRegistrationMessages": {
+                      "description": "Messages related to tax registration.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "labelFormat": {
+            "description": "Format of the shipping label.",
+            "type": ["null", "string"]
+          },
+          "labelData": {
+            "description": "Details of the label data associated with the shipment.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "packageIdentifier": {
+                  "description": "Identifier of the shipped package.",
+                  "type": ["null", "string"]
+                },
+                "trackingNumber": {
+                  "description": "Tracking number for the shipment.",
+                  "type": ["null", "string"]
+                },
+                "shipMethod": {
+                  "description": "Shipping method used for the shipment.",
+                  "type": ["null", "string"]
+                },
+                "shipMethodName": {
+                  "description": "Name of the shipping method.",
+                  "type": ["null", "string"]
+                },
+                "content": {
+                  "description": "Description of the shipped content.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "createdBefore": {
+            "description": "The timestamp indicating the maximum creation date of the shipping data to be fetched.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["createdBefore"],
+      "source_defined_primary_key": [["purchaseOrderNumber"]]
+    },
+    {
+      "name": "Orders",
+      "json_schema": {
+        "title": "Orders",
+        "description": "All orders that were updated after a specified date",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "properties": {
+          "seller_id": {
+            "description": "Identifier for the seller associated with the order",
+            "type": "string",
+            "title": "seller_id"
+          },
+          "AmazonOrderId": {
+            "description": "Unique identifier for the Amazon order",
+            "type": ["null", "string"]
+          },
+          "BuyerInfo": {
+            "description": "Information about the buyer",
+            "type": ["null", "object"],
+            "additionalProperties": true
+          },
+          "PurchaseDate": {
+            "description": "Date and time when the order was purchased",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDate": {
+            "description": "Date and time when the order was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "OrderStatus": {
+            "description": "Status of the order",
+            "type": ["null", "string"]
+          },
+          "SellerOrderId": {
+            "description": "Unique identifier given by the seller for the order",
+            "type": ["null", "string"]
+          },
+          "FulfillmentChannel": {
+            "description": "Channel through which the order is fulfilled",
+            "type": ["null", "string"]
+          },
+          "SalesChannel": {
+            "description": "Channel through which the order was sold",
+            "type": ["null", "string"]
+          },
+          "AutomatedShippingSettings": {
+            "description": "Settings related to automated shipping processes.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "HasAutomatedShippingSettings": {
+                "description": "Indicates if the order has automated shipping settings",
+                "type": ["null", "boolean"]
+              }
+            }
+          },
+          "HasRegulatedItems": {
+            "description": "Indicates if the order has regulated items",
+            "type": ["null", "boolean"]
+          },
+          "ShipServiceLevel": {
+            "description": "Service level for shipping the order",
+            "type": ["null", "string"]
+          },
+          "OrderTotal": {
+            "description": "Total amount of the order including taxes and shipping costs.",
+            "type": ["null", "object"],
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the order amount",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Total amount of the order",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "NumberOfItemsShipped": {
+            "description": "Number of items shipped in the order",
+            "type": ["null", "integer"]
+          },
+          "NumberOfItemsUnshipped": {
+            "description": "Number of items yet to be shipped in the order",
+            "type": ["null", "integer"]
+          },
+          "PaymentMethod": {
+            "description": "Payment method used for the order",
+            "type": ["null", "string"]
+          },
+          "PaymentMethodDetails": {
+            "description": "Details of the payment method used for the order.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of the payment method used",
+              "type": ["null", "string"]
+            }
+          },
+          "IsAccessPointOrder": {
+            "description": "Indicates if the order is an Amazon Hub Counter order",
+            "type": ["null", "boolean"]
+          },
+          "IsReplacementOrder": {
+            "description": "Indicates if the order is a replacement order",
+            "type": ["null", "string"]
+          },
+          "MarketplaceId": {
+            "description": "Identifier for the marketplace where the order was placed",
+            "type": ["null", "string"]
+          },
+          "ShipmentServiceLevelCategory": {
+            "description": "Service level category for shipping the order",
+            "type": ["null", "string"]
+          },
+          "OrderType": {
+            "description": "Type of the order",
+            "type": ["null", "string"]
+          },
+          "EarliestShipDate": {
+            "description": "Earliest shipment date for the order",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LatestShipDate": {
+            "description": "Latest shipment date for the order",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "IsBusinessOrder": {
+            "description": "Indicates if the order is a business order",
+            "type": ["null", "boolean"]
+          },
+          "IsSoldByAB": {
+            "description": "Indicates if the order is sold by Amazon Business",
+            "type": ["null", "boolean"]
+          },
+          "IsPrime": {
+            "description": "Indicates if the order is a Prime order",
+            "type": ["null", "boolean"]
+          },
+          "IsGlobalExpressEnabled": {
+            "description": "Indicates if global express is enabled for the order",
+            "type": ["null", "boolean"]
+          },
+          "IsPremiumOrder": {
+            "description": "Indicates if the order is a premium order",
+            "type": ["null", "boolean"]
+          },
+          "IsISPU": {
+            "description": "Indicates if the order is for In-Store Pickup",
+            "type": ["null", "boolean"]
+          },
+          "DefaultShipFromLocationAddress": {
+            "description": "The default address from which orders are shipped.",
+            "type": ["null", "object"],
+            "properties": {
+              "AddressLine1": {
+                "description": "First line of the shipping address",
+                "type": ["null", "string"]
+              },
+              "City": {
+                "description": "City of the shipping address",
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "description": "Country code of the shipping address",
+                "type": ["null", "string"]
+              },
+              "Name": {
+                "description": "Name associated with the shipping address",
+                "type": ["null", "string"]
+              },
+              "PostalCode": {
+                "description": "Postal code of the shipping address",
+                "type": ["null", "string"]
+              },
+              "StateOrRegion": {
+                "description": "State or region of the shipping address",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "EarliestDeliveryDate": {
+            "description": "Earliest estimated delivery date of the order",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "LatestDeliveryDate": {
+            "description": "Latest estimated delivery date of the order",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "ShippingAddress": {
+            "description": "The address to which the order will be shipped.",
+            "type": ["null", "object"],
+            "properties": {
+              "City": {
+                "description": "City of the shipping address",
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "description": "Country code of the shipping address",
+                "type": ["null", "string"]
+              },
+              "PostalCode": {
+                "description": "Postal code of the shipping address",
+                "type": ["null", "string"]
+              },
+              "StateOrRegion": {
+                "description": "State or region of the shipping address",
+                "type": ["null", "string"]
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["LastUpdateDate"],
+      "source_defined_primary_key": [["AmazonOrderId"]]
+    },
+    {
+      "name": "OrderItems",
+      "json_schema": {
+        "title": "Order Items",
+        "description": "All order items that were updated after a specified date",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AmazonOrderId": {
+            "description": "ID of the Amazon order",
+            "type": ["null", "string"]
+          },
+          "ASIN": {
+            "description": "Amazon Standard Identification Number of the product",
+            "type": ["null", "string"]
+          },
+          "OrderItemId": {
+            "description": "ID of the order item",
+            "type": ["null", "string"]
+          },
+          "SellerSKU": {
+            "description": "SKU of the seller",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "Title of the product",
+            "type": ["null", "string"]
+          },
+          "QuantityOrdered": {
+            "description": "Quantity of the item ordered",
+            "type": ["null", "integer"]
+          },
+          "ProductInfo": {
+            "description": "Information about the product",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "NumberOfItems": {
+                "description": "Number of items in the product",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "QuantityShipped": {
+            "description": "Quantity of the item shipped",
+            "type": ["null", "integer"]
+          },
+          "PointsGranted": {
+            "description": "Points granted for the purchase",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "PointsNumber": {
+                "description": "Number of points granted",
+                "type": ["null", "integer"]
+              },
+              "PointsMonetaryValue": {
+                "description": "Monetary value equivalent of the points granted",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "CurrencyCode": {
+                    "description": "Currency code of the monetary value",
+                    "type": ["null", "string"]
+                  },
+                  "Amount": {
+                    "description": "Amount of monetary value of points",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "ItemPrice": {
+            "description": "Price of the item",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the item price",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Amount of the item price",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "PromotionIds": {
+            "description": "IDs of promotions applied",
+            "type": ["null", "array"],
+            "items": {
+              "description": "ID of a promotion",
+              "type": ["null", "string"]
+            }
+          },
+          "ItemTax": {
+            "description": "Tax applied on the item",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the item tax",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Amount of item tax",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "ShippingPrice": {
+            "description": "Price of shipping",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the shipping price",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Amount of shipping price",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "ShippingTax": {
+            "description": "Tax applied on shipping",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the shipping tax",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Amount of shipping tax",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "ShippingDiscount": {
+            "description": "Discount applied on shipping",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the shipping discount",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Amount of shipping discount",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "ShippingDiscountTax": {
+            "description": "Tax applied on the shipping discount",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the shipping discount tax",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Amount of shipping discount tax",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "PromotionDiscount": {
+            "description": "Discount applied due to promotion",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the promotion discount",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Amount of promotion discount",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "PromotionDiscountTax": {
+            "description": "Tax applied on the promotion discount",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the promotion discount tax",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Amount of promotion discount tax",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "ScheduledDeliveryEndDate": {
+            "description": "End date for scheduled delivery",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "ScheduledDeliveryStartDate": {
+            "description": "Start date for scheduled delivery",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "CODFee": {
+            "description": "Cash on delivery fee",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the COD fee",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Amount of COD fee",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "IsGift": {
+            "description": "Flag indicating if the order is a gift",
+            "type": ["null", "string"]
+          },
+          "ConditionNote": {
+            "description": "Additional notes on the condition of the product",
+            "type": ["null", "string"]
+          },
+          "ConditionId": {
+            "description": "Condition ID of the product",
+            "type": ["null", "string"]
+          },
+          "ConditionSubtypeId": {
+            "description": "Subtype ID of the product condition",
+            "type": ["null", "string"]
+          },
+          "CODFeeDiscount": {
+            "description": "Discount on cash on delivery fee",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "CurrencyCode": {
+                "description": "Currency code of the COD fee discount",
+                "type": ["null", "string"]
+              },
+              "Amount": {
+                "description": "Amount of COD fee discount",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "TaxCollection": {
+            "description": "Information about tax collection",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "Model": {
+                "description": "Tax collection model",
+                "type": ["null", "string"]
+              },
+              "ResponsibleParty": {
+                "description": "Party responsible for tax collection",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "IsTransparency": {
+            "description": "Flag indicating if transparency is applied",
+            "type": ["null", "boolean"]
+          },
+          "IossNumber": {
+            "description": "Import One Stop Shop number",
+            "type": ["null", "string"]
+          },
+          "SerialNumberRequired": {
+            "description": "Flag indicating if serial number is required",
+            "type": ["null", "boolean"]
+          },
+          "StoreChainStoreId": {
+            "description": "ID of the store chain",
+            "type": ["null", "string"]
+          },
+          "DeemedResellerCategory": {
+            "description": "Category indicating if the seller is considered a reseller",
+            "type": ["null", "string"]
+          },
+          "PriceDesignation": {
+            "description": "Designation of the price",
+            "type": ["null", "string"]
+          },
+          "BuyerInfo": {
+            "description": "Information about the buyer",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "BuyerCustomizedInfo": {
+                "description": "Customized information provided by the buyer",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "CustomizedURL": {
+                    "description": "URL for customizations",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "GiftMessageText": {
+                "description": "Message provided as a gift",
+                "type": ["null", "string"]
+              },
+              "GiftWrapPrice": {
+                "description": "Price of gift wrapping",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "CurrencyCode": {
+                    "description": "Currency code of the gift wrapping price",
+                    "type": ["null", "string"]
+                  },
+                  "Amount": {
+                    "description": "Amount of gift wrapping price",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "GiftWrapLevel": {
+                "description": "Level of gift wrapping",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "BuyerRequestedCancel": {
+            "description": "Information about buyer's request for cancellation",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "IsBuyerRequestedCancel": {
+                "description": "Flag indicating if cancellation was requested by the buyer",
+                "type": ["null", "string"]
+              },
+              "BuyerCancelReason": {
+                "description": "Reason for buyer's cancellation request",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "SerialNumbers": {
+            "description": "List of serial numbers",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Serial number of an item",
+              "type": ["null", "string"]
+            }
+          },
+          "LastUpdateDate": {
+            "description": "Date and time of the last update",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["LastUpdateDate"],
+      "source_defined_primary_key": [["OrderItemId"]]
+    },
+    {
+      "name": "GET_ORDER_REPORT_DATA_SHIPPING",
+      "json_schema": {
+        "title": "GET_ORDER_REPORT_DATA_SHIPPING",
+        "description": "GET_ORDER_REPORT_DATA_SHIPPING",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "AmazonOrderID": {
+            "description": "Unique identifier for the Amazon order",
+            "type": ["null", "string"]
+          },
+          "AmazonSessionID": {
+            "description": "Unique identifier for the Amazon session",
+            "type": ["null", "string"]
+          },
+          "OrderDate": {
+            "description": "Date when the order was placed",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "OrderPostedDate": {
+            "description": "Date when the order was posted",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "BillingData": {
+            "description": "Data related to billing information",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "BuyerEmailAddress": {
+                "description": "Email address of the buyer",
+                "type": ["null", "string"]
+              },
+              "BuyerName": {
+                "description": "Name of the buyer",
+                "type": ["null", "string"]
+              },
+              "BuyerPhoneNumber": {
+                "description": "Phone number of the buyer",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "FulfillmentData": {
+            "description": "Data related to order fulfillment",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "FulfillmentMethod": {
+                "description": "Method used for order fulfillment",
+                "type": ["null", "string"]
+              },
+              "FulfillmentServiceLevel": {
+                "description": "Service level for fulfillment",
+                "type": ["null", "string"]
+              },
+              "Address": {
+                "description": "Shipping address details",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "Name": {
+                    "description": "Name associated with the address",
+                    "type": ["null", "string"]
+                  },
+                  "AddressFieldOne": {
+                    "description": "Address line 1",
+                    "type": ["null", "string"]
+                  },
+                  "City": {
+                    "description": "City of the shipping address",
+                    "type": ["null", "string"]
+                  },
+                  "StateOrRegion": {
+                    "description": "State or region of the shipping address",
+                    "type": ["null", "string"]
+                  },
+                  "PostalCode": {
+                    "description": "Postal code of the shipping address",
+                    "type": ["null", "string"]
+                  },
+                  "CountryCode": {
+                    "description": "Country code of the shipping address",
+                    "type": ["null", "string"]
+                  },
+                  "PhoneNumber": {
+                    "description": "Phone number associated with the address",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "IsBusinessOrder": {
+            "description": "Indicates if the order is a business order",
+            "type": ["null", "string"]
+          },
+          "Item": {
+            "description": "Details of the item ordered",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "AmazonOrderItemCode": {
+                "description": "Unique identifier for the ordered item",
+                "type": ["null", "string"]
+              },
+              "SKU": {
+                "description": "Stock Keeping Unit (SKU) for the item",
+                "type": ["null", "string"]
+              },
+              "Title": {
+                "description": "Title of the item",
+                "type": ["null", "string"]
+              },
+              "Quantity": {
+                "description": "Quantity of the item ordered",
+                "type": ["null", "string"]
+              },
+              "ProductTaxCode": {
+                "description": "Tax code for the product",
+                "type": ["null", "string"]
+              },
+              "ItemPrice": {
+                "description": "Price details for the item",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "Component": {
+                    "description": "Price components for the item",
+                    "type": ["array"],
+                    "items": { "type": ["null", "object"] },
+                    "properties": {
+                      "Type": {
+                        "description": "Type of price component",
+                        "type": ["null", "string"]
+                      },
+                      "Amount": {
+                        "description": "Amount of the price component",
+                        "type": ["null", "object"],
+                        "additionalProperties": true,
+                        "properties": {
+                          "currency": {
+                            "description": "Currency type for the component",
+                            "type": ["null", "string"]
+                          },
+                          "value": {
+                            "description": "Value of the price component",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "ItemFees": {
+                "description": "Fees associated with the item",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "Fee": {
+                    "description": "Specific fee data",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "Type": {
+                        "description": "Type of fee",
+                        "type": ["null", "string"]
+                      },
+                      "Amount": {
+                        "description": "Amount of the fee",
+                        "type": ["null", "object"],
+                        "additionalProperties": true,
+                        "properties": {
+                          "currency": {
+                            "description": "Currency type",
+                            "type": ["null", "string"]
+                          },
+                          "value": {
+                            "description": "Value of the fee",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "Promotion": {
+                "description": "Promotion details for the item",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "PromotionClaimCode": {
+                    "description": "Claim code for the promotion",
+                    "type": ["null", "string"]
+                  },
+                  "MerchantPromotionID": {
+                    "description": "ID of the merchant promotion",
+                    "type": ["null", "string"]
+                  },
+                  "Component": {
+                    "description": "Promotion amount and type",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "Type": {
+                        "description": "Type of promotion",
+                        "type": ["null", "string"]
+                      },
+                      "Amount": {
+                        "description": "Amount of the promotion",
+                        "type": ["null", "object"],
+                        "additionalProperties": true,
+                        "properties": {
+                          "currency": {
+                            "description": "Currency type",
+                            "type": ["null", "string"]
+                          },
+                          "value": {
+                            "description": "Value of the promotion",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "SignatureConfirmationRecommended": {
+                "description": "Indicates if signature confirmation is recommended",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "dataEndTime": {
+            "description": "End time for the data",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_SELLER_FEEDBACK_DATA",
+      "json_schema": {
+        "title": "Seller Feedback Data Reports",
+        "description": "Seller Feedback Data Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "date": {
+            "description": "Date when the feedback was received.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "rating": {
+            "description": "Numeric rating provided by the buyer (e.g., 1 to 5 stars).",
+            "type": ["null", "number"]
+          },
+          "comments": {
+            "description": "Text comments provided by the buyer when leaving feedback.",
+            "type": ["null", "string"]
+          },
+          "response": {
+            "description": "Optional response from the seller to the buyer's feedback.",
+            "type": ["null", "string"]
+          },
+          "order_id": {
+            "description": "Unique identifier for the order associated with the feedback.",
+            "type": ["null", "string"]
+          },
+          "rater_email": {
+            "description": "Email address of the buyer who provided the feedback.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data collection period.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["date"]
+    },
+    {
+      "name": "GET_XML_BROWSE_TREE_DATA",
+      "json_schema": {
+        "title": "XML Browse Tree Data",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "browseNodeId": {
+            "description": "The unique identifier of the browse node",
+            "type": ["string"]
+          },
+          "browseNodeAttributes": {
+            "description": "Attributes associated with the browse node",
+            "type": ["null", "object"],
+            "properties": {
+              "attribute": {
+                "description": "List of attributes",
+                "type": ["array"],
+                "items": { "type": ["null", "object"] },
+                "properties": {
+                  "name": {
+                    "description": "The name of the attribute",
+                    "type": ["null", "string"]
+                  },
+                  "text": {
+                    "description": "The text value of the attribute",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "count": {
+                "description": "The count of attributes",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "browseNodeName": {
+            "description": "The name of the browse node",
+            "type": ["null", "string"]
+          },
+          "browseNodeStoreContextName": {
+            "description": "The store context name of the browse node",
+            "type": ["null", "string"]
+          },
+          "browsePathById": {
+            "description": "The path of the browse node by ID",
+            "type": ["null", "string"]
+          },
+          "browsePathByName": {
+            "description": "The path of the browse node by name",
+            "type": ["null", "string"]
+          },
+          "hasChildren": {
+            "description": "Flag indicating if the browse node has children",
+            "type": ["string"]
+          },
+          "childNodes": {
+            "description": "Child nodes under the current node",
+            "type": ["null", "object"],
+            "properties": {
+              "count": {
+                "description": "The count of child nodes",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "The unique identifiers of child nodes",
+                "type": ["array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "productTypeDefinitions": {
+            "description": "Definitions of product types associated with the browse node",
+            "type": ["null", "string"]
+          },
+          "refinementsInformation": {
+            "description": "Information on refinements available",
+            "type": ["null", "object"],
+            "properties": {
+              "count": {
+                "description": "The count of refinements",
+                "type": ["null", "string"]
+              },
+              "refinementName": {
+                "description": "Name of the refinement",
+                "type": ["null", "object"],
+                "properties": {
+                  "refinementField": {
+                    "description": "Field related to the refinement",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "acceptedValues": {
+                        "description": "The accepted values for the refinement",
+                        "type": ["null", "string"]
+                      },
+                      "hasModifier": {
+                        "description": "Flag indicating if the refinement has a modifier",
+                        "type": ["null", "string"]
+                      },
+                      "modifiers": {
+                        "description": "Modifiers associated with the refinement",
+                        "type": ["null", "string"]
+                      },
+                      "refinementAttribute": {
+                        "description": "The attribute associated with the refinement",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "dataEndTime": {
+            "description": "The end time of the data",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"],
+      "source_defined_primary_key": [["browseNodeId"]]
+    },
+    {
+      "name": "ListFinancialEventGroups",
+      "json_schema": {
+        "title": "ListFinancialEventGroups",
+        "description": "List Financial Event Groups",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "FinancialEventGroupId": {
+            "description": "The unique identifier for the financial event group.",
+            "type": ["null", "string"]
+          },
+          "ProcessingStatus": {
+            "description": "The processing status of the financial event group.",
+            "type": ["null", "string"]
+          },
+          "FundTransferStatus": {
+            "description": "The status of the fund transfer.",
+            "type": ["null", "string"]
+          },
+          "OriginalTotal": {
+            "description": "Represents the original total amount in the default currency for the financial event group.",
+            "type": ["null", "object"],
+            "properties": {
+              "CurrencyCode": {
+                "description": "The currency code for the original total amount.",
+                "type": ["null", "string"]
+              },
+              "CurrencyAmount": {
+                "description": "The original total amount in the original currency.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "ConvertedTotal": {
+            "description": "Represents the total amount converted to a different currency within the financial event group.",
+            "type": ["null", "object"],
+            "properties": {
+              "CurrencyCode": {
+                "description": "The currency code for the converted total amount.",
+                "type": ["null", "string"]
+              },
+              "CurrencyAmount": {
+                "description": "The total amount converted to a specific currency.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "FundTransferDate": {
+            "description": "The date the fund transfer occurred.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "TraceId": {
+            "description": "The unique identifier used for tracing the financial event group.",
+            "type": ["null", "string"]
+          },
+          "AccountTail": {
+            "description": "The last digits of the account number associated with the financial event group.",
+            "type": ["null", "string"]
+          },
+          "BeginningBalance": {
+            "description": "Represents the initial balance at the beginning of the financial event group.",
+            "type": ["null", "object"],
+            "properties": {
+              "CurrencyCode": {
+                "description": "The currency code for the beginning balance.",
+                "type": ["null", "string"]
+              },
+              "CurrencyAmount": {
+                "description": "The initial balance amount before any financial event occurred.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "FinancialEventGroupStart": {
+            "description": "The start datetime of the financial event group.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "FinancialEventGroupEnd": {
+            "description": "The end datetime of the financial event group.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["FinancialEventGroupStart"],
+      "source_defined_primary_key": [["FinancialEventGroupId"]]
+    },
+    {
+      "name": "ListFinancialEvents",
+      "json_schema": {
+        "title": "ListFinancialEvents",
+        "description": "List of Financial Events",
+        "type": ["null", "object"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "ShipmentEventList": {
+            "description": "List of events related to shipments of products.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "The unique identifier of the Amazon order associated with the shipment event",
+                  "type": ["null", "string"]
+                },
+                "SellerOrderId": {
+                  "description": "The unique identifier of the seller's order associated with the shipment event",
+                  "type": ["null", "string"]
+                },
+                "MarketplaceName": {
+                  "description": "The name of the marketplace where the event occurred",
+                  "type": ["null", "string"]
+                },
+                "OrderChargeList": {
+                  "description": "List of order charges associated with the shipment event",
+                  "type": ["null", "array"]
+                },
+                "OrderChargeAdjustmentList": {
+                  "description": "List of order charge adjustments related to the shipment event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentFeeList": {
+                  "description": "List of shipment fees associated with the shipment event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentFeeAdjustmentList": {
+                  "description": "List of shipment fee adjustments related to the shipment event",
+                  "type": ["null", "array"]
+                },
+                "OrderFeeList": {
+                  "description": "List of order fees associated with the shipment event",
+                  "type": ["null", "array"]
+                },
+                "OrderFeeAdjustmentList": {
+                  "description": "List of order fee adjustments related to the shipment event",
+                  "type": ["null", "array"]
+                },
+                "DirectPaymentList": {
+                  "description": "List of direct payments associated with the shipment event",
+                  "type": ["null", "array"]
+                },
+                "PostedDate": {
+                  "description": "The date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "ShipmentItemList": {
+                  "description": "List of shipment items associated with the shipment event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentItemAdjustmentList": {
+                  "description": "List of shipment item adjustments related to the shipment event",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "RefundEventList": {
+            "description": "List of events related to refunds issued to customers.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "The unique identifier of the Amazon order associated with the refund event",
+                  "type": ["null", "string"]
+                },
+                "SellerOrderId": {
+                  "description": "The unique identifier of the seller's order associated with the refund event",
+                  "type": ["null", "string"]
+                },
+                "MarketplaceName": {
+                  "description": "The name of the marketplace where the event occurred",
+                  "type": ["null", "string"]
+                },
+                "OrderChargeList": {
+                  "description": "List of order charges associated with the refund event",
+                  "type": ["null", "array"]
+                },
+                "OrderChargeAdjustmentList": {
+                  "description": "List of order charge adjustments related to the refund event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentFeeList": {
+                  "description": "List of shipment fees associated with the refund event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentFeeAdjustmentList": {
+                  "description": "List of shipment fee adjustments related to the refund event",
+                  "type": ["null", "array"]
+                },
+                "OrderFeeList": {
+                  "description": "List of order fees associated with the refund event",
+                  "type": ["null", "array"]
+                },
+                "OrderFeeAdjustmentList": {
+                  "description": "List of order fee adjustments related to the refund event",
+                  "type": ["null", "array"]
+                },
+                "DirectPaymentList": {
+                  "description": "List of direct payments associated with the refund event",
+                  "type": ["null", "array"]
+                },
+                "PostedDate": {
+                  "description": "The date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "ShipmentItemList": {
+                  "description": "List of shipment items associated with the refund event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentItemAdjustmentList": {
+                  "description": "List of shipment item adjustments related to the refund event",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "GuaranteeClaimEventList": {
+            "description": "List of events related to guarantee claims made by customers.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "The unique identifier of the Amazon order associated with the guarantee claim event",
+                  "type": ["null", "string"]
+                },
+                "SellerOrderId": {
+                  "description": "The unique identifier of the seller's order associated with the guarantee claim event",
+                  "type": ["null", "string"]
+                },
+                "MarketplaceName": {
+                  "description": "The name of the marketplace where the event occurred",
+                  "type": ["null", "string"]
+                },
+                "OrderChargeList": {
+                  "description": "List of order charges associated with the guarantee claim event",
+                  "type": ["null", "array"]
+                },
+                "OrderChargeAdjustmentList": {
+                  "description": "List of order charge adjustments related to the guarantee claim event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentFeeList": {
+                  "description": "List of shipment fees associated with the guarantee claim event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentFeeAdjustmentList": {
+                  "description": "List of shipment fee adjustments related to the guarantee claim event",
+                  "type": ["null", "array"]
+                },
+                "OrderFeeList": {
+                  "description": "List of order fees associated with the guarantee claim event",
+                  "type": ["null", "array"]
+                },
+                "OrderFeeAdjustmentList": {
+                  "description": "List of order fee adjustments related to the guarantee claim event",
+                  "type": ["null", "array"]
+                },
+                "DirectPaymentList": {
+                  "description": "List of direct payments associated with the guarantee claim event",
+                  "type": ["null", "array"]
+                },
+                "PostedDate": {
+                  "description": "The date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "ShipmentItemList": {
+                  "description": "List of shipment items associated with the guarantee claim event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentItemAdjustmentList": {
+                  "description": "List of shipment item adjustments related to the guarantee claim event",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "ChargebackEventList": {
+            "description": "List of events related to chargebacks initiated by customers.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "The unique identifier of the Amazon order",
+                  "type": ["null", "string"]
+                },
+                "SellerOrderId": {
+                  "description": "The unique identifier of the seller's order",
+                  "type": ["null", "string"]
+                },
+                "MarketplaceName": {
+                  "description": "The name of the marketplace where the event occurred",
+                  "type": ["null", "string"]
+                },
+                "OrderChargeList": {
+                  "description": "List of order charges associated with the chargeback event",
+                  "type": ["null", "array"]
+                },
+                "OrderChargeAdjustmentList": {
+                  "description": "List of order charge adjustments related to the chargeback event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentFeeList": {
+                  "description": "List of shipment fees associated with the chargeback event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentFeeAdjustmentList": {
+                  "description": "List of shipment fee adjustments related to the chargeback event",
+                  "type": ["null", "array"]
+                },
+                "OrderFeeList": {
+                  "description": "List of order fees associated with the chargeback event",
+                  "type": ["null", "array"]
+                },
+                "OrderFeeAdjustmentList": {
+                  "description": "List of order fee adjustments related to the chargeback event",
+                  "type": ["null", "array"]
+                },
+                "DirectPaymentList": {
+                  "description": "List of direct payments associated with the chargeback event",
+                  "type": ["null", "array"]
+                },
+                "PostedDate": {
+                  "description": "The date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "ShipmentItemList": {
+                  "description": "List of shipment items associated with the chargeback event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentItemAdjustmentList": {
+                  "description": "List of shipment item adjustments related to the chargeback event",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "PayWithAmazonEventList": {
+            "description": "List of events related to payments made using Amazon's payment service.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "SellerOrderId": {
+                  "description": "The unique identifier of the seller's order associated with the payment event",
+                  "type": ["null", "string"]
+                },
+                "TransactionPostedDate": {
+                  "description": "The date and time when the transaction was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "BusinessObjectType": {
+                  "description": "Type of business object associated with the payment",
+                  "type": ["null", "string"]
+                },
+                "SalesChannel": {
+                  "description": "Sales channel through which the payment was made",
+                  "type": ["null", "string"]
+                },
+                "Charge": {
+                  "description": "Charged amount in the payment",
+                  "type": ["null", "object"]
+                },
+                "FeeList": {
+                  "description": "List of fees associated with the payment",
+                  "type": ["null", "array"]
+                },
+                "PaymentAmountType": {
+                  "description": "Type of payment amount",
+                  "type": ["null", "string"]
+                },
+                "AmountDescription": {
+                  "description": "Description of the payment amount",
+                  "type": ["null", "string"]
+                },
+                "FulfillmentChannel": {
+                  "description": "Channel through which fulfillment is done",
+                  "type": ["null", "string"]
+                },
+                "StoreName": {
+                  "description": "Name of the store on which the payment was made",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "ServiceProviderCreditEventList": {
+            "description": "List of events related to credits issued to service providers.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "ProviderTransactionType": {
+                  "description": "Type of transaction for the provider",
+                  "type": ["null", "string"]
+                },
+                "SellerOrderId": {
+                  "description": "The unique identifier of the seller's order associated with the service provider credit event",
+                  "type": ["null", "string"]
+                },
+                "MarketplaceId": {
+                  "description": "ID of the marketplace",
+                  "type": ["null", "string"]
+                },
+                "MarketplaceCountryCode": {
+                  "description": "Country code of the marketplace",
+                  "type": ["null", "string"]
+                },
+                "SellerId": {
+                  "description": "ID of the seller",
+                  "type": ["null", "string"]
+                },
+                "SellerStoreName": {
+                  "description": "Name of the seller's store",
+                  "type": ["null", "string"]
+                },
+                "ProviderId": {
+                  "description": "ID of the provider",
+                  "type": ["null", "string"]
+                },
+                "ProviderStoreName": {
+                  "description": "Name of the provider's store",
+                  "type": ["null", "string"]
+                },
+                "TransactionAmount": {
+                  "description": "Amount of the transaction",
+                  "type": ["null", "object"]
+                },
+                "TransactionCreationDate": {
+                  "description": "The date and time when the transaction was created",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "RetrochargeEventList": {
+            "description": "List of events related to retrocharge transactions.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "RetrochargeEventType": {
+                  "description": "Type of retrocharge event",
+                  "type": ["null", "string"]
+                },
+                "AmazonOrderId": {
+                  "description": "Unique identifier of the Amazon order",
+                  "type": ["null", "string"]
+                },
+                "PostedDate": {
+                  "description": "Date and time when the retrocharge event occurred",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "BaseTax": {
+                  "description": "Base tax amount",
+                  "type": ["null", "object"]
+                },
+                "ShippingTax": {
+                  "description": "Shipping tax amount",
+                  "type": ["null", "object"]
+                },
+                "MarketplaceName": {
+                  "description": "Name of the marketplace",
+                  "type": ["null", "string"]
+                },
+                "RetrochargeTaxWithheldList": {
+                  "description": "List of retrocharge tax withheld",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "RentalTransactionEventList": {
+            "description": "List of events related to rental transactions.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "The unique identifier of the Amazon order associated with the rental transaction event",
+                  "type": ["null", "string"]
+                },
+                "RentalEventType": {
+                  "description": "Type of rental event",
+                  "type": ["null", "string"]
+                },
+                "ExtensionLength": {
+                  "description": "Length of rental extension",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "PostedDate": {
+                  "description": "The date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "RentalChargeList": {
+                  "description": "List of rental charges associated with the rental transaction event",
+                  "type": ["null", "array"]
+                },
+                "RentalFeeList": {
+                  "description": "List of rental fees associated with the rental transaction event",
+                  "type": ["null", "array"]
+                },
+                "MarketplaceName": {
+                  "description": "The name of the marketplace where the event occurred",
+                  "type": ["null", "string"]
+                },
+                "RentalInitialValue": {
+                  "description": "Initial value of the rental transaction",
+                  "type": ["null", "object"]
+                },
+                "RentalReimbursement": {
+                  "description": "Reimbursement amount in the rental transaction",
+                  "type": ["null", "object"]
+                },
+                "RentalTaxWithheldList": {
+                  "description": "List of rental tax withheld in the rental transaction",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "PerformanceBondRefundEventList": {
+            "description": "List of performance bond refund events",
+            "type": "array",
+            "items": {}
+          },
+          "ProductAdsPaymentEventList": {
+            "description": "List of events related to payments for product advertisements.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "postedDate": {
+                  "description": "Date and time when the product ad payment was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "transactionType": {
+                  "description": "Type of transaction",
+                  "type": ["null", "string"]
+                },
+                "invoiceId": {
+                  "description": "Identifier of the invoice",
+                  "type": ["null", "string"]
+                },
+                "baseValue": {
+                  "description": "Base value of the product ad payment",
+                  "type": ["null", "object"]
+                },
+                "taxValue": {
+                  "description": "Tax value on the product ad payment",
+                  "type": ["null", "object"]
+                },
+                "transactionValue": {
+                  "description": "Value of the transaction",
+                  "type": ["null", "object"]
+                }
+              }
+            }
+          },
+          "ServiceFeeEventList": {
+            "description": "List of events related to service fees.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "Unique identifier of the Amazon order",
+                  "type": ["null", "string"]
+                },
+                "FeeReason": {
+                  "description": "Reason for the fee",
+                  "type": ["null", "string"]
+                },
+                "FeeList": {
+                  "description": "List of fees",
+                  "type": ["null", "array"]
+                },
+                "SellerSKU": {
+                  "description": "Seller Stock Keeping Unit",
+                  "type": ["null", "string"]
+                },
+                "FnSKU": {
+                  "description": "Fulfillment Network Stock Keeping Unit",
+                  "type": ["null", "string"]
+                },
+                "FeeDescription": {
+                  "description": "Description of the fee",
+                  "type": ["null", "string"]
+                },
+                "ASIN": {
+                  "description": "Amazon Standard Identification Number",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "SellerDealPaymentEventList": {
+            "description": "List of events related to payments for seller deals.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "postedDate": {
+                  "description": "Date and time of the seller deal payment event",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "dealId": {
+                  "description": "Identifier of the deal",
+                  "type": ["null", "string"]
+                },
+                "dealDescription": {
+                  "description": "Description of the deal",
+                  "type": ["null", "string"]
+                },
+                "eventType": {
+                  "description": "Type of event",
+                  "type": ["null", "string"]
+                },
+                "feeType": {
+                  "description": "Type of fee",
+                  "type": ["null", "string"]
+                },
+                "feeAmount": {
+                  "description": "Amount of fee",
+                  "type": ["null", "object"]
+                },
+                "taxAmount": {
+                  "description": "Tax amount",
+                  "type": ["null", "object"]
+                },
+                "totalAmount": {
+                  "description": "Total amount of the deal payment",
+                  "type": ["null", "object"]
+                }
+              }
+            }
+          },
+          "DebtRecoveryEventList": {
+            "description": "List of events related to debt recovery processes.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "DebtRecoveryType": {
+                  "description": "Type of debt recovery event",
+                  "type": ["null", "string"]
+                },
+                "RecoveryAmount": {
+                  "description": "Total amount recovered in the debt recovery",
+                  "type": ["null", "object"]
+                },
+                "OverPaymentCredit": {
+                  "description": "Amount of overpayment credit in the debt recovery",
+                  "type": ["null", "object"]
+                },
+                "DebtRecoveryItemList": {
+                  "description": "List of items involved in the debt recovery",
+                  "type": ["null", "array"]
+                },
+                "ChargeInstrumentList": {
+                  "description": "List of charge instruments involved in the debt recovery event",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "LoanServicingEventList": {
+            "description": "List of loan servicing events",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "LoanAmount": {
+                  "description": "Amount of loan",
+                  "type": ["null", "object"]
+                },
+                "SourceBusinessEventType": {
+                  "description": "Type of business event associated with the loan",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "AdjustmentEventList": {
+            "description": "List of adjustment events representing changes to financial transactions.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AdjustmentType": {
+                  "description": "Type of adjustment made",
+                  "type": ["null", "string"]
+                },
+                "PostedDate": {
+                  "description": "Date and time when the adjustment was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "AdjustmentAmount": {
+                  "description": "The amount of adjustment applied",
+                  "type": ["null", "object"]
+                },
+                "AdjustmentItemList": {
+                  "description": "List of items included in the adjustment",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "SAFETReimbursementEventList": {
+            "description": "List of events representing SAFET reimbursements.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "PostedDate": {
+                  "description": "Date and time of SAFET reimbursement event",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "SAFETClaimId": {
+                  "description": "Identifier of the SAFET claim",
+                  "type": ["null", "string"]
+                },
+                "ReimbursedAmount": {
+                  "description": "Amount reimbursed",
+                  "type": ["null", "object"]
+                },
+                "ReasonCode": {
+                  "description": "Reason code for reimbursement",
+                  "type": ["null", "string"]
+                },
+                "SAFETReimbursementItemList": {
+                  "description": "List of SAFET reimbursement items",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "SellerReviewEnrollmentPaymentEventList": {
+            "description": "List of events related to payments for seller review enrollments.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "PostedDate": {
+                  "description": "Date and time when the seller review enrollment payment was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "EnrollmentId": {
+                  "description": "Identifier of the enrollment",
+                  "type": ["null", "string"]
+                },
+                "ParentASIN": {
+                  "description": "Parent ASIN",
+                  "type": ["null", "string"]
+                },
+                "FeeComponent": {
+                  "description": "Fee component associated with the seller review enrollment payment",
+                  "type": ["null", "object"]
+                },
+                "ChargeComponent": {
+                  "description": "Charge component associated with the seller review enrollment payment",
+                  "type": ["null", "object"]
+                },
+                "TotalAmount": {
+                  "description": "Total amount of the seller review enrollment payment",
+                  "type": ["null", "object"]
+                }
+              }
+            }
+          },
+          "FBALiquidationEventList": {
+            "description": "List of FBA liquidation events",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "PostedDate": {
+                  "description": "Date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "OriginalRemovalOrderId": {
+                  "description": "Original removal order ID",
+                  "type": ["null", "string"]
+                },
+                "LiquidationProceedsAmount": {
+                  "description": "Amount of proceeds from liquidation",
+                  "type": ["null", "object"]
+                },
+                "LiquidationFeeAmount": {
+                  "description": "Amount of liquidation fee",
+                  "type": ["null", "object"]
+                }
+              }
+            }
+          },
+          "CouponPaymentEventList": {
+            "description": "List of events related to coupon payments.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "PostedDate": {
+                  "description": "Date and time when the coupon payment was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "CouponId": {
+                  "description": "Identifier of the coupon",
+                  "type": ["null", "string"]
+                },
+                "SellerCouponDescription": {
+                  "description": "Description of the seller coupon",
+                  "type": ["null", "string"]
+                },
+                "ClipOrRedemptionCount": {
+                  "description": "Number of clips or redemptions made",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "PaymentEventId": {
+                  "description": "Identifier of the payment event",
+                  "type": ["null", "string"]
+                },
+                "FeeComponent": {
+                  "description": "Fee component associated with the coupon payment",
+                  "type": ["null", "object"]
+                },
+                "ChargeComponent": {
+                  "description": "Charge component associated with the coupon payment",
+                  "type": ["null", "object"]
+                },
+                "TotalAmount": {
+                  "description": "Total amount of the coupon payment",
+                  "type": ["null", "object"]
+                }
+              }
+            }
+          },
+          "ImagingServicesFeeEventList": {
+            "description": "List of imaging services fee events",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "ImagingRequestBillingItemID": {
+                  "description": "Billing item ID for imaging request",
+                  "type": ["null", "string"]
+                },
+                "ASIN": {
+                  "description": "ASIN of the product",
+                  "type": ["null", "string"]
+                },
+                "PostedDate": {
+                  "description": "Date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "FeeList": {
+                  "description": "List of fees for imaging services",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "NetworkComminglingTransactionEventList": {
+            "description": "List of events involving network commingling transactions.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "TransactionType": {
+                  "description": "Type of transaction",
+                  "type": ["null", "string"]
+                },
+                "PostedDate": {
+                  "description": "Date and time of the network commingling transaction",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "NetCoTransactionID": {
+                  "description": "ID of the net co-transaction",
+                  "type": ["null", "string"]
+                },
+                "SwapReason": {
+                  "description": "Reason for swap",
+                  "type": ["null", "string"]
+                },
+                "ASIN": {
+                  "description": "Amazon Standard Identification Number",
+                  "type": ["null", "string"]
+                },
+                "MarketplaceId": {
+                  "description": "Identifier of the marketplace",
+                  "type": ["null", "string"]
+                },
+                "TaxExclusiveAmount": {
+                  "description": "Tax exclusive amount",
+                  "type": ["null", "object"]
+                },
+                "TaxAmount": {
+                  "description": "Amount of tax",
+                  "type": ["null", "object"]
+                }
+              }
+            }
+          },
+          "AffordabilityExpenseEventList": {
+            "description": "List of expense events related to affordability programs.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "Unique identifier of the Amazon order",
+                  "type": ["null", "string"]
+                },
+                "PostedDate": {
+                  "description": "Date and time when the expense was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "MarketplaceId": {
+                  "description": "Identifier of the marketplace",
+                  "type": ["null", "string"]
+                },
+                "TransactionType": {
+                  "description": "Type of transaction",
+                  "type": ["null", "string"]
+                },
+                "BaseExpense": {
+                  "description": "Base expense amount",
+                  "type": ["null", "object"]
+                },
+                "TaxTypeCGST": {
+                  "description": "Amount of CGST tax",
+                  "type": ["null", "object"]
+                },
+                "TaxTypeSGST": {
+                  "description": "Amount of SGST tax",
+                  "type": ["null", "object"]
+                },
+                "TaxTypeIGST": {
+                  "description": "Amount of IGST tax",
+                  "type": ["null", "object"]
+                },
+                "TotalExpense": {
+                  "description": "Total expense incurred",
+                  "type": ["null", "object"]
+                }
+              }
+            }
+          },
+          "AffordabilityExpenseReversalEventList": {
+            "description": "List of events reversing affordability expense transactions.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "Unique identifier of the Amazon order",
+                  "type": ["null", "string"]
+                },
+                "PostedDate": {
+                  "description": "Date and time when the expense reversal was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "MarketplaceId": {
+                  "description": "Identifier of the marketplace",
+                  "type": ["null", "string"]
+                },
+                "TransactionType": {
+                  "description": "Type of transaction",
+                  "type": ["null", "string"]
+                },
+                "BaseExpense": {
+                  "description": "Base expense amount",
+                  "type": ["null", "object"]
+                },
+                "TaxTypeCGST": {
+                  "description": "Amount of CGST tax",
+                  "type": ["null", "object"]
+                },
+                "TaxTypeSGST": {
+                  "description": "Amount of SGST tax",
+                  "type": ["null", "object"]
+                },
+                "TaxTypeIGST": {
+                  "description": "Amount of IGST tax",
+                  "type": ["null", "object"]
+                },
+                "TotalExpense": {
+                  "description": "Total expense reversed",
+                  "type": ["null", "object"]
+                }
+              }
+            }
+          },
+          "TrialShipmentEventList": {
+            "description": "List of events related to trial shipments.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "Unique identifier of the Amazon order",
+                  "type": ["null", "string"]
+                },
+                "FinancialEventGroupId": {
+                  "description": "Identifier of the financial event group",
+                  "type": ["null", "string"]
+                },
+                "PostedDate": {
+                  "description": "Date and time of the trial shipment event",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "SKU": {
+                  "description": "Stock Keeping Unit",
+                  "type": ["null", "string"]
+                },
+                "FeeList": {
+                  "description": "List of fees incurred during trial shipment",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "TDSReimbursementEventList": {
+            "description": "List of events representing TDS reimbursements.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "Unique identifier of the Amazon order",
+                  "type": ["null", "string"]
+                },
+                "FinancialEventGroupId": {
+                  "description": "Identifier of the financial event group",
+                  "type": ["null", "string"]
+                },
+                "PostedDate": {
+                  "description": "Date and time of the TDS reimbursement event",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "SKU": {
+                  "description": "Stock Keeping Unit",
+                  "type": ["null", "string"]
+                },
+                "FeeList": {
+                  "description": "List of fees",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "AdhocDisbursementEventList": {
+            "description": "List of adhoc disbursement events",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AdjustmentType": {
+                  "description": "Type of adjustment",
+                  "type": ["null", "string"]
+                },
+                "PostedDate": {
+                  "description": "Date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "AdjustmentAmount": {
+                  "description": "Amount of adjustment made",
+                  "type": ["null", "object"]
+                },
+                "AdjustmentItemList": {
+                  "description": "List of items adjusted",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "ShipmentSettleEventList": {
+            "description": "List of events related to settling shipments.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "AmazonOrderId": {
+                  "description": "The unique identifier of the Amazon order associated with the shipment settle event",
+                  "type": ["null", "string"]
+                },
+                "SellerOrderId": {
+                  "description": "The unique identifier of the seller's order associated with the shipment settle event",
+                  "type": ["null", "string"]
+                },
+                "MarketplaceName": {
+                  "description": "The name of the marketplace where the event occurred",
+                  "type": ["null", "string"]
+                },
+                "OrderChargeList": {
+                  "description": "List of order charges associated with the shipment settle event",
+                  "type": ["null", "array"]
+                },
+                "OrderChargeAdjustmentList": {
+                  "description": "List of order charge adjustments related to the shipment settle event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentFeeList": {
+                  "description": "List of shipment fees associated with the shipment settle event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentFeeAdjustmentList": {
+                  "description": "List of shipment fee adjustments related to the shipment settle event",
+                  "type": ["null", "array"]
+                },
+                "OrderFeeList": {
+                  "description": "List of order fees associated with the shipment settle event",
+                  "type": ["null", "array"]
+                },
+                "OrderFeeAdjustmentList": {
+                  "description": "List of order fee adjustments related to the shipment settle event",
+                  "type": ["null", "array"]
+                },
+                "DirectPaymentList": {
+                  "description": "List of direct payments associated with the shipment settle event",
+                  "type": ["null", "array"]
+                },
+                "PostedDate": {
+                  "description": "The date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "ShipmentItemList": {
+                  "description": "List of shipment items associated with the shipment settle event",
+                  "type": ["null", "array"]
+                },
+                "ShipmentItemAdjustmentList": {
+                  "description": "List of shipment item adjustments related to the shipment settle event",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "ChargeRefundEventList": {
+            "description": "List of charge refund events",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "ChargeAmount": {
+                  "description": "Amount of charge refunded",
+                  "type": ["null", "object"]
+                },
+                "ChargeType": {
+                  "description": "Type of charge being refunded",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "FailedAdhocDisbursementEventList": {
+            "description": "List of events representing failed ad-hoc disbursements.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "FundsTransfersType": {
+                  "description": "Type of funds transfer",
+                  "type": ["null", "string"]
+                },
+                "TransferId": {
+                  "description": "Identifier of the transfer",
+                  "type": ["null", "string"]
+                },
+                "DisbursementId": {
+                  "description": "Identifier of the disbursement",
+                  "type": ["null", "string"]
+                },
+                "PaymentDisbursementType": {
+                  "description": "Type of payment disbursement",
+                  "type": ["null", "string"]
+                },
+                "Status": {
+                  "description": "Status of the disbursement",
+                  "type": ["null", "string"]
+                },
+                "TransferAmount": {
+                  "description": "Amount transferred",
+                  "type": ["null", "object"]
+                },
+                "PostedDate": {
+                  "description": "Date and time when the failed adhoc disbursement event occurred",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "ValueAddedServiceChargeEventList": {
+            "description": "List of value-added service charge events",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "TransactionType": {
+                  "description": "Type of transaction associated with the service charge",
+                  "type": ["null", "string"]
+                },
+                "Description": {
+                  "description": "Description of the service charge",
+                  "type": ["null", "string"]
+                },
+                "TransactionAmount": {
+                  "description": "Amount of the transaction",
+                  "type": ["null", "object"]
+                },
+                "PostedDate": {
+                  "description": "Date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "CapacityReservationBillingEventList": {
+            "description": "List of capacity reservation billing events",
+            "type": "array",
+            "items": {}
+          },
+          "TaxWithholdingEventList": {
+            "description": "List of tax withholding events",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "PostedDate": {
+                  "description": "Date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "BaseAmount": {
+                  "description": "Base amount subject to withholding",
+                  "type": ["null", "object"]
+                },
+                "WithheldAmount": {
+                  "description": "Amount withheld for tax",
+                  "type": ["null", "object"]
+                },
+                "TaxWithholdingPeriod": {
+                  "description": "Period for tax withholding",
+                  "type": ["null", "object"]
+                }
+              }
+            }
+          },
+          "RemovalShipmentEventList": {
+            "description": "List of removal shipment events",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "PostedDate": {
+                  "description": "Date and time when the event was posted",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "MerchantOrderId": {
+                  "description": "Merchant's order ID",
+                  "type": ["null", "string"]
+                },
+                "OrderId": {
+                  "description": "Order ID",
+                  "type": ["null", "string"]
+                },
+                "TransactionType": {
+                  "description": "Type of transaction associated with the shipment",
+                  "type": ["null", "string"]
+                },
+                "RemovalShipmentItemList": {
+                  "description": "List of items in the removal shipment",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "RemovalShipmentAdjustmentEventList": {
+            "description": "List of events representing adjustments to removal shipments.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "PostedDate": {
+                  "description": "Date and time of the removal shipment adjustment",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "AdjustmentEventId": {
+                  "description": "Identifier of the removal shipment adjustment event",
+                  "type": ["null", "string"]
+                },
+                "MerchantOrderId": {
+                  "description": "Merchant's order ID",
+                  "type": ["null", "string"]
+                },
+                "OrderId": {
+                  "description": "Order ID",
+                  "type": ["null", "string"]
+                },
+                "TransactionType": {
+                  "description": "Type of transaction",
+                  "type": ["null", "string"]
+                },
+                "RemovalShipmentItemAdjustmentList": {
+                  "description": "List of item adjustments for removal shipment",
+                  "type": ["null", "array"]
+                }
+              }
+            }
+          },
+          "PostedBefore": {
+            "description": "Date and time filter for events posted before a specific date",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["PostedBefore"]
+    },
+    {
+      "name": "GET_LEDGER_DETAIL_VIEW_DATA",
+      "json_schema": {
+        "title": "Inventory Ledger Report - Detailed View",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "Date": {
+            "description": "Date of the transaction",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "FNSKU": {
+            "description": "Fulfillment Network Stock Keeping Unit",
+            "type": ["null", "string"]
+          },
+          "ASIN": {
+            "description": "Unique identifier for the Amazon Standard Identification Number",
+            "type": ["null", "string"]
+          },
+          "MSKU": {
+            "description": "Merchant Stock Keeping Unit",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "Title of the product",
+            "type": ["null", "string"]
+          },
+          "Event Type": {
+            "description": "Type of event related to the transaction",
+            "type": ["null", "string"]
+          },
+          "Reference ID": {
+            "description": "Unique identifier associated with the transaction",
+            "type": ["null", "string"]
+          },
+          "Quantity": {
+            "description": "Amount of units involved in the transaction",
+            "type": ["null", "string"]
+          },
+          "Fulfillment Center": {
+            "description": "Location where the product is fulfilled",
+            "type": ["null", "string"]
+          },
+          "Disposition": {
+            "description": "Status or outcome of the transaction",
+            "type": ["null", "string"]
+          },
+          "Reason": {
+            "description": "Reason for any discrepancy or action taken",
+            "type": ["null", "string"]
+          },
+          "Country": {
+            "description": "Country of the transaction",
+            "type": ["null", "string"]
+          },
+          "Reconciled Quantity": {
+            "description": "Quantity after reconciliation process",
+            "type": ["null", "string"]
+          },
+          "Unreconciled Quantity": {
+            "description": "Quantity yet to be reconciled",
+            "type": ["null", "string"]
+          },
+          "Date and Time": {
+            "description": "Date and Time of the transaction",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "dataEndTime": {
+            "description": "End time of the data collection period",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Date"]
+    },
+    {
+      "name": "FBA FEES",
+      "json_schema": {
+        "title": "FBA Fee Preview Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "sku": {
+            "description": "Stock Keeping Unit representing the product",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "Fulfillment Network Stock Keeping Unit representing the product",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "Amazon Standard Identification Number representing the product",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "Name of the product",
+            "type": ["null", "string"]
+          },
+          "product-group": {
+            "description": "Group to which the product belongs",
+            "type": ["null", "string"]
+          },
+          "brand": {
+            "description": "Brand of the product",
+            "type": ["null", "string"]
+          },
+          "fulfilled-by": {
+            "description": "Indicates whether the product is fulfilled by the seller or Amazon",
+            "type": ["null", "string"]
+          },
+          "your-price": {
+            "description": "Price set by the seller for the product",
+            "type": ["null", "string"]
+          },
+          "sales-price": {
+            "description": "Price at which the product is sold",
+            "type": ["null", "string"]
+          },
+          "longest-side": {
+            "description": "Length of the longest side of the product",
+            "type": ["null", "string"]
+          },
+          "median-side": {
+            "description": "Length of the median side of the product",
+            "type": ["null", "string"]
+          },
+          "shortest-side": {
+            "description": "Length of the shortest side of the product",
+            "type": ["null", "string"]
+          },
+          "length-and-girth": {
+            "description": "Combined length and girth of the product",
+            "type": ["null", "string"]
+          },
+          "unit-of-dimension": {
+            "description": "Unit of measurement for dimensions",
+            "type": ["null", "string"]
+          },
+          "item-package-weight": {
+            "description": "Weight of the product package",
+            "type": ["null", "string"]
+          },
+          "unit-of-weight": {
+            "description": "Unit of measurement for weight",
+            "type": ["null", "string"]
+          },
+          "product-size-tier": {
+            "description": "Size tier of the product",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "Currency used for the fee calculations",
+            "type": ["null", "string"]
+          },
+          "estimated-fee-total": {
+            "description": "Total estimated fees for the product",
+            "type": ["null", "string"]
+          },
+          "estimated-referral-fee-per-unit": {
+            "description": "Estimated referral fee per unit",
+            "type": ["null", "string"]
+          },
+          "estimated-variable-closing-fee": {
+            "description": "Estimated variable closing fee",
+            "type": ["null", "string"]
+          },
+          "estimated-order-handling-fee-per-order": {
+            "description": "Estimated order handling fee per order",
+            "type": ["null", "string"]
+          },
+          "estimated-pick-pack-fee-per-unit": {
+            "description": "Estimated pick and pack fee per unit",
+            "type": ["null", "string"]
+          },
+          "estimated-weight-handling-fee-per-unit": {
+            "description": "Estimated weight handling fee per unit",
+            "type": ["null", "string"]
+          },
+          "expected-fulfillment-fee-per-unit": {
+            "description": "Expected fulfillment fee per unit",
+            "type": ["null", "string"]
+          },
+          "estimated-future-fee (Current Selling on Amazon + Future Fulfillment fees)": {
+            "description": "Estimated future total fee including current Amazon selling and future fulfillment fees",
+            "type": ["null", "string"]
+          },
+          "estimated-future-order-handling-fee-per-order": {
+            "description": "Estimated future order handling fee per order",
+            "type": ["null", "string"]
+          },
+          "estimated-future-pick-pack-fee-per-unit": {
+            "description": "Estimated future pick and pack fee per unit",
+            "type": ["null", "string"]
+          },
+          "estimated-future-weight-handling-fee-per-unit": {
+            "description": "Estimated future weight handling fee per unit",
+            "type": ["null", "string"]
+          },
+          "expected-future-fulfillment-fee-per-unit": {
+            "description": "Expected future fulfillment fee per unit",
+            "type": ["null", "string"]
+          },
+          "estimated-future-referral-fee-per-unit": {
+            "description": "Estimated future referral fee per unit",
+            "type": ["null", "string"]
+          },
+          "current-fee-category": {
+            "description": "Current fee category of the product",
+            "type": ["null", "string"]
+          },
+          "future-fee-category": {
+            "description": "Future fee category of the product",
+            "type": ["null", "string"]
+          },
+          "future-fee-category-effective-date": {
+            "description": "Effective date for the future fee category in date-time format",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "dataEndTime": {
+            "description": "End time of the data in date format",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_FBA_FULFILLMENT_CUSTOMER_SHIPMENT_PROMOTION_DATA",
+      "json_schema": {
+        "title": "FBA Promotions Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "shipment-date": {
+            "description": "The date and time when the shipment was made.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "currency": {
+            "description": "The currency used for the monetary values in the data.",
+            "type": ["null", "string"]
+          },
+          "item-promotion-discount": {
+            "description": "The discount amount applied to the item as part of the promotion.",
+            "type": ["null", "string"]
+          },
+          "item-promotion-id": {
+            "description": "The unique identifier for the item promotion.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "A description of the promotion or shipment.",
+            "type": ["null", "string"]
+          },
+          "promotion-rule-value": {
+            "description": "The value associated with the promotion rule.",
+            "type": ["null", "string"]
+          },
+          "amazon-order-id": {
+            "description": "The unique identifier for the Amazon order associated with the shipment.",
+            "type": ["null", "string"]
+          },
+          "shipment-id": {
+            "description": "The unique identifier for the shipment.",
+            "type": ["null", "string"]
+          },
+          "shipment-item-id": {
+            "description": "The unique identifier for the item within the shipment.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time for the data collection period.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_FBA_MYI_UNSUPPRESSED_INVENTORY_DATA",
+      "json_schema": {
+        "title": "FBA Manage Inventory",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "sku": {
+            "description": "Stock Keeping Unit, a unique identifier for the product",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "Fulfillment Network SKU, a unique identifier for a product in Amazon's fulfillment network",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "Unique Amazon Standard Identification Number for the product",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "The name or title of the product",
+            "type": ["null", "string"]
+          },
+          "condition": {
+            "description": "The condition of the product (e.g., New, Used, Refurbished)",
+            "type": ["null", "string"]
+          },
+          "your-price": {
+            "description": "The price at which you are selling the product",
+            "type": ["null", "string"]
+          },
+          "mfn-listing-exists": {
+            "description": "Indicator if the Merchant Fulfilled Network listing exists",
+            "type": ["null", "string"]
+          },
+          "mfn-fulfillable-quantity": {
+            "description": "The quantity of Merchant Fulfilled Network inventory available for sale",
+            "type": ["null", "string"]
+          },
+          "afn-listing-exists": {
+            "description": "Indicator if the FBA listing exists on Amazon's marketplace",
+            "type": ["null", "string"]
+          },
+          "afn-warehouse-quantity": {
+            "description": "The quantity of FBA inventory stored in Amazon's warehouses",
+            "type": ["null", "string"]
+          },
+          "afn-fulfillable-quantity": {
+            "description": "The quantity of Fulfillable FBA inventory available for sale at Amazon's fulfillment centers",
+            "type": ["null", "string"]
+          },
+          "afn-unsellable-quantity": {
+            "description": "The quantity of FBA inventory that is unsellable or unavailable for purchase",
+            "type": ["null", "string"]
+          },
+          "afn-reserved-quantity": {
+            "description": "The quantity of FBA inventory reserved for pending orders",
+            "type": ["null", "string"]
+          },
+          "afn-total-quantity": {
+            "description": "The total quantity of FBA inventory available, including fulfillable, reserved, and unsellable quantities",
+            "type": ["null", "string"]
+          },
+          "per-unit-volume": {
+            "description": "The volume of the product per unit",
+            "type": ["null", "string"]
+          },
+          "afn-inbound-working-quantity": {
+            "description": "The quantity of FBA inventory being processed and prepared for sale",
+            "type": ["null", "string"]
+          },
+          "afn-inbound-shipped-quantity": {
+            "description": "The quantity of FBA inventory shipped to Amazon but not yet received",
+            "type": ["null", "string"]
+          },
+          "afn-inbound-receiving-quantity": {
+            "description": "The quantity of FBA inventory currently being received by Amazon's fulfillment centers",
+            "type": ["null", "string"]
+          },
+          "afn-researching-quantity": {
+            "description": "The quantity of FBA inventory being actively researched or investigated",
+            "type": ["null", "string"]
+          },
+          "afn-reserved-future-supply": {
+            "description": "The quantity of FBA inventory reserved for future supply transactions",
+            "type": ["null", "string"]
+          },
+          "afn-future-supply-buyable": {
+            "description": "The quantity of FBA inventory that is on order but not yet received by Amazon",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The date and time when the inventory data was last updated",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_MERCHANT_CANCELLED_LISTINGS_DATA",
+      "json_schema": {
+        "title": "Canceled Listings Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "item-name": {
+            "description": "Name of the item",
+            "type": ["null", "string"]
+          },
+          "item-description": {
+            "description": "Description of the item",
+            "type": ["null", "string"]
+          },
+          "seller-sku": {
+            "description": "Seller Stock Keeping Unit",
+            "type": ["null", "string"]
+          },
+          "price": {
+            "description": "The price of the product",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "The quantity available for the listing",
+            "type": ["null", "string"]
+          },
+          "image-url": {
+            "description": "URL of the product image",
+            "type": ["null", "string"]
+          },
+          "item-is-marketplace": {
+            "description": "Indicates if the item is sold on the marketplace",
+            "type": ["null", "string"]
+          },
+          "product-id-type": {
+            "description": "Type of product identifier used",
+            "type": ["null", "string"]
+          },
+          "zshop-shipping-fee": {
+            "description": "Shipping fee set in the Zshop",
+            "type": ["null", "string"]
+          },
+          "item-note": {
+            "description": "Additional notes or comments about the item",
+            "type": ["null", "string"]
+          },
+          "item-condition": {
+            "description": "Condition of the item",
+            "type": ["null", "string"]
+          },
+          "zshop-category1": {
+            "description": "Category of the item in Zshop",
+            "type": ["null", "string"]
+          },
+          "zshop-browse-path": {
+            "description": "Browse path in the Zshop",
+            "type": ["null", "string"]
+          },
+          "zshop-storefront-feature": {
+            "description": "Indicates if the item has a featured storefront in Zshop",
+            "type": ["null", "string"]
+          },
+          "asin1": {
+            "description": "Unique Amazon Standard Identification Number for a product 1",
+            "type": ["null", "string"]
+          },
+          "asin2": {
+            "description": "Unique Amazon Standard Identification Number for a product 2",
+            "type": ["null", "string"]
+          },
+          "asin3": {
+            "description": "Unique Amazon Standard Identification Number for a product 3",
+            "type": ["null", "string"]
+          },
+          "will-ship-internationally": {
+            "description": "Indicates if the item will be shipped internationally",
+            "type": ["null", "string"]
+          },
+          "expedited-shipping": {
+            "description": "Indicates if expedited shipping is available",
+            "type": ["null", "string"]
+          },
+          "zshop-boldface": {
+            "description": "Indicates if the item is highlighted as bold in the storefront",
+            "type": ["null", "string"]
+          },
+          "product-id": {
+            "description": "Unique product identifier",
+            "type": ["null", "string"]
+          },
+          "add-delete": {
+            "description": "Indicates whether to add or remove a listing",
+            "type": ["null", "string"]
+          },
+          "Business Price": {
+            "description": "The price set for business customers",
+            "type": ["null", "string"]
+          },
+          "Quantity Price Type": {
+            "description": "The type of pricing method used for quantity pricing",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 1": {
+            "description": "The minimum quantity threshold for applying quantity pricing tier 1",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 1": {
+            "description": "The price set for products when quantity falls into tier 1",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 2": {
+            "description": "The minimum quantity threshold for applying quantity pricing tier 2",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 2": {
+            "description": "The price set for products when quantity falls into tier 2",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 3": {
+            "description": "The minimum quantity threshold for applying quantity pricing tier 3",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 3": {
+            "description": "The price set for products when quantity falls into tier 3",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 4": {
+            "description": "The minimum quantity threshold for applying quantity pricing tier 4",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 4": {
+            "description": "The price set for products when quantity falls into tier 4",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 5": {
+            "description": "The minimum quantity threshold for applying quantity pricing tier 5",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 5": {
+            "description": "The price set for products when quantity falls into tier 5",
+            "type": ["null", "string"]
+          },
+          "merchant-shipping-group": {
+            "description": "Grouping of items for shipping purposes",
+            "type": ["null", "string"]
+          },
+          "Progressive Price Type": {
+            "description": "The type of pricing method used for progressive pricing",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 1": {
+            "description": "The lower threshold for applying progressive pricing tier 1",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 1": {
+            "description": "The price set for products falling into progressive pricing tier 1",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 2": {
+            "description": "The lower threshold for applying progressive pricing tier 2",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 2": {
+            "description": "The price set for products falling into progressive pricing tier 2",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 3": {
+            "description": "The lower threshold for applying progressive pricing tier 3",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 3": {
+            "description": "The price set for products falling into progressive pricing tier 3",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time of the data",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_MERCHANT_LISTINGS_DATA",
+      "json_schema": {
+        "title": "Active Listings Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "item-name": {
+            "description": "The name or title of the item",
+            "type": ["null", "string"]
+          },
+          "item-description": {
+            "description": "Description of the item",
+            "type": ["null", "string"]
+          },
+          "listing-id": {
+            "description": "Identifier for the listing",
+            "type": ["null", "string"]
+          },
+          "seller-sku": {
+            "description": "Seller-specific SKU (Stock Keeping Unit)",
+            "type": ["null", "string"]
+          },
+          "price": {
+            "description": "Price of the item",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "Available quantity of the item",
+            "type": ["null", "string"]
+          },
+          "open-date": {
+            "description": "Date and time when the listing was opened",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "image-url": {
+            "description": "URL of the main image of the item",
+            "type": ["null", "string"]
+          },
+          "item-is-marketplace": {
+            "description": "Indicates if the item belongs to the marketplace",
+            "type": ["null", "string"]
+          },
+          "product-id-type": {
+            "description": "Type of identifier used for the product",
+            "type": ["null", "string"]
+          },
+          "zshop-shipping-fee": {
+            "description": "Shipping fee on ZShop",
+            "type": ["null", "string"]
+          },
+          "item-note": {
+            "description": "Any additional notes related to the item",
+            "type": ["null", "string"]
+          },
+          "item-condition": {
+            "description": "The condition of the item",
+            "type": ["null", "string"]
+          },
+          "zshop-category1": {
+            "description": "Category on ZShop",
+            "type": ["null", "string"]
+          },
+          "zshop-browse-path": {
+            "description": "Browse path on the ZShop",
+            "type": ["null", "string"]
+          },
+          "zshop-storefront-feature": {
+            "description": "Storefront feature on ZShop",
+            "type": ["null", "string"]
+          },
+          "asin1": {
+            "description": "ASIN (Amazon Standard Identification Number) value 1",
+            "type": ["null", "string"]
+          },
+          "asin2": {
+            "description": "ASIN (Amazon Standard Identification Number) value 2",
+            "type": ["null", "string"]
+          },
+          "asin3": {
+            "description": "ASIN (Amazon Standard Identification Number) value 3",
+            "type": ["null", "string"]
+          },
+          "will-ship-internationally": {
+            "description": "Indicates whether international shipping is supported",
+            "type": ["null", "string"]
+          },
+          "expedited-shipping": {
+            "description": "Indicates whether expedited shipping is available",
+            "type": ["null", "string"]
+          },
+          "zshop-boldface": {
+            "description": "Indicates if the listing is in boldface",
+            "type": ["null", "string"]
+          },
+          "product-id": {
+            "description": "Unique identifier for the product",
+            "type": ["null", "string"]
+          },
+          "bid-for-featured-placement": {
+            "description": "Bid amount for featured placement",
+            "type": ["null", "string"]
+          },
+          "add-delete": {
+            "description": "Indicates whether to add or delete the listing",
+            "type": ["null", "string"]
+          },
+          "pending-quantity": {
+            "description": "Quantity of items pending fulfillment",
+            "type": ["null", "string"]
+          },
+          "fulfillment-channel": {
+            "description": "The channel through which fulfillment will be handled",
+            "type": ["null", "string"]
+          },
+          "Business Price": {
+            "description": "The price of the item for business customers",
+            "type": ["null", "string"]
+          },
+          "Quantity Price Type": {
+            "description": "The type of pricing for quantity pricing tiers",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 1": {
+            "description": "The lower bound value for quantity pricing tier 1",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 1": {
+            "description": "The price for quantity pricing tier 1",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 2": {
+            "description": "The lower bound value for quantity pricing tier 2",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 2": {
+            "description": "The price for quantity pricing tier 2",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 3": {
+            "description": "The lower bound value for quantity pricing tier 3",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 3": {
+            "description": "The price for quantity pricing tier 3",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 4": {
+            "description": "The lower bound value for quantity pricing tier 4",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 4": {
+            "description": "The price for quantity pricing tier 4",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 5": {
+            "description": "The lower bound value for quantity pricing tier 5",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 5": {
+            "description": "The price for quantity pricing tier 5",
+            "type": ["null", "string"]
+          },
+          "merchant-shipping-group": {
+            "description": "Shipping group associated with the merchant",
+            "type": ["null", "string"]
+          },
+          "Progressive Price Type": {
+            "description": "The type of pricing for progressive pricing tiers",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 1": {
+            "description": "The lower bound value for progressive pricing tier 1",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 1": {
+            "description": "The price for progressive pricing tier 1",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 2": {
+            "description": "The lower bound value for progressive pricing tier 2",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 2": {
+            "description": "The price for progressive pricing tier 2",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 3": {
+            "description": "The lower bound value for progressive pricing tier 3",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 3": {
+            "description": "The price for progressive pricing tier 3",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time for the listing data",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"],
+      "source_defined_primary_key": [["listing-id"]]
+    },
+    {
+      "name": "GET_MERCHANT_LISTINGS_DATA_BACK_COMPAT",
+      "json_schema": {
+        "title": "Open Listings Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "item-name": {
+            "description": "The name of the item",
+            "type": ["null", "string"]
+          },
+          "item-description": {
+            "description": "Description of the item",
+            "type": ["null", "string"]
+          },
+          "listing-id": {
+            "description": "Unique identifier for the listing",
+            "type": ["null", "string"]
+          },
+          "seller-sku": {
+            "description": "Seller-specific SKU for the item",
+            "type": ["null", "string"]
+          },
+          "price": {
+            "description": "The price of the item",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "Available quantity of the item",
+            "type": ["null", "string"]
+          },
+          "open-date": {
+            "description": "The date and time when the listing was opened",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "image-url": {
+            "description": "URL of the item's image",
+            "type": ["null", "string"]
+          },
+          "item-is-marketplace": {
+            "description": "Indicates if the item is listed on the marketplace",
+            "type": ["null", "string"]
+          },
+          "product-id-type": {
+            "description": "Type of product identifier",
+            "type": ["null", "string"]
+          },
+          "zshop-shipping-fee": {
+            "description": "Shipping fee on Zshop",
+            "type": ["null", "string"]
+          },
+          "item-note": {
+            "description": "Additional notes related to the item",
+            "type": ["null", "string"]
+          },
+          "item-condition": {
+            "description": "The condition of the item",
+            "type": ["null", "string"]
+          },
+          "zshop-category1": {
+            "description": "Category of the item on Zshop",
+            "type": ["null", "string"]
+          },
+          "zshop-browse-path": {
+            "description": "Browse path on the Zshop",
+            "type": ["null", "string"]
+          },
+          "zshop-storefront-feature": {
+            "description": "Feature on the Zshop storefront",
+            "type": ["null", "string"]
+          },
+          "asin1": {
+            "description": "Unique identifier for the first ASIN",
+            "type": ["null", "string"]
+          },
+          "asin2": {
+            "description": "Unique identifier for the second ASIN",
+            "type": ["null", "string"]
+          },
+          "asin3": {
+            "description": "Unique identifier for the third ASIN",
+            "type": ["null", "string"]
+          },
+          "will-ship-internationally": {
+            "description": "Indicates if the item will ship internationally",
+            "type": ["null", "string"]
+          },
+          "expedited-shipping": {
+            "description": "Indicates if expedited shipping is available",
+            "type": ["null", "string"]
+          },
+          "zshop-boldface": {
+            "description": "Indicates if the item is displayed in boldface",
+            "type": ["null", "string"]
+          },
+          "product-id": {
+            "description": "Unique identifier for the product",
+            "type": ["null", "string"]
+          },
+          "bid-for-featured-placement": {
+            "description": "Bidding information for featured placement",
+            "type": ["null", "string"]
+          },
+          "add-delete": {
+            "description": "Indicates if an item should be added or deleted",
+            "type": ["null", "string"]
+          },
+          "pending-quantity": {
+            "description": "Quantity pending fulfillment",
+            "type": ["null", "string"]
+          },
+          "Business Price": {
+            "description": "The price of the item for business customers",
+            "type": ["null", "string"]
+          },
+          "Quantity Price Type": {
+            "description": "The type of pricing for quantity pricing tiers",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 1": {
+            "description": "The lower boundary for the first quantity pricing tier",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 1": {
+            "description": "The price associated with the first quantity pricing tier",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 2": {
+            "description": "The lower boundary for the second quantity pricing tier",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 2": {
+            "description": "The price associated with the second quantity pricing tier",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 3": {
+            "description": "The lower boundary for the third quantity pricing tier",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 3": {
+            "description": "The price associated with the third quantity pricing tier",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 4": {
+            "description": "The lower boundary for the fourth quantity pricing tier",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 4": {
+            "description": "The price associated with the fourth quantity pricing tier",
+            "type": ["null", "string"]
+          },
+          "Quantity Lower Bound 5": {
+            "description": "The lower boundary for the fifth quantity pricing tier",
+            "type": ["null", "string"]
+          },
+          "Quantity Price 5": {
+            "description": "The price associated with the fifth quantity pricing tier",
+            "type": ["null", "string"]
+          },
+          "merchant-shipping-group": {
+            "description": "Grouping for merchant shipping preferences",
+            "type": ["null", "string"]
+          },
+          "Progressive Price Type": {
+            "description": "The type of pricing for progressive pricing tiers",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 1": {
+            "description": "The lower boundary for a progressive pricing tier",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 1": {
+            "description": "The price associated with the first progressive pricing tier",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 2": {
+            "description": "The second lower boundary for a progressive pricing tier",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 2": {
+            "description": "The price associated with the second progressive pricing tier",
+            "type": ["null", "string"]
+          },
+          "Progressive Lower Bound 3": {
+            "description": "The third lower boundary for a progressive pricing tier",
+            "type": ["null", "string"]
+          },
+          "Progressive Price 3": {
+            "description": "The price associated with the third progressive pricing tier",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The date when the data was last updated",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"],
+      "source_defined_primary_key": [["listing-id"]]
+    },
+    {
+      "name": "GET_MERCHANT_LISTINGS_INACTIVE_DATA",
+      "json_schema": {
+        "title": "Inactive Listings Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "item-name": {
+            "description": "Name of the product item",
+            "type": ["null", "string"]
+          },
+          "item-description": {
+            "description": "Description of the product listing",
+            "type": ["null", "string"]
+          },
+          "listing-id": {
+            "description": "Unique identifier for the listing",
+            "type": ["null", "string"]
+          },
+          "seller-sku": {
+            "description": "Seller Stock Keeping Unit (SKU)",
+            "type": ["null", "string"]
+          },
+          "price": {
+            "description": "Price of the product listing",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "Available quantity of the product",
+            "type": ["null", "string"]
+          },
+          "open-date": {
+            "description": "Date and time when the listing was opened",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "image-url": {
+            "description": "URL of the product image",
+            "type": ["null", "string"]
+          },
+          "item-is-marketplace": {
+            "description": "Flag indicating if the item is listed on the marketplace",
+            "type": ["null", "string"]
+          },
+          "product-id-type": {
+            "description": "Type of product identifier",
+            "type": ["null", "string"]
+          },
+          "zshop-shipping-fee": {
+            "description": "Shipping fee on Zshop",
+            "type": ["null", "string"]
+          },
+          "item-note": {
+            "description": "Any additional notes related to the item",
+            "type": ["null", "string"]
+          },
+          "item-condition": {
+            "description": "Condition of the item (e.g., New, Used)",
+            "type": ["null", "string"]
+          },
+          "zshop-category1": {
+            "description": "Category of the product on Zshop",
+            "type": ["null", "string"]
+          },
+          "zshop-browse-path": {
+            "description": "Browse path on Zshop",
+            "type": ["null", "string"]
+          },
+          "zshop-storefront-feature": {
+            "description": "Storefront feature on Zshop",
+            "type": ["null", "string"]
+          },
+          "asin1": {
+            "description": "Amazon Standard Identification Number (ASIN) 1 of the product",
+            "type": ["null", "string"]
+          },
+          "asin2": {
+            "description": "Amazon Standard Identification Number (ASIN) 2 of the product",
+            "type": ["null", "string"]
+          },
+          "asin3": {
+            "description": "Amazon Standard Identification Number (ASIN) 3 of the product",
+            "type": ["null", "string"]
+          },
+          "will-ship-internationally": {
+            "description": "Flag indicating if the product will ship internationally",
+            "type": ["null", "string"]
+          },
+          "expedited-shipping": {
+            "description": "Flag indicating if expedited shipping is available for the product",
+            "type": ["null", "string"]
+          },
+          "zshop-boldface": {
+            "description": "Flag indicating if the listing is in boldface on Zshop",
+            "type": ["null", "string"]
+          },
+          "product-id": {
+            "description": "Unique identifier for the product",
+            "type": ["null", "string"]
+          },
+          "bid-for-featured-placement": {
+            "description": "Flag indicating if the product is eligible for featured placement bids",
+            "type": ["null", "string"]
+          },
+          "add-delete": {
+            "description": "Flag indicating if the listing is to be added or deleted",
+            "type": ["null", "string"]
+          },
+          "pending-quantity": {
+            "description": "Quantity of items pending for listing",
+            "type": ["null", "string"]
+          },
+          "fulfillment-channel": {
+            "description": "Channel through which fulfillment is done (e.g., FBA, MFN)",
+            "type": ["null", "string"]
+          },
+          "merchant-shipping-group": {
+            "description": "Grouping of items for merchant shipping purposes",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data in date format",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"],
+      "source_defined_primary_key": [["listing-id"]]
+    },
+    {
+      "name": "GET_STRANDED_INVENTORY_UI_DATA",
+      "json_schema": {
+        "title": "FBA Stranded Inventory Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "primary-action": {
+            "description": "Primary action to be taken for the inventory",
+            "type": ["null", "string"]
+          },
+          "date-stranded": {
+            "description": "Date when the inventory was stranded",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "Date-to-take-auto-removal": {
+            "description": "Date when the stranded inventory will be automatically removed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "status-primary": {
+            "description": "Primary status of the inventory",
+            "type": ["null", "string"]
+          },
+          "status-secondary": {
+            "description": "Secondary status of the inventory",
+            "type": ["null", "string"]
+          },
+          "error-message": {
+            "description": "Any error message related to the inventory status",
+            "type": ["null", "string"]
+          },
+          "stranded-reason": {
+            "description": "Reason why the inventory is stranded",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "Amazon Standard Identification Number (ASIN) of the product",
+            "type": ["null", "string"]
+          },
+          "sku": {
+            "description": "Stock Keeping Unit (SKU) of the product",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "Fulfillment Network Stock Keeping Unit (FNSKU) of the product",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "Name of the product",
+            "type": ["null", "string"]
+          },
+          "condition": {
+            "description": "Condition of the product in the inventory",
+            "type": ["null", "string"]
+          },
+          "fulfilled-by": {
+            "description": "Who fulfills the product",
+            "type": ["null", "string"]
+          },
+          "fulfillable-qty": {
+            "description": "Quantity of the product that is fulfillable",
+            "type": ["null", "string"]
+          },
+          "your-price": {
+            "description": "Price set for the product by the seller",
+            "type": ["null", "string"]
+          },
+          "unfulfillable-qty": {
+            "description": "Quantity of the product that is unfulfillable",
+            "type": ["null", "string"]
+          },
+          "reserved-quantity": {
+            "description": "Quantity of the product that is reserved",
+            "type": ["null", "string"]
+          },
+          "inbound-shipped-qty": {
+            "description": "Quantity of the product that has been shipped to the fulfillment center",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_XML_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL",
+      "json_schema": {
+        "title": "XML Orders By Order Date Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "LastUpdatedDate": {
+            "description": "The date and time when the order was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "SalesChannel": {
+            "description": "The sales channel through which the order was made.",
+            "type": ["null", "string"]
+          },
+          "OrderStatus": {
+            "description": "The status of the order.",
+            "type": ["null", "string"]
+          },
+          "AmazonOrderID": {
+            "description": "The unique identifier for the order on Amazon.",
+            "type": ["null", "string"]
+          },
+          "PurchaseDate": {
+            "description": "The date and time when the order was purchased.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "OrderItem": {
+            "description": "Details about the individual items in the order.",
+            "type": ["array"],
+            "items": { "type": ["null", "object"] },
+            "properties": {
+              "ItemStatus": {
+                "description": "The status of the order item.",
+                "type": ["null", "string"]
+              },
+              "ProductName": {
+                "description": "The name of the product.",
+                "type": ["null", "string"]
+              },
+              "ItemPrice": {
+                "description": "Contains the price information for the item.",
+                "type": ["null", "object"],
+                "properties": {
+                  "Component": {
+                    "description": "Breakdown of item components if applicable.",
+                    "type": ["array"],
+                    "items": { "type": ["null", "object"] },
+                    "properties": {
+                      "Type": {
+                        "description": "The type of item price component.",
+                        "type": ["null", "string"]
+                      },
+                      "Amount": {
+                        "description": "The total amount for the item.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "currency": {
+                            "description": "The currency in which the item price is specified.",
+                            "type": ["null", "string"]
+                          },
+                          "value": {
+                            "description": "The value of the item price.",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "ASIN": {
+                "description": "The Amazon Standard Identification Number for the product.",
+                "type": ["null", "string"]
+              },
+              "Quantity": {
+                "description": "The quantity of the product ordered.",
+                "type": ["null", "string"]
+              },
+              "AmazonOrderItemCode": {
+                "description": "The unique identifier for the order item on Amazon.",
+                "type": ["null", "string"]
+              },
+              "SKU": {
+                "description": "The Stock Keeping Unit for the product.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "FulfillmentData": {
+            "description": "Contains data related to order fulfillment.",
+            "type": ["null", "object"],
+            "properties": {
+              "Address": {
+                "description": "Contains the address information for order shipping.",
+                "type": ["null", "object"],
+                "properties": {
+                  "State": {
+                    "description": "The state for the order's shipping address.",
+                    "type": ["null", "string"]
+                  },
+                  "PostalCode": {
+                    "description": "The postal code for the order's shipping address.",
+                    "type": ["null", "string"]
+                  },
+                  "Country": {
+                    "description": "The country for the order's shipping address.",
+                    "type": ["null", "string"]
+                  },
+                  "City": {
+                    "description": "The city for the order's shipping address.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "ShipServiceLevel": {
+                "description": "The service level chosen for shipping the order.",
+                "type": ["null", "string"]
+              },
+              "FulfillmentChannel": {
+                "description": "The channel used for fulfilling the order.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "IsBusinessOrder": {
+            "description": "Indicates if the order is a business order.",
+            "type": ["null", "string"]
+          },
+          "MerchantOrderID": {
+            "description": "The unique identifier for the order set by the merchant.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time for the data in the response.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["LastUpdatedDate"],
+      "source_defined_primary_key": [["AmazonOrderID"]]
+    },
+    {
+      "name": "GET_MERCHANTS_LISTINGS_FYP_REPORT",
+      "json_schema": {
+        "title": "Suppressed Listings Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "Status": {
+            "description": "Current status of the listing (Active, Inactive, Under Review, etc.)",
+            "type": ["null", "string"]
+          },
+          "Reason": {
+            "description": "Reason for the listing status change or issue",
+            "type": ["null", "string"]
+          },
+          "SKU": {
+            "description": "Stock Keeping Unit for the product",
+            "type": ["null", "string"]
+          },
+          "ASIN": {
+            "description": "Unique Amazon Standard Identification Number for the product",
+            "type": ["null", "string"]
+          },
+          "Product name": {
+            "description": "Name of the product listed",
+            "type": ["null", "string"]
+          },
+          "Condition": {
+            "description": "Condition of the product (New, Used, Refurbished, etc.)",
+            "type": ["null", "string"]
+          },
+          "Status Change Date": {
+            "description": "Date when the status of the listing was last changed",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "Issue Description": {
+            "description": "Description of any issues with the product",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the report data",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_FBA_SNS_FORECAST_DATA",
+      "json_schema": {
+        "title": "Subscribe and Save Forecast Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "offer-state": {
+            "description": "Current state of the offer for the product.",
+            "type": ["null", "string"]
+          },
+          "snapshot-date": {
+            "description": "Date and time when the snapshot of the data was taken.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sku": {
+            "description": "Stock Keeping Unit (SKU) for the product.",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "Fulfillment Network SKU (FNSKU) for the product.",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "Unique identifier for the ASIN (Amazon Standard Identification Number).",
+            "type": ["null", "string"]
+          },
+          "estimated-avg-sns-discount-next-8-weeks": {
+            "description": "Estimated average discount on Subscribe & Save units for the next 8 weeks.",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "Name of the product associated with the ASIN.",
+            "type": ["null", "string"]
+          },
+          "country": {
+            "description": "Country for which the forecast data is applicable.",
+            "type": ["null", "string"]
+          },
+          "active-subscriptions": {
+            "description": "Number of active subscriptions for the ASIN in the specified country.",
+            "type": ["null", "string"]
+          },
+          "week-1-start-date": {
+            "description": "Start date and time for week 1 of the forecast period.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "scheduled-sns-units-week-1": {
+            "description": "Number of scheduled Subscribe & Save units for week 1.",
+            "type": ["null", "string"]
+          },
+          "scheduled-sns-units-week-2": {
+            "description": "Number of scheduled Subscribe & Save units for week 2.",
+            "type": ["null", "string"]
+          },
+          "scheduled-sns-units-week-3": {
+            "description": "Number of scheduled Subscribe & Save units for week 3.",
+            "type": ["null", "string"]
+          },
+          "scheduled-sns-units-week-4": {
+            "description": "Number of scheduled Subscribe & Save units for week 4.",
+            "type": ["null", "string"]
+          },
+          "scheduled-sns-units-week-5": {
+            "description": "Number of scheduled Subscribe & Save units for week 5.",
+            "type": ["null", "string"]
+          },
+          "scheduled-sns-units-week-6": {
+            "description": "Number of scheduled Subscribe & Save units for week 6.",
+            "type": ["null", "string"]
+          },
+          "scheduled-sns-units-week-7": {
+            "description": "Number of scheduled Subscribe & Save units for week 7.",
+            "type": ["null", "string"]
+          },
+          "scheduled-sns-units-week-8": {
+            "description": "Number of scheduled Subscribe & Save units for week 8.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time for the forecast data, indicated in date format.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "Performance_Data",
+      "json_schema": {
+        "title": "Subscribe and Save Performance Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "offer-state": {
+            "description": "Current state of the offer for the product.",
+            "type": ["null", "string"]
+          },
+          "snapshot-date": {
+            "description": "Date and time when the snapshot of data is taken.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sku": {
+            "description": "Stock Keeping Unit for the product.",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "Fulfillment Network SKU.",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "Unique identifier for the product ASIN.",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "Name of the product.",
+            "type": ["null", "string"]
+          },
+          "country": {
+            "description": "Country where the data is collected.",
+            "type": ["null", "string"]
+          },
+          "week-1-start-date": {
+            "description": "Start date of week 1 in date-time format.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sns-units-shipped-week-1": {
+            "description": "Units shipped on SNS for week 1.",
+            "type": ["null", "string"]
+          },
+          "oos-rate-week-1": {
+            "description": "Out of stock rate for week 1.",
+            "type": ["null", "string"]
+          },
+          "sns-sale-price-week-1": {
+            "description": "Sale price on SNS for week 1.",
+            "type": ["null", "string"]
+          },
+          "sns-discount-week-1": {
+            "description": "Discount applied in week 1 on SNS.",
+            "type": ["null", "string"]
+          },
+          "sns-units-shipped-week-2": {
+            "description": "Units shipped on SNS for week 2.",
+            "type": ["null", "string"]
+          },
+          "oos-rate-week-2": {
+            "description": "Out of stock rate for week 2.",
+            "type": ["null", "string"]
+          },
+          "sns-sale-price-week-2": {
+            "description": "Sale price on SNS for week 2.",
+            "type": ["null", "string"]
+          },
+          "sns-discount-week-2": {
+            "description": "Discount applied in week 2 on SNS.",
+            "type": ["null", "string"]
+          },
+          "sns-units-shipped-week-3": {
+            "description": "Units shipped on SNS for week 3.",
+            "type": ["null", "string"]
+          },
+          "oos-rate-week-3": {
+            "description": "Out of stock rate for week 3.",
+            "type": ["null", "string"]
+          },
+          "sns-sale-price-week-3": {
+            "description": "Sale price on SNS for week 3.",
+            "type": ["null", "string"]
+          },
+          "sns-discount-week-3": {
+            "description": "Discount applied in week 3 on SNS.",
+            "type": ["null", "string"]
+          },
+          "sns-units-shipped-week-4": {
+            "description": "Units shipped on SNS for week 4.",
+            "type": ["null", "string"]
+          },
+          "oos-rate-week-4": {
+            "description": "Out of stock rate for week 4.",
+            "type": ["null", "string"]
+          },
+          "sns-sale-price-week-4": {
+            "description": "Sale price on SNS for week 4.",
+            "type": ["null", "string"]
+          },
+          "sns-discount-week-4": {
+            "description": "Discount applied in week 4 on SNS.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data in date format.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_FLAT_FILE_ARCHIVED_ORDERS_DATA_BY_ORDER_DATE",
+      "json_schema": {
+        "title": "Flat File Archived Orders Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "amazon-order-id": {
+            "description": "The unique identifier for the Amazon order",
+            "type": ["null", "string"]
+          },
+          "merchant-order-id": {
+            "description": "The merchant's unique identifier for the order",
+            "type": ["null", "string"]
+          },
+          "purchase-date": {
+            "description": "The date and time when the order was purchased",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "last-updated-date": {
+            "description": "The date and time when the order was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "order-status": {
+            "description": "The status of the order",
+            "type": ["null", "string"]
+          },
+          "fulfillment-channel": {
+            "description": "The type of fulfillment channel",
+            "type": ["null", "string"]
+          },
+          "sales-channel": {
+            "description": "The sales channel where the order was made",
+            "type": ["null", "string"]
+          },
+          "order-channel": {
+            "description": "The channel through which the order was placed",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "The URL of the product",
+            "type": ["null", "string"]
+          },
+          "ship-service-level": {
+            "description": "The service level for shipping",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "The name of the product",
+            "type": ["null", "string"]
+          },
+          "sku": {
+            "description": "The stock keeping unit of the product",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "The Amazon Standard Identification Number for the product",
+            "type": ["null", "string"]
+          },
+          "item-status": {
+            "description": "The status of the item",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "The quantity of the product",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency used for the transaction",
+            "type": ["null", "string"]
+          },
+          "item-price": {
+            "description": "The price of the item",
+            "type": ["null", "string"]
+          },
+          "item-tax": {
+            "description": "Tax applied to the item",
+            "type": ["null", "string"]
+          },
+          "shipping-price": {
+            "description": "The price of shipping",
+            "type": ["null", "string"]
+          },
+          "shipping-tax": {
+            "description": "Tax applied to shipping",
+            "type": ["null", "string"]
+          },
+          "gift-wrap-price": {
+            "description": "The price of gift wrapping",
+            "type": ["null", "string"]
+          },
+          "gift-wrap-tax": {
+            "description": "The tax applied to gift wrapping",
+            "type": ["null", "string"]
+          },
+          "item-promotion-discount": {
+            "description": "Discount applied to the item",
+            "type": ["null", "string"]
+          },
+          "ship-promotion-discount": {
+            "description": "Discount applied to shipping",
+            "type": ["null", "string"]
+          },
+          "ship-country": {
+            "description": "The country where the item is to be shipped",
+            "type": ["null", "string"]
+          },
+          "ship-promotion-id": {
+            "description": "ID of the shipping promotion",
+            "type": ["null", "string"]
+          },
+          "promotion-ids": {
+            "description": "IDs of promotions applied",
+            "type": ["null", "string"]
+          },
+          "is-business-order": {
+            "description": "Indicates if the order is a business order",
+            "type": ["null", "string"]
+          },
+          "purchase-order-number": {
+            "description": "The purchase order number",
+            "type": ["null", "string"]
+          },
+          "price-designation": {
+            "description": "The designation of the price",
+            "type": ["null", "string"]
+          },
+          "is-replacement-order": {
+            "description": "Indicates if the order is a replacement order",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time of the data",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["last-updated-date"]
+    },
+    {
+      "name": "GET_FLAT_FILE_RETURNS_DATA_BY_RETURN_DATE",
+      "json_schema": {
+        "title": "Flat File Returns Report by Return Date",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "Order ID": {
+            "description": "Unique identifier of the order.",
+            "type": ["null", "string"]
+          },
+          "Order date": {
+            "description": "Date and time when the order was placed.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "Return request date": {
+            "description": "Date and time when the return request was initiated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "Return request status": {
+            "description": "Status of the return request.",
+            "type": ["null", "string"]
+          },
+          "Amazon RMA ID": {
+            "description": "Amazon's Return Merchandise Authorization ID.",
+            "type": ["null", "string"]
+          },
+          "Merchant RMA ID": {
+            "description": "Merchant's Return Merchandise Authorization ID.",
+            "type": ["null", "string"]
+          },
+          "Label type": {
+            "description": "Type of return shipping label.",
+            "type": ["null", "string"]
+          },
+          "Label cost": {
+            "description": "Cost associated with the return shipping label.",
+            "type": ["null", "string"]
+          },
+          "Currency code": {
+            "description": "The currency code used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "Return carrier": {
+            "description": "Carrier used for returning the item.",
+            "type": ["null", "string"]
+          },
+          "Tracking ID": {
+            "description": "Tracking ID for the return shipment.",
+            "type": ["null", "string"]
+          },
+          "Label to be paid by": {
+            "description": "Party responsible for paying the return label costs.",
+            "type": ["null", "string"]
+          },
+          "A-to-Z Claim": {
+            "description": "Indicates if a claim has been made through Amazon A-to-Z Guarantee.",
+            "type": ["null", "string"]
+          },
+          "Is prime": {
+            "description": "Indicates if the order was fulfilled through Amazon Prime.",
+            "type": ["null", "string"]
+          },
+          "ASIN": {
+            "description": "Amazon Standard Identification Number of the product.",
+            "type": ["null", "string"]
+          },
+          "Merchant SKU": {
+            "description": "Merchant Stock Keeping Unit of the product.",
+            "type": ["null", "string"]
+          },
+          "Item Name": {
+            "description": "Name or description of the returned item.",
+            "type": ["null", "string"]
+          },
+          "Return quantity": {
+            "description": "Number of items being returned.",
+            "type": ["null", "string"]
+          },
+          "Return Reason": {
+            "description": "Reason provided for returning the item.",
+            "type": ["null", "string"]
+          },
+          "In policy": {
+            "description": "Flag indicating if the return is within the return policy.",
+            "type": ["null", "string"]
+          },
+          "Return type": {
+            "description": "Type of return (e.g., refund, replacement).",
+            "type": ["null", "string"]
+          },
+          "Resolution": {
+            "description": "Resolution status of the return request.",
+            "type": ["null", "string"]
+          },
+          "Invoice number": {
+            "description": "Unique identifier of the invoice related to the return.",
+            "type": ["null", "string"]
+          },
+          "Return delivery date": {
+            "description": "Date and time when the return was delivered.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "Order Amount": {
+            "description": "Total amount of the order.",
+            "type": ["null", "string"]
+          },
+          "Order quantity": {
+            "description": "Number of items ordered.",
+            "type": ["null", "string"]
+          },
+          "SafeT Action reason": {
+            "description": "Reason for the action taken by Amazon SafeT.",
+            "type": ["null", "string"]
+          },
+          "SafeT claim id": {
+            "description": "Unique identifier of the SafeT claim.",
+            "type": ["null", "string"]
+          },
+          "SafeT claim state": {
+            "description": "State of the SafeT claim.",
+            "type": ["null", "string"]
+          },
+          "SafeT claim creation time": {
+            "description": "Date and time when the SafeT claim was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "SafeT claim reimbursement amount": {
+            "description": "Amount reimbursed by SafeT for the claim.",
+            "type": ["null", "string"]
+          },
+          "Refunded Amount": {
+            "description": "Total amount refunded for the return.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data retrieval period.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_FBA_INVENTORY_PLANNING_DATA",
+      "json_schema": {
+        "title": "FBA Manage Inventory Health Report",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "snapshot-date": {
+            "description": "Date and time when the inventory snapshot was taken",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sku": {
+            "description": "Stock Keeping Unit (SKU) for the product",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "Fulfillment Network SKU for the product",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "Unique identifier for the product in Amazon's catalog",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "Name of the product",
+            "type": ["null", "string"]
+          },
+          "condition": {
+            "description": "Condition of the product (e.g., New, Used, Refurbished)",
+            "type": ["null", "string"]
+          },
+          "available": {
+            "description": "Quantity of the product currently available for sale",
+            "type": ["null", "string"]
+          },
+          "pending-removal-quantity": {
+            "description": "Quantity of the product pending removal from inventory",
+            "type": ["null", "string"]
+          },
+          "inv-age-0-to-90-days": {
+            "description": "Quantity of product inventory aged between 0 to 90 days",
+            "type": ["null", "string"]
+          },
+          "inv-age-91-to-180-days": {
+            "description": "Quantity of product inventory aged between 91 to 180 days",
+            "type": ["null", "string"]
+          },
+          "inv-age-181-to-270-days": {
+            "description": "Quantity of product inventory aged between 181 to 270 days",
+            "type": ["null", "string"]
+          },
+          "inv-age-271-to-365-days": {
+            "description": "Quantity of product inventory aged between 271 to 365 days",
+            "type": ["null", "string"]
+          },
+          "inv-age-365-plus-days": {
+            "description": "Quantity of product inventory aged 365+ days",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "Currency in which the monetary values are represented",
+            "type": ["null", "string"]
+          },
+          "qty-to-be-charged-ltsf-9-mo": {
+            "description": "Quantity to be charged long-term storage fee for the next 9 months",
+            "type": ["null", "string"]
+          },
+          "projected-ltsf-9-mo": {
+            "description": "Projected long-term storage fee for the next 9 months",
+            "type": ["null", "string"]
+          },
+          "qty-to-be-charged-ltsf-12-mo": {
+            "description": "Quantity to be charged long-term storage fee for the next 12 months",
+            "type": ["null", "string"]
+          },
+          "estimated-ltsf-next-charge": {
+            "description": "Estimated long-term storage fee for the next charge",
+            "type": ["null", "string"]
+          },
+          "units-shipped-t7": {
+            "description": "Units of the product shipped in the last 7 days",
+            "type": ["null", "string"]
+          },
+          "units-shipped-t30": {
+            "description": "Units of the product shipped in the last 30 days",
+            "type": ["null", "string"]
+          },
+          "units-shipped-t60": {
+            "description": "Units of the product shipped in the last 60 days",
+            "type": ["null", "string"]
+          },
+          "units-shipped-t90": {
+            "description": "Units of the product shipped in the last 90 days",
+            "type": ["null", "string"]
+          },
+          "alert": {
+            "description": "Flag indicating if there is any alert related to the inventory planning data",
+            "type": ["null", "string"]
+          },
+          "your-price": {
+            "description": "Your set price for the product",
+            "type": ["null", "string"]
+          },
+          "sales-price": {
+            "description": "Current sales price of the product",
+            "type": ["null", "string"]
+          },
+          "lowest-price-new-plus-shipping": {
+            "description": "Lowest price including shipping for a new product",
+            "type": ["null", "string"]
+          },
+          "lowest-price-used": {
+            "description": "Lowest price for a used product",
+            "type": ["null", "string"]
+          },
+          "recommended-action": {
+            "description": "Recommended action to manage the inventory",
+            "type": ["null", "string"]
+          },
+          "healthy-inventory-level": {
+            "description": "Recommended healthy level of inventory for the product",
+            "type": ["null", "string"]
+          },
+          "recommended-sales-price": {
+            "description": "Recommended sales price for the product",
+            "type": ["null", "string"]
+          },
+          "recommended-sale-duration-days": {
+            "description": "Recommended duration for the product to be on sale",
+            "type": ["null", "string"]
+          },
+          "recommended-removal-quantity": {
+            "description": "Recommended quantity of product to be removed from inventory",
+            "type": ["null", "string"]
+          },
+          "estimated-cost-savings-of-recommended-actions": {
+            "description": "Estimated cost savings by taking recommended actions",
+            "type": ["null", "string"]
+          },
+          "sell-through": {
+            "description": "Rate at which the product is selling",
+            "type": ["null", "string"]
+          },
+          "item-volume": {
+            "description": "Volume of the item in storage units",
+            "type": ["null", "string"]
+          },
+          "volume-unit-measurement": {
+            "description": "Unit of measurement for the volume of the product",
+            "type": ["null", "string"]
+          },
+          "storage-type": {
+            "description": "Type of storage used for the product (e.g., Standard, Oversized)",
+            "type": ["null", "string"]
+          },
+          "storage-volume": {
+            "description": "Volume occupied by the product in storage",
+            "type": ["null", "string"]
+          },
+          "marketplace": {
+            "description": "Marketplace identifier where the product is listed",
+            "type": ["null", "string"]
+          },
+          "product-group": {
+            "description": "Product grouping identifier",
+            "type": ["null", "string"]
+          },
+          "sales-rank": {
+            "description": "Sales rank of the product in the marketplace",
+            "type": ["null", "string"]
+          },
+          "days-of-supply": {
+            "description": "Number of days for which the inventory is expected to last",
+            "type": ["null", "string"]
+          },
+          "estimated-excess-quantity": {
+            "description": "Estimated excess quantity of the product in inventory",
+            "type": ["null", "string"]
+          },
+          "weeks-of-cover-t30": {
+            "description": "Number of weeks the current inventory will cover at the sales rate over the last 30 days",
+            "type": ["null", "string"]
+          },
+          "weeks-of-cover-t90": {
+            "description": "Number of weeks the current inventory will cover at the sales rate over the last 90 days",
+            "type": ["null", "string"]
+          },
+          "featuredoffer-price": {
+            "description": "Featured offer price of the product",
+            "type": ["null", "string"]
+          },
+          "sales-shipped-last-7-days": {
+            "description": "Quantity of the product shipped in the last 7 days",
+            "type": ["null", "string"]
+          },
+          "sales-shipped-last-30-days": {
+            "description": "Quantity of the product shipped in the last 30 days",
+            "type": ["null", "string"]
+          },
+          "sales-shipped-last-60-days": {
+            "description": "Quantity of the product shipped in the last 60 days",
+            "type": ["null", "string"]
+          },
+          "sales-shipped-last-90-days": {
+            "description": "Quantity of the product shipped in the last 90 days",
+            "type": ["null", "string"]
+          },
+          "inv-age-0-to-30-days": {
+            "description": "Quantity of product inventory aged between 0 to 30 days",
+            "type": ["null", "string"]
+          },
+          "inv-age-31-to-60-days": {
+            "description": "Quantity of product inventory aged between 31 to 60 days",
+            "type": ["null", "string"]
+          },
+          "inv-age-61-to-90-days": {
+            "description": "Quantity of product inventory aged between 61 to 90 days",
+            "type": ["null", "string"]
+          },
+          "inv-age-181-to-330-days": {
+            "description": "Quantity of product inventory aged between 181 to 330 days",
+            "type": ["null", "string"]
+          },
+          "inv-age-331-to-365-days": {
+            "description": "Quantity of product inventory aged between 331 to 365 days",
+            "type": ["null", "string"]
+          },
+          "estimated-storage-cost-next-month": {
+            "description": "Estimated storage cost for the next month",
+            "type": ["null", "string"]
+          },
+          "inbound-quantity": {
+            "description": "Quantity of the product currently in transit to Amazon's fulfillment center",
+            "type": ["null", "string"]
+          },
+          "inbound-working": {
+            "description": "Quantity of the product in the fulfillment center being processed",
+            "type": ["null", "string"]
+          },
+          "inbound-shipped": {
+            "description": "Quantity of the product shipped to the fulfillment center but not yet received",
+            "type": ["null", "string"]
+          },
+          "inbound-received": {
+            "description": "Quantity of the product received in the fulfillment center but not yet available for sale",
+            "type": ["null", "string"]
+          },
+          "no-sale-last-6-months": {
+            "description": "Indicator if there were no sales in the last 6 months",
+            "type": ["null", "string"]
+          },
+          "reserved-quantity": {
+            "description": "Quantity of the product reserved for future sales",
+            "type": ["null", "string"]
+          },
+          "unfulfillable-quantity": {
+            "description": "Quantity of the product that is unfulfillable",
+            "type": ["null", "string"]
+          },
+          "estimated-ais-181-210-days": {
+            "description": "Estimated quantity of units to be charged in days 181-210",
+            "type": ["null", "number"]
+          },
+          "estimated-ais-211-240-days": {
+            "description": "Estimated quantity of units to be charged in days 211-240",
+            "type": ["null", "number"]
+          },
+          "estimated-ais-241-270-days": {
+            "description": "Estimated quantity of units to be charged in days 241-270",
+            "type": ["null", "number"]
+          },
+          "estimated-ais-271-300-days": {
+            "description": "Estimated quantity of units to be charged in days 271-300",
+            "type": ["null", "number"]
+          },
+          "estimated-ais-301-330-days": {
+            "description": "Estimated quantity of units to be charged in days 301-330",
+            "type": ["null", "number"]
+          },
+          "estimated-ais-331-365-days": {
+            "description": "Estimated quantity of units to be charged in days 331-365",
+            "type": ["null", "number"]
+          },
+          "estimated-ais-365-plus-days": {
+            "description": "Estimated quantity of units to be charged in days 365+",
+            "type": ["null", "number"]
+          },
+          "quantity-to-be-charged-ais-181-210-days": {
+            "description": "Quantity to be charged in days 181-210 based on inventory health",
+            "type": ["null", "integer"]
+          },
+          "quantity-to-be-charged-ais-211-240-days": {
+            "description": "Quantity to be charged in days 211-240 based on inventory health",
+            "type": ["null", "integer"]
+          },
+          "quantity-to-be-charged-ais-241-270-days": {
+            "description": "Quantity to be charged in days 241-270 based on inventory health",
+            "type": ["null", "integer"]
+          },
+          "quantity-to-be-charged-ais-271-300-days": {
+            "description": "Quantity to be charged in days 271-300 based on inventory health",
+            "type": ["null", "integer"]
+          },
+          "quantity-to-be-charged-ais-301-330-days": {
+            "description": "Quantity to be charged in days 301-330 based on inventory health",
+            "type": ["null", "integer"]
+          },
+          "quantity-to-be-charged-ais-331-365-days": {
+            "description": "Quantity to be charged in days 331-365 based on inventory health",
+            "type": ["null", "integer"]
+          },
+          "quantity-to-be-charged-ais-365-plus-days": {
+            "description": "Quantity to be charged in days 365+ based on inventory health",
+            "type": ["null", "integer"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data snapshot in date format",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "GET_LEDGER_SUMMARY_VIEW_DATA",
+      "json_schema": {
+        "title": "Inventory Ledger Report - Summary View",
+        "description": "",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "Date": {
+            "description": "Date of the event",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "FNSKU": {
+            "description": "Fulfillment Network Stock Keeping Unit",
+            "type": ["null", "string"]
+          },
+          "ASIN": {
+            "description": "Amazon Standard Identification Number for the product",
+            "type": ["null", "string"]
+          },
+          "MSKU": {
+            "description": "Merchant Stock Keeping Unit",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "Title of the product",
+            "type": ["null", "string"]
+          },
+          "Disposition": {
+            "description": "Action taken with the products",
+            "type": ["null", "string"]
+          },
+          "Starting Warehouse Balance": {
+            "description": "The balance of products at the start of the period",
+            "type": ["null", "string"]
+          },
+          "In Transit Between Warehouses": {
+            "description": "Products moving between warehouses",
+            "type": ["null", "string"]
+          },
+          "Receipts": {
+            "description": "Products received",
+            "type": ["null", "string"]
+          },
+          "Customer Shipments": {
+            "description": "Products shipped to customers",
+            "type": ["null", "string"]
+          },
+          "Customer Returns": {
+            "description": "Products returned by customers",
+            "type": ["null", "string"]
+          },
+          "Vendor Returns": {
+            "description": "Products returned by vendors",
+            "type": ["null", "string"]
+          },
+          "Warehouse Transfer In/Out": {
+            "description": "Products transferred in or out of the warehouse",
+            "type": ["null", "string"]
+          },
+          "Found": {
+            "description": "Products that were found",
+            "type": ["null", "string"]
+          },
+          "Lost": {
+            "description": "Products that are lost",
+            "type": ["null", "string"]
+          },
+          "Damaged": {
+            "description": "Products that are damaged",
+            "type": ["null", "string"]
+          },
+          "Disposed": {
+            "description": "Products that have been disposed of",
+            "type": ["null", "string"]
+          },
+          "Other Events": {
+            "description": "Any other events related to the product",
+            "type": ["null", "string"]
+          },
+          "Ending Warehouse Balance": {
+            "description": "The balance of products at the end of the period",
+            "type": ["null", "string"]
+          },
+          "Unknown Events": {
+            "description": "Any events with unknown causes",
+            "type": ["null", "string"]
+          },
+          "Location": {
+            "description": "Location of the warehouse",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "End time of the data",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Date"]
+    },
+    {
+      "name": "FBA_REIMBURSEMENTS",
+      "json_schema": {
+        "title": "FBA Reimbursements Data",
+        "description": "FBA Reimbursements Data Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "properties": {
+          "approval-date": {
+            "description": "The date and time when the reimbursement was approved.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "reimbursement-id": {
+            "description": "The unique identifier for the reimbursement record.",
+            "type": ["null", "string"]
+          },
+          "case-id": {
+            "description": "The case ID associated with the reimbursement.",
+            "type": ["null", "string"]
+          },
+          "amazon-order-id": {
+            "description": "The unique identifier for the Amazon order related to the reimbursement.",
+            "type": ["null", "string"]
+          },
+          "reason": {
+            "description": "The reason provided for the reimbursement.",
+            "type": ["null", "string"]
+          },
+          "sku": {
+            "description": "The Stock Keeping Unit (SKU) of the product.",
+            "type": ["null", "string"]
+          },
+          "fnsku": {
+            "description": "The Fulfillment Network SKU of the product.",
+            "type": ["null", "string"]
+          },
+          "asin": {
+            "description": "The Amazon Standard Identification Number (ASIN) of the product.",
+            "type": ["null", "string"]
+          },
+          "product-name": {
+            "description": "The name of the product for which the reimbursement was issued.",
+            "type": ["null", "string"]
+          },
+          "condition": {
+            "description": "The condition of the product for which the reimbursement was issued.",
+            "type": ["null", "string"]
+          },
+          "currency-unit": {
+            "description": "The currency unit used for the reimbursement amount.",
+            "type": ["null", "string"]
+          },
+          "amount-per-unit": {
+            "description": "The amount reimbursed per unit of the product.",
+            "type": ["null", "string"]
+          },
+          "quantity-reimbursed-cash": {
+            "description": "The quantity of the product reimbursed in cash.",
+            "type": ["null", "string"]
+          },
+          "amount-total": {
+            "description": "The total amount reimbursed for the product.",
+            "type": ["null", "string"]
+          },
+          "quantity-reimbursed-inventory": {
+            "description": "The quantity of the product added back to inventory as reimbursement.",
+            "type": ["null", "string"]
+          },
+          "quantity-reimbursed-total": {
+            "description": "The total quantity of the product reimbursed.",
+            "type": ["null", "string"]
+          },
+          "original-reimbursement-id": {
+            "description": "The original reimbursement ID associated with the record.",
+            "type": ["null", "string"]
+          },
+          "original-reimbursement-type": {
+            "description": "The type of original reimbursement.",
+            "type": ["null", "string"]
+          },
+          "dataEndTime": {
+            "description": "The end time of the data represented in the record.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["dataEndTime"]
+    },
+    {
+      "name": "VendorOrders",
+      "json_schema": {
+        "title": "Vendor Orders",
+        "description": "All vendor purchase orders that were updated after a specified date",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "purchaseOrderNumber": {
+            "description": "Purchase order number",
+            "type": ["null", "string"]
+          },
+          "purchaseOrderState": {
+            "description": "State of the purchase order",
+            "type": ["null", "string"]
+          },
+          "orderDetails": {
+            "description": "Details of the vendor order.",
+            "type": ["null", "object"],
+            "properties": {
+              "purchaseOrderDate": {
+                "description": "Purchase order creation date and time",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "purchaseOrderChangedDate": {
+                "description": "Date and time when the purchase order was last changed",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "purchaseOrderStateChangedDate": {
+                "description": "Date and time when the purchase order state changed",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "purchaseOrderType": {
+                "description": "Type of purchase order",
+                "type": ["null", "string"]
+              },
+              "importDetails": {
+                "description": "Details related to import of the order",
+                "type": ["null", "object"],
+                "properties": {
+                  "methodOfPayment": {
+                    "description": "Method of payment for import",
+                    "type": ["null", "string"]
+                  },
+                  "internationalCommercialTerms": {
+                    "description": "International commercial terms",
+                    "type": ["null", "string"]
+                  },
+                  "portOfDelivery": {
+                    "description": "Port of delivery",
+                    "type": ["null", "string"]
+                  },
+                  "importContainers": {
+                    "description": "Information about import containers",
+                    "type": ["null", "string"]
+                  },
+                  "shippingInstructions": {
+                    "description": "Instructions for shipping",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "dealCode": {
+                "description": "Deal code associated with the order",
+                "type": ["null", "string"]
+              },
+              "paymentMethod": {
+                "description": "Payment method for the order",
+                "type": ["null", "string"]
+              },
+              "buyingParty": {
+                "description": "Information about the party making the purchase",
+                "type": ["null", "object"],
+                "properties": {
+                  "partyId": {
+                    "description": "ID of the buying party",
+                    "type": ["null", "string"]
+                  },
+                  "address": {
+                    "description": "The address details of the buying party",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the party",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine1": {
+                        "description": "Address Line 1",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine2": {
+                        "description": "Address Line 2",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine3": {
+                        "description": "Address Line 3",
+                        "type": ["null", "string"]
+                      },
+                      "city": {
+                        "description": "City name",
+                        "type": ["null", "string"]
+                      },
+                      "county": {
+                        "description": "County name",
+                        "type": ["null", "string"]
+                      },
+                      "district": {
+                        "description": "District name",
+                        "type": ["null", "string"]
+                      },
+                      "stateOrRegion": {
+                        "description": "State or region",
+                        "type": ["null", "string"]
+                      },
+                      "postalCode": {
+                        "description": "Postal code",
+                        "type": ["null", "string"]
+                      },
+                      "countryCode": {
+                        "description": "Country code",
+                        "type": ["null", "string"]
+                      },
+                      "phone": {
+                        "description": "Phone number",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "taxInfo": {
+                    "description": "Tax information of the buying party",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "taxType": {
+                        "description": "Type of tax",
+                        "type": ["null", "string"]
+                      },
+                      "taxRegistrationNumber": {
+                        "description": "Tax registration number",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              },
+              "sellingParty": {
+                "description": "Information about the party selling the products",
+                "type": ["null", "object"],
+                "properties": {
+                  "partyId": {
+                    "description": "ID of the selling party",
+                    "type": ["null", "string"]
+                  },
+                  "address": {
+                    "description": "The address details of the selling party",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the party",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine1": {
+                        "description": "Address Line 1",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine2": {
+                        "description": "Address Line 2",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine3": {
+                        "description": "Address Line 3",
+                        "type": ["null", "string"]
+                      },
+                      "city": {
+                        "description": "City name",
+                        "type": ["null", "string"]
+                      },
+                      "county": {
+                        "description": "County name",
+                        "type": ["null", "string"]
+                      },
+                      "district": {
+                        "description": "District name",
+                        "type": ["null", "string"]
+                      },
+                      "stateOrRegion": {
+                        "description": "State or region",
+                        "type": ["null", "string"]
+                      },
+                      "postalCode": {
+                        "description": "Postal code",
+                        "type": ["null", "string"]
+                      },
+                      "countryCode": {
+                        "description": "Country code",
+                        "type": ["null", "string"]
+                      },
+                      "phone": {
+                        "description": "Phone number",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "taxInfo": {
+                    "description": "Tax information of the selling party",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "taxType": {
+                        "description": "Type of tax",
+                        "type": ["null", "string"]
+                      },
+                      "taxRegistrationNumber": {
+                        "description": "Tax registration number",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              },
+              "shipToParty": {
+                "description": "Information about the party to which the order is shipped",
+                "type": ["null", "object"],
+                "properties": {
+                  "partyId": {
+                    "description": "ID of the ship-to party",
+                    "type": ["null", "string"]
+                  },
+                  "address": {
+                    "description": "The address details of the ship-to party",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the party",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine1": {
+                        "description": "Address Line 1",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine2": {
+                        "description": "Address Line 2",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine3": {
+                        "description": "Address Line 3",
+                        "type": ["null", "string"]
+                      },
+                      "city": {
+                        "description": "City name",
+                        "type": ["null", "string"]
+                      },
+                      "county": {
+                        "description": "County name",
+                        "type": ["null", "string"]
+                      },
+                      "district": {
+                        "description": "District name",
+                        "type": ["null", "string"]
+                      },
+                      "stateOrRegion": {
+                        "description": "State or region",
+                        "type": ["null", "string"]
+                      },
+                      "postalCode": {
+                        "description": "Postal code",
+                        "type": ["null", "string"]
+                      },
+                      "countryCode": {
+                        "description": "Country code",
+                        "type": ["null", "string"]
+                      },
+                      "phone": {
+                        "description": "Phone number",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "taxInfo": {
+                    "description": "Tax information of the ship-to party",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "taxType": {
+                        "description": "Type of tax",
+                        "type": ["null", "string"]
+                      },
+                      "taxRegistrationNumber": {
+                        "description": "Tax registration number",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              },
+              "billToParty": {
+                "description": "Information about the party to which the bill for the order is sent",
+                "type": ["null", "object"],
+                "properties": {
+                  "partyId": {
+                    "description": "ID of the bill-to party",
+                    "type": ["null", "string"]
+                  },
+                  "address": {
+                    "description": "The address details of the bill-to party",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the party",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine1": {
+                        "description": "Address Line 1",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine2": {
+                        "description": "Address Line 2",
+                        "type": ["null", "string"]
+                      },
+                      "addressLine3": {
+                        "description": "Address Line 3",
+                        "type": ["null", "string"]
+                      },
+                      "city": {
+                        "description": "City name",
+                        "type": ["null", "string"]
+                      },
+                      "county": {
+                        "description": "County name",
+                        "type": ["null", "string"]
+                      },
+                      "district": {
+                        "description": "District name",
+                        "type": ["null", "string"]
+                      },
+                      "stateOrRegion": {
+                        "description": "State or region",
+                        "type": ["null", "string"]
+                      },
+                      "postalCode": {
+                        "description": "Postal code",
+                        "type": ["null", "string"]
+                      },
+                      "countryCode": {
+                        "description": "Country code",
+                        "type": ["null", "string"]
+                      },
+                      "phone": {
+                        "description": "Phone number",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "taxInfo": {
+                    "description": "Tax information of the bill-to party",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "taxType": {
+                        "description": "Type of tax",
+                        "type": ["null", "string"]
+                      },
+                      "taxRegistrationNumber": {
+                        "description": "Tax registration number",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              },
+              "shipWindow": {
+                "description": "Shipping window details",
+                "type": ["null", "string"]
+              },
+              "deliveryWindow": {
+                "description": "Delivery window details",
+                "type": ["null", "string"]
+              },
+              "items": {
+                "description": "List of items included in the order",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "itemSequenceNumber": {
+                      "description": "Sequence number of the item",
+                      "type": ["null", "string"]
+                    },
+                    "amazonProductIdentifier": {
+                      "description": "Product identifier assigned by Amazon",
+                      "type": ["null", "string"]
+                    },
+                    "vendorProductIdentifier": {
+                      "description": "Product identifier assigned by the vendor",
+                      "type": ["null", "string"]
+                    },
+                    "orderedQuantity": {
+                      "description": "Quantity ordered for the item",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "Quantity amount",
+                          "type": ["null", "integer"]
+                        },
+                        "unitOfMeasure": {
+                          "description": "Unit of measurement",
+                          "type": ["null", "string"]
+                        },
+                        "unitSize": {
+                          "description": "Size of the unit",
+                          "type": ["null", "integer"]
+                        }
+                      }
+                    },
+                    "isBackOrderAllowed": {
+                      "description": "Flag indicating if back orders are allowed for the item",
+                      "type": ["null", "boolean"]
+                    },
+                    "netCost": {
+                      "description": "Net cost of the item",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "Cost amount",
+                          "type": ["null", "string"]
+                        },
+                        "currencyCode": {
+                          "description": "Currency code",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "listPrice": {
+                      "description": "List price of the item",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "Price amount",
+                          "type": ["null", "string"]
+                        },
+                        "currencyCode": {
+                          "description": "Currency code",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "changedBefore": {
+            "description": "The date and time before which the order details were last changed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["changedBefore"],
+      "source_defined_primary_key": [["purchaseOrderNumber"]]
+    },
+    {
+      "name": "GET_VENDOR_FORECASTING_FRESH_REPORT",
+      "json_schema": {
+        "title": "Vendor Forecasting Fresh Report",
+        "description": "A report with forward looking mean, P70, P80, and P90 weekly customer demand forecasts. Data is reported at the ASIN level for the most recent weekly forecast generation date.",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "forecastGenerationDate": {
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "asin": { "type": ["null", "string"] },
+          "startDate": { "type": ["null", "string"], "format": "date" },
+          "endDate": { "type": ["null", "string"], "format": "date" },
+          "meanForecastUnits": { "type": ["null", "number"] },
+          "p70ForecastUnits": { "type": ["null", "number"] },
+          "p80ForecastUnits": { "type": ["null", "number"] },
+          "p90ForecastUnits": { "type": ["null", "number"] },
+          "dataEndTime": { "type": ["null", "string"], "format": "date" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"]
+    },
+    {
+      "name": "GET_VENDOR_FORECASTING_RETAIL_REPORT",
+      "json_schema": {
+        "title": "Vendor Forecasting Retail Report",
+        "description": "A report with forward looking mean, P70, P80, and P90 weekly customer demand forecasts. Data is reported at the ASIN level for the most recent weekly forecast generation date.",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "forecastGenerationDate": {
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "asin": { "type": ["null", "string"] },
+          "startDate": { "type": ["null", "string"], "format": "date" },
+          "endDate": { "type": ["null", "string"], "format": "date" },
+          "meanForecastUnits": { "type": ["null", "number"] },
+          "p70ForecastUnits": { "type": ["null", "number"] },
+          "p80ForecastUnits": { "type": ["null", "number"] },
+          "p90ForecastUnits": { "type": ["null", "number"] },
+          "dataEndTime": { "type": ["null", "string"], "format": "date" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"]
+    },
+    {
+      "name": "GET_BRAND_ANALYTICS_MARKET_BASKET_REPORT",
+      "json_schema": {
+        "title": "Brand Analytics Market Basket Reports",
+        "description": "Brand Analytics Market Basket Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "startDate": {
+            "description": "The start date of the data collection period.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "endDate": {
+            "description": "The end date of the data collection period.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "asin": {
+            "description": "The ASIN (Amazon Standard Identification Number) of the product.",
+            "type": ["null", "string"]
+          },
+          "purchasedWithAsin": {
+            "description": "The ASINs of the products that were frequently purchased with this ASIN.",
+            "type": ["null", "string"]
+          },
+          "purchasedWithRank": {
+            "description": "The ranking of products that were frequently purchased with this ASIN.",
+            "type": ["null", "integer"]
+          },
+          "combinationPct": {
+            "description": "The percentage of times this ASIN was purchased with another ASIN.",
+            "type": ["null", "number"]
+          },
+          "dataEndTime": {
+            "description": "The date and time when the data collection ended.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "queryEndDate": {
+            "description": "The end date of the query period.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["endDate"]
+    },
+    {
+      "name": "GET_BRAND_ANALYTICS_SEARCH_TERMS_REPORT",
+      "json_schema": {
+        "title": "Brand Analytics Search Terms Reports",
+        "description": "Brand Analytics Search Terms Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "departmentName": {
+            "description": "The name of the department or category associated with the search term.",
+            "type": ["null", "string"]
+          },
+          "searchTerm": {
+            "description": "The specific term or keyword entered by users in search queries.",
+            "type": ["null", "string"]
+          },
+          "searchFrequencyRank": {
+            "description": "The ranking of this search term based on its frequency of occurrence in search queries.",
+            "type": ["null", "number"]
+          },
+          "clickedAsin": {
+            "description": "The ASIN (Amazon Standard Identification Number) that was clicked for this search term.",
+            "type": ["null", "string"]
+          },
+          "clickShareRank": {
+            "description": "The ranking of this search term based on the click share it received.",
+            "type": ["null", "number"]
+          },
+          "clickShare": {
+            "description": "The share of total clicks that this search term received out of all the clicks in the report period.",
+            "type": ["null", "number"]
+          },
+          "conversionShare": {
+            "description": "The share of total conversions attributed to this search term out of all conversions in the report period.",
+            "type": ["null", "number"]
+          },
+          "dataEndTime": {
+            "description": "The end time of the data collection period for this report.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "queryEndDate": {
+            "description": "The end date of the search term query.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["queryEndDate"]
+    },
+    {
+      "name": "GET_BRAND_ANALYTICS_REPEAT_PURCHASE_REPORT",
+      "json_schema": {
+        "title": "Brand Analytics Repeat Purchase Reports",
+        "description": "Brand Analytics Repeat Purchase Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "startDate": {
+            "description": "The start date of the data collection period in date format.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "endDate": {
+            "description": "The end date of the data collection period in date format.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "asin": {
+            "description": "The unique identifier for the ASIN (Amazon Standard Identification Number).",
+            "type": ["null", "string"]
+          },
+          "orders": {
+            "description": "The total number of orders placed during the specified time period.",
+            "type": ["null", "integer"]
+          },
+          "uniqueCustomers": {
+            "description": "The total number of unique customers who made purchases during the specified time period.",
+            "type": ["null", "integer"]
+          },
+          "repeatCustomersPctTotal": {
+            "description": "The percentage of repeat customers out of the total customers.",
+            "type": ["null", "number"]
+          },
+          "repeatPurchaseRevenue": {
+            "description": "The revenue generated from repeat purchases.",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "The amount of repeat purchase revenue.",
+                "type": ["null", "number"]
+              },
+              "currencyCode": {
+                "description": "The currency code (e.g., USD) for the repeat purchase revenue amount.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "repeatPurchaseRevenuePctTotal": {
+            "description": "The percentage of repeat purchase revenue out of the total revenue.",
+            "type": ["null", "number"]
+          },
+          "dataEndTime": {
+            "description": "The end time of the data collection period in date format.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "queryEndDate": {
+            "description": "The end date of the query period for data analysis in date format.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["endDate"]
+    },
+    {
+      "name": "GET_SALES_AND_TRAFFIC_REPORT",
+      "json_schema": {
+        "title": "Seller Sales and Traffic Business Report - By Asin",
+        "description": "Seller retail analytics reports - Sales and Traffic Business Report",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "queryEndDate": {
+            "description": "The date and time when the query for sales and traffic data ends.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "parentAsin": {
+            "description": "The parent ASIN of the product if it is part of a variation.",
+            "type": ["null", "string"]
+          },
+          "childAsin": {
+            "description": "The child ASIN (Amazon Standard Identification Number) of the product.",
+            "type": ["null", "string"]
+          },
+          "sku": {
+            "description": "The Stock Keeping Unit (SKU) of the product.",
+            "type": ["null", "string"]
+          },
+          "salesByAsin": {
+            "description": "Sales data grouped by ASIN",
+            "type": "object",
+            "properties": {
+              "unitsOrdered": {
+                "description": "The total units of the product ordered.",
+                "type": ["null", "number"]
+              },
+              "orderedProductSales": {
+                "description": "Sales information for each product sold",
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "description": "The total amount of ordered product sales.",
+                    "type": ["null", "number"]
+                  },
+                  "currencyCode": {
+                    "description": "The currency code of the sales amount.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "totalOrderItems": {
+                "description": "The total number of order items placed.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "trafficByAsin": {
+            "description": "Traffic data grouped by ASIN",
+            "type": "object",
+            "properties": {
+              "browserSessions": {
+                "description": "The total number of browsing sessions.",
+                "type": ["null", "number"]
+              },
+              "mobileAppSessions": {
+                "description": "The total number of sessions from mobile apps.",
+                "type": ["null", "number"]
+              },
+              "sessions": {
+                "description": "The total number of sessions across all platforms.",
+                "type": ["null", "number"]
+              },
+              "browserSessionPercentage": {
+                "description": "The percentage of browsing sessions in relation to total sessions.",
+                "type": ["null", "number"]
+              },
+              "mobileAppSessionPercentage": {
+                "description": "The percentage of sessions from mobile apps in relation to total sessions.",
+                "type": ["null", "number"]
+              },
+              "sessionPercentage": {
+                "description": "The percentage of sessions in relation to total sessions.",
+                "type": ["null", "number"]
+              },
+              "browserPageViews": {
+                "description": "The total number of page views from browsers.",
+                "type": ["null", "number"]
+              },
+              "mobileAppPageViews": {
+                "description": "The total number of page views from mobile apps.",
+                "type": ["null", "number"]
+              },
+              "pageViews": {
+                "description": "The total number of page views across all platforms.",
+                "type": ["null", "number"]
+              },
+              "browserPageViewsPercentage": {
+                "description": "The percentage of page views from browsers in relation to total views.",
+                "type": ["null", "number"]
+              },
+              "mobileAppPageViewsPercentage": {
+                "description": "The percentage of page views from mobile apps in relation to total views.",
+                "type": ["null", "number"]
+              },
+              "pageViewsPercentage": {
+                "description": "The percentage of page views in relation to total views.",
+                "type": ["null", "number"]
+              },
+              "buyBoxPercentage": {
+                "description": "The percentage of views where the product was in the buy box.",
+                "type": ["null", "number"]
+              },
+              "unitSessionPercentage": {
+                "description": "The percentage of product views that led to sessions.",
+                "type": ["null", "number"]
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["queryEndDate"]
+    },
+    {
+      "name": "GET_VENDOR_SALES_REPORT",
+      "json_schema": {
+        "title": "Vendor Sales Reports",
+        "description": "Vendor Sales Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "startDate": {
+            "description": "The start date and time for the sales report data.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "endDate": {
+            "description": "The end date and time for the sales report data.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "asin": {
+            "description": "The unique Amazon Standard Identification Number for the product.",
+            "type": ["null", "string"]
+          },
+          "customerReturns": {
+            "description": "The number of units of the product that customers returned.",
+            "type": ["null", "number"]
+          },
+          "orderedRevenue": {
+            "description": "The total revenue generated from customer orders.",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "The revenue amount in the specified currency.",
+                "type": ["null", "number"]
+              },
+              "currencyCode": {
+                "description": "The currency code for the revenue amount.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "orderedUnits": {
+            "description": "The total number of units of the product ordered by customers.",
+            "type": ["null", "number"]
+          },
+          "shippedCogs": {
+            "description": "The cost of goods sold for the shipped units.",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "The cost amount in the specified currency.",
+                "type": ["null", "number"]
+              },
+              "currencyCode": {
+                "description": "The currency code for the cost amount.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "shippedRevenue": {
+            "description": "The total revenue generated from the shipped units.",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "The revenue amount in the specified currency.",
+                "type": ["null", "number"]
+              },
+              "currencyCode": {
+                "description": "The currency code for the revenue amount.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "shippedUnits": {
+            "description": "The total number of units of the product shipped to customers.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["endDate"]
+    },
+    {
+      "name": "GET_VENDOR_INVENTORY_REPORT",
+      "json_schema": {
+        "title": "Vendor Inventory Data",
+        "description": "Vendor Inventory Data Reports",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "startDate": {
+            "description": "Start date and time for the period of data captured.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "endDate": {
+            "description": "End date and time for the period of data captured.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "asin": {
+            "description": "Amazon Standard Identification Number of the product associated with the data.",
+            "type": ["null", "string"]
+          },
+          "vendorConfirmationRate": {
+            "description": "Rate at which the vendor confirms incoming orders.",
+            "type": ["null", "number"]
+          },
+          "netReceivedAmount": {
+            "description": "Amount received after deducting any fees or charges.",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "Received amount in the specified currency.",
+                "type": ["null", "number"]
+              },
+              "currencyCode": {
+                "description": "Currency code of the received amount.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "netReceivedUnits": {
+            "description": "Total number of units received after deducting any returns or losses.",
+            "type": ["null", "number"]
+          },
+          "openPurchaseOrderQuantity": {
+            "description": "Number of units that have been ordered but not yet received or processed.",
+            "type": ["null", "number"]
+          },
+          "overallVendorLeadTime": {
+            "description": "Average lead time it takes for the vendor to fulfill an order.",
+            "type": ["null", "number"]
+          },
+          "sellThroughRate": {
+            "description": "Percentage of inventory sold within a defined period.",
+            "type": ["null", "number"]
+          },
+          "sellableOnHandInventory": {
+            "description": "Sellable inventory on hand.",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "Total amount of sellable inventory in the specified currency.",
+                "type": ["null", "number"]
+              },
+              "currencyCode": {
+                "description": "Currency code of the sellable inventory amount.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "sellableOnHandUnits": {
+            "description": "Total units of sellable inventory on hand.",
+            "type": ["null", "number"]
+          },
+          "unfilledCustomerOrderedUnits": {
+            "description": "Number of units ordered by customers but not yet fulfilled.",
+            "type": ["null", "number"]
+          },
+          "unsellableOnHandInventory": {
+            "description": "Inventory that cannot be sold in its current state.",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "Total amount of unsellable inventory in the specified currency.",
+                "type": ["null", "number"]
+              },
+              "currencyCode": {
+                "description": "Currency code of the unsellable inventory amount.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "aged90PlusDaysSellableUnits": {
+            "description": "Number of units that have been in inventory for more than 90 days and are still sellable.",
+            "type": ["null", "number"]
+          },
+          "unhealthyInventory": {
+            "description": "Inventory that may be damaged, expired, or otherwise unfit for sale.",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "Total amount of unhealthy inventory in the specified currency.",
+                "type": ["null", "number"]
+              },
+              "currencyCode": {
+                "description": "Currency code of the unhealthy inventory amount.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "unhealthyUnits": {
+            "description": "Total units of unhealthy inventory.",
+            "type": ["null", "number"]
+          },
+          "dataEndTime": {
+            "description": "End time for the data captured.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "queryEndDate": {
+            "description": "End date for querying the data.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["endDate"]
+    },
+    {
+      "name": "GET_VENDOR_NET_PURE_PRODUCT_MARGIN_REPORT",
+      "json_schema": {
+        "title": "Net Pure Product Margin Report",
+        "description": "The Net Pure Product Margin report shares data with vendors on Amazon's profit margin selling the vendor's items both at an aggregated level (across the vendor's entire catalog of items) and at a per-ASIN level. Data is available at different date range aggregation levels: DAY, WEEK, MONTH, QUARTER, YEAR. Requests can span multiple date range periods.",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "startDate": {
+            "description": "The date representing the start date of the report period",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "endDate": {
+            "description": "The date representing the end date of the report period",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "asin": {
+            "description": "The unique identifier for the Amazon Standard Identification Number (ASIN) of the product",
+            "type": ["null", "string"]
+          },
+          "netPureProductMargin": {
+            "description": "The net profit margin of the product after deducting all costs associated with production",
+            "type": ["null", "number"]
+          },
+          "dataEndTime": {
+            "description": "The timestamp indicating the end time of the data collection period",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "queryEndDate": {
+            "description": "The date of the query end date used for fetching the report data",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["endDate"]
+    },
+    {
+      "name": "GET_VENDOR_REAL_TIME_INVENTORY_REPORT",
+      "json_schema": {
+        "title": "Rapid Retail Analytics Inventory Report",
+        "description": "This report shares inventory data at an ASIN level, aggregated to an hourly granularity. Requests can span multiple date range periods, including the current day.",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "startTime": {
+            "description": "The timestamp when the real-time inventory report query starts.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "endTime": {
+            "description": "The timestamp when the real-time inventory report query ends.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "asin": {
+            "description": "Unique identifier for the product on Amazon.",
+            "type": ["null", "string"]
+          },
+          "highlyAvailableInventory": {
+            "description": "Indicator for products with high availability in inventory.",
+            "type": ["null", "integer"]
+          },
+          "dataEndTime": {
+            "description": "The timestamp when the inventory data is current until.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "queryEndDate": {
+            "description": "The end date of the query period for real-time inventory report data.",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["endTime"]
+    },
+    {
+      "name": "GET_VENDOR_TRAFFIC_REPORT",
+      "json_schema": {
+        "title": "Vendor Traffic Report",
+        "description": "This report shares data on the customer traffic to the detail pages of the vendor's items both at an aggregated level (across the vendor's entire catalog of items) and at a per-ASIN level. Data is available for different date range aggregation levels: DAY, WEEK, MONTH, QUARTER, YEAR. Requests can span multiple date range periods.",
+        "type": "object",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "startDate": {
+            "description": "The date when the data collection started",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "endDate": {
+            "description": "The date when the data collection ended",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "asin": {
+            "description": "Unique identifier for the Amazon Standard Identification Number",
+            "type": ["null", "string"]
+          },
+          "glanceViews": {
+            "description": "Total number of quick views on the product",
+            "type": ["null", "integer"]
+          },
+          "dataEndTime": {
+            "description": "The timestamp indicating the end time of the data collection",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "queryEndDate": {
+            "description": "The date when the query for data collection ended",
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["endDate"]
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/erd/estimated_relationships.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/erd/estimated_relationships.json
@@ -1,0 +1,247 @@
+{
+  "streams": [
+    {
+      "name": "FBA_CUSTOMER_RETURNS",
+      "relations": {
+        "order-id": "Order_DATE_GENERAL.amazon-order-id"
+      }
+    },
+    {
+      "name": "GET_AFN_INVENTORY_DATA",
+      "relations": {}
+    },
+    {
+      "name": "GET_AFN_INVENTORY_DATA_BY_COUNTRY",
+      "relations": {}
+    },
+    {
+      "name": "Order detail",
+      "relations": {
+        "order-id": "Order_DATE_GENERAL.amazon-order-id"
+      }
+    },
+    {
+      "name": "GET_FBA_FULFILLMENT_REMOVAL_SHIPMENT_DETAIL_DATA",
+      "relations": {
+        "order-id": "Order_DATE_GENERAL.amazon-order-id"
+      }
+    },
+    {
+      "name": "FBA_REPLACEMENT",
+      "relations": {
+        "original-amazon-order-id": "Order_DATE_GENERAL.amazon-order-id"
+      }
+    },
+    {
+      "name": "FEE_CHARGES",
+      "relations": {}
+    },
+    {
+      "name": "Fee_charges",
+      "relations": {}
+    },
+    {
+      "name": "GET_RESTOCK_INVENTORY_RECOMMENDATIONS_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_FLAT_FILE_ACTIONABLE_ORDER_DATA_SHIPPING",
+      "relations": {
+        "order-id": "Order_DATE_GENERAL.amazon-order-id"
+      }
+    },
+    {
+      "name": "GET_FLAT_FILE_OPEN_LISTINGS_DATA",
+      "relations": {}
+    },
+    {
+      "name": "Order_DATE_GENERAL",
+      "relations": {}
+    },
+    {
+      "name": "GET_FLAT_FILE_ALL_ORDERS_DATA_BY_LAST_UPDATE_GENERAL",
+      "relations": {}
+    },
+    {
+      "name": "GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE",
+      "relations": {
+        "order-id": "Order_DATE_GENERAL.amazon-order-id",
+        "merchant-order-id": "Order_DATE_GENERAL.merchant-order-id"
+      }
+    },
+    {
+      "name": "GET_AMAZON_FULFILLED_SHIPMENTS_DATA_GENERAL",
+      "relations": {
+        "amazon-order-id": "Order_DATE_GENERAL.amazon-order-id",
+        "merchant-order-id": "Order_DATE_GENERAL.merchant-order-id",
+        "shipment-id": "VendorOrders.purchaseOrderNumber"
+      }
+    },
+    {
+      "name": "GET_MERCHANT_LISTINGS_ALL_DATA",
+      "relations": {}
+    },
+    {
+      "name": "VendorDirectFulfillmentShipping",
+      "relations": {}
+    },
+    {
+      "name": "Orders",
+      "relations": {}
+    },
+    {
+      "name": "OrderItems",
+      "relations": {
+        "AmazonOrderId": "Orders.AmazonOrderId"
+      }
+    },
+    {
+      "name": "GET_ORDER_REPORT_DATA_SHIPPING",
+      "relations": {}
+    },
+    {
+      "name": "GET_SELLER_FEEDBACK_DATA",
+      "relations": {
+        "order_id": "Order_DATE_GENERAL.amazon-order-id"
+      }
+    },
+    {
+      "name": "GET_XML_BROWSE_TREE_DATA",
+      "relations": {}
+    },
+    {
+      "name": "ListFinancialEventGroups",
+      "relations": {}
+    },
+    {
+      "name": "ListFinancialEvents",
+      "relations": {}
+    },
+    {
+      "name": "GET_LEDGER_DETAIL_VIEW_DATA",
+      "relations": {}
+    },
+    {
+      "name": "FBA FEES",
+      "relations": {}
+    },
+    {
+      "name": "GET_FBA_FULFILLMENT_CUSTOMER_SHIPMENT_PROMOTION_DATA",
+      "relations": {
+        "amazon-order-id": "Order_DATE_GENERAL.amazon-order-id"
+      }
+    },
+    {
+      "name": "GET_FBA_MYI_UNSUPPRESSED_INVENTORY_DATA",
+      "relations": {}
+    },
+    {
+      "name": "GET_MERCHANT_CANCELLED_LISTINGS_DATA",
+      "relations": {}
+    },
+    {
+      "name": "GET_MERCHANT_LISTINGS_DATA",
+      "relations": {}
+    },
+    {
+      "name": "GET_MERCHANT_LISTINGS_DATA_BACK_COMPAT",
+      "relations": {}
+    },
+    {
+      "name": "GET_MERCHANT_LISTINGS_INACTIVE_DATA",
+      "relations": {}
+    },
+    {
+      "name": "GET_STRANDED_INVENTORY_UI_DATA",
+      "relations": {}
+    },
+    {
+      "name": "GET_XML_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL",
+      "relations": {}
+    },
+    {
+      "name": "GET_MERCHANTS_LISTINGS_FYP_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_FBA_SNS_FORECAST_DATA",
+      "relations": {}
+    },
+    {
+      "name": "Performance_Data",
+      "relations": {}
+    },
+    {
+      "name": "GET_FLAT_FILE_ARCHIVED_ORDERS_DATA_BY_ORDER_DATE",
+      "relations": {}
+    },
+    {
+      "name": "GET_FLAT_FILE_RETURNS_DATA_BY_RETURN_DATE",
+      "relations": {
+        "Order ID": "Order_DATE_GENERAL.amazon-order-id"
+      }
+    },
+    {
+      "name": "GET_FBA_INVENTORY_PLANNING_DATA",
+      "relations": {}
+    },
+    {
+      "name": "GET_LEDGER_SUMMARY_VIEW_DATA",
+      "relations": {}
+    },
+    {
+      "name": "FBA_REIMBURSEMENTS",
+      "relations": {
+        "amazon-order-id": "Order_DATE_GENERAL.amazon-order-id"
+      }
+    },
+    {
+      "name": "VendorOrders",
+      "relations": {}
+    },
+    {
+      "name": "GET_VENDOR_FORECASTING_FRESH_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_VENDOR_FORECASTING_RETAIL_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_BRAND_ANALYTICS_MARKET_BASKET_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_BRAND_ANALYTICS_SEARCH_TERMS_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_BRAND_ANALYTICS_REPEAT_PURCHASE_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_SALES_AND_TRAFFIC_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_VENDOR_SALES_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_VENDOR_INVENTORY_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_VENDOR_NET_PURE_PRODUCT_MARGIN_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_VENDOR_REAL_TIME_INVENTORY_REPORT",
+      "relations": {}
+    },
+    {
+      "name": "GET_VENDOR_TRAFFIC_REPORT",
+      "relations": {}
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/erd/source.dbml
@@ -1,0 +1,1085 @@
+Table "GET_AFN_INVENTORY_DATA" {
+    "seller-sku" string
+    "fulfillment-channel-sku" string
+    "asin" string
+    "condition-type" string
+    "Warehouse-Condition-code" string
+    "Quantity Available" string
+    "dataEndTime" string
+}
+
+Table "GET_AFN_INVENTORY_DATA_BY_COUNTRY" {
+    "seller-sku" string
+    "fulfillment-channel-sku" string
+    "asin" string
+    "condition-type" string
+    "country" string
+    "quantity-for-local-fulfillment" string
+    "dataEndTime" string
+}
+
+Table "GET_FBA_FULFILLMENT_REMOVAL_SHIPMENT_DETAIL_DATA" {
+    "removal-date" string
+    "order-id" string
+    "shipment-date" string
+    "sku" string
+    "fnsku" string
+    "disposition" string
+    "quantity shipped" string
+    "carrier" string
+    "tracking-number" string
+    "dataEndTime" string
+}
+
+Table "GET_RESTOCK_INVENTORY_RECOMMENDATIONS_REPORT" {
+    "Country" string
+    "Product Name" string
+    "FNSKU" string
+    "Merchant SKU" string
+    "ASIN" string
+    "Condition" string
+    "Supplier" string
+    "Supplier part no." string
+    "Currency code" string
+    "Price" string
+    "Sales last 30 days" string
+    "Units Sold Last 30 Days" string
+    "Total Units" string
+    "Inbound" string
+    "Available" string
+    "FC transfer" string
+    "FC Processing" string
+    "Customer Order" string
+    "Unfulfillable" string
+    "Working" string
+    "Shipped" string
+    "Receiving" string
+    "Fulfilled by" string
+    "Total Days of Supply (including units from open shipments)" string
+    "Days of Supply at Amazon Fulfillment Network" string
+    "Alert" string
+    "Recommended replenishment qty" string
+    "Recommended ship date" string
+    "Recommended action" string
+    "Unit storage size" string
+    "dataEndTime" string
+}
+
+Table "GET_FLAT_FILE_ACTIONABLE_ORDER_DATA_SHIPPING" {
+    "order-id" string
+    "order-item-id" string
+    "purchase-date" string
+    "payments-date" string
+    "reporting-date" string
+    "promise-date" string
+    "days-past-promise" string
+    "buyer-email" string
+    "buyer-phone-number" string
+    "is-business-order" string
+    "quantity-purchased" string
+    "quantity-shipped" string
+    "quantity-to-ship" string
+    "product-name" string
+    "purchase-order-number" string
+    "recipient-name" string
+    "ship-city" string
+    "ship-country" string
+    "ship-postal-code" string
+    "ship-promotion-discount" string
+    "ship-service-level" string
+    "ship-state" string
+    "shipping-price" string
+    "shipping-tax" string
+    "sku" string
+    "dataEndTime" string
+}
+
+Table "GET_FLAT_FILE_OPEN_LISTINGS_DATA" {
+    "sku" string
+    "asin" string
+    "price" string
+    "quantity" string
+    "Business Price" string
+    "Quantity Price Type" string
+    "Quantity Lower Bound 1" string
+    "Quantity Price 1" string
+    "Quantity Lower Bound 2" string
+    "Quantity Price 2" string
+    "Quantity Lower Bound 3" string
+    "Quantity Price 3" string
+    "Quantity Lower Bound 4" string
+    "Quantity Price 4" string
+    "Quantity Lower Bound 5" string
+    "Quantity Price 5" string
+    "Progressive Price Type" string
+    "Progressive Lower Bound 1" string
+    "Progressive Price 1" string
+    "Progressive Lower Bound 2" string
+    "Progressive Price 2" string
+    "Progressive Lower Bound 3" string
+    "Progressive Price 3" string
+    "dataEndTime" string
+}
+
+Table "GET_FLAT_FILE_ALL_ORDERS_DATA_BY_LAST_UPDATE_GENERAL" {
+    "amazon-order-id" string [pk]
+    "merchant-order-id" string
+    "purchase-date" string
+    "last-updated-date" string
+    "order-status" string
+    "fulfillment-channel" string
+    "sales-channel" string
+    "order-channel" string
+    "ship-service-level" string
+    "product-name" string
+    "sku" string
+    "asin" string
+    "item-status" string
+    "quantity" string
+    "currency" string
+    "item-price" string
+    "item-tax" string
+    "shipping-price" string
+    "shipping-tax" string
+    "gift-wrap-price" string
+    "gift-wrap-tax" string
+    "item-promotion-discount" string
+    "ship-promotion-discount" string
+    "ship-city" string
+    "ship-state" string
+    "ship-postal-code" string
+    "ship-country" string
+    "promotion-ids" string
+    "cpf" string
+    "is-business-order" string
+    "purchase-order-number" string
+    "price-designation" string
+    "signature-confirmation-recommended" string
+    "dataEndTime" string
+}
+
+Table "GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE" {
+    "settlement-id" string
+    "settlement-start-date" string
+    "settlement-end-date" string
+    "deposit-date" string
+    "total-amount" string
+    "currency" string
+    "transaction-type" string
+    "order-id" string
+    "merchant-order-id" string
+    "adjustment-id" string
+    "shipment-id" string
+    "marketplace-name" string
+    "shipment-fee-type" string
+    "shipment-fee-amount" string
+    "order-fee-type" string
+    "order-fee-amount" string
+    "fulfillment-id" string
+    "posted-date" string
+    "order-item-code" string
+    "merchant-order-item-id" string
+    "merchant-adjustment-item-id" string
+    "sku" string
+    "quantity-purchased" string
+    "price-type" string
+    "price-amount" string
+    "item-related-fee-type" string
+    "item-related-fee-amount" string
+    "misc-fee-amount" string
+    "other-fee-amount" string
+    "other-fee-reason-description" string
+    "promotion-id" string
+    "promotion-type" string
+    "promotion-amount" string
+    "direct-payment-type" string
+    "direct-payment-amount" string
+    "other-amount" string
+    "report_id" string
+    "dataEndTime" string
+}
+
+Table "GET_AMAZON_FULFILLED_SHIPMENTS_DATA_GENERAL" {
+    "amazon-order-id" string
+    "merchant-order-id" string
+    "shipment-id" string
+    "shipment-item-id" string
+    "amazon-order-item-id" string
+    "merchant-order-item-id" string
+    "purchase-date" string
+    "payments-date" string
+    "shipment-date" string
+    "reporting-date" string
+    "buyer-email" string
+    "buyer-name" string
+    "buyer-phone-number" string
+    "sku" string
+    "product-name" string
+    "quantity-shipped" string
+    "currency" string
+    "item-price" string
+    "item-tax" string
+    "shipping-price" string
+    "shipping-tax" string
+    "gift-wrap-price" string
+    "gift-wrap-tax" string
+    "ship-service-level" string
+    "recipient-name" string
+    "ship-address-1" string
+    "ship-address-2" string
+    "ship-address-3" string
+    "ship-city" string
+    "ship-state" string
+    "ship-postal-code" string
+    "ship-country" string
+    "ship-phone-number" string
+    "bill-address-1" string
+    "bill-address-2" string
+    "bill-address-3" string
+    "bill-city" string
+    "bill-state" string
+    "bill-postal-code" string
+    "bill-country" string
+    "item-promotion-discount" string
+    "ship-promotion-discount" string
+    "carrier" string
+    "tracking-number" string
+    "estimated-arrival-date" string
+    "fulfillment-center-id" string
+    "fulfillment-channel" string
+    "sales-channel" string
+    "dataEndTime" string
+}
+
+Table "GET_MERCHANT_LISTINGS_ALL_DATA" {
+    "item-name" string
+    "item-description" string
+    "listing-id" string [pk]
+    "seller-sku" string
+    "price" string
+    "quantity" string
+    "open-date" string
+    "image-url" string
+    "item-is-marketplace" string
+    "product-id-type" string
+    "zshop-shipping-fee" string
+    "item-note" string
+    "item-condition" string
+    "zshop-category1" string
+    "zshop-browse-path" string
+    "zshop-storefront-feature" string
+    "asin1" string
+    "asin2" string
+    "asin3" string
+    "will-ship-internationally" string
+    "expedited-shipping" string
+    "zshop-boldface" string
+    "product-id" string
+    "bid-for-featured-placement" string
+    "add-delete" string
+    "pending-quantity" string
+    "fulfillment-channel" string
+    "merchant-shipping-group" string
+    "status" string
+    "dataEndTime" string
+}
+
+Table "VendorDirectFulfillmentShipping" {
+    "purchaseOrderNumber" string [pk]
+    "sellingParty" object
+    "shipFromParty" object
+    "labelFormat" string
+    "labelData" array
+    "createdBefore" string
+}
+
+Table "Orders" {
+    "seller_id" string
+    "AmazonOrderId" string [pk]
+    "BuyerInfo" object
+    "PurchaseDate" string
+    "LastUpdateDate" string
+    "OrderStatus" string
+    "SellerOrderId" string
+    "FulfillmentChannel" string
+    "SalesChannel" string
+    "AutomatedShippingSettings" object
+    "HasRegulatedItems" boolean
+    "ShipServiceLevel" string
+    "OrderTotal" object
+    "NumberOfItemsShipped" integer
+    "NumberOfItemsUnshipped" integer
+    "PaymentMethod" string
+    "PaymentMethodDetails" array
+    "IsAccessPointOrder" boolean
+    "IsReplacementOrder" string
+    "MarketplaceId" string
+    "ShipmentServiceLevelCategory" string
+    "OrderType" string
+    "EarliestShipDate" string
+    "LatestShipDate" string
+    "IsBusinessOrder" boolean
+    "IsSoldByAB" boolean
+    "IsPrime" boolean
+    "IsGlobalExpressEnabled" boolean
+    "IsPremiumOrder" boolean
+    "IsISPU" boolean
+    "DefaultShipFromLocationAddress" object
+    "EarliestDeliveryDate" string
+    "LatestDeliveryDate" string
+    "ShippingAddress" object
+}
+
+Table "OrderItems" {
+    "AmazonOrderId" string
+    "ASIN" string
+    "OrderItemId" string [pk]
+    "SellerSKU" string
+    "Title" string
+    "QuantityOrdered" integer
+    "ProductInfo" object
+    "QuantityShipped" integer
+    "PointsGranted" object
+    "ItemPrice" object
+    "PromotionIds" array
+    "ItemTax" object
+    "ShippingPrice" object
+    "ShippingTax" object
+    "ShippingDiscount" object
+    "ShippingDiscountTax" object
+    "PromotionDiscount" object
+    "PromotionDiscountTax" object
+    "ScheduledDeliveryEndDate" string
+    "ScheduledDeliveryStartDate" string
+    "CODFee" object
+    "IsGift" string
+    "ConditionNote" string
+    "ConditionId" string
+    "ConditionSubtypeId" string
+    "CODFeeDiscount" object
+    "TaxCollection" object
+    "IsTransparency" boolean
+    "IossNumber" string
+    "SerialNumberRequired" boolean
+    "StoreChainStoreId" string
+    "DeemedResellerCategory" string
+    "PriceDesignation" string
+    "BuyerInfo" object
+    "BuyerRequestedCancel" object
+    "SerialNumbers" array
+    "LastUpdateDate" string
+}
+
+Table "GET_ORDER_REPORT_DATA_SHIPPING" {
+    "AmazonOrderID" string
+    "AmazonSessionID" string
+    "OrderDate" string
+    "OrderPostedDate" string
+    "BillingData" object
+    "FulfillmentData" object
+    "IsBusinessOrder" string
+    "Item" object
+    "dataEndTime" string
+}
+
+Table "GET_SELLER_FEEDBACK_DATA" {
+    "date" string
+    "rating" number
+    "comments" string
+    "response" string
+    "order_id" string
+    "rater_email" string
+    "dataEndTime" string
+}
+
+Table "GET_XML_BROWSE_TREE_DATA" {
+    "browseNodeId" string [pk]
+    "browseNodeAttributes" object
+    "browseNodeName" string
+    "browseNodeStoreContextName" string
+    "browsePathById" string
+    "browsePathByName" string
+    "hasChildren" string
+    "childNodes" object
+    "productTypeDefinitions" string
+    "refinementsInformation" object
+    "dataEndTime" string
+}
+
+Table "ListFinancialEventGroups" {
+    "FinancialEventGroupId" string [pk]
+    "ProcessingStatus" string
+    "FundTransferStatus" string
+    "OriginalTotal" object
+    "ConvertedTotal" object
+    "FundTransferDate" string
+    "TraceId" string
+    "AccountTail" string
+    "BeginningBalance" object
+    "FinancialEventGroupStart" string
+    "FinancialEventGroupEnd" string
+}
+
+Table "ListFinancialEvents" {
+    "ShipmentEventList" array
+    "RefundEventList" array
+    "GuaranteeClaimEventList" array
+    "ChargebackEventList" array
+    "PayWithAmazonEventList" array
+    "ServiceProviderCreditEventList" array
+    "RetrochargeEventList" array
+    "RentalTransactionEventList" array
+    "PerformanceBondRefundEventList" array
+    "ProductAdsPaymentEventList" array
+    "ServiceFeeEventList" array
+    "SellerDealPaymentEventList" array
+    "DebtRecoveryEventList" array
+    "LoanServicingEventList" array
+    "AdjustmentEventList" array
+    "SAFETReimbursementEventList" array
+    "SellerReviewEnrollmentPaymentEventList" array
+    "FBALiquidationEventList" array
+    "CouponPaymentEventList" array
+    "ImagingServicesFeeEventList" array
+    "NetworkComminglingTransactionEventList" array
+    "AffordabilityExpenseEventList" array
+    "AffordabilityExpenseReversalEventList" array
+    "TrialShipmentEventList" array
+    "TDSReimbursementEventList" array
+    "AdhocDisbursementEventList" array
+    "ShipmentSettleEventList" array
+    "ChargeRefundEventList" array
+    "FailedAdhocDisbursementEventList" array
+    "ValueAddedServiceChargeEventList" array
+    "CapacityReservationBillingEventList" array
+    "TaxWithholdingEventList" array
+    "RemovalShipmentEventList" array
+    "RemovalShipmentAdjustmentEventList" array
+    "PostedBefore" string
+}
+
+Table "GET_LEDGER_DETAIL_VIEW_DATA" {
+    "Date" string
+    "FNSKU" string
+    "ASIN" string
+    "MSKU" string
+    "Title" string
+    "Event Type" string
+    "Reference ID" string
+    "Quantity" string
+    "Fulfillment Center" string
+    "Disposition" string
+    "Reason" string
+    "Country" string
+    "Reconciled Quantity" string
+    "Unreconciled Quantity" string
+    "Date and Time" string
+    "dataEndTime" string
+}
+
+Table "GET_FBA_FULFILLMENT_CUSTOMER_SHIPMENT_PROMOTION_DATA" {
+    "shipment-date" string
+    "currency" string
+    "item-promotion-discount" string
+    "item-promotion-id" string
+    "description" string
+    "promotion-rule-value" string
+    "amazon-order-id" string
+    "shipment-id" string
+    "shipment-item-id" string
+    "dataEndTime" string
+}
+
+Table "GET_FBA_MYI_UNSUPPRESSED_INVENTORY_DATA" {
+    "sku" string
+    "fnsku" string
+    "asin" string
+    "product-name" string
+    "condition" string
+    "your-price" string
+    "mfn-listing-exists" string
+    "mfn-fulfillable-quantity" string
+    "afn-listing-exists" string
+    "afn-warehouse-quantity" string
+    "afn-fulfillable-quantity" string
+    "afn-unsellable-quantity" string
+    "afn-reserved-quantity" string
+    "afn-total-quantity" string
+    "per-unit-volume" string
+    "afn-inbound-working-quantity" string
+    "afn-inbound-shipped-quantity" string
+    "afn-inbound-receiving-quantity" string
+    "afn-researching-quantity" string
+    "afn-reserved-future-supply" string
+    "afn-future-supply-buyable" string
+    "dataEndTime" string
+}
+
+Table "GET_MERCHANT_CANCELLED_LISTINGS_DATA" {
+    "item-name" string
+    "item-description" string
+    "seller-sku" string
+    "price" string
+    "quantity" string
+    "image-url" string
+    "item-is-marketplace" string
+    "product-id-type" string
+    "zshop-shipping-fee" string
+    "item-note" string
+    "item-condition" string
+    "zshop-category1" string
+    "zshop-browse-path" string
+    "zshop-storefront-feature" string
+    "asin1" string
+    "asin2" string
+    "asin3" string
+    "will-ship-internationally" string
+    "expedited-shipping" string
+    "zshop-boldface" string
+    "product-id" string
+    "add-delete" string
+    "Business Price" string
+    "Quantity Price Type" string
+    "Quantity Lower Bound 1" string
+    "Quantity Price 1" string
+    "Quantity Lower Bound 2" string
+    "Quantity Price 2" string
+    "Quantity Lower Bound 3" string
+    "Quantity Price 3" string
+    "Quantity Lower Bound 4" string
+    "Quantity Price 4" string
+    "Quantity Lower Bound 5" string
+    "Quantity Price 5" string
+    "merchant-shipping-group" string
+    "Progressive Price Type" string
+    "Progressive Lower Bound 1" string
+    "Progressive Price 1" string
+    "Progressive Lower Bound 2" string
+    "Progressive Price 2" string
+    "Progressive Lower Bound 3" string
+    "Progressive Price 3" string
+    "dataEndTime" string
+}
+
+Table "GET_MERCHANT_LISTINGS_DATA" {
+    "item-name" string
+    "item-description" string
+    "listing-id" string [pk]
+    "seller-sku" string
+    "price" string
+    "quantity" string
+    "open-date" string
+    "image-url" string
+    "item-is-marketplace" string
+    "product-id-type" string
+    "zshop-shipping-fee" string
+    "item-note" string
+    "item-condition" string
+    "zshop-category1" string
+    "zshop-browse-path" string
+    "zshop-storefront-feature" string
+    "asin1" string
+    "asin2" string
+    "asin3" string
+    "will-ship-internationally" string
+    "expedited-shipping" string
+    "zshop-boldface" string
+    "product-id" string
+    "bid-for-featured-placement" string
+    "add-delete" string
+    "pending-quantity" string
+    "fulfillment-channel" string
+    "Business Price" string
+    "Quantity Price Type" string
+    "Quantity Lower Bound 1" string
+    "Quantity Price 1" string
+    "Quantity Lower Bound 2" string
+    "Quantity Price 2" string
+    "Quantity Lower Bound 3" string
+    "Quantity Price 3" string
+    "Quantity Lower Bound 4" string
+    "Quantity Price 4" string
+    "Quantity Lower Bound 5" string
+    "Quantity Price 5" string
+    "merchant-shipping-group" string
+    "Progressive Price Type" string
+    "Progressive Lower Bound 1" string
+    "Progressive Price 1" string
+    "Progressive Lower Bound 2" string
+    "Progressive Price 2" string
+    "Progressive Lower Bound 3" string
+    "Progressive Price 3" string
+    "dataEndTime" string
+}
+
+Table "GET_MERCHANT_LISTINGS_DATA_BACK_COMPAT" {
+    "item-name" string
+    "item-description" string
+    "listing-id" string [pk]
+    "seller-sku" string
+    "price" string
+    "quantity" string
+    "open-date" string
+    "image-url" string
+    "item-is-marketplace" string
+    "product-id-type" string
+    "zshop-shipping-fee" string
+    "item-note" string
+    "item-condition" string
+    "zshop-category1" string
+    "zshop-browse-path" string
+    "zshop-storefront-feature" string
+    "asin1" string
+    "asin2" string
+    "asin3" string
+    "will-ship-internationally" string
+    "expedited-shipping" string
+    "zshop-boldface" string
+    "product-id" string
+    "bid-for-featured-placement" string
+    "add-delete" string
+    "pending-quantity" string
+    "Business Price" string
+    "Quantity Price Type" string
+    "Quantity Lower Bound 1" string
+    "Quantity Price 1" string
+    "Quantity Lower Bound 2" string
+    "Quantity Price 2" string
+    "Quantity Lower Bound 3" string
+    "Quantity Price 3" string
+    "Quantity Lower Bound 4" string
+    "Quantity Price 4" string
+    "Quantity Lower Bound 5" string
+    "Quantity Price 5" string
+    "merchant-shipping-group" string
+    "Progressive Price Type" string
+    "Progressive Lower Bound 1" string
+    "Progressive Price 1" string
+    "Progressive Lower Bound 2" string
+    "Progressive Price 2" string
+    "Progressive Lower Bound 3" string
+    "Progressive Price 3" string
+    "dataEndTime" string
+}
+
+Table "GET_MERCHANT_LISTINGS_INACTIVE_DATA" {
+    "item-name" string
+    "item-description" string
+    "listing-id" string [pk]
+    "seller-sku" string
+    "price" string
+    "quantity" string
+    "open-date" string
+    "image-url" string
+    "item-is-marketplace" string
+    "product-id-type" string
+    "zshop-shipping-fee" string
+    "item-note" string
+    "item-condition" string
+    "zshop-category1" string
+    "zshop-browse-path" string
+    "zshop-storefront-feature" string
+    "asin1" string
+    "asin2" string
+    "asin3" string
+    "will-ship-internationally" string
+    "expedited-shipping" string
+    "zshop-boldface" string
+    "product-id" string
+    "bid-for-featured-placement" string
+    "add-delete" string
+    "pending-quantity" string
+    "fulfillment-channel" string
+    "merchant-shipping-group" string
+    "dataEndTime" string
+}
+
+Table "GET_STRANDED_INVENTORY_UI_DATA" {
+    "primary-action" string
+    "date-stranded" string
+    "Date-to-take-auto-removal" string
+    "status-primary" string
+    "status-secondary" string
+    "error-message" string
+    "stranded-reason" string
+    "asin" string
+    "sku" string
+    "fnsku" string
+    "product-name" string
+    "condition" string
+    "fulfilled-by" string
+    "fulfillable-qty" string
+    "your-price" string
+    "unfulfillable-qty" string
+    "reserved-quantity" string
+    "inbound-shipped-qty" string
+    "dataEndTime" string
+}
+
+Table "GET_XML_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL" {
+    "LastUpdatedDate" string
+    "SalesChannel" string
+    "OrderStatus" string
+    "AmazonOrderID" string [pk]
+    "PurchaseDate" string
+    "OrderItem" array
+    "FulfillmentData" object
+    "IsBusinessOrder" string
+    "MerchantOrderID" string
+    "dataEndTime" string
+}
+
+Table "GET_MERCHANTS_LISTINGS_FYP_REPORT" {
+    "Status" string
+    "Reason" string
+    "SKU" string
+    "ASIN" string
+    "Product name" string
+    "Condition" string
+    "Status Change Date" string
+    "Issue Description" string
+    "dataEndTime" string
+}
+
+Table "GET_FBA_SNS_FORECAST_DATA" {
+    "offer-state" string
+    "snapshot-date" string
+    "sku" string
+    "fnsku" string
+    "asin" string
+    "estimated-avg-sns-discount-next-8-weeks" string
+    "product-name" string
+    "country" string
+    "active-subscriptions" string
+    "week-1-start-date" string
+    "scheduled-sns-units-week-1" string
+    "scheduled-sns-units-week-2" string
+    "scheduled-sns-units-week-3" string
+    "scheduled-sns-units-week-4" string
+    "scheduled-sns-units-week-5" string
+    "scheduled-sns-units-week-6" string
+    "scheduled-sns-units-week-7" string
+    "scheduled-sns-units-week-8" string
+    "dataEndTime" string
+}
+
+Table "GET_FLAT_FILE_ARCHIVED_ORDERS_DATA_BY_ORDER_DATE" {
+    "amazon-order-id" string
+    "merchant-order-id" string
+    "purchase-date" string
+    "last-updated-date" string
+    "order-status" string
+    "fulfillment-channel" string
+    "sales-channel" string
+    "order-channel" string
+    "url" string
+    "ship-service-level" string
+    "product-name" string
+    "sku" string
+    "asin" string
+    "item-status" string
+    "quantity" string
+    "currency" string
+    "item-price" string
+    "item-tax" string
+    "shipping-price" string
+    "shipping-tax" string
+    "gift-wrap-price" string
+    "gift-wrap-tax" string
+    "item-promotion-discount" string
+    "ship-promotion-discount" string
+    "ship-country" string
+    "ship-promotion-id" string
+    "promotion-ids" string
+    "is-business-order" string
+    "purchase-order-number" string
+    "price-designation" string
+    "is-replacement-order" string
+    "dataEndTime" string
+}
+
+Table "GET_FLAT_FILE_RETURNS_DATA_BY_RETURN_DATE" {
+    "Order ID" string
+    "Order date" string
+    "Return request date" string
+    "Return request status" string
+    "Amazon RMA ID" string
+    "Merchant RMA ID" string
+    "Label type" string
+    "Label cost" string
+    "Currency code" string
+    "Return carrier" string
+    "Tracking ID" string
+    "Label to be paid by" string
+    "A-to-Z Claim" string
+    "Is prime" string
+    "ASIN" string
+    "Merchant SKU" string
+    "Item Name" string
+    "Return quantity" string
+    "Return Reason" string
+    "In policy" string
+    "Return type" string
+    "Resolution" string
+    "Invoice number" string
+    "Return delivery date" string
+    "Order Amount" string
+    "Order quantity" string
+    "SafeT Action reason" string
+    "SafeT claim id" string
+    "SafeT claim state" string
+    "SafeT claim creation time" string
+    "SafeT claim reimbursement amount" string
+    "Refunded Amount" string
+    "dataEndTime" string
+}
+
+Table "GET_FBA_INVENTORY_PLANNING_DATA" {
+    "snapshot-date" string
+    "sku" string
+    "fnsku" string
+    "asin" string
+    "product-name" string
+    "condition" string
+    "available" string
+    "pending-removal-quantity" string
+    "inv-age-0-to-90-days" string
+    "inv-age-91-to-180-days" string
+    "inv-age-181-to-270-days" string
+    "inv-age-271-to-365-days" string
+    "inv-age-365-plus-days" string
+    "currency" string
+    "qty-to-be-charged-ltsf-9-mo" string
+    "projected-ltsf-9-mo" string
+    "qty-to-be-charged-ltsf-12-mo" string
+    "estimated-ltsf-next-charge" string
+    "units-shipped-t7" string
+    "units-shipped-t30" string
+    "units-shipped-t60" string
+    "units-shipped-t90" string
+    "alert" string
+    "your-price" string
+    "sales-price" string
+    "lowest-price-new-plus-shipping" string
+    "lowest-price-used" string
+    "recommended-action" string
+    "healthy-inventory-level" string
+    "recommended-sales-price" string
+    "recommended-sale-duration-days" string
+    "recommended-removal-quantity" string
+    "estimated-cost-savings-of-recommended-actions" string
+    "sell-through" string
+    "item-volume" string
+    "volume-unit-measurement" string
+    "storage-type" string
+    "storage-volume" string
+    "marketplace" string
+    "product-group" string
+    "sales-rank" string
+    "days-of-supply" string
+    "estimated-excess-quantity" string
+    "weeks-of-cover-t30" string
+    "weeks-of-cover-t90" string
+    "featuredoffer-price" string
+    "sales-shipped-last-7-days" string
+    "sales-shipped-last-30-days" string
+    "sales-shipped-last-60-days" string
+    "sales-shipped-last-90-days" string
+    "inv-age-0-to-30-days" string
+    "inv-age-31-to-60-days" string
+    "inv-age-61-to-90-days" string
+    "inv-age-181-to-330-days" string
+    "inv-age-331-to-365-days" string
+    "estimated-storage-cost-next-month" string
+    "inbound-quantity" string
+    "inbound-working" string
+    "inbound-shipped" string
+    "inbound-received" string
+    "no-sale-last-6-months" string
+    "reserved-quantity" string
+    "unfulfillable-quantity" string
+    "estimated-ais-181-210-days" number
+    "estimated-ais-211-240-days" number
+    "estimated-ais-241-270-days" number
+    "estimated-ais-271-300-days" number
+    "estimated-ais-301-330-days" number
+    "estimated-ais-331-365-days" number
+    "estimated-ais-365-plus-days" number
+    "quantity-to-be-charged-ais-181-210-days" integer
+    "quantity-to-be-charged-ais-211-240-days" integer
+    "quantity-to-be-charged-ais-241-270-days" integer
+    "quantity-to-be-charged-ais-271-300-days" integer
+    "quantity-to-be-charged-ais-301-330-days" integer
+    "quantity-to-be-charged-ais-331-365-days" integer
+    "quantity-to-be-charged-ais-365-plus-days" integer
+    "dataEndTime" string
+}
+
+Table "GET_LEDGER_SUMMARY_VIEW_DATA" {
+    "Date" string
+    "FNSKU" string
+    "ASIN" string
+    "MSKU" string
+    "Title" string
+    "Disposition" string
+    "Starting Warehouse Balance" string
+    "In Transit Between Warehouses" string
+    "Receipts" string
+    "Customer Shipments" string
+    "Customer Returns" string
+    "Vendor Returns" string
+    "Warehouse Transfer In/Out" string
+    "Found" string
+    "Lost" string
+    "Damaged" string
+    "Disposed" string
+    "Other Events" string
+    "Ending Warehouse Balance" string
+    "Unknown Events" string
+    "Location" string
+    "dataEndTime" string
+}
+
+Table "VendorOrders" {
+    "purchaseOrderNumber" string [pk]
+    "purchaseOrderState" string
+    "orderDetails" object
+    "changedBefore" string
+}
+
+Table "GET_VENDOR_FORECASTING_FRESH_REPORT" {
+    "forecastGenerationDate" string
+    "asin" string
+    "startDate" string
+    "endDate" string
+    "meanForecastUnits" number
+    "p70ForecastUnits" number
+    "p80ForecastUnits" number
+    "p90ForecastUnits" number
+    "dataEndTime" string
+}
+
+Table "GET_VENDOR_FORECASTING_RETAIL_REPORT" {
+    "forecastGenerationDate" string
+    "asin" string
+    "startDate" string
+    "endDate" string
+    "meanForecastUnits" number
+    "p70ForecastUnits" number
+    "p80ForecastUnits" number
+    "p90ForecastUnits" number
+    "dataEndTime" string
+}
+
+Table "GET_BRAND_ANALYTICS_MARKET_BASKET_REPORT" {
+    "startDate" string
+    "endDate" string
+    "asin" string
+    "purchasedWithAsin" string
+    "purchasedWithRank" integer
+    "combinationPct" number
+    "dataEndTime" string
+    "queryEndDate" string
+}
+
+Table "GET_BRAND_ANALYTICS_SEARCH_TERMS_REPORT" {
+    "departmentName" string
+    "searchTerm" string
+    "searchFrequencyRank" number
+    "clickedAsin" string
+    "clickShareRank" number
+    "clickShare" number
+    "conversionShare" number
+    "dataEndTime" string
+    "queryEndDate" string
+}
+
+Table "GET_BRAND_ANALYTICS_REPEAT_PURCHASE_REPORT" {
+    "startDate" string
+    "endDate" string
+    "asin" string
+    "orders" integer
+    "uniqueCustomers" integer
+    "repeatCustomersPctTotal" number
+    "repeatPurchaseRevenue" object
+    "repeatPurchaseRevenuePctTotal" number
+    "dataEndTime" string
+    "queryEndDate" string
+}
+
+Table "GET_SALES_AND_TRAFFIC_REPORT" {
+    "queryEndDate" string
+    "parentAsin" string
+    "childAsin" string
+    "sku" string
+    "salesByAsin" object
+    "trafficByAsin" object
+}
+
+Table "GET_VENDOR_SALES_REPORT" {
+    "startDate" string
+    "endDate" string
+    "asin" string
+    "customerReturns" number
+    "orderedRevenue" object
+    "orderedUnits" number
+    "shippedCogs" object
+    "shippedRevenue" object
+    "shippedUnits" number
+}
+
+Table "GET_VENDOR_INVENTORY_REPORT" {
+    "startDate" string
+    "endDate" string
+    "asin" string
+    "vendorConfirmationRate" number
+    "netReceivedAmount" object
+    "netReceivedUnits" number
+    "openPurchaseOrderQuantity" number
+    "overallVendorLeadTime" number
+    "sellThroughRate" number
+    "sellableOnHandInventory" object
+    "sellableOnHandUnits" number
+    "unfilledCustomerOrderedUnits" number
+    "unsellableOnHandInventory" object
+    "aged90PlusDaysSellableUnits" number
+    "unhealthyInventory" object
+    "unhealthyUnits" number
+    "dataEndTime" string
+    "queryEndDate" string
+}
+
+Table "GET_VENDOR_NET_PURE_PRODUCT_MARGIN_REPORT" {
+    "startDate" string
+    "endDate" string
+    "asin" string
+    "netPureProductMargin" number
+    "dataEndTime" string
+    "queryEndDate" string
+}
+
+Table "GET_VENDOR_REAL_TIME_INVENTORY_REPORT" {
+    "startTime" string
+    "endTime" string
+    "asin" string
+    "highlyAvailableInventory" integer
+    "dataEndTime" string
+    "queryEndDate" string
+}
+
+Table "GET_VENDOR_TRAFFIC_REPORT" {
+    "startDate" string
+    "endDate" string
+    "asin" string
+    "glanceViews" integer
+    "dataEndTime" string
+    "queryEndDate" string
+}
+
+Ref {
+    "GET_AMAZON_FULFILLED_SHIPMENTS_DATA_GENERAL"."shipment-id" <> "VendorOrders"."purchaseOrderNumber"
+}
+
+Ref {
+    "OrderItems"."AmazonOrderId" <> "Orders"."AmazonOrderId"
+}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -18,6 +18,7 @@ data:
   dockerImageTag: 4.4.1
   dockerRepository: airbyte/source-amazon-seller-partner
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
+  erdUrl: https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships
   githubIssueLabel: source-amazon-seller-partner
   icon: amazonsellerpartner.svg
   license: MIT


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/9173 for source-amazon-seller-partner

## How
By running `airbyte-ci --name=source-amazon-seller-partner generate-erd`

The publish has been done as part of the airbyte-ci command executed locally.

## User Impact
ERD is now available on https://dbdocs.io/airbyteio/source-amazon-seller-partner

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌

