### PR TITLE
[ISSUE 9173] add ERD files for source-jira

### DIFF
--- a/airbyte-integrations/connectors/source-jira/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-jira/erd/discovered_catalog.json
@@ -1,0 +1,12850 @@
+{
+  "streams": [
+    {
+      "name": "application_roles",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "key": {
+            "description": "The key identifier of the application role.",
+            "type": "string"
+          },
+          "groups": {
+            "description": "The groups associated with the application role.",
+            "uniqueItems": true,
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "name": {
+            "description": "The display name of the application role.",
+            "type": "string"
+          },
+          "defaultGroups": {
+            "description": "The groups that are granted default access for this application role.",
+            "uniqueItems": true,
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "selectedByDefault": {
+            "description": "Determines if this application role should be selected by default on user creation.",
+            "type": "boolean"
+          },
+          "defined": { "description": "Deprecated.", "type": "boolean" },
+          "numberOfSeats": {
+            "description": "The maximum count of users allowed on the license.",
+            "type": "integer"
+          },
+          "remainingSeats": {
+            "description": "The count of remaining user seats on the license.",
+            "type": "integer"
+          },
+          "userCount": {
+            "description": "The total count of users that are counted against the license limit.",
+            "type": "integer"
+          },
+          "userCountDescription": {
+            "description": "Describes the type of users being counted against your license. For more information, refer to the provided link.",
+            "type": "string"
+          },
+          "hasUnlimitedSeats": {
+            "description": "Indicates if the application role has unlimited user seats.",
+            "type": "boolean"
+          },
+          "platform": {
+            "description": "Indicates if the application role belongs to Jira platform (`jira-core`).",
+            "type": "boolean"
+          },
+          "groupDetails": {
+            "description": "Details about the groups associated with the application role.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "object"] }
+          },
+          "defaultGroupsDetails": {
+            "description": "Details of default groups assigned to application roles.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Information about a specific default group.",
+              "type": ["null", "object"],
+              "properties": {
+                "groupId": {
+                  "description": "The unique identifier of the group.",
+                  "type": ["null", "string"]
+                },
+                "name": {
+                  "description": "The name of the group.",
+                  "type": ["null", "string"]
+                },
+                "self": {
+                  "description": "The URL for accessing the group details.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of an application role."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["key"]],
+      "is_resumable": true
+    },
+    {
+      "name": "avatars",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": { "description": "The ID of the avatar.", "type": "string" },
+          "owner": {
+            "description": "The owner of the avatar. For a system avatar, the owner is null (and nothing is returned). For non-system avatars, this is the appropriate identifier, such as the ID for a project or the account ID for a user.",
+            "type": "string",
+            "readOnly": true
+          },
+          "isSystemAvatar": {
+            "description": "Whether the avatar is a system avatar.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isSelected": {
+            "description": "Whether the avatar is used in Jira. For example, shown as a project's avatar.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isDeletable": {
+            "description": "Whether the avatar can be deleted.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "fileName": {
+            "description": "The file name of the avatar icon. Returned for system avatars.",
+            "type": "string",
+            "readOnly": true
+          },
+          "urls": {
+            "description": "The list of avatar icon URLs.",
+            "type": "object",
+            "additionalProperties": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": true,
+        "description": "List of system avatars."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "boards",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique identifier of the board.",
+            "type": ["null", "integer"]
+          },
+          "self": {
+            "description": "URI that points to the board data.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "Name of the board.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "Type of the board.",
+            "type": ["null", "string"]
+          },
+          "projectId": {
+            "description": "ID of the project to which the board belongs.",
+            "type": ["null", "string"]
+          },
+          "projectKey": {
+            "description": "Key of the project to which the board belongs.",
+            "type": ["null", "string"]
+          },
+          "location": {
+            "description": "Information about the location of the board.",
+            "type": ["null", "object"],
+            "properties": {
+              "projectId": {
+                "description": "ID of the project to which the board location belongs.",
+                "type": ["null", "integer"]
+              },
+              "userId": {
+                "description": "ID of the user associated with the board location.",
+                "type": ["null", "integer"]
+              },
+              "userAccountId": {
+                "description": "Account ID of the user associated with the board location.",
+                "type": ["null", "string"]
+              },
+              "displayName": {
+                "description": "Display name of the board location.",
+                "type": ["null", "string"]
+              },
+              "projectName": {
+                "description": "Name of the project to which the board location belongs.",
+                "type": ["null", "string"]
+              },
+              "projectKey": {
+                "description": "Key of the project to which the board location belongs.",
+                "type": ["null", "string"]
+              },
+              "projectTypeKey": {
+                "description": "Type key of the project to which the board location belongs.",
+                "type": ["null", "string"]
+              },
+              "avatarURI": {
+                "description": "URI for the avatar of the board location.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Name of the board location.",
+                "type": ["null", "string"]
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "dashboards",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "The description of the dashboard.",
+            "type": "string"
+          },
+          "id": { "description": "The ID of the dashboard.", "type": "string" },
+          "isFavourite": {
+            "description": "Indicates whether the dashboard is marked as a favorite by the user.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The name of the dashboard.",
+            "type": "string"
+          },
+          "owner": {
+            "description": "Details of the owner of the dashboard.",
+            "type": "object",
+            "properties": {
+              "key": {
+                "description": "Deprecated. Use `accountId` for privacy reasons.",
+                "type": "string"
+              },
+              "self": {
+                "description": "The URL of the dashboard owner details.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Deprecated. Use `accountId` for privacy reasons.",
+                "type": "string"
+              },
+              "displayName": {
+                "description": "The display name of the dashboard owner. Privacy settings may affect the display value.",
+                "type": "string"
+              },
+              "active": {
+                "description": "Indicates whether the owner is an active user.",
+                "type": "boolean"
+              },
+              "accountId": {
+                "description": "The account ID of the dashboard owner.",
+                "maxLength": 128,
+                "type": "string"
+              },
+              "avatarUrls": {
+                "description": "The avatars of the dashboard owner.",
+                "type": "object",
+                "properties": {
+                  "16x16": {
+                    "type": "string",
+                    "description": "The URL of the user's 16x16 pixel avatar."
+                  },
+                  "24x24": {
+                    "type": "string",
+                    "description": "The URL of the user's 24x24 pixel avatar."
+                  },
+                  "32x32": {
+                    "type": "string",
+                    "description": "The URL of the user's 32x32 pixel avatar."
+                  },
+                  "48x48": {
+                    "type": "string",
+                    "description": "The URL of the user's 48x48 pixel avatar."
+                  }
+                }
+              }
+            }
+          },
+          "popularity": {
+            "description": "The number of users who have marked this dashboard as a favorite.",
+            "type": "integer"
+          },
+          "rank": {
+            "description": "The rank of the dashboard.",
+            "type": "integer"
+          },
+          "self": {
+            "description": "The URL of the dashboard details.",
+            "type": "string"
+          },
+          "sharePermissions": {
+            "description": "Details of any share permissions for the dashboard.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "description": "The unique identifier of the share permission.",
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "The type of share permission:\n\n *  `group` Shared with a group. If set in a request, then specify `sharePermission.group` as well.\n *  `project` Shared with a project. If set in a request, then specify `sharePermission.project` as well.\n *  `projectRole` Share with a project role in a project. This value is not returned in responses. It is used in requests, where it needs to be specify with `projectId` and `projectRoleId`.\n *  `global` Shared globally. If set in a request, no other `sharePermission` properties need to be specified.\n *  `loggedin` Shared with all logged-in users. Note: This value is set in a request by specifying `authenticated` as the `type`.\n *  `project-unknown` Shared with a project that the user does not have access to. Cannot be set in a request.",
+                  "enum": [
+                    "group",
+                    "project",
+                    "projectRole",
+                    "global",
+                    "loggedin",
+                    "authenticated",
+                    "project-unknown"
+                  ]
+                },
+                "project": {
+                  "description": "The project that the filter is shared with.",
+                  "type": "object",
+                  "properties": {
+                    "expand": {
+                      "type": "string",
+                      "description": "Expand options that include additional project details in the response.",
+                      "xml": { "attribute": true }
+                    },
+                    "self": {
+                      "type": "string",
+                      "description": "The URL of the project details."
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "The ID of the project."
+                    },
+                    "key": {
+                      "type": "string",
+                      "description": "The key of the project."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "A brief description of the project."
+                    },
+                    "lead": {
+                      "description": "The username of the project lead.",
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the user."
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "accountId": {
+                          "maxLength": 128,
+                          "type": "string",
+                          "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                        },
+                        "accountType": {
+                          "type": "string",
+                          "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                          "enum": ["atlassian", "app", "customer", "unknown"]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "emailAddress": {
+                          "type": "string",
+                          "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                        },
+                        "avatarUrls": {
+                          "description": "The avatars of the user.",
+                          "type": "object",
+                          "properties": {
+                            "16x16": {
+                              "type": "string",
+                              "description": "The URL of the item's 16x16 pixel avatar."
+                            },
+                            "24x24": {
+                              "type": "string",
+                              "description": "The URL of the item's 24x24 pixel avatar."
+                            },
+                            "32x32": {
+                              "type": "string",
+                              "description": "The URL of the item's 32x32 pixel avatar."
+                            },
+                            "48x48": {
+                              "type": "string",
+                              "description": "The URL of the item's 48x48 pixel avatar."
+                            }
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value."
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the user is active."
+                        },
+                        "timeZone": {
+                          "type": "string",
+                          "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null."
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                        },
+                        "groups": {
+                          "description": "The groups that the user belongs to.",
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of group."
+                                  },
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL for these group details."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "applicationRoles": {
+                          "description": "The application roles the user is assigned to.",
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the application role."
+                                  },
+                                  "groups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups associated with the application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The display name of the application role."
+                                  },
+                                  "defaultGroups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups that are granted default access for this application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "selectedByDefault": {
+                                    "type": "boolean",
+                                    "description": "Determines whether this application role should be selected by default on user creation."
+                                  },
+                                  "defined": {
+                                    "type": "boolean",
+                                    "description": "Deprecated."
+                                  },
+                                  "numberOfSeats": {
+                                    "type": "integer",
+                                    "description": "The maximum count of users on your license."
+                                  },
+                                  "remainingSeats": {
+                                    "type": "integer",
+                                    "description": "The count of users remaining on your license."
+                                  },
+                                  "userCount": {
+                                    "type": "integer",
+                                    "description": "The number of users counting against your license."
+                                  },
+                                  "userCountDescription": {
+                                    "type": "string",
+                                    "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                  },
+                                  "hasUnlimitedSeats": { "type": "boolean" },
+                                  "platform": {
+                                    "type": "boolean",
+                                    "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "expand": {
+                          "type": "string",
+                          "description": "Expand options that include additional user details in the response.",
+                          "xml": { "attribute": true }
+                        }
+                      }
+                    },
+                    "components": {
+                      "type": "array",
+                      "description": "List of the components contained in the project.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "type": "string",
+                            "description": "The URL of the component."
+                          },
+                          "id": {
+                            "type": "string",
+                            "description": "The unique identifier for the component."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The unique name for the component in the project. Required when creating a component. Optional when updating a component. The maximum length is 255 characters."
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "The description for the component. Optional when creating or updating a component."
+                          },
+                          "lead": {
+                            "description": "The user details for the component's lead user.",
+                            "type": "object",
+                            "properties": {
+                              "self": {
+                                "type": "string",
+                                "description": "The URL of the user."
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "accountId": {
+                                "maxLength": 128,
+                                "type": "string",
+                                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                              },
+                              "accountType": {
+                                "type": "string",
+                                "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                                "enum": [
+                                  "atlassian",
+                                  "app",
+                                  "customer",
+                                  "unknown"
+                                ]
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "emailAddress": {
+                                "type": "string",
+                                "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                              },
+                              "avatarUrls": {
+                                "description": "The avatars of the user.",
+                                "type": "object",
+                                "properties": {
+                                  "16x16": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 16x16 pixel avatar."
+                                  },
+                                  "24x24": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 24x24 pixel avatar."
+                                  },
+                                  "32x32": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 32x32 pixel avatar."
+                                  },
+                                  "48x48": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 48x48 pixel avatar."
+                                  }
+                                }
+                              },
+                              "displayName": {
+                                "type": "string",
+                                "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value."
+                              },
+                              "active": {
+                                "type": "boolean",
+                                "description": "Whether the user is active."
+                              },
+                              "timeZone": {
+                                "type": "string",
+                                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null."
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                              },
+                              "groups": {
+                                "description": "The groups that the user belongs to.",
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The name of group."
+                                        },
+                                        "self": {
+                                          "type": "string",
+                                          "description": "The URL for these group details."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "applicationRoles": {
+                                "description": "The application roles the user is assigned to.",
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "key": {
+                                          "type": "string",
+                                          "description": "The key of the application role."
+                                        },
+                                        "groups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups associated with the application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The display name of the application role."
+                                        },
+                                        "defaultGroups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups that are granted default access for this application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "selectedByDefault": {
+                                          "type": "boolean",
+                                          "description": "Determines whether this application role should be selected by default on user creation."
+                                        },
+                                        "defined": {
+                                          "type": "boolean",
+                                          "description": "Deprecated."
+                                        },
+                                        "numberOfSeats": {
+                                          "type": "integer",
+                                          "description": "The maximum count of users on your license."
+                                        },
+                                        "remainingSeats": {
+                                          "type": "integer",
+                                          "description": "The count of users remaining on your license."
+                                        },
+                                        "userCount": {
+                                          "type": "integer",
+                                          "description": "The number of users counting against your license."
+                                        },
+                                        "userCountDescription": {
+                                          "type": "string",
+                                          "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                        },
+                                        "hasUnlimitedSeats": {
+                                          "type": "boolean"
+                                        },
+                                        "platform": {
+                                          "type": "boolean",
+                                          "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "expand": {
+                                "type": "string",
+                                "description": "Expand options that include additional user details in the response.",
+                                "xml": { "attribute": true }
+                              }
+                            }
+                          },
+                          "leadUserName": {
+                            "type": "string",
+                            "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                          },
+                          "leadAccountId": {
+                            "maxLength": 128,
+                            "type": "string",
+                            "description": "The accountId of the component's lead user. The accountId uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*.",
+                            "writeOnly": true
+                          },
+                          "assigneeType": {
+                            "type": "string",
+                            "description": "The nominal user type used to determine the assignee for issues created with this component. See `realAssigneeType` for details on how the type of the user, and hence the user, assigned to issues is determined. Can take the following values:\n\n *  `PROJECT_LEAD` the assignee to any issues created with this component is nominally the lead for the project the component is in.\n *  `COMPONENT_LEAD` the assignee to any issues created with this component is nominally the lead for the component.\n *  `UNASSIGNED` an assignee is not set for issues created with this component.\n *  `PROJECT_DEFAULT` the assignee to any issues created with this component is nominally the default assignee for the project that the component is in.\n\nDefault value: `PROJECT_DEFAULT`.  \nOptional when creating or updating a component.",
+                            "enum": [
+                              "PROJECT_DEFAULT",
+                              "COMPONENT_LEAD",
+                              "PROJECT_LEAD",
+                              "UNASSIGNED"
+                            ]
+                          },
+                          "assignee": {
+                            "description": "The details of the user associated with `assigneeType`, if any. See `realAssignee` for details of the user assigned to issues created with this component.",
+                            "type": "object",
+                            "properties": {
+                              "self": {
+                                "type": "string",
+                                "description": "The URL of the user."
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "accountId": {
+                                "maxLength": 128,
+                                "type": "string",
+                                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                              },
+                              "accountType": {
+                                "type": "string",
+                                "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                                "enum": [
+                                  "atlassian",
+                                  "app",
+                                  "customer",
+                                  "unknown"
+                                ]
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "emailAddress": {
+                                "type": "string",
+                                "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                              },
+                              "avatarUrls": {
+                                "description": "The avatars of the user.",
+                                "type": "object",
+                                "properties": {
+                                  "16x16": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 16x16 pixel avatar."
+                                  },
+                                  "24x24": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 24x24 pixel avatar."
+                                  },
+                                  "32x32": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 32x32 pixel avatar."
+                                  },
+                                  "48x48": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 48x48 pixel avatar."
+                                  }
+                                }
+                              },
+                              "displayName": {
+                                "type": "string",
+                                "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value."
+                              },
+                              "active": {
+                                "type": "boolean",
+                                "description": "Whether the user is active."
+                              },
+                              "timeZone": {
+                                "type": "string",
+                                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null."
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                              },
+                              "groups": {
+                                "description": "The groups that the user belongs to.",
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The name of group."
+                                        },
+                                        "self": {
+                                          "type": "string",
+                                          "description": "The URL for these group details."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "applicationRoles": {
+                                "description": "The application roles the user is assigned to.",
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "key": {
+                                          "type": "string",
+                                          "description": "The key of the application role."
+                                        },
+                                        "groups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups associated with the application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The display name of the application role."
+                                        },
+                                        "defaultGroups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups that are granted default access for this application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "selectedByDefault": {
+                                          "type": "boolean",
+                                          "description": "Determines whether this application role should be selected by default on user creation."
+                                        },
+                                        "defined": {
+                                          "type": "boolean",
+                                          "description": "Deprecated."
+                                        },
+                                        "numberOfSeats": {
+                                          "type": "integer",
+                                          "description": "The maximum count of users on your license."
+                                        },
+                                        "remainingSeats": {
+                                          "type": "integer",
+                                          "description": "The count of users remaining on your license."
+                                        },
+                                        "userCount": {
+                                          "type": "integer",
+                                          "description": "The number of users counting against your license."
+                                        },
+                                        "userCountDescription": {
+                                          "type": "string",
+                                          "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                        },
+                                        "hasUnlimitedSeats": {
+                                          "type": "boolean"
+                                        },
+                                        "platform": {
+                                          "type": "boolean",
+                                          "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "expand": {
+                                "type": "string",
+                                "description": "Expand options that include additional user details in the response.",
+                                "xml": { "attribute": true }
+                              }
+                            }
+                          },
+                          "realAssigneeType": {
+                            "type": "string",
+                            "description": "The type of the assignee that is assigned to issues created with this component, when an assignee cannot be set from the `assigneeType`. For example, `assigneeType` is set to `COMPONENT_LEAD` but no component lead is set. This property is set to one of the following values:\n\n *  `PROJECT_LEAD` when `assigneeType` is `PROJECT_LEAD` and the project lead has permission to be assigned issues in the project that the component is in.\n *  `COMPONENT_LEAD` when `assignee`Type is `COMPONENT_LEAD` and the component lead has permission to be assigned issues in the project that the component is in.\n *  `UNASSIGNED` when `assigneeType` is `UNASSIGNED` and Jira is configured to allow unassigned issues.\n *  `PROJECT_DEFAULT` when none of the preceding cases are true.",
+                            "enum": [
+                              "PROJECT_DEFAULT",
+                              "COMPONENT_LEAD",
+                              "PROJECT_LEAD",
+                              "UNASSIGNED"
+                            ]
+                          },
+                          "realAssignee": {
+                            "description": "The user assigned to issues created with this component, when `assigneeType` does not identify a valid assignee.",
+                            "type": "object",
+                            "properties": {
+                              "self": {
+                                "type": "string",
+                                "description": "The URL of the user."
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "accountId": {
+                                "maxLength": 128,
+                                "type": "string",
+                                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                              },
+                              "accountType": {
+                                "type": "string",
+                                "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                                "enum": [
+                                  "atlassian",
+                                  "app",
+                                  "customer",
+                                  "unknown"
+                                ]
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "emailAddress": {
+                                "type": "string",
+                                "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                              },
+                              "avatarUrls": {
+                                "description": "The avatars of the user.",
+                                "type": "object",
+                                "properties": {
+                                  "16x16": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 16x16 pixel avatar."
+                                  },
+                                  "24x24": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 24x24 pixel avatar."
+                                  },
+                                  "32x32": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 32x32 pixel avatar."
+                                  },
+                                  "48x48": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 48x48 pixel avatar."
+                                  }
+                                }
+                              },
+                              "displayName": {
+                                "type": "string",
+                                "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value."
+                              },
+                              "active": {
+                                "type": "boolean",
+                                "description": "Whether the user is active."
+                              },
+                              "timeZone": {
+                                "type": "string",
+                                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null."
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                              },
+                              "groups": {
+                                "description": "The groups that the user belongs to.",
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The name of group."
+                                        },
+                                        "self": {
+                                          "type": "string",
+                                          "description": "The URL for these group details."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "applicationRoles": {
+                                "description": "The application roles the user is assigned to.",
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "key": {
+                                          "type": "string",
+                                          "description": "The key of the application role."
+                                        },
+                                        "groups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups associated with the application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The display name of the application role."
+                                        },
+                                        "defaultGroups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups that are granted default access for this application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "selectedByDefault": {
+                                          "type": "boolean",
+                                          "description": "Determines whether this application role should be selected by default on user creation."
+                                        },
+                                        "defined": {
+                                          "type": "boolean",
+                                          "description": "Deprecated."
+                                        },
+                                        "numberOfSeats": {
+                                          "type": "integer",
+                                          "description": "The maximum count of users on your license."
+                                        },
+                                        "remainingSeats": {
+                                          "type": "integer",
+                                          "description": "The count of users remaining on your license."
+                                        },
+                                        "userCount": {
+                                          "type": "integer",
+                                          "description": "The number of users counting against your license."
+                                        },
+                                        "userCountDescription": {
+                                          "type": "string",
+                                          "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                        },
+                                        "hasUnlimitedSeats": {
+                                          "type": "boolean"
+                                        },
+                                        "platform": {
+                                          "type": "boolean",
+                                          "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "expand": {
+                                "type": "string",
+                                "description": "Expand options that include additional user details in the response.",
+                                "xml": { "attribute": true }
+                              }
+                            }
+                          },
+                          "isAssigneeTypeValid": {
+                            "type": "boolean",
+                            "description": "Whether a user is associated with `assigneeType`. For example, if the `assigneeType` is set to `COMPONENT_LEAD` but the component lead is not set, then `false` is returned."
+                          },
+                          "project": {
+                            "type": "string",
+                            "description": "The key of the project the component is assigned to. Required when creating a component. Can't be updated."
+                          },
+                          "projectId": {
+                            "type": "integer",
+                            "description": "The ID of the project the component is assigned to."
+                          }
+                        }
+                      }
+                    },
+                    "issueTypes": {
+                      "type": "array",
+                      "description": "List of the issue types available in the project.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "type": "string",
+                            "description": "The URL of these issue type details."
+                          },
+                          "id": {
+                            "type": "string",
+                            "description": "The ID of the issue type."
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "The description of the issue type."
+                          },
+                          "iconUrl": {
+                            "type": "string",
+                            "description": "The URL of the issue type's avatar."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the issue type."
+                          },
+                          "subtask": {
+                            "type": "boolean",
+                            "description": "Whether this issue type is used to create subtasks."
+                          },
+                          "avatarId": {
+                            "type": "integer",
+                            "description": "The ID of the issue type's avatar."
+                          },
+                          "entityId": {
+                            "type": "string",
+                            "description": "Unique ID for next-gen projects."
+                          },
+                          "hierarchyLevel": {
+                            "type": "integer",
+                            "description": "Hierarchy level of the issue type."
+                          },
+                          "scope": {
+                            "description": "Details of the next-gen projects the issue type is available in.",
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "description": "The type of scope.",
+                                "enum": ["PROJECT", "TEMPLATE"]
+                              },
+                              "project": {
+                                "description": "The project the item has scope in.",
+                                "type": "object",
+                                "properties": {
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL of the project details."
+                                  },
+                                  "id": {
+                                    "type": "string",
+                                    "description": "The ID of the project."
+                                  },
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the project."
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of the project."
+                                  },
+                                  "projectTypeKey": {
+                                    "type": "string",
+                                    "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                                    "enum": [
+                                      "software",
+                                      "service_desk",
+                                      "business"
+                                    ]
+                                  },
+                                  "simplified": {
+                                    "type": "boolean",
+                                    "description": "Whether or not the project is simplified."
+                                  },
+                                  "avatarUrls": {
+                                    "description": "The URLs of the project's avatars.",
+                                    "type": "object",
+                                    "properties": {
+                                      "16x16": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 16x16 pixel avatar."
+                                      },
+                                      "24x24": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 24x24 pixel avatar."
+                                      },
+                                      "32x32": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 32x32 pixel avatar."
+                                      },
+                                      "48x48": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 48x48 pixel avatar."
+                                      }
+                                    }
+                                  },
+                                  "projectCategory": {
+                                    "description": "The category the project belongs to.",
+                                    "type": "object",
+                                    "properties": {
+                                      "self": {
+                                        "type": "string",
+                                        "description": "The URL of the project category."
+                                      },
+                                      "id": {
+                                        "type": "string",
+                                        "description": "The ID of the project category."
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "The name of the project category."
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "description": "The description of the project category."
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "A link to information about this project, such as project documentation."
+                    },
+                    "email": {
+                      "type": "string",
+                      "description": "An email address associated with the project."
+                    },
+                    "assigneeType": {
+                      "type": "string",
+                      "description": "The default assignee when creating issues for this project.",
+                      "enum": ["PROJECT_LEAD", "UNASSIGNED"]
+                    },
+                    "versions": {
+                      "type": "array",
+                      "description": "The versions defined in the project. For more information, see [Create version](#api-rest-api-3-version-post).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "expand": {
+                            "type": "string",
+                            "description": "Use [expand](em>#expansion) to include additional information about version in the response. This parameter accepts a comma-separated list. Expand options include:\n\n *  `operations` Returns the list of operations available for this version.\n *  `issuesstatus` Returns the count of issues in this version for each of the status categories *to do*, *in progress*, *done*, and *unmapped*. The *unmapped* property contains a count of issues with a status other than *to do*, *in progress*, and *done*.\n\nOptional for create and update.",
+                            "xml": { "attribute": true }
+                          },
+                          "self": {
+                            "type": "string",
+                            "description": "The URL of the version."
+                          },
+                          "id": {
+                            "type": "string",
+                            "description": "The ID of the version."
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "The description of the version. Optional when creating or updating a version."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The unique name of the version. Required when creating a version. Optional when updating a version. The maximum length is 255 characters."
+                          },
+                          "archived": {
+                            "type": "boolean",
+                            "description": "Indicates that the version is archived. Optional when creating or updating a version."
+                          },
+                          "released": {
+                            "type": "boolean",
+                            "description": "Indicates that the version is released. If the version is released a request to release again is ignored. Not applicable when creating a version. Optional when updating a version."
+                          },
+                          "startDate": {
+                            "type": "string",
+                            "description": "The start date of the version. Expressed in ISO 8601 format (yyyy-mm-dd). Optional when creating or updating a version.",
+                            "format": "date"
+                          },
+                          "releaseDate": {
+                            "type": "string",
+                            "description": "The release date of the version. Expressed in ISO 8601 format (yyyy-mm-dd). Optional when creating or updating a version.",
+                            "format": "date"
+                          },
+                          "overdue": {
+                            "type": "boolean",
+                            "description": "Indicates that the version is overdue."
+                          },
+                          "userStartDate": {
+                            "type": "string",
+                            "description": "The date on which work on this version is expected to start, expressed in the instance's *Day/Month/Year Format* date format."
+                          },
+                          "userReleaseDate": {
+                            "type": "string",
+                            "description": "The date on which work on this version is expected to finish, expressed in the instance's *Day/Month/Year Format* date format."
+                          },
+                          "project": {
+                            "type": "string",
+                            "description": "Deprecated. Use `projectId`."
+                          },
+                          "projectId": {
+                            "type": "integer",
+                            "description": "The ID of the project to which this version is attached. Required when creating a version. Not applicable when updating a version."
+                          },
+                          "moveUnfixedIssuesTo": {
+                            "type": "string",
+                            "description": "The URL of the self link to the version to which all unfixed issues are moved when a version is released. Not applicable when creating a version. Optional when updating a version."
+                          },
+                          "operations": {
+                            "type": "array",
+                            "description": "If the expand option `operations` is used, returns the list of operations available for this version.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": { "type": "string" },
+                                "styleClass": { "type": "string" },
+                                "iconClass": { "type": "string" },
+                                "label": { "type": "string" },
+                                "title": { "type": "string" },
+                                "href": { "type": "string" },
+                                "weight": { "type": "integer" }
+                              }
+                            }
+                          },
+                          "issuesStatusForFixVersion": {
+                            "description": "If the expand option `issuesstatus` is used, returns the count of issues in this version for each of the status categories *to do*, *in progress*, *done*, and *unmapped*. The *unmapped* property contains a count of issues with a status other than *to do*, *in progress*, and *done*.",
+                            "type": "object",
+                            "properties": {
+                              "unmapped": {
+                                "type": "integer",
+                                "description": "Count of issues with a status other than *to do*, *in progress*, and *done*."
+                              },
+                              "toDo": {
+                                "type": "integer",
+                                "description": "Count of issues with status *to do*."
+                              },
+                              "inProgress": {
+                                "type": "integer",
+                                "description": "Count of issues with status *in progress*."
+                              },
+                              "done": {
+                                "type": "integer",
+                                "description": "Count of issues with status *done*."
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the project."
+                    },
+                    "roles": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The name and self URL for each role defined in the project. For more information, see [Create project role](#api-rest-api-3-role-post)."
+                    },
+                    "avatarUrls": {
+                      "description": "The URLs of the project's avatars.",
+                      "type": "object",
+                      "properties": {
+                        "16x16": {
+                          "type": "string",
+                          "description": "The URL of the item's 16x16 pixel avatar."
+                        },
+                        "24x24": {
+                          "type": "string",
+                          "description": "The URL of the item's 24x24 pixel avatar."
+                        },
+                        "32x32": {
+                          "type": "string",
+                          "description": "The URL of the item's 32x32 pixel avatar."
+                        },
+                        "48x48": {
+                          "type": "string",
+                          "description": "The URL of the item's 48x48 pixel avatar."
+                        }
+                      }
+                    },
+                    "projectCategory": {
+                      "description": "The category the project belongs to.",
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the project category."
+                        },
+                        "id": {
+                          "type": "string",
+                          "description": "The ID of the project category."
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The name of the project category. Required on create, optional on update."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "The description of the project category. Required on create, optional on update."
+                        }
+                      }
+                    },
+                    "projectTypeKey": {
+                      "type": "string",
+                      "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                      "enum": ["software", "service_desk", "business"]
+                    },
+                    "simplified": {
+                      "type": "boolean",
+                      "description": "Whether the project is simplified."
+                    },
+                    "style": {
+                      "type": "string",
+                      "description": "The type of the project.",
+                      "enum": ["classic", "next-gen"]
+                    },
+                    "favourite": {
+                      "type": "boolean",
+                      "description": "Whether the project is selected as a favorite."
+                    },
+                    "isPrivate": {
+                      "type": "boolean",
+                      "description": "Whether the project is private."
+                    },
+                    "issueTypeHierarchy": {
+                      "description": "The issue type hierarchy for the project",
+                      "type": "object",
+                      "properties": {
+                        "level": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": { "type": "integer" },
+                              "name": { "type": "string" },
+                              "aboveLevelId": { "type": "integer" },
+                              "belowLevelId": { "type": "integer" },
+                              "projectConfigurationId": { "type": "integer" },
+                              "level": { "type": "integer" },
+                              "issueTypeIds": {
+                                "type": "array",
+                                "items": { "type": "integer" }
+                              },
+                              "externalUuid": { "type": "string" },
+                              "globalHierarchyLevel": {
+                                "type": "string",
+                                "enum": ["SUBTASK", "BASE", "EPIC"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "permissions": {
+                      "description": "User permissions on the project",
+                      "type": "object",
+                      "properties": {
+                        "canEdit": {
+                          "type": "boolean",
+                          "description": "Whether the logged user can edit the project."
+                        }
+                      }
+                    },
+                    "properties": {
+                      "type": "object",
+                      "description": "Map of project properties"
+                    },
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique ID for next-gen projects."
+                    },
+                    "insight": {
+                      "description": "Insights about the project.",
+                      "type": "object",
+                      "properties": {
+                        "totalIssueCount": {
+                          "type": "integer",
+                          "description": "Total issue count."
+                        },
+                        "lastIssueUpdateTime": {
+                          "type": "string",
+                          "description": "The last issue update time.",
+                          "format": "date-time"
+                        }
+                      }
+                    },
+                    "deleted": {
+                      "type": "boolean",
+                      "description": "Whether the project is marked as deleted."
+                    },
+                    "retentionTillDate": {
+                      "type": "string",
+                      "description": "The date when the project is deleted permanently.",
+                      "format": "date-time"
+                    },
+                    "deletedDate": {
+                      "type": "string",
+                      "description": "The date when the project was marked as deleted.",
+                      "format": "date-time"
+                    },
+                    "deletedBy": {
+                      "description": "The user who marked the project as deleted.",
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the user."
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "accountId": {
+                          "maxLength": 128,
+                          "type": "string",
+                          "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                        },
+                        "accountType": {
+                          "type": "string",
+                          "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                          "enum": ["atlassian", "app", "customer", "unknown"]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "emailAddress": {
+                          "type": "string",
+                          "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                        },
+                        "avatarUrls": {
+                          "description": "The avatars of the user.",
+                          "type": "object",
+                          "properties": {
+                            "16x16": {
+                              "type": "string",
+                              "description": "The URL of the item's 16x16 pixel avatar."
+                            },
+                            "24x24": {
+                              "type": "string",
+                              "description": "The URL of the item's 24x24 pixel avatar."
+                            },
+                            "32x32": {
+                              "type": "string",
+                              "description": "The URL of the item's 32x32 pixel avatar."
+                            },
+                            "48x48": {
+                              "type": "string",
+                              "description": "The URL of the item's 48x48 pixel avatar."
+                            }
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value."
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the user is active."
+                        },
+                        "timeZone": {
+                          "type": "string",
+                          "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null."
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                        },
+                        "groups": {
+                          "description": "The groups that the user belongs to.",
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of group."
+                                  },
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL for these group details."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "applicationRoles": {
+                          "description": "The application roles the user is assigned to.",
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the application role."
+                                  },
+                                  "groups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups associated with the application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The display name of the application role."
+                                  },
+                                  "defaultGroups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups that are granted default access for this application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "selectedByDefault": {
+                                    "type": "boolean",
+                                    "description": "Determines whether this application role should be selected by default on user creation."
+                                  },
+                                  "defined": {
+                                    "type": "boolean",
+                                    "description": "Deprecated."
+                                  },
+                                  "numberOfSeats": {
+                                    "type": "integer",
+                                    "description": "The maximum count of users on your license."
+                                  },
+                                  "remainingSeats": {
+                                    "type": "integer",
+                                    "description": "The count of users remaining on your license."
+                                  },
+                                  "userCount": {
+                                    "type": "integer",
+                                    "description": "The number of users counting against your license."
+                                  },
+                                  "userCountDescription": {
+                                    "type": "string",
+                                    "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                  },
+                                  "hasUnlimitedSeats": { "type": "boolean" },
+                                  "platform": {
+                                    "type": "boolean",
+                                    "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "expand": {
+                          "type": "string",
+                          "description": "Expand options that include additional user details in the response.",
+                          "xml": { "attribute": true }
+                        }
+                      }
+                    },
+                    "archived": {
+                      "type": "boolean",
+                      "description": "Whether the project is archived."
+                    },
+                    "archivedDate": {
+                      "type": "string",
+                      "description": "The date when the project was archived.",
+                      "format": "date-time"
+                    },
+                    "archivedBy": {
+                      "description": "The user who archived the project.",
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the user."
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "accountId": {
+                          "maxLength": 128,
+                          "type": "string",
+                          "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                        },
+                        "accountType": {
+                          "type": "string",
+                          "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                          "enum": ["atlassian", "app", "customer", "unknown"]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "emailAddress": {
+                          "type": "string",
+                          "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                        },
+                        "avatarUrls": {
+                          "description": "The avatars of the user.",
+                          "type": "object",
+                          "properties": {
+                            "16x16": {
+                              "type": "string",
+                              "description": "The URL of the item's 16x16 pixel avatar."
+                            },
+                            "24x24": {
+                              "type": "string",
+                              "description": "The URL of the item's 24x24 pixel avatar."
+                            },
+                            "32x32": {
+                              "type": "string",
+                              "description": "The URL of the item's 32x32 pixel avatar."
+                            },
+                            "48x48": {
+                              "type": "string",
+                              "description": "The URL of the item's 48x48 pixel avatar."
+                            }
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value."
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the user is active."
+                        },
+                        "timeZone": {
+                          "type": "string",
+                          "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null."
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null."
+                        },
+                        "groups": {
+                          "description": "The groups that the user belongs to.",
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of group."
+                                  },
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL for these group details."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "applicationRoles": {
+                          "description": "The application roles the user is assigned to.",
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the application role."
+                                  },
+                                  "groups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups associated with the application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The display name of the application role."
+                                  },
+                                  "defaultGroups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups that are granted default access for this application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "selectedByDefault": {
+                                    "type": "boolean",
+                                    "description": "Determines whether this application role should be selected by default on user creation."
+                                  },
+                                  "defined": {
+                                    "type": "boolean",
+                                    "description": "Deprecated."
+                                  },
+                                  "numberOfSeats": {
+                                    "type": "integer",
+                                    "description": "The maximum count of users on your license."
+                                  },
+                                  "remainingSeats": {
+                                    "type": "integer",
+                                    "description": "The count of users remaining on your license."
+                                  },
+                                  "userCount": {
+                                    "type": "integer",
+                                    "description": "The number of users counting against your license."
+                                  },
+                                  "userCountDescription": {
+                                    "type": "string",
+                                    "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                  },
+                                  "hasUnlimitedSeats": { "type": "boolean" },
+                                  "platform": {
+                                    "type": "boolean",
+                                    "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "expand": {
+                          "type": "string",
+                          "description": "Expand options that include additional user details in the response.",
+                          "xml": { "attribute": true }
+                        }
+                      }
+                    }
+                  }
+                },
+                "role": {
+                  "description": "The project role that the filter is shared with.  \nFor a request, specify the `id` for the role. You must also specify the `project` object and `id` for the project that the role is in.",
+                  "type": "object",
+                  "properties": {
+                    "self": {
+                      "type": "string",
+                      "description": "The URL the project role details."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the project role."
+                    },
+                    "id": {
+                      "type": "integer",
+                      "description": "The ID of the project role."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "The description of the project role."
+                    },
+                    "actors": {
+                      "type": "array",
+                      "description": "The list of users who act in this role.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "The ID of the role actor."
+                          },
+                          "displayName": {
+                            "type": "string",
+                            "description": "The display name of the role actor. For users, depending on the user\u2019s privacy setting, this may return an alternative value for the user's name."
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The type of role actor.",
+                            "enum": [
+                              "atlassian-group-role-actor",
+                              "atlassian-user-role-actor"
+                            ]
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                          },
+                          "avatarUrl": {
+                            "type": "string",
+                            "description": "The avatar of the role actor."
+                          },
+                          "actorUser": {
+                            "type": "object",
+                            "properties": {
+                              "accountId": {
+                                "maxLength": 128,
+                                "type": "string",
+                                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Returns *unknown* if the record is deleted and corrupted, for example, as the result of a server import."
+                              }
+                            }
+                          },
+                          "actorGroup": {
+                            "type": "object",
+                            "properties": {
+                              "displayName": {
+                                "type": "string",
+                                "description": "The display name of the group."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The name of the group"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "scope": {
+                      "description": "The scope of the role. Indicated for roles associated with [next-gen projects](https://confluence.atlassian.com/x/loMyO).",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "The type of scope.",
+                          "enum": ["PROJECT", "TEMPLATE"]
+                        },
+                        "project": {
+                          "description": "The project the item has scope in.",
+                          "type": "object",
+                          "properties": {
+                            "self": {
+                              "type": "string",
+                              "description": "The URL of the project details."
+                            },
+                            "id": {
+                              "type": "string",
+                              "description": "The ID of the project."
+                            },
+                            "key": {
+                              "type": "string",
+                              "description": "The key of the project."
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the project."
+                            },
+                            "projectTypeKey": {
+                              "type": "string",
+                              "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                              "enum": ["software", "service_desk", "business"]
+                            },
+                            "simplified": {
+                              "type": "boolean",
+                              "description": "Whether or not the project is simplified."
+                            },
+                            "avatarUrls": {
+                              "description": "The URLs of the project's avatars.",
+                              "type": "object",
+                              "properties": {
+                                "16x16": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 16x16 pixel avatar."
+                                },
+                                "24x24": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 24x24 pixel avatar."
+                                },
+                                "32x32": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 32x32 pixel avatar."
+                                },
+                                "48x48": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 48x48 pixel avatar."
+                                }
+                              }
+                            },
+                            "projectCategory": {
+                              "description": "The category the project belongs to.",
+                              "type": "object",
+                              "properties": {
+                                "self": {
+                                  "type": "string",
+                                  "description": "The URL of the project category."
+                                },
+                                "id": {
+                                  "type": "string",
+                                  "description": "The ID of the project category."
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "description": "The name of the project category."
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "The description of the project category."
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "translatedName": {
+                      "type": "string",
+                      "description": "The translated name of the project role."
+                    },
+                    "currentUserRole": {
+                      "type": "boolean",
+                      "description": "Whether the calling user is part of this role."
+                    },
+                    "admin": {
+                      "type": "boolean",
+                      "description": "Whether this role is the admin role for the project."
+                    },
+                    "roleConfigurable": {
+                      "type": "boolean",
+                      "description": "Whether the roles are configurable for this project."
+                    },
+                    "default": {
+                      "type": "boolean",
+                      "description": "Whether this role is the default role for the project"
+                    }
+                  }
+                },
+                "group": {
+                  "description": "The group that the filter is shared with.",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "The name of group."
+                    },
+                    "self": {
+                      "type": "string",
+                      "description": "The URL for these group details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "view": {
+            "description": "The URL of the dashboard.",
+            "type": "string"
+          },
+          "editpermission": {
+            "description": "List of items representing the specific edit permissions assigned for the dashboard.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "group": {
+                  "description": "The group associated with the edit permission.",
+                  "type": ["null", "object"]
+                },
+                "id": {
+                  "description": "The ID of the edit permission.",
+                  "type": ["null", "integer"]
+                },
+                "project": {
+                  "description": "The project associated with the edit permission.",
+                  "type": ["null", "object"]
+                },
+                "role": {
+                  "description": "The role associated with the edit permission.",
+                  "type": ["null", "object"]
+                },
+                "type": {
+                  "description": "The type of edit permission.",
+                  "type": ["null", "string"]
+                },
+                "user": {
+                  "description": "The user associated with the edit permission.",
+                  "type": ["null", "object"]
+                }
+              }
+            }
+          },
+          "isWritable": {
+            "description": "Indicates whether the dashboard is writable.",
+            "type": ["null", "boolean"]
+          },
+          "systemDashboard": {
+            "description": "Information about the system dashboard.",
+            "type": ["null", "boolean"]
+          },
+          "editPermissions": {
+            "description": "Details about the users/groups who have edit permissions for the dashboard.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "List of edit permissions for the dashboard.",
+              "type": ["null", "object"]
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of a dashboard."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "filters",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "expand": {
+            "description": "Expands the additional information about the filter",
+            "type": "string"
+          },
+          "self": {
+            "type": "string",
+            "description": "The URL of the filter.",
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique identifier for the filter.",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the filter. Must be unique."
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of the filter."
+          },
+          "owner": {
+            "description": "The user who owns the filter. This is defaulted to the creator of the filter, however Jira administrators can change the owner of a shared filter in the admin settings.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "self": {
+                "type": "string",
+                "description": "The URL of the user.",
+                "readOnly": true
+              },
+              "key": {
+                "type": "string",
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+              },
+              "accountId": {
+                "maxLength": 128,
+                "type": "string",
+                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+              },
+              "accountType": {
+                "type": "string",
+                "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                "readOnly": true,
+                "enum": ["atlassian", "app", "customer", "unknown"]
+              },
+              "name": {
+                "type": "string",
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+              },
+              "emailAddress": {
+                "type": "string",
+                "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                "readOnly": true
+              },
+              "avatarUrls": {
+                "description": "The avatars of the user.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "16x16": {
+                    "type": "string",
+                    "description": "The URL of the item's 16x16 pixel avatar."
+                  },
+                  "24x24": {
+                    "type": "string",
+                    "description": "The URL of the item's 24x24 pixel avatar."
+                  },
+                  "32x32": {
+                    "type": "string",
+                    "description": "The URL of the item's 32x32 pixel avatar."
+                  },
+                  "48x48": {
+                    "type": "string",
+                    "description": "The URL of the item's 48x48 pixel avatar."
+                  }
+                }
+              },
+              "displayName": {
+                "type": "string",
+                "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                "readOnly": true
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Whether the user is active.",
+                "readOnly": true
+              },
+              "timeZone": {
+                "type": "string",
+                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                "readOnly": true
+              },
+              "locale": {
+                "type": "string",
+                "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                "readOnly": true
+              },
+              "groups": {
+                "description": "The groups that the user belongs to.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "size": { "type": "integer", "xml": { "attribute": true } },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "The name of group."
+                        },
+                        "self": {
+                          "type": "string",
+                          "description": "The URL for these group details.",
+                          "readOnly": true
+                        }
+                      }
+                    }
+                  },
+                  "pagingCallback": { "type": "object" },
+                  "callback": { "type": "object" },
+                  "max-results": {
+                    "type": "integer",
+                    "xml": { "name": "max-results", "attribute": true }
+                  }
+                }
+              },
+              "applicationRoles": {
+                "description": "The application roles the user is assigned to.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "size": { "type": "integer", "xml": { "attribute": true } },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "The key of the application role."
+                        },
+                        "groups": {
+                          "uniqueItems": true,
+                          "type": "array",
+                          "description": "The groups associated with the application role.",
+                          "items": { "type": "string" }
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The display name of the application role."
+                        },
+                        "defaultGroups": {
+                          "uniqueItems": true,
+                          "type": "array",
+                          "description": "The groups that are granted default access for this application role.",
+                          "items": { "type": "string" }
+                        },
+                        "selectedByDefault": {
+                          "type": "boolean",
+                          "description": "Determines whether this application role should be selected by default on user creation."
+                        },
+                        "defined": {
+                          "type": "boolean",
+                          "description": "Deprecated."
+                        },
+                        "numberOfSeats": {
+                          "type": "integer",
+                          "description": "The maximum count of users on your license."
+                        },
+                        "remainingSeats": {
+                          "type": "integer",
+                          "description": "The count of users remaining on your license."
+                        },
+                        "userCount": {
+                          "type": "integer",
+                          "description": "The number of users counting against your license."
+                        },
+                        "userCountDescription": {
+                          "type": "string",
+                          "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                        },
+                        "hasUnlimitedSeats": { "type": "boolean" },
+                        "platform": {
+                          "type": "boolean",
+                          "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                        }
+                      }
+                    }
+                  },
+                  "pagingCallback": { "type": "object" },
+                  "callback": { "type": "object" },
+                  "max-results": {
+                    "type": "integer",
+                    "xml": { "name": "max-results", "attribute": true }
+                  }
+                }
+              },
+              "expand": {
+                "type": "string",
+                "description": "Expand options that include additional user details in the response.",
+                "readOnly": true,
+                "xml": { "attribute": true }
+              }
+            }
+          },
+          "jql": {
+            "type": "string",
+            "description": "The JQL query for the filter. For example, *project = SSP AND issuetype = Bug*.",
+            "readOnly": true
+          },
+          "viewUrl": {
+            "type": "string",
+            "description": "A URL to view the filter results in Jira, using the ID of the filter. For example, *https://your-domain.atlassian.net/issues/?filter=10100*.",
+            "readOnly": true
+          },
+          "searchUrl": {
+            "type": "string",
+            "description": "A URL to view the filter results in Jira, using the [Search for issues using JQL](#api-rest-api-3-filter-search-get) operation with the filter's JQL string to return the filter results. For example, *https://your-domain.atlassian.net/rest/api/3/search?jql=project+%3D+SSP+AND+issuetype+%3D+Bug*.",
+            "readOnly": true
+          },
+          "favourite": {
+            "type": "boolean",
+            "description": "Whether the filter is selected as a favorite by any users, not including the filter owner.",
+            "readOnly": true
+          },
+          "favouritedCount": {
+            "type": "integer",
+            "description": "The count of how many users have selected this filter as a favorite, including the filter owner.",
+            "readOnly": true
+          },
+          "sharePermissions": {
+            "type": "array",
+            "description": "The groups and projects that the filter is shared with. This can be specified when updating a filter, but not when creating a filter.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "description": "The unique identifier of the share permission.",
+                  "readOnly": true
+                },
+                "type": {
+                  "type": "string",
+                  "description": "The type of share permission:\n\n *  `group` Shared with a group. If set in a request, then specify `sharePermission.group` as well.\n *  `project` Shared with a project. If set in a request, then specify `sharePermission.project` as well.\n *  `projectRole` Share with a project role in a project. This value is not returned in responses. It is used in requests, where it needs to be specify with `projectId` and `projectRoleId`.\n *  `global` Shared globally. If set in a request, no other `sharePermission` properties need to be specified.\n *  `loggedin` Shared with all logged-in users. Note: This value is set in a request by specifying `authenticated` as the `type`.\n *  `project-unknown` Shared with a project that the user does not have access to. Cannot be set in a request.",
+                  "enum": [
+                    "group",
+                    "project",
+                    "projectRole",
+                    "global",
+                    "loggedin",
+                    "authenticated",
+                    "project-unknown"
+                  ]
+                },
+                "project": {
+                  "description": "The project that the filter is shared with. This is similar to the project object returned by [Get project](#api-rest-api-3-project-projectIdOrKey-get) but it contains a subset of the properties, which are: `self`, `id`, `key`, `assigneeType`, `name`, `roles`, `avatarUrls`, `projectType`, `simplified`.  \nFor a request, specify the `id` for the project.",
+                  "type": "object",
+                  "properties": {
+                    "expand": {
+                      "type": "string",
+                      "description": "Expand options that include additional project details in the response.",
+                      "readOnly": true,
+                      "xml": { "attribute": true }
+                    },
+                    "self": {
+                      "type": "string",
+                      "description": "The URL of the project details.",
+                      "readOnly": true
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "The ID of the project."
+                    },
+                    "key": {
+                      "type": "string",
+                      "description": "The key of the project.",
+                      "readOnly": true
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "A brief description of the project.",
+                      "readOnly": true
+                    },
+                    "lead": {
+                      "description": "The username of the project lead.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the user.",
+                          "readOnly": true
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "accountId": {
+                          "maxLength": 128,
+                          "type": "string",
+                          "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                        },
+                        "accountType": {
+                          "type": "string",
+                          "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                          "readOnly": true,
+                          "enum": ["atlassian", "app", "customer", "unknown"]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "emailAddress": {
+                          "type": "string",
+                          "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "avatarUrls": {
+                          "description": "The avatars of the user.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "16x16": {
+                              "type": "string",
+                              "description": "The URL of the item's 16x16 pixel avatar."
+                            },
+                            "24x24": {
+                              "type": "string",
+                              "description": "The URL of the item's 24x24 pixel avatar."
+                            },
+                            "32x32": {
+                              "type": "string",
+                              "description": "The URL of the item's 32x32 pixel avatar."
+                            },
+                            "48x48": {
+                              "type": "string",
+                              "description": "The URL of the item's 48x48 pixel avatar."
+                            }
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                          "readOnly": true
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the user is active.",
+                          "readOnly": true
+                        },
+                        "timeZone": {
+                          "type": "string",
+                          "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "groups": {
+                          "description": "The groups that the user belongs to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of group."
+                                  },
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL for these group details.",
+                                    "readOnly": true
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "applicationRoles": {
+                          "description": "The application roles the user is assigned to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the application role."
+                                  },
+                                  "groups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups associated with the application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The display name of the application role."
+                                  },
+                                  "defaultGroups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups that are granted default access for this application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "selectedByDefault": {
+                                    "type": "boolean",
+                                    "description": "Determines whether this application role should be selected by default on user creation."
+                                  },
+                                  "defined": {
+                                    "type": "boolean",
+                                    "description": "Deprecated."
+                                  },
+                                  "numberOfSeats": {
+                                    "type": "integer",
+                                    "description": "The maximum count of users on your license."
+                                  },
+                                  "remainingSeats": {
+                                    "type": "integer",
+                                    "description": "The count of users remaining on your license."
+                                  },
+                                  "userCount": {
+                                    "type": "integer",
+                                    "description": "The number of users counting against your license."
+                                  },
+                                  "userCountDescription": {
+                                    "type": "string",
+                                    "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                  },
+                                  "hasUnlimitedSeats": { "type": "boolean" },
+                                  "platform": {
+                                    "type": "boolean",
+                                    "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "expand": {
+                          "type": "string",
+                          "description": "Expand options that include additional user details in the response.",
+                          "readOnly": true,
+                          "xml": { "attribute": true }
+                        }
+                      }
+                    },
+                    "components": {
+                      "type": "array",
+                      "description": "List of the components contained in the project.",
+                      "readOnly": true,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "type": "string",
+                            "description": "The URL of the component.",
+                            "readOnly": true
+                          },
+                          "id": {
+                            "type": "string",
+                            "description": "The unique identifier for the component.",
+                            "readOnly": true
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The unique name for the component in the project. Required when creating a component. Optional when updating a component. The maximum length is 255 characters."
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "The description for the component. Optional when creating or updating a component."
+                          },
+                          "lead": {
+                            "description": "The user details for the component's lead user.",
+                            "readOnly": true,
+                            "type": "object",
+                            "properties": {
+                              "self": {
+                                "type": "string",
+                                "description": "The URL of the user.",
+                                "readOnly": true
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "accountId": {
+                                "maxLength": 128,
+                                "type": "string",
+                                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                              },
+                              "accountType": {
+                                "type": "string",
+                                "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                                "readOnly": true,
+                                "enum": [
+                                  "atlassian",
+                                  "app",
+                                  "customer",
+                                  "unknown"
+                                ]
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "emailAddress": {
+                                "type": "string",
+                                "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                                "readOnly": true
+                              },
+                              "avatarUrls": {
+                                "description": "The avatars of the user.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "16x16": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 16x16 pixel avatar."
+                                  },
+                                  "24x24": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 24x24 pixel avatar."
+                                  },
+                                  "32x32": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 32x32 pixel avatar."
+                                  },
+                                  "48x48": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 48x48 pixel avatar."
+                                  }
+                                }
+                              },
+                              "displayName": {
+                                "type": "string",
+                                "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                                "readOnly": true
+                              },
+                              "active": {
+                                "type": "boolean",
+                                "description": "Whether the user is active.",
+                                "readOnly": true
+                              },
+                              "timeZone": {
+                                "type": "string",
+                                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                                "readOnly": true
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                                "readOnly": true
+                              },
+                              "groups": {
+                                "description": "The groups that the user belongs to.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The name of group."
+                                        },
+                                        "self": {
+                                          "type": "string",
+                                          "description": "The URL for these group details.",
+                                          "readOnly": true
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "applicationRoles": {
+                                "description": "The application roles the user is assigned to.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "key": {
+                                          "type": "string",
+                                          "description": "The key of the application role."
+                                        },
+                                        "groups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups associated with the application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The display name of the application role."
+                                        },
+                                        "defaultGroups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups that are granted default access for this application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "selectedByDefault": {
+                                          "type": "boolean",
+                                          "description": "Determines whether this application role should be selected by default on user creation."
+                                        },
+                                        "defined": {
+                                          "type": "boolean",
+                                          "description": "Deprecated."
+                                        },
+                                        "numberOfSeats": {
+                                          "type": "integer",
+                                          "description": "The maximum count of users on your license."
+                                        },
+                                        "remainingSeats": {
+                                          "type": "integer",
+                                          "description": "The count of users remaining on your license."
+                                        },
+                                        "userCount": {
+                                          "type": "integer",
+                                          "description": "The number of users counting against your license."
+                                        },
+                                        "userCountDescription": {
+                                          "type": "string",
+                                          "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                        },
+                                        "hasUnlimitedSeats": {
+                                          "type": "boolean"
+                                        },
+                                        "platform": {
+                                          "type": "boolean",
+                                          "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "expand": {
+                                "type": "string",
+                                "description": "Expand options that include additional user details in the response.",
+                                "readOnly": true,
+                                "xml": { "attribute": true }
+                              }
+                            }
+                          },
+                          "leadUserName": {
+                            "type": "string",
+                            "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                          },
+                          "leadAccountId": {
+                            "maxLength": 128,
+                            "type": "string",
+                            "description": "The accountId of the component's lead user. The accountId uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*.",
+                            "writeOnly": true
+                          },
+                          "assigneeType": {
+                            "type": "string",
+                            "description": "The nominal user type used to determine the assignee for issues created with this component. See `realAssigneeType` for details on how the type of the user, and hence the user, assigned to issues is determined. Can take the following values:\n\n *  `PROJECT_LEAD` the assignee to any issues created with this component is nominally the lead for the project the component is in.\n *  `COMPONENT_LEAD` the assignee to any issues created with this component is nominally the lead for the component.\n *  `UNASSIGNED` an assignee is not set for issues created with this component.\n *  `PROJECT_DEFAULT` the assignee to any issues created with this component is nominally the default assignee for the project that the component is in.\n\nDefault value: `PROJECT_DEFAULT`.  \nOptional when creating or updating a component.",
+                            "enum": [
+                              "PROJECT_DEFAULT",
+                              "COMPONENT_LEAD",
+                              "PROJECT_LEAD",
+                              "UNASSIGNED"
+                            ]
+                          },
+                          "assignee": {
+                            "description": "The details of the user associated with `assigneeType`, if any. See `realAssignee` for details of the user assigned to issues created with this component.",
+                            "readOnly": true,
+                            "type": "object",
+                            "properties": {
+                              "self": {
+                                "type": "string",
+                                "description": "The URL of the user.",
+                                "readOnly": true
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "accountId": {
+                                "maxLength": 128,
+                                "type": "string",
+                                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                              },
+                              "accountType": {
+                                "type": "string",
+                                "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                                "readOnly": true,
+                                "enum": [
+                                  "atlassian",
+                                  "app",
+                                  "customer",
+                                  "unknown"
+                                ]
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "emailAddress": {
+                                "type": "string",
+                                "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                                "readOnly": true
+                              },
+                              "avatarUrls": {
+                                "description": "The avatars of the user.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "16x16": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 16x16 pixel avatar."
+                                  },
+                                  "24x24": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 24x24 pixel avatar."
+                                  },
+                                  "32x32": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 32x32 pixel avatar."
+                                  },
+                                  "48x48": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 48x48 pixel avatar."
+                                  }
+                                }
+                              },
+                              "displayName": {
+                                "type": "string",
+                                "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                                "readOnly": true
+                              },
+                              "active": {
+                                "type": "boolean",
+                                "description": "Whether the user is active.",
+                                "readOnly": true
+                              },
+                              "timeZone": {
+                                "type": "string",
+                                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                                "readOnly": true
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                                "readOnly": true
+                              },
+                              "groups": {
+                                "description": "The groups that the user belongs to.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The name of group."
+                                        },
+                                        "self": {
+                                          "type": "string",
+                                          "description": "The URL for these group details.",
+                                          "readOnly": true
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "applicationRoles": {
+                                "description": "The application roles the user is assigned to.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "key": {
+                                          "type": "string",
+                                          "description": "The key of the application role."
+                                        },
+                                        "groups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups associated with the application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The display name of the application role."
+                                        },
+                                        "defaultGroups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups that are granted default access for this application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "selectedByDefault": {
+                                          "type": "boolean",
+                                          "description": "Determines whether this application role should be selected by default on user creation."
+                                        },
+                                        "defined": {
+                                          "type": "boolean",
+                                          "description": "Deprecated."
+                                        },
+                                        "numberOfSeats": {
+                                          "type": "integer",
+                                          "description": "The maximum count of users on your license."
+                                        },
+                                        "remainingSeats": {
+                                          "type": "integer",
+                                          "description": "The count of users remaining on your license."
+                                        },
+                                        "userCount": {
+                                          "type": "integer",
+                                          "description": "The number of users counting against your license."
+                                        },
+                                        "userCountDescription": {
+                                          "type": "string",
+                                          "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                        },
+                                        "hasUnlimitedSeats": {
+                                          "type": "boolean"
+                                        },
+                                        "platform": {
+                                          "type": "boolean",
+                                          "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "expand": {
+                                "type": "string",
+                                "description": "Expand options that include additional user details in the response.",
+                                "readOnly": true,
+                                "xml": { "attribute": true }
+                              }
+                            }
+                          },
+                          "realAssigneeType": {
+                            "type": "string",
+                            "description": "The type of the assignee that is assigned to issues created with this component, when an assignee cannot be set from the `assigneeType`. For example, `assigneeType` is set to `COMPONENT_LEAD` but no component lead is set. This property is set to one of the following values:\n\n *  `PROJECT_LEAD` when `assigneeType` is `PROJECT_LEAD` and the project lead has permission to be assigned issues in the project that the component is in.\n *  `COMPONENT_LEAD` when `assignee`Type is `COMPONENT_LEAD` and the component lead has permission to be assigned issues in the project that the component is in.\n *  `UNASSIGNED` when `assigneeType` is `UNASSIGNED` and Jira is configured to allow unassigned issues.\n *  `PROJECT_DEFAULT` when none of the preceding cases are true.",
+                            "readOnly": true,
+                            "enum": [
+                              "PROJECT_DEFAULT",
+                              "COMPONENT_LEAD",
+                              "PROJECT_LEAD",
+                              "UNASSIGNED"
+                            ]
+                          },
+                          "realAssignee": {
+                            "description": "The user assigned to issues created with this component, when `assigneeType` does not identify a valid assignee.",
+                            "readOnly": true,
+                            "type": "object",
+                            "properties": {
+                              "self": {
+                                "type": "string",
+                                "description": "The URL of the user.",
+                                "readOnly": true
+                              },
+                              "key": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "accountId": {
+                                "maxLength": 128,
+                                "type": "string",
+                                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                              },
+                              "accountType": {
+                                "type": "string",
+                                "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                                "readOnly": true,
+                                "enum": [
+                                  "atlassian",
+                                  "app",
+                                  "customer",
+                                  "unknown"
+                                ]
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                              },
+                              "emailAddress": {
+                                "type": "string",
+                                "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                                "readOnly": true
+                              },
+                              "avatarUrls": {
+                                "description": "The avatars of the user.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "16x16": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 16x16 pixel avatar."
+                                  },
+                                  "24x24": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 24x24 pixel avatar."
+                                  },
+                                  "32x32": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 32x32 pixel avatar."
+                                  },
+                                  "48x48": {
+                                    "type": "string",
+                                    "description": "The URL of the item's 48x48 pixel avatar."
+                                  }
+                                }
+                              },
+                              "displayName": {
+                                "type": "string",
+                                "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                                "readOnly": true
+                              },
+                              "active": {
+                                "type": "boolean",
+                                "description": "Whether the user is active.",
+                                "readOnly": true
+                              },
+                              "timeZone": {
+                                "type": "string",
+                                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                                "readOnly": true
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                                "readOnly": true
+                              },
+                              "groups": {
+                                "description": "The groups that the user belongs to.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The name of group."
+                                        },
+                                        "self": {
+                                          "type": "string",
+                                          "description": "The URL for these group details.",
+                                          "readOnly": true
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "applicationRoles": {
+                                "description": "The application roles the user is assigned to.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "size": {
+                                    "type": "integer",
+                                    "xml": { "attribute": true }
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "key": {
+                                          "type": "string",
+                                          "description": "The key of the application role."
+                                        },
+                                        "groups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups associated with the application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "The display name of the application role."
+                                        },
+                                        "defaultGroups": {
+                                          "uniqueItems": true,
+                                          "type": "array",
+                                          "description": "The groups that are granted default access for this application role.",
+                                          "items": { "type": "string" }
+                                        },
+                                        "selectedByDefault": {
+                                          "type": "boolean",
+                                          "description": "Determines whether this application role should be selected by default on user creation."
+                                        },
+                                        "defined": {
+                                          "type": "boolean",
+                                          "description": "Deprecated."
+                                        },
+                                        "numberOfSeats": {
+                                          "type": "integer",
+                                          "description": "The maximum count of users on your license."
+                                        },
+                                        "remainingSeats": {
+                                          "type": "integer",
+                                          "description": "The count of users remaining on your license."
+                                        },
+                                        "userCount": {
+                                          "type": "integer",
+                                          "description": "The number of users counting against your license."
+                                        },
+                                        "userCountDescription": {
+                                          "type": "string",
+                                          "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                        },
+                                        "hasUnlimitedSeats": {
+                                          "type": "boolean"
+                                        },
+                                        "platform": {
+                                          "type": "boolean",
+                                          "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "pagingCallback": { "type": "object" },
+                                  "callback": { "type": "object" },
+                                  "max-results": {
+                                    "type": "integer",
+                                    "xml": {
+                                      "name": "max-results",
+                                      "attribute": true
+                                    }
+                                  }
+                                }
+                              },
+                              "expand": {
+                                "type": "string",
+                                "description": "Expand options that include additional user details in the response.",
+                                "readOnly": true,
+                                "xml": { "attribute": true }
+                              }
+                            }
+                          },
+                          "isAssigneeTypeValid": {
+                            "type": "boolean",
+                            "description": "Whether a user is associated with `assigneeType`. For example, if the `assigneeType` is set to `COMPONENT_LEAD` but the component lead is not set, then `false` is returned.",
+                            "readOnly": true
+                          },
+                          "project": {
+                            "type": "string",
+                            "description": "The key of the project the component is assigned to. Required when creating a component. Can't be updated."
+                          },
+                          "projectId": {
+                            "type": "integer",
+                            "description": "The ID of the project the component is assigned to.",
+                            "readOnly": true
+                          }
+                        }
+                      }
+                    },
+                    "issueTypes": {
+                      "type": "array",
+                      "description": "List of the issue types available in the project.",
+                      "readOnly": true,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "type": "string",
+                            "description": "The URL of these issue type details.",
+                            "readOnly": true
+                          },
+                          "id": {
+                            "type": "string",
+                            "description": "The ID of the issue type.",
+                            "readOnly": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "The description of the issue type.",
+                            "readOnly": true
+                          },
+                          "iconUrl": {
+                            "type": "string",
+                            "description": "The URL of the issue type's avatar.",
+                            "readOnly": true
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the issue type.",
+                            "readOnly": true
+                          },
+                          "subtask": {
+                            "type": "boolean",
+                            "description": "Whether this issue type is used to create subtasks.",
+                            "readOnly": true
+                          },
+                          "avatarId": {
+                            "type": "integer",
+                            "description": "The ID of the issue type's avatar.",
+                            "readOnly": true
+                          },
+                          "entityId": {
+                            "type": "string",
+                            "description": "Unique ID for next-gen projects.",
+                            "readOnly": true
+                          },
+                          "hierarchyLevel": {
+                            "type": "integer",
+                            "description": "Hierarchy level of the issue type.",
+                            "readOnly": true
+                          },
+                          "scope": {
+                            "description": "Details of the next-gen projects the issue type is available in.",
+                            "readOnly": true,
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "description": "The type of scope.",
+                                "readOnly": true,
+                                "enum": ["PROJECT", "TEMPLATE"]
+                              },
+                              "project": {
+                                "description": "The project the item has scope in.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL of the project details.",
+                                    "readOnly": true
+                                  },
+                                  "id": {
+                                    "type": "string",
+                                    "description": "The ID of the project."
+                                  },
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the project.",
+                                    "readOnly": true
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of the project.",
+                                    "readOnly": true
+                                  },
+                                  "projectTypeKey": {
+                                    "type": "string",
+                                    "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                                    "readOnly": true,
+                                    "enum": [
+                                      "software",
+                                      "service_desk",
+                                      "business"
+                                    ]
+                                  },
+                                  "simplified": {
+                                    "type": "boolean",
+                                    "description": "Whether or not the project is simplified.",
+                                    "readOnly": true
+                                  },
+                                  "avatarUrls": {
+                                    "description": "The URLs of the project's avatars.",
+                                    "readOnly": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "16x16": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 16x16 pixel avatar."
+                                      },
+                                      "24x24": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 24x24 pixel avatar."
+                                      },
+                                      "32x32": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 32x32 pixel avatar."
+                                      },
+                                      "48x48": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 48x48 pixel avatar."
+                                      }
+                                    }
+                                  },
+                                  "projectCategory": {
+                                    "description": "The category the project belongs to.",
+                                    "readOnly": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "self": {
+                                        "type": "string",
+                                        "description": "The URL of the project category.",
+                                        "readOnly": true
+                                      },
+                                      "id": {
+                                        "type": "string",
+                                        "description": "The ID of the project category.",
+                                        "readOnly": true
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "The name of the project category.",
+                                        "readOnly": true
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "description": "The description of the project category.",
+                                        "readOnly": true
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "A link to information about this project, such as project documentation.",
+                      "readOnly": true
+                    },
+                    "email": {
+                      "type": "string",
+                      "description": "An email address associated with the project."
+                    },
+                    "assigneeType": {
+                      "type": "string",
+                      "description": "The default assignee when creating issues for this project.",
+                      "readOnly": true,
+                      "enum": ["PROJECT_LEAD", "UNASSIGNED"]
+                    },
+                    "versions": {
+                      "type": "array",
+                      "description": "The versions defined in the project. For more information, see [Create version](#api-rest-api-3-version-post).",
+                      "readOnly": true,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "expand": {
+                            "type": "string",
+                            "description": "Use [expand](em>#expansion) to include additional information about version in the response. This parameter accepts a comma-separated list. Expand options include:\n\n *  `operations` Returns the list of operations available for this version.\n *  `issuesstatus` Returns the count of issues in this version for each of the status categories *to do*, *in progress*, *done*, and *unmapped*. The *unmapped* property contains a count of issues with a status other than *to do*, *in progress*, and *done*.\n\nOptional for create and update.",
+                            "xml": { "attribute": true }
+                          },
+                          "self": {
+                            "type": "string",
+                            "description": "The URL of the version.",
+                            "readOnly": true
+                          },
+                          "id": {
+                            "type": "string",
+                            "description": "The ID of the version.",
+                            "readOnly": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "The description of the version. Optional when creating or updating a version."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The unique name of the version. Required when creating a version. Optional when updating a version. The maximum length is 255 characters."
+                          },
+                          "archived": {
+                            "type": "boolean",
+                            "description": "Indicates that the version is archived. Optional when creating or updating a version."
+                          },
+                          "released": {
+                            "type": "boolean",
+                            "description": "Indicates that the version is released. If the version is released a request to release again is ignored. Not applicable when creating a version. Optional when updating a version."
+                          },
+                          "startDate": {
+                            "type": "string",
+                            "description": "The start date of the version. Expressed in ISO 8601 format (yyyy-mm-dd). Optional when creating or updating a version.",
+                            "format": "date"
+                          },
+                          "releaseDate": {
+                            "type": "string",
+                            "description": "The release date of the version. Expressed in ISO 8601 format (yyyy-mm-dd). Optional when creating or updating a version.",
+                            "format": "date"
+                          },
+                          "overdue": {
+                            "type": "boolean",
+                            "description": "Indicates that the version is overdue.",
+                            "readOnly": true
+                          },
+                          "userStartDate": {
+                            "type": "string",
+                            "description": "The date on which work on this version is expected to start, expressed in the instance's *Day/Month/Year Format* date format.",
+                            "readOnly": true
+                          },
+                          "userReleaseDate": {
+                            "type": "string",
+                            "description": "The date on which work on this version is expected to finish, expressed in the instance's *Day/Month/Year Format* date format.",
+                            "readOnly": true
+                          },
+                          "project": {
+                            "type": "string",
+                            "description": "Deprecated. Use `projectId`."
+                          },
+                          "projectId": {
+                            "type": "integer",
+                            "description": "The ID of the project to which this version is attached. Required when creating a version. Not applicable when updating a version."
+                          },
+                          "moveUnfixedIssuesTo": {
+                            "type": "string",
+                            "description": "The URL of the self link to the version to which all unfixed issues are moved when a version is released. Not applicable when creating a version. Optional when updating a version."
+                          },
+                          "operations": {
+                            "type": "array",
+                            "description": "If the expand option `operations` is used, returns the list of operations available for this version.",
+                            "readOnly": true,
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": { "type": "string" },
+                                "styleClass": { "type": "string" },
+                                "iconClass": { "type": "string" },
+                                "label": { "type": "string" },
+                                "title": { "type": "string" },
+                                "href": { "type": "string" },
+                                "weight": { "type": "integer" }
+                              }
+                            }
+                          },
+                          "issuesStatusForFixVersion": {
+                            "description": "If the expand option `issuesstatus` is used, returns the count of issues in this version for each of the status categories *to do*, *in progress*, *done*, and *unmapped*. The *unmapped* property contains a count of issues with a status other than *to do*, *in progress*, and *done*.",
+                            "readOnly": true,
+                            "type": "object",
+                            "properties": {
+                              "unmapped": {
+                                "type": "integer",
+                                "description": "Count of issues with a status other than *to do*, *in progress*, and *done*.",
+                                "readOnly": true
+                              },
+                              "toDo": {
+                                "type": "integer",
+                                "description": "Count of issues with status *to do*.",
+                                "readOnly": true
+                              },
+                              "inProgress": {
+                                "type": "integer",
+                                "description": "Count of issues with status *in progress*.",
+                                "readOnly": true
+                              },
+                              "done": {
+                                "type": "integer",
+                                "description": "Count of issues with status *done*.",
+                                "readOnly": true
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the project.",
+                      "readOnly": true
+                    },
+                    "roles": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The name and self URL for each role defined in the project. For more information, see [Create project role](#api-rest-api-3-role-post).",
+                      "readOnly": true
+                    },
+                    "avatarUrls": {
+                      "description": "The URLs of the project's avatars.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "16x16": {
+                          "type": "string",
+                          "description": "The URL of the item's 16x16 pixel avatar."
+                        },
+                        "24x24": {
+                          "type": "string",
+                          "description": "The URL of the item's 24x24 pixel avatar."
+                        },
+                        "32x32": {
+                          "type": "string",
+                          "description": "The URL of the item's 32x32 pixel avatar."
+                        },
+                        "48x48": {
+                          "type": "string",
+                          "description": "The URL of the item's 48x48 pixel avatar."
+                        }
+                      }
+                    },
+                    "projectCategory": {
+                      "description": "The category the project belongs to.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the project category.",
+                          "readOnly": true
+                        },
+                        "id": {
+                          "type": "string",
+                          "description": "The ID of the project category.",
+                          "readOnly": true
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The name of the project category. Required on create, optional on update."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "The description of the project category. Required on create, optional on update."
+                        }
+                      }
+                    },
+                    "projectTypeKey": {
+                      "type": "string",
+                      "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                      "readOnly": true,
+                      "enum": ["software", "service_desk", "business"]
+                    },
+                    "simplified": {
+                      "type": "boolean",
+                      "description": "Whether the project is simplified.",
+                      "readOnly": true
+                    },
+                    "style": {
+                      "type": "string",
+                      "description": "The type of the project.",
+                      "readOnly": true,
+                      "enum": ["classic", "next-gen"]
+                    },
+                    "favourite": {
+                      "type": "boolean",
+                      "description": "Whether the project is selected as a favorite."
+                    },
+                    "isPrivate": {
+                      "type": "boolean",
+                      "description": "Whether the project is private.",
+                      "readOnly": true
+                    },
+                    "issueTypeHierarchy": {
+                      "description": "The issue type hierarchy for the project",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "level": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": { "type": "integer" },
+                              "name": { "type": "string" },
+                              "aboveLevelId": { "type": "integer" },
+                              "belowLevelId": { "type": "integer" },
+                              "projectConfigurationId": { "type": "integer" },
+                              "level": { "type": "integer" },
+                              "issueTypeIds": {
+                                "type": "array",
+                                "items": { "type": "integer" }
+                              },
+                              "externalUuid": { "type": "string" },
+                              "globalHierarchyLevel": {
+                                "type": "string",
+                                "enum": ["SUBTASK", "BASE", "EPIC"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "permissions": {
+                      "description": "User permissions on the project",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "canEdit": {
+                          "type": "boolean",
+                          "description": "Whether the logged user can edit the project.",
+                          "readOnly": true
+                        }
+                      }
+                    },
+                    "properties": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Map of project properties",
+                      "readOnly": true
+                    },
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique ID for next-gen projects.",
+                      "readOnly": true
+                    },
+                    "insight": {
+                      "description": "Insights about the project.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "totalIssueCount": {
+                          "type": "integer",
+                          "description": "Total issue count.",
+                          "readOnly": true
+                        },
+                        "lastIssueUpdateTime": {
+                          "type": "string",
+                          "description": "The last issue update time.",
+                          "format": "date-time",
+                          "readOnly": true
+                        }
+                      }
+                    },
+                    "deleted": {
+                      "type": "boolean",
+                      "description": "Whether the project is marked as deleted.",
+                      "readOnly": true
+                    },
+                    "retentionTillDate": {
+                      "type": "string",
+                      "description": "The date when the project is deleted permanently.",
+                      "format": "date-time",
+                      "readOnly": true
+                    },
+                    "deletedDate": {
+                      "type": "string",
+                      "description": "The date when the project was marked as deleted.",
+                      "format": "date-time",
+                      "readOnly": true
+                    },
+                    "deletedBy": {
+                      "description": "The user who marked the project as deleted.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the user.",
+                          "readOnly": true
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "accountId": {
+                          "maxLength": 128,
+                          "type": "string",
+                          "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                        },
+                        "accountType": {
+                          "type": "string",
+                          "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                          "readOnly": true,
+                          "enum": ["atlassian", "app", "customer", "unknown"]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "emailAddress": {
+                          "type": "string",
+                          "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "avatarUrls": {
+                          "description": "The avatars of the user.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "16x16": {
+                              "type": "string",
+                              "description": "The URL of the item's 16x16 pixel avatar."
+                            },
+                            "24x24": {
+                              "type": "string",
+                              "description": "The URL of the item's 24x24 pixel avatar."
+                            },
+                            "32x32": {
+                              "type": "string",
+                              "description": "The URL of the item's 32x32 pixel avatar."
+                            },
+                            "48x48": {
+                              "type": "string",
+                              "description": "The URL of the item's 48x48 pixel avatar."
+                            }
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                          "readOnly": true
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the user is active.",
+                          "readOnly": true
+                        },
+                        "timeZone": {
+                          "type": "string",
+                          "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "groups": {
+                          "description": "The groups that the user belongs to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of group."
+                                  },
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL for these group details.",
+                                    "readOnly": true
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "applicationRoles": {
+                          "description": "The application roles the user is assigned to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the application role."
+                                  },
+                                  "groups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups associated with the application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The display name of the application role."
+                                  },
+                                  "defaultGroups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups that are granted default access for this application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "selectedByDefault": {
+                                    "type": "boolean",
+                                    "description": "Determines whether this application role should be selected by default on user creation."
+                                  },
+                                  "defined": {
+                                    "type": "boolean",
+                                    "description": "Deprecated."
+                                  },
+                                  "numberOfSeats": {
+                                    "type": "integer",
+                                    "description": "The maximum count of users on your license."
+                                  },
+                                  "remainingSeats": {
+                                    "type": "integer",
+                                    "description": "The count of users remaining on your license."
+                                  },
+                                  "userCount": {
+                                    "type": "integer",
+                                    "description": "The number of users counting against your license."
+                                  },
+                                  "userCountDescription": {
+                                    "type": "string",
+                                    "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                  },
+                                  "hasUnlimitedSeats": { "type": "boolean" },
+                                  "platform": {
+                                    "type": "boolean",
+                                    "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "expand": {
+                          "type": "string",
+                          "description": "Expand options that include additional user details in the response.",
+                          "readOnly": true,
+                          "xml": { "attribute": true }
+                        }
+                      }
+                    },
+                    "archived": {
+                      "type": "boolean",
+                      "description": "Whether the project is archived.",
+                      "readOnly": true
+                    },
+                    "archivedDate": {
+                      "type": "string",
+                      "description": "The date when the project was archived.",
+                      "format": "date-time",
+                      "readOnly": true
+                    },
+                    "archivedBy": {
+                      "description": "The user who archived the project.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the user.",
+                          "readOnly": true
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "accountId": {
+                          "maxLength": 128,
+                          "type": "string",
+                          "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                        },
+                        "accountType": {
+                          "type": "string",
+                          "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                          "readOnly": true,
+                          "enum": ["atlassian", "app", "customer", "unknown"]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "emailAddress": {
+                          "type": "string",
+                          "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "avatarUrls": {
+                          "description": "The avatars of the user.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "16x16": {
+                              "type": "string",
+                              "description": "The URL of the item's 16x16 pixel avatar."
+                            },
+                            "24x24": {
+                              "type": "string",
+                              "description": "The URL of the item's 24x24 pixel avatar."
+                            },
+                            "32x32": {
+                              "type": "string",
+                              "description": "The URL of the item's 32x32 pixel avatar."
+                            },
+                            "48x48": {
+                              "type": "string",
+                              "description": "The URL of the item's 48x48 pixel avatar."
+                            }
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                          "readOnly": true
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the user is active.",
+                          "readOnly": true
+                        },
+                        "timeZone": {
+                          "type": "string",
+                          "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "groups": {
+                          "description": "The groups that the user belongs to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of group."
+                                  },
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL for these group details.",
+                                    "readOnly": true
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "applicationRoles": {
+                          "description": "The application roles the user is assigned to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the application role."
+                                  },
+                                  "groups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups associated with the application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The display name of the application role."
+                                  },
+                                  "defaultGroups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups that are granted default access for this application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "selectedByDefault": {
+                                    "type": "boolean",
+                                    "description": "Determines whether this application role should be selected by default on user creation."
+                                  },
+                                  "defined": {
+                                    "type": "boolean",
+                                    "description": "Deprecated."
+                                  },
+                                  "numberOfSeats": {
+                                    "type": "integer",
+                                    "description": "The maximum count of users on your license."
+                                  },
+                                  "remainingSeats": {
+                                    "type": "integer",
+                                    "description": "The count of users remaining on your license."
+                                  },
+                                  "userCount": {
+                                    "type": "integer",
+                                    "description": "The number of users counting against your license."
+                                  },
+                                  "userCountDescription": {
+                                    "type": "string",
+                                    "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                  },
+                                  "hasUnlimitedSeats": { "type": "boolean" },
+                                  "platform": {
+                                    "type": "boolean",
+                                    "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "expand": {
+                          "type": "string",
+                          "description": "Expand options that include additional user details in the response.",
+                          "readOnly": true,
+                          "xml": { "attribute": true }
+                        }
+                      }
+                    }
+                  }
+                },
+                "role": {
+                  "description": "The project role that the filter is shared with.  \nFor a request, specify the `id` for the role. You must also specify the `project` object and `id` for the project that the role is in.",
+                  "type": "object",
+                  "properties": {
+                    "self": {
+                      "type": "string",
+                      "description": "The URL the project role details.",
+                      "readOnly": true
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the project role."
+                    },
+                    "id": {
+                      "type": "integer",
+                      "description": "The ID of the project role.",
+                      "readOnly": true
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "The description of the project role.",
+                      "readOnly": true
+                    },
+                    "actors": {
+                      "type": "array",
+                      "description": "The list of users who act in this role.",
+                      "readOnly": true,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "The ID of the role actor.",
+                            "readOnly": true
+                          },
+                          "displayName": {
+                            "type": "string",
+                            "description": "The display name of the role actor. For users, depending on the user\u2019s privacy setting, this may return an alternative value for the user's name.",
+                            "readOnly": true
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The type of role actor.",
+                            "readOnly": true,
+                            "enum": [
+                              "atlassian-group-role-actor",
+                              "atlassian-user-role-actor"
+                            ]
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                            "readOnly": true
+                          },
+                          "avatarUrl": {
+                            "type": "string",
+                            "description": "The avatar of the role actor.",
+                            "readOnly": true
+                          },
+                          "actorUser": {
+                            "readOnly": true,
+                            "type": "object",
+                            "properties": {
+                              "accountId": {
+                                "maxLength": 128,
+                                "type": "string",
+                                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Returns *unknown* if the record is deleted and corrupted, for example, as the result of a server import.",
+                                "readOnly": true
+                              }
+                            }
+                          },
+                          "actorGroup": {
+                            "readOnly": true,
+                            "type": "object",
+                            "properties": {
+                              "displayName": {
+                                "type": "string",
+                                "description": "The display name of the group."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The name of the group"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "scope": {
+                      "description": "The scope of the role. Indicated for roles associated with [next-gen projects](https://confluence.atlassian.com/x/loMyO).",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "The type of scope.",
+                          "readOnly": true,
+                          "enum": ["PROJECT", "TEMPLATE"]
+                        },
+                        "project": {
+                          "description": "The project the item has scope in.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "self": {
+                              "type": "string",
+                              "description": "The URL of the project details.",
+                              "readOnly": true
+                            },
+                            "id": {
+                              "type": "string",
+                              "description": "The ID of the project."
+                            },
+                            "key": {
+                              "type": "string",
+                              "description": "The key of the project.",
+                              "readOnly": true
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the project.",
+                              "readOnly": true
+                            },
+                            "projectTypeKey": {
+                              "type": "string",
+                              "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                              "readOnly": true,
+                              "enum": ["software", "service_desk", "business"]
+                            },
+                            "simplified": {
+                              "type": "boolean",
+                              "description": "Whether or not the project is simplified.",
+                              "readOnly": true
+                            },
+                            "avatarUrls": {
+                              "description": "The URLs of the project's avatars.",
+                              "readOnly": true,
+                              "type": "object",
+                              "properties": {
+                                "16x16": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 16x16 pixel avatar."
+                                },
+                                "24x24": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 24x24 pixel avatar."
+                                },
+                                "32x32": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 32x32 pixel avatar."
+                                },
+                                "48x48": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 48x48 pixel avatar."
+                                }
+                              }
+                            },
+                            "projectCategory": {
+                              "description": "The category the project belongs to.",
+                              "readOnly": true,
+                              "type": "object",
+                              "properties": {
+                                "self": {
+                                  "type": "string",
+                                  "description": "The URL of the project category.",
+                                  "readOnly": true
+                                },
+                                "id": {
+                                  "type": "string",
+                                  "description": "The ID of the project category.",
+                                  "readOnly": true
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "description": "The name of the project category.",
+                                  "readOnly": true
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "The description of the project category.",
+                                  "readOnly": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "translatedName": {
+                      "type": "string",
+                      "description": "The translated name of the project role."
+                    },
+                    "currentUserRole": {
+                      "type": "boolean",
+                      "description": "Whether the calling user is part of this role."
+                    },
+                    "admin": {
+                      "type": "boolean",
+                      "description": "Whether this role is the admin role for the project.",
+                      "readOnly": true
+                    },
+                    "roleConfigurable": {
+                      "type": "boolean",
+                      "description": "Whether the roles are configurable for this project.",
+                      "readOnly": true
+                    },
+                    "default": {
+                      "type": "boolean",
+                      "description": "Whether this role is the default role for the project",
+                      "readOnly": true
+                    }
+                  }
+                },
+                "group": {
+                  "description": "The group that the filter is shared with. For a request, specify the `name` property for the group.",
+                  "type": "object",
+                  "properties": {
+                    "groupId": { "type": ["null", "string"] },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of group."
+                    },
+                    "self": {
+                      "type": "string",
+                      "description": "The URL for these group details.",
+                      "readOnly": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "isWritable": {
+            "description": "Indicates if the filter is writable or read-only",
+            "type": "boolean"
+          },
+          "approximateLastUsed": {
+            "description": "The approximate last time the filter was used",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "subscriptions": {
+            "type": "array",
+            "description": "The users that are subscribed to the filter.",
+            "readOnly": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "description": "The ID of the filter subscription.",
+                  "readOnly": true
+                },
+                "user": {
+                  "description": "The user subscribing to filter.",
+                  "readOnly": true,
+                  "type": "object",
+                  "properties": {
+                    "self": {
+                      "type": "string",
+                      "description": "The URL of the user.",
+                      "readOnly": true
+                    },
+                    "key": {
+                      "type": "string",
+                      "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                    },
+                    "accountId": {
+                      "maxLength": 128,
+                      "type": "string",
+                      "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                    },
+                    "accountType": {
+                      "type": "string",
+                      "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                      "readOnly": true,
+                      "enum": ["atlassian", "app", "customer", "unknown"]
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                    },
+                    "emailAddress": {
+                      "type": "string",
+                      "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                      "readOnly": true
+                    },
+                    "avatarUrls": {
+                      "description": "The avatars of the user.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "16x16": {
+                          "type": "string",
+                          "description": "The URL of the item's 16x16 pixel avatar."
+                        },
+                        "24x24": {
+                          "type": "string",
+                          "description": "The URL of the item's 24x24 pixel avatar."
+                        },
+                        "32x32": {
+                          "type": "string",
+                          "description": "The URL of the item's 32x32 pixel avatar."
+                        },
+                        "48x48": {
+                          "type": "string",
+                          "description": "The URL of the item's 48x48 pixel avatar."
+                        }
+                      }
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                      "readOnly": true
+                    },
+                    "active": {
+                      "type": "boolean",
+                      "description": "Whether the user is active.",
+                      "readOnly": true
+                    },
+                    "timeZone": {
+                      "type": "string",
+                      "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                      "readOnly": true
+                    },
+                    "locale": {
+                      "type": "string",
+                      "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                      "readOnly": true
+                    },
+                    "groups": {
+                      "description": "The groups that the user belongs to.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "size": {
+                          "type": "integer",
+                          "xml": { "attribute": true }
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "The name of group."
+                              },
+                              "self": {
+                                "type": "string",
+                                "description": "The URL for these group details.",
+                                "readOnly": true
+                              }
+                            }
+                          }
+                        },
+                        "pagingCallback": { "type": "object" },
+                        "callback": { "type": "object" },
+                        "max-results": {
+                          "type": "integer",
+                          "xml": { "name": "max-results", "attribute": true }
+                        }
+                      }
+                    },
+                    "applicationRoles": {
+                      "description": "The application roles the user is assigned to.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "size": {
+                          "type": "integer",
+                          "xml": { "attribute": true }
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "description": "The key of the application role."
+                              },
+                              "groups": {
+                                "uniqueItems": true,
+                                "type": "array",
+                                "description": "The groups associated with the application role.",
+                                "items": { "type": "string" }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The display name of the application role."
+                              },
+                              "defaultGroups": {
+                                "uniqueItems": true,
+                                "type": "array",
+                                "description": "The groups that are granted default access for this application role.",
+                                "items": { "type": "string" }
+                              },
+                              "selectedByDefault": {
+                                "type": "boolean",
+                                "description": "Determines whether this application role should be selected by default on user creation."
+                              },
+                              "defined": {
+                                "type": "boolean",
+                                "description": "Deprecated."
+                              },
+                              "numberOfSeats": {
+                                "type": "integer",
+                                "description": "The maximum count of users on your license."
+                              },
+                              "remainingSeats": {
+                                "type": "integer",
+                                "description": "The count of users remaining on your license."
+                              },
+                              "userCount": {
+                                "type": "integer",
+                                "description": "The number of users counting against your license."
+                              },
+                              "userCountDescription": {
+                                "type": "string",
+                                "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                              },
+                              "hasUnlimitedSeats": { "type": "boolean" },
+                              "platform": {
+                                "type": "boolean",
+                                "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                              }
+                            }
+                          }
+                        },
+                        "pagingCallback": { "type": "object" },
+                        "callback": { "type": "object" },
+                        "max-results": {
+                          "type": "integer",
+                          "xml": { "name": "max-results", "attribute": true }
+                        }
+                      }
+                    },
+                    "expand": {
+                      "type": "string",
+                      "description": "Expand options that include additional user details in the response.",
+                      "readOnly": true,
+                      "xml": { "attribute": true }
+                    }
+                  }
+                },
+                "group": {
+                  "description": "The group subscribing to filter.",
+                  "readOnly": true,
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "The name of group."
+                    },
+                    "self": {
+                      "type": "string",
+                      "description": "The URL for these group details.",
+                      "readOnly": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of a filter."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "groups",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the group.",
+            "type": ["null", "string"]
+          },
+          "groupId": {
+            "description": "The ID of the group, if available, which uniquely identifies the group across all Atlassian products. For example, *952d12c3-5b5b-4d04-bb32-44d383afc4b2*.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "The list of groups found in a search, including header text (Showing X of Y matching groups) and total of matched groups."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["groupId"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_fields",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": { "description": "The ID of the field.", "type": "string" },
+          "key": { "description": "The key of the field.", "type": "string" },
+          "name": { "description": "The name of the field.", "type": "string" },
+          "custom": {
+            "description": "Whether the field is a custom field.",
+            "type": "boolean"
+          },
+          "orderable": {
+            "description": "Whether the content of the field can be used to order lists.",
+            "type": "boolean"
+          },
+          "navigable": {
+            "description": "Whether the field can be used as a column on the issue navigator.",
+            "type": "boolean"
+          },
+          "searchable": {
+            "description": "Whether the content of the field can be searched.",
+            "type": "boolean"
+          },
+          "clauseNames": {
+            "description": "The names that can be used to reference the field in an advanced search. For more information, see [Advanced searching - fields reference](https://confluence.atlassian.com/x/gwORLQ).",
+            "uniqueItems": true,
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "scope": {
+            "description": "The scope of the field.",
+            "type": ["object", "null"],
+            "properties": {
+              "type": {
+                "description": "The type of scope.",
+                "type": "string",
+                "readOnly": true,
+                "enum": ["PROJECT", "TEMPLATE"]
+              },
+              "project": {
+                "description": "The project the item has scope in.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "description": "The URL of the project details.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "id": {
+                    "description": "The ID of the project.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "The key of the project.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "name": {
+                    "description": "The name of the project.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "projectTypeKey": {
+                    "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                    "type": "string",
+                    "readOnly": true,
+                    "enum": ["software", "service_desk", "business"]
+                  },
+                  "simplified": {
+                    "description": "Whether or not the project is simplified.",
+                    "type": "boolean",
+                    "readOnly": true
+                  },
+                  "avatarUrls": {
+                    "description": "The URLs of the project's avatars.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "16x16": {
+                        "description": "The URL of the item's 16x16 pixel avatar.",
+                        "type": "string"
+                      },
+                      "24x24": {
+                        "description": "The URL of the item's 24x24 pixel avatar.",
+                        "type": "string"
+                      },
+                      "32x32": {
+                        "description": "The URL of the item's 32x32 pixel avatar.",
+                        "type": "string"
+                      },
+                      "48x48": {
+                        "description": "The URL of the item's 48x48 pixel avatar.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "projectCategory": {
+                    "description": "The category the project belongs to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "self": {
+                        "description": "The URL of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "id": {
+                        "description": "The ID of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "description": {
+                        "description": "The name of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "name": {
+                        "description": "The description of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "schema": {
+            "description": "The data schema for the field.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "description": "The data type of the field.",
+                "type": "string",
+                "readOnly": true
+              },
+              "items": {
+                "description": "When the data type is an array, the name of the field items within the array.",
+                "type": "string",
+                "readOnly": true
+              },
+              "system": {
+                "description": "If the field is a system field, the name of the field.",
+                "type": "string",
+                "readOnly": true
+              },
+              "custom": {
+                "description": "If the field is a custom field, the URI of the field.",
+                "type": "string",
+                "readOnly": true
+              },
+              "customId": {
+                "description": "If the field is a custom field, the custom ID of the field.",
+                "type": "integer",
+                "readOnly": true
+              },
+              "configuration": {
+                "description": "If the field is a custom field, the configuration of the field.",
+                "type": "object",
+                "additionalProperties": true,
+                "readOnly": true
+              }
+            }
+          },
+          "untranslatedName": {
+            "description": "The untranslated name of the field.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details about a field."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_field_configurations",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the field configuration.",
+            "type": "integer"
+          },
+          "name": {
+            "description": "The name of the field configuration.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of the field configuration.",
+            "type": "string"
+          },
+          "isDefault": {
+            "description": "Whether the field configuration is the default.",
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of a field configuration."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_link_types",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the issue link type. Used as the type of issue link in `issueLink` resource. Required on create when `name` isn't provided. Otherwise, read only.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the issue link type. Used as the type of issue link in `issueLink` resource. Required on create when `id` isn't provided. Otherwise, read only.",
+            "type": "string"
+          },
+          "inward": {
+            "description": "The description of the issue link type inward link. Read only in `issueLink` resource. Required on create and optional on update in `issueLinkType` resource. Otherwise, read only.",
+            "type": "string"
+          },
+          "outward": {
+            "description": "The description of the issue link type outward link. Read only in `issueLink` resource. Required on create and optional on update in `issueLinkType` resource. Otherwise, read only.",
+            "type": "string"
+          },
+          "self": {
+            "description": "The URL of the issue link type. Read only.",
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": true,
+        "description": "A list of issue link type beans."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_navigator_settings",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "label": {
+            "description": "The label representing the data displayed in the issue navigator column.",
+            "type": "string"
+          },
+          "value": {
+            "description": "The actual value/data associated with the label in the issue navigator column.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of an issue navigator column item."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_notification_schemes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "expand": {
+            "description": "Expand options that include additional notification scheme details in the response.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The ID of the notification scheme.",
+            "type": "integer"
+          },
+          "self": { "description": "", "type": "string" },
+          "name": {
+            "description": "The name of the notification scheme.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of the notification scheme.",
+            "type": "string"
+          },
+          "notificationSchemeEvents": {
+            "description": "The notification events and associated recipients.",
+            "type": ["array", "null"],
+            "items": {
+              "type": "object",
+              "properties": {
+                "event": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the event. The event can be a Jira system event or a custom event.",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "description": "The name of the event.",
+                      "type": "string"
+                    },
+                    "description": {
+                      "description": "The description of the event.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "notifications": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "expand": {
+                        "description": "Expand options that include additional event notification details in the response.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The ID of the notification.",
+                        "type": "integer"
+                      },
+                      "notificationType": {
+                        "description": "Identifies the recipients of the notification.",
+                        "type": "string",
+                        "enum": [
+                          "CurrentAssignee",
+                          "Reporter",
+                          "CurrentUser",
+                          "ProjectLead",
+                          "ComponentLead",
+                          "User",
+                          "Group",
+                          "ProjectRole",
+                          "EmailAddress",
+                          "AllWatchers",
+                          "UserCustomField",
+                          "GroupCustomField"
+                        ]
+                      },
+                      "parameter": {
+                        "description": "The value of the `notificationType`.",
+                        "type": "string"
+                      },
+                      "group": {
+                        "description": "The specified group.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "The name of group.",
+                            "type": "string"
+                          },
+                          "self": {
+                            "description": "The URL for these group details.",
+                            "type": "string",
+                            "readOnly": true
+                          }
+                        }
+                      },
+                      "field": {
+                        "description": "The custom user or group field.",
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "The ID of the field.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "The key of the field.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The name of the field.",
+                            "type": "string"
+                          },
+                          "custom": {
+                            "description": "Whether the field is a custom field.",
+                            "type": "boolean"
+                          },
+                          "orderable": {
+                            "description": "Whether the content of the field can be used to order lists.",
+                            "type": "boolean"
+                          },
+                          "navigable": {
+                            "description": "Whether the field can be used as a column on the issue navigator.",
+                            "type": "boolean"
+                          },
+                          "searchable": {
+                            "description": "Whether the content of the field can be searched.",
+                            "type": "boolean"
+                          },
+                          "clauseNames": {
+                            "description": "The names that can be used to reference the field in an advanced search.",
+                            "uniqueItems": true,
+                            "type": "array",
+                            "items": { "type": "string" }
+                          },
+                          "scope": {
+                            "description": "The scope of the field.",
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "description": "The type of scope.",
+                                "type": "string",
+                                "readOnly": true,
+                                "enum": ["PROJECT", "TEMPLATE"]
+                              },
+                              "project": {
+                                "description": "The project the item has scope in.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "self": {
+                                    "description": "The URL of the project details.",
+                                    "type": "string",
+                                    "readOnly": true
+                                  },
+                                  "id": {
+                                    "description": "The ID of the project.",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "description": "The key of the project.",
+                                    "type": "string",
+                                    "readOnly": true
+                                  },
+                                  "name": {
+                                    "description": "The name of the project.",
+                                    "type": "string",
+                                    "readOnly": true
+                                  },
+                                  "projectTypeKey": {
+                                    "description": "The project type of the project.",
+                                    "type": "string",
+                                    "readOnly": true,
+                                    "enum": [
+                                      "software",
+                                      "service_desk",
+                                      "business"
+                                    ]
+                                  },
+                                  "simplified": {
+                                    "description": "Whether or not the project is simplified.",
+                                    "type": "boolean",
+                                    "readOnly": true
+                                  },
+                                  "avatarUrls": {
+                                    "description": "The URLs of the project's avatars.",
+                                    "readOnly": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "16x16": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 16x16 pixel avatar."
+                                      },
+                                      "24x24": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 24x24 pixel avatar."
+                                      },
+                                      "32x32": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 32x32 pixel avatar."
+                                      },
+                                      "48x48": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 48x48 pixel avatar."
+                                      }
+                                    }
+                                  },
+                                  "projectCategory": {
+                                    "description": "The category the project belongs to.",
+                                    "readOnly": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "self": {
+                                        "description": "The URL of the project category.",
+                                        "type": "string",
+                                        "readOnly": true
+                                      },
+                                      "id": {
+                                        "description": "The ID of the project category.",
+                                        "type": "string",
+                                        "readOnly": true
+                                      },
+                                      "description": {
+                                        "description": "The name of the project category.",
+                                        "type": "string",
+                                        "readOnly": true
+                                      },
+                                      "name": {
+                                        "description": "The description of the project category.",
+                                        "type": "string",
+                                        "readOnly": true
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "schema": {
+                            "description": "The data schema for the field.",
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "description": "The data type of the field.",
+                                "type": "string",
+                                "readOnly": true
+                              },
+                              "items": {
+                                "description": "When the data type is an array, the name of the field items within the array.",
+                                "type": "string",
+                                "readOnly": true
+                              },
+                              "system": {
+                                "description": "If the field is a system field, the name of the field.",
+                                "type": "string",
+                                "readOnly": true
+                              },
+                              "custom": {
+                                "description": "If the field is a custom field, the URI of the field.",
+                                "type": "string",
+                                "readOnly": true
+                              },
+                              "customId": {
+                                "description": "If the field is a custom field, the custom ID of the field.",
+                                "type": "integer",
+                                "readOnly": true
+                              },
+                              "configuration": {
+                                "description": "If the field is a custom field, the configuration of the field.",
+                                "type": "object",
+                                "additionalProperties": true,
+                                "readOnly": true
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "emailAddress": {
+                        "description": "The email address.",
+                        "type": "string"
+                      },
+                      "projectRole": {
+                        "description": "The specified project role.",
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "description": "The URL the project role details.",
+                            "type": "string",
+                            "readOnly": true
+                          },
+                          "name": {
+                            "description": "The name of the project role.",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "The ID of the project role.",
+                            "type": "integer",
+                            "readOnly": true
+                          },
+                          "description": {
+                            "description": "The description of the project role.",
+                            "type": "string",
+                            "readOnly": true
+                          },
+                          "actors": {
+                            "description": "The list of users who act in this role.",
+                            "type": "array",
+                            "readOnly": true,
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "description": "The ID of the role actor.",
+                                  "type": "integer",
+                                  "readOnly": true
+                                },
+                                "displayName": {
+                                  "description": "The display name of the role actor.",
+                                  "type": "string",
+                                  "readOnly": true
+                                },
+                                "type": {
+                                  "description": "The type of role actor.",
+                                  "type": "string",
+                                  "readOnly": true,
+                                  "enum": [
+                                    "atlassian-group-role-actor",
+                                    "atlassian-user-role-actor"
+                                  ]
+                                },
+                                "name": {
+                                  "description": "This property is no longer available and will be removed from the documentation soon.",
+                                  "type": "string",
+                                  "readOnly": true
+                                },
+                                "avatarUrl": {
+                                  "description": "The avatar of the role actor.",
+                                  "type": "string",
+                                  "readOnly": true
+                                },
+                                "actorUser": {
+                                  "readOnly": true,
+                                  "type": "object",
+                                  "properties": {
+                                    "accountId": {
+                                      "description": "The account ID of the user.",
+                                      "maxLength": 128,
+                                      "type": "string",
+                                      "readOnly": true
+                                    }
+                                  }
+                                },
+                                "actorGroup": {
+                                  "readOnly": true,
+                                  "type": "object",
+                                  "properties": {
+                                    "displayName": {
+                                      "description": "The display name of the group.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "The name of the group",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "scope": {
+                            "description": "The scope of the role.",
+                            "readOnly": true,
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "description": "The type of scope.",
+                                "readOnly": true,
+                                "enum": ["PROJECT", "TEMPLATE"]
+                              },
+                              "project": {
+                                "description": "The project the item has scope in.",
+                                "readOnly": true,
+                                "type": "object",
+                                "properties": {
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL of the project details.",
+                                    "readOnly": true
+                                  },
+                                  "id": {
+                                    "type": "string",
+                                    "description": "The ID of the project."
+                                  },
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the project.",
+                                    "readOnly": true
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of the project.",
+                                    "readOnly": true
+                                  },
+                                  "projectTypeKey": {
+                                    "type": "string",
+                                    "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                                    "readOnly": true,
+                                    "enum": [
+                                      "software",
+                                      "service_desk",
+                                      "business"
+                                    ]
+                                  },
+                                  "simplified": {
+                                    "type": "boolean",
+                                    "description": "Whether or not the project is simplified.",
+                                    "readOnly": true
+                                  },
+                                  "avatarUrls": {
+                                    "description": "The URLs of the project's avatars.",
+                                    "readOnly": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "16x16": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 16x16 pixel avatar."
+                                      },
+                                      "24x24": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 24x24 pixel avatar."
+                                      },
+                                      "32x32": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 32x32 pixel avatar."
+                                      },
+                                      "48x48": {
+                                        "type": "string",
+                                        "description": "The URL of the item's 48x48 pixel avatar."
+                                      }
+                                    }
+                                  },
+                                  "projectCategory": {
+                                    "description": "The category the project belongs to.",
+                                    "readOnly": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "self": {
+                                        "type": "string",
+                                        "description": "The URL of the project category.",
+                                        "readOnly": true
+                                      },
+                                      "id": {
+                                        "type": "string",
+                                        "description": "The ID of the project category.",
+                                        "readOnly": true
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "The name of the project category.",
+                                        "readOnly": true
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "description": "The description of the project category.",
+                                        "readOnly": true
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "translatedName": {
+                            "description": "The translated name of the project role.",
+                            "type": "string"
+                          },
+                          "currentUserRole": {
+                            "description": "Whether the calling user is part of this role.",
+                            "type": "boolean"
+                          },
+                          "admin": {
+                            "description": "Whether this role is the admin role for the project.",
+                            "type": "boolean",
+                            "readOnly": true
+                          },
+                          "roleConfigurable": {
+                            "description": "Whether the roles are configurable for this project.",
+                            "type": "boolean",
+                            "readOnly": true
+                          },
+                          "default": {
+                            "description": "Whether this role is the default role for the project",
+                            "type": "boolean",
+                            "readOnly": true
+                          }
+                        }
+                      },
+                      "user": {
+                        "description": "The specified user.",
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "description": "The URL of the user.",
+                            "type": "string",
+                            "readOnly": true
+                          },
+                          "name": {
+                            "description": "This property is no longer available and will be removed from the documentation soon.",
+                            "type": "string",
+                            "readOnly": true
+                          },
+                          "key": {
+                            "description": "This property is no longer available and will be removed from the documentation soon.",
+                            "type": "string",
+                            "readOnly": true
+                          },
+                          "accountId": {
+                            "description": "The account ID of the user.",
+                            "maxLength": 128,
+                            "type": "string"
+                          },
+                          "emailAddress": {
+                            "description": "The email address of the user.",
+                            "type": "string",
+                            "readOnly": true
+                          },
+                          "avatarUrls": {
+                            "description": "The avatars of the user.",
+                            "readOnly": true,
+                            "type": "object",
+                            "properties": {
+                              "16x16": {
+                                "type": "string",
+                                "description": "The URL of the item's 16x16 pixel avatar."
+                              },
+                              "24x24": {
+                                "type": "string",
+                                "description": "The URL of the item's 24x24 pixel avatar."
+                              },
+                              "32x32": {
+                                "type": "string",
+                                "description": "The URL of the item's 32x32 pixel avatar."
+                              },
+                              "48x48": {
+                                "type": "string",
+                                "description": "The URL of the item's 48x48 pixel avatar."
+                              }
+                            }
+                          },
+                          "displayName": {
+                            "description": "The display name of the user.",
+                            "type": "string",
+                            "readOnly": true
+                          },
+                          "active": {
+                            "description": "Whether the user is active.",
+                            "type": "boolean",
+                            "readOnly": true
+                          },
+                          "timeZone": {
+                            "description": "The time zone specified in the user's profile.",
+                            "type": "string",
+                            "readOnly": true
+                          },
+                          "accountType": {
+                            "description": "The type of account represented by this user.",
+                            "type": "string",
+                            "readOnly": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "scope": {
+            "description": "The scope of the notification scheme.",
+            "type": ["object", "null"],
+            "properties": {
+              "type": {
+                "description": "The type of scope.",
+                "type": "string",
+                "readOnly": true,
+                "enum": ["PROJECT", "TEMPLATE"]
+              },
+              "project": {
+                "description": "The project the item has scope in.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "description": "The URL of the project details.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "id": {
+                    "description": "The ID of the project.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "The key of the project.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "name": {
+                    "description": "The name of the project.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "projectTypeKey": {
+                    "description": "The project type of the project.",
+                    "type": "string",
+                    "readOnly": true,
+                    "enum": ["software", "service_desk", "business"]
+                  },
+                  "simplified": {
+                    "description": "Whether or not the project is simplified.",
+                    "type": "boolean",
+                    "readOnly": true
+                  },
+                  "avatarUrls": {
+                    "description": "The URLs of the project's avatars.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "16x16": {
+                        "type": "string",
+                        "description": "The URL of the item's 16x16 pixel avatar."
+                      },
+                      "24x24": {
+                        "type": "string",
+                        "description": "The URL of the item's 24x24 pixel avatar."
+                      },
+                      "32x32": {
+                        "type": "string",
+                        "description": "The URL of the item's 32x32 pixel avatar."
+                      },
+                      "48x48": {
+                        "type": "string",
+                        "description": "The URL of the item's 48x48 pixel avatar."
+                      }
+                    }
+                  },
+                  "projectCategory": {
+                    "description": "The category the project belongs to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "self": {
+                        "description": "The URL of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "id": {
+                        "description": "The ID of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "description": {
+                        "description": "The name of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "name": {
+                        "description": "The description of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details about a notification scheme."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_priorities",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the issue priority.",
+            "type": "string"
+          },
+          "statusColor": {
+            "description": "The color used to indicate the issue priority.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of the issue priority.",
+            "type": "string"
+          },
+          "iconUrl": {
+            "description": "The URL of the icon for the issue priority.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the issue priority.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The ID of the issue priority.",
+            "type": "string"
+          },
+          "isDefault": {
+            "description": "Indicates if this issue priority is the default.",
+            "type": ["null", "boolean"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "An issue priority."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_resolutions",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the issue resolution.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The ID of the issue resolution.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of the issue resolution.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the issue resolution.",
+            "type": "string"
+          },
+          "isDefault": {
+            "description": "Indicates if this is the default issue resolution.",
+            "type": ["null", "boolean"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of an issue resolution."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_security_schemes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the issue security scheme.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "The ID of the issue security scheme.",
+            "type": "integer",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the issue security scheme.",
+            "type": "string",
+            "readOnly": true
+          },
+          "description": {
+            "description": "The description of the issue security scheme.",
+            "type": "string",
+            "readOnly": true
+          },
+          "defaultSecurityLevelId": {
+            "description": "The ID of the default security level.",
+            "type": "integer",
+            "readOnly": true
+          },
+          "levels": {
+            "description": "The issue security levels associated with the security scheme.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "self": {
+                  "description": "The URL of the issue level security item.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "id": {
+                  "description": "The unique identifier of the issue security level.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "description": {
+                  "description": "A brief description of the issue security level.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "name": {
+                  "description": "The unique name of the issue security level.",
+                  "type": "string",
+                  "readOnly": true
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "List of security schemes."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_types",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "description": "Details about an issue type.",
+        "properties": {
+          "avatarId": {
+            "description": "The ID of the issue type's avatar.",
+            "type": ["null", "integer"],
+            "readOnly": true
+          },
+          "description": {
+            "description": "The description of the issue type.",
+            "type": ["null", "string"],
+            "readOnly": true
+          },
+          "entityId": {
+            "description": "Unique ID for next-gen projects.",
+            "type": ["null", "string"],
+            "readOnly": true
+          },
+          "hierarchyLevel": {
+            "description": "Hierarchy level of the issue type.",
+            "type": ["null", "integer"],
+            "readOnly": true
+          },
+          "iconUrl": {
+            "description": "The URL of the issue type's avatar.",
+            "type": ["null", "string"],
+            "readOnly": true
+          },
+          "id": {
+            "description": "The ID of the issue type.",
+            "type": ["null", "string"],
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the issue type.",
+            "type": ["null", "string"],
+            "readOnly": true
+          },
+          "self": {
+            "description": "The URL of these issue type details.",
+            "type": ["null", "string"],
+            "readOnly": true
+          },
+          "subtask": {
+            "description": "The URL of these issue type details.",
+            "type": ["null", "boolean"],
+            "readOnly": true
+          },
+          "scope": {
+            "description": "Details of the next-gen projects the issue type is available in.",
+            "readOnly": true,
+            "type": ["null", "object"],
+            "properties": {
+              "type": {
+                "description": "The type of scope.",
+                "type": ["null", "string"],
+                "readOnly": true
+              },
+              "project": {
+                "description": "The project the item has scope in.",
+                "readOnly": true,
+                "type": ["null", "object"],
+                "properties": {
+                  "self": {
+                    "description": "The URL of the project details.",
+                    "type": ["null", "string"],
+                    "readOnly": true
+                  },
+                  "id": {
+                    "description": "The ID of the project.",
+                    "type": ["null", "string"]
+                  },
+                  "key": {
+                    "description": "The key of the project.",
+                    "type": ["null", "string"],
+                    "readOnly": true
+                  },
+                  "name": {
+                    "description": "The name of the project.",
+                    "type": ["null", "string"],
+                    "readOnly": true
+                  },
+                  "projectTypeKey": {
+                    "description": "The project type of the project.",
+                    "type": ["null", "string"],
+                    "readOnly": true,
+                    "enum": ["software", "service_desk", "business"]
+                  },
+                  "simplified": {
+                    "description": "Whether or not the project is simplified.",
+                    "type": "boolean",
+                    "readOnly": true
+                  },
+                  "avatarUrls": {
+                    "description": "The URLs of the project's avatars.",
+                    "readOnly": true,
+                    "type": ["null", "object"],
+                    "properties": {
+                      "16x16": {
+                        "description": "The URL of the item's 16x16 pixel avatar.",
+                        "type": ["null", "string"]
+                      },
+                      "24x24": {
+                        "description": "The URL of the item's 24x24 pixel avatar.",
+                        "type": ["null", "string"]
+                      },
+                      "32x32": {
+                        "description": "The URL of the item's 32x32 pixel avatar.",
+                        "type": ["null", "string"]
+                      },
+                      "48x48": {
+                        "description": "The URL of the item's 48x48 pixel avatar.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "projectCategory": {
+                    "description": "The category the project belongs to.",
+                    "readOnly": true,
+                    "type": ["null", "object"],
+                    "properties": {
+                      "self": {
+                        "description": "The URL of the project category.",
+                        "type": ["null", "string"],
+                        "readOnly": true
+                      },
+                      "id": {
+                        "description": "The ID of the project category.",
+                        "type": ["null", "string"],
+                        "readOnly": true
+                      },
+                      "description": {
+                        "description": "The name of the project category.",
+                        "type": ["null", "string"],
+                        "readOnly": true
+                      },
+                      "name": {
+                        "description": "The description of the project category.",
+                        "type": ["null", "string"],
+                        "readOnly": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "untranslatedName": {
+            "description": "The untranslated name of the issue type.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_type_schemes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the issue type scheme.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name given to the issue type scheme.",
+            "type": "string"
+          },
+          "description": {
+            "description": "A brief description of the issue type scheme.",
+            "type": "string"
+          },
+          "defaultIssueTypeId": {
+            "description": "The ID of the default issue type associated with the issue type scheme.",
+            "type": "string"
+          },
+          "isDefault": {
+            "description": "Indicates whether the issue type scheme is set as the default.",
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of an issue type scheme."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_type_screen_schemes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the issue type screen scheme.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the issue type screen scheme.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of the issue type screen scheme.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of an issue type screen scheme."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "jira_settings",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The unique ID of the application property. The ID is the same as the key.",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key identifier of the application property. The key is the same as the ID.",
+            "type": "string"
+          },
+          "value": {
+            "description": "The new value assigned to the application property.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name or title of the application property.",
+            "type": "string"
+          },
+          "desc": {
+            "description": "The description of the application property.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The data type (e.g., string, number) of the application property.",
+            "type": "string"
+          },
+          "defaultValue": {
+            "description": "The default value of the application property.",
+            "type": "string"
+          },
+          "example": {
+            "description": "An example or sample value for the application property.",
+            "type": "string"
+          },
+          "allowedValues": {
+            "description": "The allowed values for the application property, if applicable.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of an application property."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "labels",
+      "json_schema": {
+        "type": ["object", "null"],
+        "properties": {
+          "label": {
+            "description": "The label associated with the issue in Jira.",
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["label"]],
+      "is_resumable": true
+    },
+    {
+      "name": "permissions",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "key": {
+            "description": "Unique key identifier for the permission",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "Name of the permission",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "Type of permission",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "Description of the permission",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details about permissions."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["key"]],
+      "is_resumable": true
+    },
+    {
+      "name": "permission_schemes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "expand": {
+            "description": "The expand options available for the permission scheme.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "The ID of the permission scheme.",
+            "type": "integer",
+            "readOnly": true
+          },
+          "self": {
+            "description": "The URL of the permission scheme.",
+            "type": "string",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the permission scheme. Must be unique.",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description for the permission scheme.",
+            "type": "string"
+          },
+          "scope": {
+            "description": "The scope of the permission scheme.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "description": "The type of scope.",
+                "type": "string",
+                "readOnly": true,
+                "enum": ["PROJECT", "TEMPLATE"]
+              },
+              "project": {
+                "description": "The project the item has scope in.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "description": "The URL of the project details.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "id": {
+                    "description": "The ID of the project.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "The key of the project.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "name": {
+                    "description": "The name of the project.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "projectTypeKey": {
+                    "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                    "type": "string",
+                    "readOnly": true,
+                    "enum": ["software", "service_desk", "business"]
+                  },
+                  "simplified": {
+                    "description": "Whether or not the project is simplified.",
+                    "type": "boolean",
+                    "readOnly": true
+                  },
+                  "avatarUrls": {
+                    "description": "The URLs of the project's avatars.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "16x16": {
+                        "description": "The URL of the item's 16x16 pixel avatar.",
+                        "type": "string"
+                      },
+                      "24x24": {
+                        "description": "The URL of the item's 24x24 pixel avatar.",
+                        "type": "string"
+                      },
+                      "32x32": {
+                        "description": "The URL of the item's 32x32 pixel avatar.",
+                        "type": "string"
+                      },
+                      "48x48": {
+                        "description": "The URL of the item's 48x48 pixel avatar.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "projectCategory": {
+                    "description": "The category the project belongs to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "self": {
+                        "description": "The URL of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "id": {
+                        "description": "The ID of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "description": {
+                        "description": "The name of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "name": {
+                        "description": "The description of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "permissions": {
+            "description": "The permission scheme to create or update. See [About permission schemes and grants](#about-permission-schemes-and-grants) for more information.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "description": "The ID of the permission granted details.",
+                  "type": "integer",
+                  "readOnly": true
+                },
+                "self": {
+                  "description": "The URL of the permission granted details.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "holder": {
+                  "description": "The user or group being granted the permission. It consists of a `type` and a type-dependent `parameter`. See [Holder object](#holder-object) in *Get all permission schemes* for more information.",
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "description": "The type of permission holder.",
+                      "type": "string"
+                    },
+                    "parameter": {
+                      "description": "The identifier of permission holder.",
+                      "type": "string"
+                    },
+                    "expand": {
+                      "description": "Expand options that include additional permission holder details in the response.",
+                      "type": "string",
+                      "readOnly": true
+                    },
+                    "value": { "type": ["null", "string"] }
+                  }
+                },
+                "permission": {
+                  "description": "The permission to grant. This permission can be one of the built-in permissions or a custom permission added by an app. See [Built-in permissions](#built-in-permissions) in *Get all permission schemes* for more information about the built-in permissions. See the [project permission](https://developer.atlassian.com/cloud/jira/platform/modules/project-permission/) and [global permission](https://developer.atlassian.com/cloud/jira/platform/modules/global-permission/) module documentation for more information about custom permissions.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "List of all permission schemes."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "projects",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "expand": {
+            "description": "Expand options that include additional project details in the response.",
+            "type": "string",
+            "readOnly": true,
+            "xml": {
+              "description": "Data in XML format for expanded project details.",
+              "attribute": true
+            }
+          },
+          "self": {
+            "description": "The URL of the project details.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": { "description": "The ID of the project.", "type": "string" },
+          "key": {
+            "description": "The key of the project.",
+            "type": "string",
+            "readOnly": true
+          },
+          "description": {
+            "description": "A brief description of the project.",
+            "type": "string",
+            "readOnly": true
+          },
+          "lead": {
+            "description": "The username of the project lead.",
+            "readOnly": true
+          },
+          "components": {
+            "description": "List of the components contained in the project.",
+            "type": "array",
+            "readOnly": true
+          },
+          "issueTypes": {
+            "description": "List of the issue types available in the project.",
+            "type": "array",
+            "readOnly": true
+          },
+          "url": {
+            "description": "A link to information about this project, such as project documentation.",
+            "type": "string",
+            "readOnly": true
+          },
+          "email": {
+            "description": "An email address associated with the project.",
+            "type": "string"
+          },
+          "assigneeType": {
+            "description": "The default assignee when creating issues for this project.",
+            "type": "string",
+            "readOnly": true,
+            "enum": ["PROJECT_LEAD", "UNASSIGNED"]
+          },
+          "versions": {
+            "description": "The versions defined in the project. For more information, see [Create version](#api-rest-api-3-version-post).",
+            "type": "array",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the project.",
+            "type": "string",
+            "readOnly": true
+          },
+          "roles": {
+            "description": "The name and self URL for each role defined in the project. For more information, see [Create project role](#api-rest-api-3-role-post).",
+            "type": "object",
+            "additionalProperties": true,
+            "readOnly": true
+          },
+          "avatarUrls": {
+            "description": "The URLs of the project's avatars.",
+            "readOnly": true
+          },
+          "projectCategory": {
+            "description": "The category the project belongs to.",
+            "readOnly": true
+          },
+          "projectTypeKey": {
+            "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+            "type": "string",
+            "readOnly": true,
+            "enum": ["software", "service_desk", "business"]
+          },
+          "simplified": {
+            "description": "Whether the project is simplified.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "style": {
+            "description": "The type of the project.",
+            "type": "string",
+            "readOnly": true,
+            "enum": ["classic", "next-gen"]
+          },
+          "favourite": {
+            "description": "Whether the project is selected as a favorite.",
+            "type": "boolean"
+          },
+          "isPrivate": {
+            "description": "Whether the project is private.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "issueTypeHierarchy": {
+            "description": "The issue type hierarchy for the project",
+            "readOnly": true
+          },
+          "permissions": {
+            "description": "User permissions on the project",
+            "readOnly": true
+          },
+          "properties": {
+            "description": "Map of project properties",
+            "type": "object",
+            "additionalProperties": true,
+            "readOnly": true
+          },
+          "uuid": {
+            "description": "Unique ID for next-gen projects.",
+            "type": "string",
+            "readOnly": true
+          },
+          "insight": {
+            "description": "Insights about the project.",
+            "readOnly": true
+          },
+          "deleted": {
+            "description": "Whether the project is marked as deleted.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "retentionTillDate": {
+            "description": "The date when the project is deleted permanently.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "deletedDate": {
+            "description": "The date when the project was marked as deleted.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "deletedBy": {
+            "description": "The user who marked the project as deleted.",
+            "readOnly": true
+          },
+          "archived": {
+            "description": "Whether the project is archived.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "archivedDate": {
+            "description": "The date when the project was archived.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "archivedBy": {
+            "description": "The user who archived the project.",
+            "readOnly": true
+          },
+          "entityId": {
+            "description": "The unique identifier of the project entity.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details about a project."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "project_categories",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the project category.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "The ID of the project category.",
+            "type": "string",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the project category. Required on create, optional on update.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of the project category. Required on create, optional on update.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "description": "A project category."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "project_roles",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "description": "Project Roles",
+        "properties": {
+          "actors": {
+            "description": "A list of actors assigned to the project role",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of an actor (group or user)",
+              "type": ["null", "object"],
+              "properties": {
+                "actorGroup": {
+                  "description": "Details of an actor group",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "displayName": {
+                      "description": "The display name of the actor group.",
+                      "type": ["null", "string"]
+                    },
+                    "groupId": {
+                      "description": "The ID of the actor group.",
+                      "type": ["null", "string"]
+                    },
+                    "name": {
+                      "description": "The name of the actor group.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "actorUser": {
+                  "description": "Details of an actor user",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "accountId": {
+                      "description": "The account ID of the actor user.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "avatarUrl": {
+                  "description": "The URL of the user's avatar.",
+                  "type": ["null", "string"]
+                },
+                "displayName": {
+                  "description": "The display name of the actor.",
+                  "type": ["null", "string"]
+                },
+                "id": {
+                  "description": "The ID of the actor.",
+                  "type": ["null", "integer"]
+                },
+                "name": {
+                  "description": "The name of the actor.",
+                  "type": ["null", "string"]
+                },
+                "type": {
+                  "description": "The type of the actor (e.g., user or group).",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "admin": {
+            "description": "Flag indicating if the user has admin role.",
+            "type": ["null", "boolean"]
+          },
+          "currentUserRole": {
+            "description": "The role assigned to the current user.",
+            "type": ["null", "boolean"]
+          },
+          "default": {
+            "description": "Flag indicating if it is the default role.",
+            "type": ["null", "boolean"]
+          },
+          "description": {
+            "description": "The description of the project role.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The ID of the project role.",
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "description": "The name of the project role.",
+            "type": ["null", "string"]
+          },
+          "roleConfigurable": {
+            "description": "Flag indicating if the role is configurable.",
+            "type": ["null", "boolean"]
+          },
+          "scope": {
+            "description": "Details of the next-gen projects the issue type is available in.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "type": {
+                "description": "The type of scope (e.g., project).",
+                "type": ["null", "string"],
+                "readOnly": true
+              },
+              "project": {
+                "description": "The project the item has scope in.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "description": "The URL of the project details.",
+                    "type": ["null", "string"],
+                    "readOnly": true
+                  },
+                  "id": {
+                    "description": "The ID of the project.",
+                    "type": ["null", "string"]
+                  },
+                  "key": {
+                    "description": "The key of the project.",
+                    "type": ["null", "string"],
+                    "readOnly": true
+                  },
+                  "name": {
+                    "description": "The name of the project.",
+                    "type": ["null", "string"],
+                    "readOnly": true
+                  },
+                  "projectTypeKey": {
+                    "description": "The project type of the project.",
+                    "type": ["null", "string"],
+                    "readOnly": true
+                  },
+                  "simplified": {
+                    "description": "Flag indicating if the project is simplified.",
+                    "type": ["null", "boolean"],
+                    "readOnly": true
+                  },
+                  "avatarUrls": {
+                    "description": "The URLs of the project's avatars.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "16x16": {
+                        "description": "The URL of the item's 16x16 pixel avatar.",
+                        "type": ["null", "string"]
+                      },
+                      "24x24": {
+                        "description": "The URL of the item's 24x24 pixel avatar.",
+                        "type": ["null", "string"]
+                      },
+                      "32x32": {
+                        "description": "The URL of the item's 32x32 pixel avatar.",
+                        "type": ["null", "string"]
+                      },
+                      "48x48": {
+                        "description": "The URL of the item's 48x48 pixel avatar.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "projectCategory": {
+                    "description": "The category the project belongs to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "self": {
+                        "description": "The URL of the project category.",
+                        "type": ["null", "string"],
+                        "readOnly": true
+                      },
+                      "id": {
+                        "description": "The ID of the project category.",
+                        "type": ["null", "string"],
+                        "readOnly": true
+                      },
+                      "description": {
+                        "description": "The name of the project category.",
+                        "type": ["null", "string"],
+                        "readOnly": true
+                      },
+                      "name": {
+                        "description": "The description of the project category.",
+                        "type": ["null", "string"],
+                        "readOnly": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "self": {
+            "description": "The URL of the project role details.",
+            "type": ["null", "string"]
+          },
+          "translatedName": {
+            "description": "The translated name of the project role.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "project_types",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "key": {
+            "description": "The key of the project type.",
+            "type": "string",
+            "readOnly": true
+          },
+          "formattedKey": {
+            "description": "The formatted key of the project type.",
+            "type": "string",
+            "readOnly": true
+          },
+          "descriptionI18nKey": {
+            "description": "The key of the project type's description.",
+            "type": "string",
+            "readOnly": true
+          },
+          "icon": {
+            "description": "The icon of the project type.",
+            "type": "string",
+            "readOnly": true
+          },
+          "color": {
+            "description": "The color of the project type.",
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details about a project type."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "is_resumable": true
+    },
+    {
+      "name": "screens",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the screen.",
+            "type": "integer",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the screen.",
+            "type": "string",
+            "readOnly": true
+          },
+          "description": {
+            "description": "The description of the screen.",
+            "type": "string",
+            "readOnly": true
+          },
+          "scope": {
+            "description": "The scope of the screen.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "description": "The type of scope.",
+                "type": "string",
+                "readOnly": true,
+                "enum": ["PROJECT", "TEMPLATE"]
+              },
+              "project": {
+                "description": "The project the item has scope in.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "description": "The URL of the project details.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "id": {
+                    "description": "The ID of the project.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "The key of the project.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "name": {
+                    "description": "The name of the project.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "projectTypeKey": {
+                    "description": "The project type of the project.",
+                    "type": "string",
+                    "readOnly": true,
+                    "enum": ["software", "service_desk", "business"]
+                  },
+                  "simplified": {
+                    "description": "Whether or not the project is simplified.",
+                    "type": "boolean",
+                    "readOnly": true
+                  },
+                  "avatarUrls": {
+                    "description": "The URLs of the project's avatars.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "16x16": {
+                        "description": "The URL of the item's 16x16 pixel avatar.",
+                        "type": "string"
+                      },
+                      "24x24": {
+                        "description": "The URL of the item's 24x24 pixel avatar.",
+                        "type": "string"
+                      },
+                      "32x32": {
+                        "description": "The URL of the item's 32x32 pixel avatar.",
+                        "type": "string"
+                      },
+                      "48x48": {
+                        "description": "The URL of the item's 48x48 pixel avatar.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "projectCategory": {
+                    "description": "The category the project belongs to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "self": {
+                        "description": "The URL of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "id": {
+                        "description": "The ID of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "description": {
+                        "description": "The name of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      },
+                      "name": {
+                        "description": "The description of the project category.",
+                        "type": "string",
+                        "readOnly": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "screen_schemes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the screen scheme.",
+            "type": "integer"
+          },
+          "name": {
+            "description": "The name of the screen scheme.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of the screen scheme.",
+            "type": "string"
+          },
+          "screens": {
+            "description": "The IDs of the screens for the screen types of the screen scheme.",
+            "type": "object",
+            "properties": {
+              "edit": {
+                "description": "The ID of the edit screen.",
+                "type": "integer"
+              },
+              "create": {
+                "description": "The ID of the create screen.",
+                "type": "integer"
+              },
+              "view": {
+                "description": "The ID of the view screen.",
+                "type": "integer"
+              },
+              "default": {
+                "description": "The ID of the default screen. Required when creating a screen scheme.",
+                "type": "integer"
+              }
+            }
+          },
+          "issueTypeScreenSchemes": {
+            "description": "Issue type screen schemes associated with the screen scheme.",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "description": "A screen scheme."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "time_tracking",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "required": ["key"],
+        "type": "object",
+        "properties": {
+          "key": {
+            "description": "The key associated with the time tracking provider.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the time tracking provider.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL of the configuration page for the time tracking provider app. This property is only returned if the `adminPageKey` property is set in the module descriptor of the time tracking provider app.",
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details about the time tracking provider."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["key"]],
+      "is_resumable": true
+    },
+    {
+      "name": "users",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the user.",
+            "type": "string",
+            "readOnly": true
+          },
+          "key": {
+            "description": "Deprecated property. See the deprecation notice for details.",
+            "type": "string"
+          },
+          "accountId": {
+            "description": "The account ID of the user, uniquely identifying the user across all Atlassian products. Required in requests.",
+            "maxLength": 128,
+            "type": "string"
+          },
+          "accountType": {
+            "description": "The user account type. Can be one of: \n- `atlassian`: regular Atlassian user account \n- `app`: system account used for Connect applications and OAuth \n- `customer`: Jira Service Desk account representing an external service desk",
+            "type": "string",
+            "readOnly": true,
+            "enum": ["atlassian", "app", "customer", "unknown"]
+          },
+          "name": {
+            "description": "Deprecated property. See the deprecation notice for details.",
+            "type": "string"
+          },
+          "emailAddress": {
+            "description": "The email address of the user. May be null based on privacy settings.",
+            "type": "string",
+            "readOnly": true
+          },
+          "avatarUrls": {
+            "description": "The avatars of the user.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "16x16": {
+                "description": "The URL of the 16x16 pixel avatar.",
+                "type": "string"
+              },
+              "24x24": {
+                "description": "The URL of the 24x24 pixel avatar.",
+                "type": "string"
+              },
+              "32x32": {
+                "description": "The URL of the 32x32 pixel avatar.",
+                "type": "string"
+              },
+              "48x48": {
+                "description": "The URL of the 48x48 pixel avatar.",
+                "type": "string"
+              }
+            }
+          },
+          "displayName": {
+            "description": "The display name of the user. May return an alternative value based on privacy settings.",
+            "type": "string",
+            "readOnly": true
+          },
+          "active": {
+            "description": "Indicates whether the user is active.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "timeZone": {
+            "description": "The time zone specified in the user's profile. May be null based on privacy settings.",
+            "type": "string",
+            "readOnly": true
+          },
+          "locale": {
+            "description": "The locale of the user. May be null based on privacy settings.",
+            "type": "string",
+            "readOnly": true
+          },
+          "groups": {
+            "description": "The groups to which the user belongs.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "size": {
+                "description": "The size of the groups.",
+                "type": "integer",
+                "xml": { "attribute": true }
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "description": "The name of the group.",
+                      "type": "string"
+                    },
+                    "self": {
+                      "description": "The URL for group details.",
+                      "type": "string",
+                      "readOnly": true
+                    }
+                  }
+                }
+              },
+              "pagingCallback": {
+                "description": "The callback for pagination.",
+                "type": "object"
+              },
+              "callback": {
+                "description": "The callback for fetching more groups.",
+                "type": "object"
+              },
+              "max-results": {
+                "description": "The maximum number of results to be returned.",
+                "type": "integer",
+                "xml": { "name": "max-results", "attribute": true }
+              }
+            }
+          },
+          "applicationRoles": {
+            "description": "The application roles assigned to the user.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "size": {
+                "description": "The size of the application roles.",
+                "type": "integer",
+                "xml": { "attribute": true }
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the application role.",
+                      "type": "string"
+                    },
+                    "groups": {
+                      "description": "The groups associated with the application role.",
+                      "uniqueItems": true,
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "name": {
+                      "description": "The display name of the application role.",
+                      "type": "string"
+                    },
+                    "defaultGroups": {
+                      "description": "The groups granted default access for this application role.",
+                      "uniqueItems": true,
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "selectedByDefault": {
+                      "description": "Specifies if this application role should be selected by default on user creation.",
+                      "type": "boolean"
+                    },
+                    "defined": {
+                      "description": "Deprecated field.",
+                      "type": "boolean"
+                    },
+                    "numberOfSeats": {
+                      "description": "The maximum user count on the license.",
+                      "type": "integer"
+                    },
+                    "remainingSeats": {
+                      "description": "The remaining user count on the license.",
+                      "type": "integer"
+                    },
+                    "userCount": {
+                      "description": "The number of users counting against the license.",
+                      "type": "integer"
+                    },
+                    "userCountDescription": {
+                      "description": "The type of users being counted against the license.",
+                      "type": "string"
+                    },
+                    "hasUnlimitedSeats": {
+                      "description": "Indicates if the application role has unlimited seats.",
+                      "type": "boolean"
+                    },
+                    "platform": {
+                      "description": "Indicates if the application role belongs to Jira platform (`jira-core`).",
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "pagingCallback": {
+                "description": "The callback for pagination.",
+                "type": "object"
+              },
+              "callback": {
+                "description": "The callback for fetching more application roles.",
+                "type": "object"
+              },
+              "max-results": {
+                "description": "The maximum number of results to be returned.",
+                "type": "integer",
+                "xml": { "name": "max-results", "attribute": true }
+              }
+            }
+          },
+          "expand": {
+            "description": "Options to include additional user details in the response.",
+            "type": "string",
+            "readOnly": true,
+            "xml": { "attribute": true }
+          }
+        },
+        "additionalProperties": true,
+        "description": "A user with details as permitted by the user's Atlassian Account privacy settings. However, be aware of these exceptions:\n\n *  User record deleted from Atlassian: This occurs as the result of a right to be forgotten request. In this case, `displayName` provides an indication and other parameters have default values or are blank (for example, email is blank).\n *  User record corrupted: This occurs as a results of events such as a server import and can only happen to deleted users. In this case, `accountId` returns *unknown* and all other parameters have fallback values.\n *  User record unavailable: This usually occurs due to an internal service outage. In this case, all parameters have fallback values.",
+        "xml": { "name": "user" }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["accountId"]],
+      "is_resumable": true
+    },
+    {
+      "name": "workflows",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The unique identifier and name of the workflow.",
+            "type": "object",
+            "properties": {
+              "entityId": { "type": ["null", "string"] },
+              "name": {
+                "description": "The name of the workflow.",
+                "type": "string"
+              }
+            }
+          },
+          "entityId": {
+            "description": "The unique identifier of the workflow.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The unique name the workflow.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The detailed description of the workflow.",
+            "type": "string"
+          },
+          "transitions": {
+            "description": "The transitions available within the workflow.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "description": "The unique identifier of the transition.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the transition.",
+                  "type": "string"
+                },
+                "description": {
+                  "description": "The detailed description of the transition.",
+                  "type": "string"
+                },
+                "from": {
+                  "description": "The statuses the transition can start from.",
+                  "type": "array",
+                  "items": {
+                    "description": "The statuses the transition can start from.",
+                    "type": "string"
+                  }
+                },
+                "to": {
+                  "description": "The status that the transition moves the issue to.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "The type of the transition.",
+                  "type": "string",
+                  "enum": ["global", "initial", "directed"]
+                },
+                "screen": {
+                  "description": "The screen associated with the transition.",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "description": "The unique identifier of the screen.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "rules": {
+                  "type": "object",
+                  "properties": {
+                    "conditions": {
+                      "description": "The conditions that must be met for the transition to occur.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "description": "The type of the transition rule.",
+                            "type": "string"
+                          },
+                          "configuration": {
+                            "description": "The configuration of the transition rule (availability may vary)."
+                          }
+                        }
+                      }
+                    },
+                    "validators": {
+                      "description": "Validation checks performed during the transition.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "description": "The type of the validator.",
+                            "type": "string"
+                          },
+                          "configuration": {
+                            "description": "The configuration of the validator (availability may vary)."
+                          }
+                        }
+                      }
+                    },
+                    "postFunctions": {
+                      "description": "Actions that occur after a transition.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "description": "The type of the post function.",
+                            "type": "string"
+                          },
+                          "configuration": {
+                            "description": "The configuration of the post function (availability may vary)."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "statuses": {
+            "description": "The various statuses that the workflow can have.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "description": "The unique identifier of the issue status.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the status in the workflow.",
+                  "type": "string"
+                },
+                "properties": {
+                  "type": "object",
+                  "properties": {
+                    "issueEditable": {
+                      "description": "Indicates whether issues are editable in this status.",
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "created": {
+            "description": "The date and time when the workflow was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated": {
+            "description": "The date and time when the workflow was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        },
+        "readOnly": true
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["entityId"], ["name"]],
+      "is_resumable": true
+    },
+    {
+      "name": "workflow_schemes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the workflow scheme.",
+            "type": "integer",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the workflow scheme. The name must be unique. The maximum length is 255 characters. Required when creating a workflow scheme.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of the workflow scheme.",
+            "type": "string"
+          },
+          "defaultWorkflow": {
+            "description": "The name of the default workflow for the workflow scheme. The default workflow has *All Unassigned Issue Types* assigned to it in Jira. If `defaultWorkflow` is not specified when creating a workflow scheme, it is set to *Jira Workflow (jira)*.",
+            "type": "string"
+          },
+          "issueTypeMappings": {
+            "description": "The issue type to workflow mappings, where each mapping is an issue type ID and workflow name pair. Note that an issue type can only be mapped to one workflow in a workflow scheme.",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "originalDefaultWorkflow": {
+            "description": "For draft workflow schemes, this property is the name of the default workflow for the original workflow scheme. The default workflow has *All Unassigned Issue Types* assigned to it in Jira.",
+            "type": "string",
+            "readOnly": true
+          },
+          "originalIssueTypeMappings": {
+            "description": "For draft workflow schemes, this property is the issue type to workflow mappings for the original workflow scheme, where each mapping is an issue type ID and workflow name pair. Note that an issue type can only be mapped to one workflow in a workflow scheme.",
+            "type": "object",
+            "additionalProperties": true,
+            "readOnly": true
+          },
+          "draft": {
+            "description": "Whether the workflow scheme is a draft or not.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "lastModifiedUser": {
+            "description": "The user that last modified the draft workflow scheme. A modification is a change to the issue type-project mappings only. This property does not apply to non-draft workflows.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "self": {
+                "description": "The URL of the user.",
+                "type": "string",
+                "readOnly": true
+              },
+              "key": {
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                "type": "string"
+              },
+              "accountId": {
+                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests.",
+                "maxLength": 128,
+                "type": "string"
+              },
+              "accountType": {
+                "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                "type": "string",
+                "readOnly": true,
+                "enum": ["atlassian", "app", "customer", "unknown"]
+              },
+              "name": {
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                "type": "string"
+              },
+              "emailAddress": {
+                "description": "The email address of the user. Depending on the user's privacy setting, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "avatarUrls": {
+                "description": "The avatars of the user.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "16x16": {
+                    "description": "The URL of the item's 16x16 pixel avatar.",
+                    "type": "string"
+                  },
+                  "24x24": {
+                    "description": "The URL of the item's 24x24 pixel avatar.",
+                    "type": "string"
+                  },
+                  "32x32": {
+                    "description": "The URL of the item's 32x32 pixel avatar.",
+                    "type": "string"
+                  },
+                  "48x48": {
+                    "description": "The URL of the item's 48x48 pixel avatar.",
+                    "type": "string"
+                  }
+                }
+              },
+              "displayName": {
+                "description": "The display name of the user. Depending on the user's privacy setting, this may return an alternative value.",
+                "type": "string",
+                "readOnly": true
+              },
+              "active": {
+                "description": "Whether the user is active.",
+                "type": "boolean",
+                "readOnly": true
+              },
+              "timeZone": {
+                "description": "The time zone specified in the user's profile. Depending on the user's privacy setting, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "locale": {
+                "description": "The locale of the user. Depending on the user's privacy setting, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "groups": {
+                "description": "The groups that the user belongs to.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "size": { "type": "integer", "xml": { "attribute": true } },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "The name of group.",
+                          "type": "string"
+                        },
+                        "self": {
+                          "description": "The URL for these group details.",
+                          "type": "string",
+                          "readOnly": true
+                        }
+                      }
+                    }
+                  },
+                  "pagingCallback": { "type": "object" },
+                  "callback": { "type": "object" },
+                  "max-results": {
+                    "type": "integer",
+                    "xml": { "name": "max-results", "attribute": true }
+                  }
+                }
+              },
+              "applicationRoles": {
+                "description": "The application roles the user is assigned to.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "size": { "type": "integer", "xml": { "attribute": true } },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the application role.",
+                          "type": "string"
+                        },
+                        "groups": {
+                          "description": "The groups associated with the application role.",
+                          "uniqueItems": true,
+                          "type": "array",
+                          "items": { "type": "string" }
+                        },
+                        "name": {
+                          "description": "The display name of the application role.",
+                          "type": "string"
+                        },
+                        "defaultGroups": {
+                          "description": "The groups that are granted default access for this application role.",
+                          "uniqueItems": true,
+                          "type": "array",
+                          "items": { "type": "string" }
+                        },
+                        "selectedByDefault": {
+                          "description": "Determines whether this application role should be selected by default on user creation.",
+                          "type": "boolean"
+                        },
+                        "defined": {
+                          "description": "Deprecated.",
+                          "type": "boolean"
+                        },
+                        "numberOfSeats": {
+                          "description": "The maximum count of users on your license.",
+                          "type": "integer"
+                        },
+                        "remainingSeats": {
+                          "description": "The count of users remaining on your license.",
+                          "type": "integer"
+                        },
+                        "userCount": {
+                          "description": "The number of users counting against your license.",
+                          "type": "integer"
+                        },
+                        "userCountDescription": {
+                          "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license.",
+                          "type": "string"
+                        },
+                        "hasUnlimitedSeats": { "type": "boolean" },
+                        "platform": {
+                          "description": "Indicates if the application role belongs to Jira platform (`jira-core`).",
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  },
+                  "pagingCallback": { "type": "object" },
+                  "callback": { "type": "object" },
+                  "max-results": {
+                    "type": "integer",
+                    "xml": { "name": "max-results", "attribute": true }
+                  }
+                }
+              },
+              "expand": {
+                "description": "Expand options that include additional user details in the response.",
+                "type": "string",
+                "readOnly": true,
+                "xml": { "attribute": true }
+              }
+            }
+          },
+          "lastModified": {
+            "description": "The date-time that the draft workflow scheme was last modified. A modification is a change to the issue type-project mappings only. This property does not apply to non-draft workflows.",
+            "type": "string",
+            "readOnly": true
+          },
+          "self": {
+            "description": "URL of the workflow scheme resource.",
+            "type": "string",
+            "readOnly": true
+          },
+          "updateDraftIfNeeded": {
+            "description": "Whether to create or update a draft workflow scheme when updating an active workflow scheme. An active workflow scheme is a workflow scheme that is used by at least one project. The following examples show how this property works:\n\n *  Update an active workflow scheme with `updateDraftIfNeeded` set to `true`: If a draft workflow scheme exists, it is updated. Otherwise, a draft workflow scheme is created.\n *  Update an active workflow scheme with `updateDraftIfNeeded` set to `false`: An error is returned, as active workflow schemes cannot be updated.\n *  Update an inactive workflow scheme with `updateDraftIfNeeded` set to `true`: The workflow scheme is updated, as inactive workflow schemes do not require drafts to update.\n\nDefaults to `false`.",
+            "type": "boolean"
+          },
+          "issueTypes": {
+            "description": "The issue types available in Jira.",
+            "type": "object",
+            "readOnly": true
+          }
+        },
+        "readOnly": true
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "workflow_statuses",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the status.",
+            "type": "string",
+            "readOnly": true
+          },
+          "description": {
+            "description": "The description of the status.",
+            "type": "string",
+            "readOnly": true
+          },
+          "iconUrl": {
+            "description": "The URL of the icon used to represent the status.",
+            "type": "string",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the status.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "The ID of the status.",
+            "type": "string",
+            "readOnly": true
+          },
+          "statusCategory": {
+            "description": "The category assigned to the status.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "self": {
+                "description": "The URL of the status category.",
+                "type": "string",
+                "readOnly": true
+              },
+              "id": {
+                "description": "The ID of the status category.",
+                "type": "integer",
+                "readOnly": true
+              },
+              "key": {
+                "description": "The key of the status category.",
+                "type": "string",
+                "readOnly": true
+              },
+              "colorName": {
+                "description": "The name of the color used to represent the status category.",
+                "type": "string",
+                "readOnly": true
+              },
+              "name": {
+                "description": "The name of the status category.",
+                "type": "string",
+                "readOnly": true
+              }
+            }
+          },
+          "scope": {
+            "description": "The scope of the status.",
+            "type": ["null", "object"]
+          },
+          "untranslatedName": {
+            "description": "The untranslated name of the status.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "A status."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "workflow_status_categories",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the status category.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "The ID of the status category.",
+            "type": "integer",
+            "readOnly": true
+          },
+          "key": {
+            "description": "The key of the status category.",
+            "type": "string",
+            "readOnly": true
+          },
+          "colorName": {
+            "description": "The name of the color used to represent the status category.",
+            "type": "string",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the status category.",
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": true,
+        "description": "A status category."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "filter_sharing",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The unique identifier of the share permission.",
+            "readOnly": true
+          },
+          "filterId": {
+            "type": ["null", "string"],
+            "description": "Id of the related filter"
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of share permission:\n\n *  `group` Shared with a group. If set in a request, then specify `sharePermission.group` as well.\n *  `project` Shared with a project. If set in a request, then specify `sharePermission.project` as well.\n *  `projectRole` Share with a project role in a project. This value is not returned in responses. It is used in requests, where it needs to be specify with `projectId` and `projectRoleId`.\n *  `global` Shared globally. If set in a request, no other `sharePermission` properties need to be specified.\n *  `loggedin` Shared with all logged-in users. Note: This value is set in a request by specifying `authenticated` as the `type`.\n *  `project-unknown` Shared with a project that the user does not have access to. Cannot be set in a request.",
+            "enum": [
+              "group",
+              "project",
+              "projectRole",
+              "global",
+              "loggedin",
+              "authenticated",
+              "project-unknown"
+            ]
+          },
+          "project": {
+            "description": "The project that the filter is shared with. This is similar to the project object returned by [Get project](#api-rest-api-3-project-projectIdOrKey-get) but it contains a subset of the properties, which are: `self`, `id`, `key`, `assigneeType`, `name`, `roles`, `avatarUrls`, `projectType`, `simplified`.  \nFor a request, specify the `id` for the project.",
+            "type": "object",
+            "properties": {
+              "expand": {
+                "type": "string",
+                "description": "Expand options that include additional project details in the response.",
+                "readOnly": true,
+                "xml": { "attribute": true }
+              },
+              "self": {
+                "type": "string",
+                "description": "The URL of the project details.",
+                "readOnly": true
+              },
+              "id": {
+                "type": "string",
+                "description": "The ID of the project."
+              },
+              "key": {
+                "type": "string",
+                "description": "The key of the project.",
+                "readOnly": true
+              },
+              "description": {
+                "type": "string",
+                "description": "A brief description of the project.",
+                "readOnly": true
+              },
+              "lead": {
+                "description": "The username of the project lead.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "type": "string",
+                    "description": "The URL of the user.",
+                    "readOnly": true
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                  },
+                  "accountId": {
+                    "maxLength": 128,
+                    "type": "string",
+                    "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                  },
+                  "accountType": {
+                    "type": "string",
+                    "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                    "readOnly": true,
+                    "enum": ["atlassian", "app", "customer", "unknown"]
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                  },
+                  "emailAddress": {
+                    "type": "string",
+                    "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                    "readOnly": true
+                  },
+                  "avatarUrls": {
+                    "description": "The avatars of the user.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "16x16": {
+                        "type": "string",
+                        "description": "The URL of the item's 16x16 pixel avatar."
+                      },
+                      "24x24": {
+                        "type": "string",
+                        "description": "The URL of the item's 24x24 pixel avatar."
+                      },
+                      "32x32": {
+                        "type": "string",
+                        "description": "The URL of the item's 32x32 pixel avatar."
+                      },
+                      "48x48": {
+                        "type": "string",
+                        "description": "The URL of the item's 48x48 pixel avatar."
+                      }
+                    }
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                    "readOnly": true
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "Whether the user is active.",
+                    "readOnly": true
+                  },
+                  "timeZone": {
+                    "type": "string",
+                    "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                    "readOnly": true
+                  },
+                  "locale": {
+                    "type": "string",
+                    "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                    "readOnly": true
+                  },
+                  "groups": {
+                    "description": "The groups that the user belongs to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "type": "integer",
+                        "xml": { "attribute": true }
+                      },
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "The name of group."
+                            },
+                            "self": {
+                              "type": "string",
+                              "description": "The URL for these group details.",
+                              "readOnly": true
+                            }
+                          }
+                        }
+                      },
+                      "pagingCallback": { "type": "object" },
+                      "callback": { "type": "object" },
+                      "max-results": {
+                        "type": "integer",
+                        "xml": { "name": "max-results", "attribute": true }
+                      }
+                    }
+                  },
+                  "applicationRoles": {
+                    "description": "The application roles the user is assigned to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "type": "integer",
+                        "xml": { "attribute": true }
+                      },
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "The key of the application role."
+                            },
+                            "groups": {
+                              "uniqueItems": true,
+                              "type": "array",
+                              "description": "The groups associated with the application role.",
+                              "items": { "type": "string" }
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The display name of the application role."
+                            },
+                            "defaultGroups": {
+                              "uniqueItems": true,
+                              "type": "array",
+                              "description": "The groups that are granted default access for this application role.",
+                              "items": { "type": "string" }
+                            },
+                            "selectedByDefault": {
+                              "type": "boolean",
+                              "description": "Determines whether this application role should be selected by default on user creation."
+                            },
+                            "defined": {
+                              "type": "boolean",
+                              "description": "Deprecated."
+                            },
+                            "numberOfSeats": {
+                              "type": "integer",
+                              "description": "The maximum count of users on your license."
+                            },
+                            "remainingSeats": {
+                              "type": "integer",
+                              "description": "The count of users remaining on your license."
+                            },
+                            "userCount": {
+                              "type": "integer",
+                              "description": "The number of users counting against your license."
+                            },
+                            "userCountDescription": {
+                              "type": "string",
+                              "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                            },
+                            "hasUnlimitedSeats": { "type": "boolean" },
+                            "platform": {
+                              "type": "boolean",
+                              "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                            }
+                          }
+                        }
+                      },
+                      "pagingCallback": { "type": "object" },
+                      "callback": { "type": "object" },
+                      "max-results": {
+                        "type": "integer",
+                        "xml": { "name": "max-results", "attribute": true }
+                      }
+                    }
+                  },
+                  "expand": {
+                    "type": "string",
+                    "description": "Expand options that include additional user details in the response.",
+                    "readOnly": true,
+                    "xml": { "attribute": true }
+                  }
+                }
+              },
+              "components": {
+                "type": "array",
+                "description": "List of the components contained in the project.",
+                "readOnly": true,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "self": {
+                      "type": "string",
+                      "description": "The URL of the component.",
+                      "readOnly": true
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "The unique identifier for the component.",
+                      "readOnly": true
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The unique name for the component in the project. Required when creating a component. Optional when updating a component. The maximum length is 255 characters."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "The description for the component. Optional when creating or updating a component."
+                    },
+                    "lead": {
+                      "description": "The user details for the component's lead user.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the user.",
+                          "readOnly": true
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "accountId": {
+                          "maxLength": 128,
+                          "type": "string",
+                          "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                        },
+                        "accountType": {
+                          "type": "string",
+                          "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                          "readOnly": true,
+                          "enum": ["atlassian", "app", "customer", "unknown"]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "emailAddress": {
+                          "type": "string",
+                          "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "avatarUrls": {
+                          "description": "The avatars of the user.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "16x16": {
+                              "type": "string",
+                              "description": "The URL of the item's 16x16 pixel avatar."
+                            },
+                            "24x24": {
+                              "type": "string",
+                              "description": "The URL of the item's 24x24 pixel avatar."
+                            },
+                            "32x32": {
+                              "type": "string",
+                              "description": "The URL of the item's 32x32 pixel avatar."
+                            },
+                            "48x48": {
+                              "type": "string",
+                              "description": "The URL of the item's 48x48 pixel avatar."
+                            }
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                          "readOnly": true
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the user is active.",
+                          "readOnly": true
+                        },
+                        "timeZone": {
+                          "type": "string",
+                          "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "groups": {
+                          "description": "The groups that the user belongs to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of group."
+                                  },
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL for these group details.",
+                                    "readOnly": true
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "applicationRoles": {
+                          "description": "The application roles the user is assigned to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the application role."
+                                  },
+                                  "groups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups associated with the application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The display name of the application role."
+                                  },
+                                  "defaultGroups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups that are granted default access for this application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "selectedByDefault": {
+                                    "type": "boolean",
+                                    "description": "Determines whether this application role should be selected by default on user creation."
+                                  },
+                                  "defined": {
+                                    "type": "boolean",
+                                    "description": "Deprecated."
+                                  },
+                                  "numberOfSeats": {
+                                    "type": "integer",
+                                    "description": "The maximum count of users on your license."
+                                  },
+                                  "remainingSeats": {
+                                    "type": "integer",
+                                    "description": "The count of users remaining on your license."
+                                  },
+                                  "userCount": {
+                                    "type": "integer",
+                                    "description": "The number of users counting against your license."
+                                  },
+                                  "userCountDescription": {
+                                    "type": "string",
+                                    "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                  },
+                                  "hasUnlimitedSeats": { "type": "boolean" },
+                                  "platform": {
+                                    "type": "boolean",
+                                    "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "expand": {
+                          "type": "string",
+                          "description": "Expand options that include additional user details in the response.",
+                          "readOnly": true,
+                          "xml": { "attribute": true }
+                        }
+                      }
+                    },
+                    "leadUserName": {
+                      "type": "string",
+                      "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                    },
+                    "leadAccountId": {
+                      "maxLength": 128,
+                      "type": "string",
+                      "description": "The accountId of the component's lead user. The accountId uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*.",
+                      "writeOnly": true
+                    },
+                    "assigneeType": {
+                      "type": "string",
+                      "description": "The nominal user type used to determine the assignee for issues created with this component. See `realAssigneeType` for details on how the type of the user, and hence the user, assigned to issues is determined. Can take the following values:\n\n *  `PROJECT_LEAD` the assignee to any issues created with this component is nominally the lead for the project the component is in.\n *  `COMPONENT_LEAD` the assignee to any issues created with this component is nominally the lead for the component.\n *  `UNASSIGNED` an assignee is not set for issues created with this component.\n *  `PROJECT_DEFAULT` the assignee to any issues created with this component is nominally the default assignee for the project that the component is in.\n\nDefault value: `PROJECT_DEFAULT`.  \nOptional when creating or updating a component.",
+                      "enum": [
+                        "PROJECT_DEFAULT",
+                        "COMPONENT_LEAD",
+                        "PROJECT_LEAD",
+                        "UNASSIGNED"
+                      ]
+                    },
+                    "assignee": {
+                      "description": "The details of the user associated with `assigneeType`, if any. See `realAssignee` for details of the user assigned to issues created with this component.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the user.",
+                          "readOnly": true
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "accountId": {
+                          "maxLength": 128,
+                          "type": "string",
+                          "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                        },
+                        "accountType": {
+                          "type": "string",
+                          "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                          "readOnly": true,
+                          "enum": ["atlassian", "app", "customer", "unknown"]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "emailAddress": {
+                          "type": "string",
+                          "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "avatarUrls": {
+                          "description": "The avatars of the user.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "16x16": {
+                              "type": "string",
+                              "description": "The URL of the item's 16x16 pixel avatar."
+                            },
+                            "24x24": {
+                              "type": "string",
+                              "description": "The URL of the item's 24x24 pixel avatar."
+                            },
+                            "32x32": {
+                              "type": "string",
+                              "description": "The URL of the item's 32x32 pixel avatar."
+                            },
+                            "48x48": {
+                              "type": "string",
+                              "description": "The URL of the item's 48x48 pixel avatar."
+                            }
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                          "readOnly": true
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the user is active.",
+                          "readOnly": true
+                        },
+                        "timeZone": {
+                          "type": "string",
+                          "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "groups": {
+                          "description": "The groups that the user belongs to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of group."
+                                  },
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL for these group details.",
+                                    "readOnly": true
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "applicationRoles": {
+                          "description": "The application roles the user is assigned to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the application role."
+                                  },
+                                  "groups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups associated with the application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The display name of the application role."
+                                  },
+                                  "defaultGroups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups that are granted default access for this application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "selectedByDefault": {
+                                    "type": "boolean",
+                                    "description": "Determines whether this application role should be selected by default on user creation."
+                                  },
+                                  "defined": {
+                                    "type": "boolean",
+                                    "description": "Deprecated."
+                                  },
+                                  "numberOfSeats": {
+                                    "type": "integer",
+                                    "description": "The maximum count of users on your license."
+                                  },
+                                  "remainingSeats": {
+                                    "type": "integer",
+                                    "description": "The count of users remaining on your license."
+                                  },
+                                  "userCount": {
+                                    "type": "integer",
+                                    "description": "The number of users counting against your license."
+                                  },
+                                  "userCountDescription": {
+                                    "type": "string",
+                                    "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                  },
+                                  "hasUnlimitedSeats": { "type": "boolean" },
+                                  "platform": {
+                                    "type": "boolean",
+                                    "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "expand": {
+                          "type": "string",
+                          "description": "Expand options that include additional user details in the response.",
+                          "readOnly": true,
+                          "xml": { "attribute": true }
+                        }
+                      }
+                    },
+                    "realAssigneeType": {
+                      "type": "string",
+                      "description": "The type of the assignee that is assigned to issues created with this component, when an assignee cannot be set from the `assigneeType`. For example, `assigneeType` is set to `COMPONENT_LEAD` but no component lead is set. This property is set to one of the following values:\n\n *  `PROJECT_LEAD` when `assigneeType` is `PROJECT_LEAD` and the project lead has permission to be assigned issues in the project that the component is in.\n *  `COMPONENT_LEAD` when `assignee`Type is `COMPONENT_LEAD` and the component lead has permission to be assigned issues in the project that the component is in.\n *  `UNASSIGNED` when `assigneeType` is `UNASSIGNED` and Jira is configured to allow unassigned issues.\n *  `PROJECT_DEFAULT` when none of the preceding cases are true.",
+                      "readOnly": true,
+                      "enum": [
+                        "PROJECT_DEFAULT",
+                        "COMPONENT_LEAD",
+                        "PROJECT_LEAD",
+                        "UNASSIGNED"
+                      ]
+                    },
+                    "realAssignee": {
+                      "description": "The user assigned to issues created with this component, when `assigneeType` does not identify a valid assignee.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "description": "The URL of the user.",
+                          "readOnly": true
+                        },
+                        "key": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "accountId": {
+                          "maxLength": 128,
+                          "type": "string",
+                          "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                        },
+                        "accountType": {
+                          "type": "string",
+                          "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                          "readOnly": true,
+                          "enum": ["atlassian", "app", "customer", "unknown"]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                        },
+                        "emailAddress": {
+                          "type": "string",
+                          "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "avatarUrls": {
+                          "description": "The avatars of the user.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "16x16": {
+                              "type": "string",
+                              "description": "The URL of the item's 16x16 pixel avatar."
+                            },
+                            "24x24": {
+                              "type": "string",
+                              "description": "The URL of the item's 24x24 pixel avatar."
+                            },
+                            "32x32": {
+                              "type": "string",
+                              "description": "The URL of the item's 32x32 pixel avatar."
+                            },
+                            "48x48": {
+                              "type": "string",
+                              "description": "The URL of the item's 48x48 pixel avatar."
+                            }
+                          }
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                          "readOnly": true
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Whether the user is active.",
+                          "readOnly": true
+                        },
+                        "timeZone": {
+                          "type": "string",
+                          "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "locale": {
+                          "type": "string",
+                          "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                          "readOnly": true
+                        },
+                        "groups": {
+                          "description": "The groups that the user belongs to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of group."
+                                  },
+                                  "self": {
+                                    "type": "string",
+                                    "description": "The URL for these group details.",
+                                    "readOnly": true
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "applicationRoles": {
+                          "description": "The application roles the user is assigned to.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "type": "integer",
+                              "xml": { "attribute": true }
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string",
+                                    "description": "The key of the application role."
+                                  },
+                                  "groups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups associated with the application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The display name of the application role."
+                                  },
+                                  "defaultGroups": {
+                                    "uniqueItems": true,
+                                    "type": "array",
+                                    "description": "The groups that are granted default access for this application role.",
+                                    "items": { "type": "string" }
+                                  },
+                                  "selectedByDefault": {
+                                    "type": "boolean",
+                                    "description": "Determines whether this application role should be selected by default on user creation."
+                                  },
+                                  "defined": {
+                                    "type": "boolean",
+                                    "description": "Deprecated."
+                                  },
+                                  "numberOfSeats": {
+                                    "type": "integer",
+                                    "description": "The maximum count of users on your license."
+                                  },
+                                  "remainingSeats": {
+                                    "type": "integer",
+                                    "description": "The count of users remaining on your license."
+                                  },
+                                  "userCount": {
+                                    "type": "integer",
+                                    "description": "The number of users counting against your license."
+                                  },
+                                  "userCountDescription": {
+                                    "type": "string",
+                                    "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                                  },
+                                  "hasUnlimitedSeats": { "type": "boolean" },
+                                  "platform": {
+                                    "type": "boolean",
+                                    "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                                  }
+                                }
+                              }
+                            },
+                            "pagingCallback": { "type": "object" },
+                            "callback": { "type": "object" },
+                            "max-results": {
+                              "type": "integer",
+                              "xml": {
+                                "name": "max-results",
+                                "attribute": true
+                              }
+                            }
+                          }
+                        },
+                        "expand": {
+                          "type": "string",
+                          "description": "Expand options that include additional user details in the response.",
+                          "readOnly": true,
+                          "xml": { "attribute": true }
+                        }
+                      }
+                    },
+                    "isAssigneeTypeValid": {
+                      "type": "boolean",
+                      "description": "Whether a user is associated with `assigneeType`. For example, if the `assigneeType` is set to `COMPONENT_LEAD` but the component lead is not set, then `false` is returned.",
+                      "readOnly": true
+                    },
+                    "project": {
+                      "type": "string",
+                      "description": "The key of the project the component is assigned to. Required when creating a component. Can't be updated."
+                    },
+                    "projectId": {
+                      "type": "integer",
+                      "description": "The ID of the project the component is assigned to.",
+                      "readOnly": true
+                    }
+                  }
+                }
+              },
+              "issueTypes": {
+                "type": "array",
+                "description": "List of the issue types available in the project.",
+                "readOnly": true,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "self": {
+                      "type": "string",
+                      "description": "The URL of these issue type details.",
+                      "readOnly": true
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "The ID of the issue type.",
+                      "readOnly": true
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "The description of the issue type.",
+                      "readOnly": true
+                    },
+                    "iconUrl": {
+                      "type": "string",
+                      "description": "The URL of the issue type's avatar.",
+                      "readOnly": true
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the issue type.",
+                      "readOnly": true
+                    },
+                    "subtask": {
+                      "type": "boolean",
+                      "description": "Whether this issue type is used to create subtasks.",
+                      "readOnly": true
+                    },
+                    "avatarId": {
+                      "type": "integer",
+                      "description": "The ID of the issue type's avatar.",
+                      "readOnly": true
+                    },
+                    "entityId": {
+                      "type": "string",
+                      "description": "Unique ID for next-gen projects.",
+                      "readOnly": true
+                    },
+                    "hierarchyLevel": {
+                      "type": "integer",
+                      "description": "Hierarchy level of the issue type.",
+                      "readOnly": true
+                    },
+                    "scope": {
+                      "description": "Details of the next-gen projects the issue type is available in.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "The type of scope.",
+                          "readOnly": true,
+                          "enum": ["PROJECT", "TEMPLATE"]
+                        },
+                        "project": {
+                          "description": "The project the item has scope in.",
+                          "readOnly": true,
+                          "type": "object",
+                          "properties": {
+                            "self": {
+                              "type": "string",
+                              "description": "The URL of the project details.",
+                              "readOnly": true
+                            },
+                            "id": {
+                              "type": "string",
+                              "description": "The ID of the project."
+                            },
+                            "key": {
+                              "type": "string",
+                              "description": "The key of the project.",
+                              "readOnly": true
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The name of the project.",
+                              "readOnly": true
+                            },
+                            "projectTypeKey": {
+                              "type": "string",
+                              "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                              "readOnly": true,
+                              "enum": ["software", "service_desk", "business"]
+                            },
+                            "simplified": {
+                              "type": "boolean",
+                              "description": "Whether or not the project is simplified.",
+                              "readOnly": true
+                            },
+                            "avatarUrls": {
+                              "description": "The URLs of the project's avatars.",
+                              "readOnly": true,
+                              "type": "object",
+                              "properties": {
+                                "16x16": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 16x16 pixel avatar."
+                                },
+                                "24x24": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 24x24 pixel avatar."
+                                },
+                                "32x32": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 32x32 pixel avatar."
+                                },
+                                "48x48": {
+                                  "type": "string",
+                                  "description": "The URL of the item's 48x48 pixel avatar."
+                                }
+                              }
+                            },
+                            "projectCategory": {
+                              "description": "The category the project belongs to.",
+                              "readOnly": true,
+                              "type": "object",
+                              "properties": {
+                                "self": {
+                                  "type": "string",
+                                  "description": "The URL of the project category.",
+                                  "readOnly": true
+                                },
+                                "id": {
+                                  "type": "string",
+                                  "description": "The ID of the project category.",
+                                  "readOnly": true
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "description": "The name of the project category.",
+                                  "readOnly": true
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "The description of the project category.",
+                                  "readOnly": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "url": {
+                "type": "string",
+                "description": "A link to information about this project, such as project documentation.",
+                "readOnly": true
+              },
+              "email": {
+                "type": "string",
+                "description": "An email address associated with the project."
+              },
+              "assigneeType": {
+                "type": "string",
+                "description": "The default assignee when creating issues for this project.",
+                "readOnly": true,
+                "enum": ["PROJECT_LEAD", "UNASSIGNED"]
+              },
+              "versions": {
+                "type": "array",
+                "description": "The versions defined in the project. For more information, see [Create version](#api-rest-api-3-version-post).",
+                "readOnly": true,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "expand": {
+                      "type": "string",
+                      "description": "Use [expand](em>#expansion) to include additional information about version in the response. This parameter accepts a comma-separated list. Expand options include:\n\n *  `operations` Returns the list of operations available for this version.\n *  `issuesstatus` Returns the count of issues in this version for each of the status categories *to do*, *in progress*, *done*, and *unmapped*. The *unmapped* property contains a count of issues with a status other than *to do*, *in progress*, and *done*.\n\nOptional for create and update.",
+                      "xml": { "attribute": true }
+                    },
+                    "self": {
+                      "type": "string",
+                      "description": "The URL of the version.",
+                      "readOnly": true
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "The ID of the version.",
+                      "readOnly": true
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "The description of the version. Optional when creating or updating a version."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The unique name of the version. Required when creating a version. Optional when updating a version. The maximum length is 255 characters."
+                    },
+                    "archived": {
+                      "type": "boolean",
+                      "description": "Indicates that the version is archived. Optional when creating or updating a version."
+                    },
+                    "released": {
+                      "type": "boolean",
+                      "description": "Indicates that the version is released. If the version is released a request to release again is ignored. Not applicable when creating a version. Optional when updating a version."
+                    },
+                    "startDate": {
+                      "type": "string",
+                      "description": "The start date of the version. Expressed in ISO 8601 format (yyyy-mm-dd). Optional when creating or updating a version.",
+                      "format": "date"
+                    },
+                    "releaseDate": {
+                      "type": "string",
+                      "description": "The release date of the version. Expressed in ISO 8601 format (yyyy-mm-dd). Optional when creating or updating a version.",
+                      "format": "date"
+                    },
+                    "overdue": {
+                      "type": "boolean",
+                      "description": "Indicates that the version is overdue.",
+                      "readOnly": true
+                    },
+                    "userStartDate": {
+                      "type": "string",
+                      "description": "The date on which work on this version is expected to start, expressed in the instance's *Day/Month/Year Format* date format.",
+                      "readOnly": true
+                    },
+                    "userReleaseDate": {
+                      "type": "string",
+                      "description": "The date on which work on this version is expected to finish, expressed in the instance's *Day/Month/Year Format* date format.",
+                      "readOnly": true
+                    },
+                    "project": {
+                      "type": "string",
+                      "description": "Deprecated. Use `projectId`."
+                    },
+                    "projectId": {
+                      "type": "integer",
+                      "description": "The ID of the project to which this version is attached. Required when creating a version. Not applicable when updating a version."
+                    },
+                    "moveUnfixedIssuesTo": {
+                      "type": "string",
+                      "description": "The URL of the self link to the version to which all unfixed issues are moved when a version is released. Not applicable when creating a version. Optional when updating a version."
+                    },
+                    "operations": {
+                      "type": "array",
+                      "description": "If the expand option `operations` is used, returns the list of operations available for this version.",
+                      "readOnly": true,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "styleClass": { "type": "string" },
+                          "iconClass": { "type": "string" },
+                          "label": { "type": "string" },
+                          "title": { "type": "string" },
+                          "href": { "type": "string" },
+                          "weight": { "type": "integer" }
+                        }
+                      }
+                    },
+                    "issuesStatusForFixVersion": {
+                      "description": "If the expand option `issuesstatus` is used, returns the count of issues in this version for each of the status categories *to do*, *in progress*, *done*, and *unmapped*. The *unmapped* property contains a count of issues with a status other than *to do*, *in progress*, and *done*.",
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "unmapped": {
+                          "type": "integer",
+                          "description": "Count of issues with a status other than *to do*, *in progress*, and *done*.",
+                          "readOnly": true
+                        },
+                        "toDo": {
+                          "type": "integer",
+                          "description": "Count of issues with status *to do*.",
+                          "readOnly": true
+                        },
+                        "inProgress": {
+                          "type": "integer",
+                          "description": "Count of issues with status *in progress*.",
+                          "readOnly": true
+                        },
+                        "done": {
+                          "type": "integer",
+                          "description": "Count of issues with status *done*.",
+                          "readOnly": true
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "name": {
+                "type": "string",
+                "description": "The name of the project.",
+                "readOnly": true
+              },
+              "roles": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "The name and self URL for each role defined in the project. For more information, see [Create project role](#api-rest-api-3-role-post).",
+                "readOnly": true
+              },
+              "avatarUrls": {
+                "description": "The URLs of the project's avatars.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "16x16": {
+                    "type": "string",
+                    "description": "The URL of the item's 16x16 pixel avatar."
+                  },
+                  "24x24": {
+                    "type": "string",
+                    "description": "The URL of the item's 24x24 pixel avatar."
+                  },
+                  "32x32": {
+                    "type": "string",
+                    "description": "The URL of the item's 32x32 pixel avatar."
+                  },
+                  "48x48": {
+                    "type": "string",
+                    "description": "The URL of the item's 48x48 pixel avatar."
+                  }
+                }
+              },
+              "projectCategory": {
+                "description": "The category the project belongs to.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "type": "string",
+                    "description": "The URL of the project category.",
+                    "readOnly": true
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "The ID of the project category.",
+                    "readOnly": true
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the project category. Required on create, optional on update."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The description of the project category. Required on create, optional on update."
+                  }
+                }
+              },
+              "projectTypeKey": {
+                "type": "string",
+                "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                "readOnly": true,
+                "enum": ["software", "service_desk", "business"]
+              },
+              "simplified": {
+                "type": "boolean",
+                "description": "Whether the project is simplified.",
+                "readOnly": true
+              },
+              "style": {
+                "type": "string",
+                "description": "The type of the project.",
+                "readOnly": true,
+                "enum": ["classic", "next-gen"]
+              },
+              "favourite": {
+                "type": "boolean",
+                "description": "Whether the project is selected as a favorite."
+              },
+              "isPrivate": {
+                "type": "boolean",
+                "description": "Whether the project is private.",
+                "readOnly": true
+              },
+              "issueTypeHierarchy": {
+                "description": "The issue type hierarchy for the project",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "level": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "integer" },
+                        "name": { "type": "string" },
+                        "aboveLevelId": { "type": "integer" },
+                        "belowLevelId": { "type": "integer" },
+                        "projectConfigurationId": { "type": "integer" },
+                        "level": { "type": "integer" },
+                        "issueTypeIds": {
+                          "type": "array",
+                          "items": { "type": "integer" }
+                        },
+                        "externalUuid": { "type": "string" },
+                        "globalHierarchyLevel": {
+                          "type": "string",
+                          "enum": ["SUBTASK", "BASE", "EPIC"]
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "permissions": {
+                "description": "User permissions on the project",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "canEdit": {
+                    "type": "boolean",
+                    "description": "Whether the logged user can edit the project.",
+                    "readOnly": true
+                  }
+                }
+              },
+              "properties": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Map of project properties",
+                "readOnly": true
+              },
+              "uuid": {
+                "type": "string",
+                "description": "Unique ID for next-gen projects.",
+                "readOnly": true
+              },
+              "insight": {
+                "description": "Insights about the project.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "totalIssueCount": {
+                    "type": "integer",
+                    "description": "Total issue count.",
+                    "readOnly": true
+                  },
+                  "lastIssueUpdateTime": {
+                    "type": "string",
+                    "description": "The last issue update time.",
+                    "format": "date-time",
+                    "readOnly": true
+                  }
+                }
+              },
+              "deleted": {
+                "type": "boolean",
+                "description": "Whether the project is marked as deleted.",
+                "readOnly": true
+              },
+              "retentionTillDate": {
+                "type": "string",
+                "description": "The date when the project is deleted permanently.",
+                "format": "date-time",
+                "readOnly": true
+              },
+              "deletedDate": {
+                "type": "string",
+                "description": "The date when the project was marked as deleted.",
+                "format": "date-time",
+                "readOnly": true
+              },
+              "deletedBy": {
+                "description": "The user who marked the project as deleted.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "type": "string",
+                    "description": "The URL of the user.",
+                    "readOnly": true
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                  },
+                  "accountId": {
+                    "maxLength": 128,
+                    "type": "string",
+                    "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                  },
+                  "accountType": {
+                    "type": "string",
+                    "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                    "readOnly": true,
+                    "enum": ["atlassian", "app", "customer", "unknown"]
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                  },
+                  "emailAddress": {
+                    "type": "string",
+                    "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                    "readOnly": true
+                  },
+                  "avatarUrls": {
+                    "description": "The avatars of the user.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "16x16": {
+                        "type": "string",
+                        "description": "The URL of the item's 16x16 pixel avatar."
+                      },
+                      "24x24": {
+                        "type": "string",
+                        "description": "The URL of the item's 24x24 pixel avatar."
+                      },
+                      "32x32": {
+                        "type": "string",
+                        "description": "The URL of the item's 32x32 pixel avatar."
+                      },
+                      "48x48": {
+                        "type": "string",
+                        "description": "The URL of the item's 48x48 pixel avatar."
+                      }
+                    }
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                    "readOnly": true
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "Whether the user is active.",
+                    "readOnly": true
+                  },
+                  "timeZone": {
+                    "type": "string",
+                    "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                    "readOnly": true
+                  },
+                  "locale": {
+                    "type": "string",
+                    "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                    "readOnly": true
+                  },
+                  "groups": {
+                    "description": "The groups that the user belongs to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "type": "integer",
+                        "xml": { "attribute": true }
+                      },
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "The name of group."
+                            },
+                            "self": {
+                              "type": "string",
+                              "description": "The URL for these group details.",
+                              "readOnly": true
+                            }
+                          }
+                        }
+                      },
+                      "pagingCallback": { "type": "object" },
+                      "callback": { "type": "object" },
+                      "max-results": {
+                        "type": "integer",
+                        "xml": { "name": "max-results", "attribute": true }
+                      }
+                    }
+                  },
+                  "applicationRoles": {
+                    "description": "The application roles the user is assigned to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "type": "integer",
+                        "xml": { "attribute": true }
+                      },
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "The key of the application role."
+                            },
+                            "groups": {
+                              "uniqueItems": true,
+                              "type": "array",
+                              "description": "The groups associated with the application role.",
+                              "items": { "type": "string" }
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The display name of the application role."
+                            },
+                            "defaultGroups": {
+                              "uniqueItems": true,
+                              "type": "array",
+                              "description": "The groups that are granted default access for this application role.",
+                              "items": { "type": "string" }
+                            },
+                            "selectedByDefault": {
+                              "type": "boolean",
+                              "description": "Determines whether this application role should be selected by default on user creation."
+                            },
+                            "defined": {
+                              "type": "boolean",
+                              "description": "Deprecated."
+                            },
+                            "numberOfSeats": {
+                              "type": "integer",
+                              "description": "The maximum count of users on your license."
+                            },
+                            "remainingSeats": {
+                              "type": "integer",
+                              "description": "The count of users remaining on your license."
+                            },
+                            "userCount": {
+                              "type": "integer",
+                              "description": "The number of users counting against your license."
+                            },
+                            "userCountDescription": {
+                              "type": "string",
+                              "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                            },
+                            "hasUnlimitedSeats": { "type": "boolean" },
+                            "platform": {
+                              "type": "boolean",
+                              "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                            }
+                          }
+                        }
+                      },
+                      "pagingCallback": { "type": "object" },
+                      "callback": { "type": "object" },
+                      "max-results": {
+                        "type": "integer",
+                        "xml": { "name": "max-results", "attribute": true }
+                      }
+                    }
+                  },
+                  "expand": {
+                    "type": "string",
+                    "description": "Expand options that include additional user details in the response.",
+                    "readOnly": true,
+                    "xml": { "attribute": true }
+                  }
+                }
+              },
+              "archived": {
+                "type": "boolean",
+                "description": "Whether the project is archived.",
+                "readOnly": true
+              },
+              "archivedDate": {
+                "type": "string",
+                "description": "The date when the project was archived.",
+                "format": "date-time",
+                "readOnly": true
+              },
+              "archivedBy": {
+                "description": "The user who archived the project.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "type": "string",
+                    "description": "The URL of the user.",
+                    "readOnly": true
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                  },
+                  "accountId": {
+                    "maxLength": 128,
+                    "type": "string",
+                    "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests."
+                  },
+                  "accountType": {
+                    "type": "string",
+                    "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                    "readOnly": true,
+                    "enum": ["atlassian", "app", "customer", "unknown"]
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details."
+                  },
+                  "emailAddress": {
+                    "type": "string",
+                    "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                    "readOnly": true
+                  },
+                  "avatarUrls": {
+                    "description": "The avatars of the user.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "16x16": {
+                        "type": "string",
+                        "description": "The URL of the item's 16x16 pixel avatar."
+                      },
+                      "24x24": {
+                        "type": "string",
+                        "description": "The URL of the item's 24x24 pixel avatar."
+                      },
+                      "32x32": {
+                        "type": "string",
+                        "description": "The URL of the item's 32x32 pixel avatar."
+                      },
+                      "48x48": {
+                        "type": "string",
+                        "description": "The URL of the item's 48x48 pixel avatar."
+                      }
+                    }
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                    "readOnly": true
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "Whether the user is active.",
+                    "readOnly": true
+                  },
+                  "timeZone": {
+                    "type": "string",
+                    "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                    "readOnly": true
+                  },
+                  "locale": {
+                    "type": "string",
+                    "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                    "readOnly": true
+                  },
+                  "groups": {
+                    "description": "The groups that the user belongs to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "type": "integer",
+                        "xml": { "attribute": true }
+                      },
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "The name of group."
+                            },
+                            "self": {
+                              "type": "string",
+                              "description": "The URL for these group details.",
+                              "readOnly": true
+                            }
+                          }
+                        }
+                      },
+                      "pagingCallback": { "type": "object" },
+                      "callback": { "type": "object" },
+                      "max-results": {
+                        "type": "integer",
+                        "xml": { "name": "max-results", "attribute": true }
+                      }
+                    }
+                  },
+                  "applicationRoles": {
+                    "description": "The application roles the user is assigned to.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "type": "integer",
+                        "xml": { "attribute": true }
+                      },
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "The key of the application role."
+                            },
+                            "groups": {
+                              "uniqueItems": true,
+                              "type": "array",
+                              "description": "The groups associated with the application role.",
+                              "items": { "type": "string" }
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The display name of the application role."
+                            },
+                            "defaultGroups": {
+                              "uniqueItems": true,
+                              "type": "array",
+                              "description": "The groups that are granted default access for this application role.",
+                              "items": { "type": "string" }
+                            },
+                            "selectedByDefault": {
+                              "type": "boolean",
+                              "description": "Determines whether this application role should be selected by default on user creation."
+                            },
+                            "defined": {
+                              "type": "boolean",
+                              "description": "Deprecated."
+                            },
+                            "numberOfSeats": {
+                              "type": "integer",
+                              "description": "The maximum count of users on your license."
+                            },
+                            "remainingSeats": {
+                              "type": "integer",
+                              "description": "The count of users remaining on your license."
+                            },
+                            "userCount": {
+                              "type": "integer",
+                              "description": "The number of users counting against your license."
+                            },
+                            "userCountDescription": {
+                              "type": "string",
+                              "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license."
+                            },
+                            "hasUnlimitedSeats": { "type": "boolean" },
+                            "platform": {
+                              "type": "boolean",
+                              "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+                            }
+                          }
+                        }
+                      },
+                      "pagingCallback": { "type": "object" },
+                      "callback": { "type": "object" },
+                      "max-results": {
+                        "type": "integer",
+                        "xml": { "name": "max-results", "attribute": true }
+                      }
+                    }
+                  },
+                  "expand": {
+                    "type": "string",
+                    "description": "Expand options that include additional user details in the response.",
+                    "readOnly": true,
+                    "xml": { "attribute": true }
+                  }
+                }
+              }
+            }
+          },
+          "role": {
+            "description": "The project role that the filter is shared with.  \nFor a request, specify the `id` for the role. You must also specify the `project` object and `id` for the project that the role is in.",
+            "type": "object",
+            "properties": {
+              "self": {
+                "type": "string",
+                "description": "The URL the project role details.",
+                "readOnly": true
+              },
+              "name": {
+                "type": "string",
+                "description": "The name of the project role."
+              },
+              "id": {
+                "type": "integer",
+                "description": "The ID of the project role.",
+                "readOnly": true
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of the project role.",
+                "readOnly": true
+              },
+              "actors": {
+                "type": "array",
+                "description": "The list of users who act in this role.",
+                "readOnly": true,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "The ID of the role actor.",
+                      "readOnly": true
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "description": "The display name of the role actor. For users, depending on the user\u2019s privacy setting, this may return an alternative value for the user's name.",
+                      "readOnly": true
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The type of role actor.",
+                      "readOnly": true,
+                      "enum": [
+                        "atlassian-group-role-actor",
+                        "atlassian-user-role-actor"
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                      "readOnly": true
+                    },
+                    "avatarUrl": {
+                      "type": "string",
+                      "description": "The avatar of the role actor.",
+                      "readOnly": true
+                    },
+                    "actorUser": {
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "accountId": {
+                          "maxLength": 128,
+                          "type": "string",
+                          "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Returns *unknown* if the record is deleted and corrupted, for example, as the result of a server import.",
+                          "readOnly": true
+                        }
+                      }
+                    },
+                    "actorGroup": {
+                      "readOnly": true,
+                      "type": "object",
+                      "properties": {
+                        "displayName": {
+                          "type": "string",
+                          "description": "The display name of the group."
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The name of the group"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "scope": {
+                "description": "The scope of the role. Indicated for roles associated with [next-gen projects](https://confluence.atlassian.com/x/loMyO).",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "The type of scope.",
+                    "readOnly": true,
+                    "enum": ["PROJECT", "TEMPLATE"]
+                  },
+                  "project": {
+                    "description": "The project the item has scope in.",
+                    "readOnly": true,
+                    "type": "object",
+                    "properties": {
+                      "self": {
+                        "type": "string",
+                        "description": "The URL of the project details.",
+                        "readOnly": true
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "The ID of the project."
+                      },
+                      "key": {
+                        "type": "string",
+                        "description": "The key of the project.",
+                        "readOnly": true
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "The name of the project.",
+                        "readOnly": true
+                      },
+                      "projectTypeKey": {
+                        "type": "string",
+                        "description": "The [project type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes) of the project.",
+                        "readOnly": true,
+                        "enum": ["software", "service_desk", "business"]
+                      },
+                      "simplified": {
+                        "type": "boolean",
+                        "description": "Whether or not the project is simplified.",
+                        "readOnly": true
+                      },
+                      "avatarUrls": {
+                        "description": "The URLs of the project's avatars.",
+                        "readOnly": true,
+                        "type": "object",
+                        "properties": {
+                          "16x16": {
+                            "type": "string",
+                            "description": "The URL of the item's 16x16 pixel avatar."
+                          },
+                          "24x24": {
+                            "type": "string",
+                            "description": "The URL of the item's 24x24 pixel avatar."
+                          },
+                          "32x32": {
+                            "type": "string",
+                            "description": "The URL of the item's 32x32 pixel avatar."
+                          },
+                          "48x48": {
+                            "type": "string",
+                            "description": "The URL of the item's 48x48 pixel avatar."
+                          }
+                        }
+                      },
+                      "projectCategory": {
+                        "description": "The category the project belongs to.",
+                        "readOnly": true,
+                        "type": "object",
+                        "properties": {
+                          "self": {
+                            "type": "string",
+                            "description": "The URL of the project category.",
+                            "readOnly": true
+                          },
+                          "id": {
+                            "type": "string",
+                            "description": "The ID of the project category.",
+                            "readOnly": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "The name of the project category.",
+                            "readOnly": true
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The description of the project category.",
+                            "readOnly": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "translatedName": {
+                "type": "string",
+                "description": "The translated name of the project role."
+              },
+              "currentUserRole": {
+                "type": "boolean",
+                "description": "Whether the calling user is part of this role."
+              },
+              "admin": {
+                "type": "boolean",
+                "description": "Whether this role is the admin role for the project.",
+                "readOnly": true
+              },
+              "roleConfigurable": {
+                "type": "boolean",
+                "description": "Whether the roles are configurable for this project.",
+                "readOnly": true
+              },
+              "default": {
+                "type": "boolean",
+                "description": "Whether this role is the default role for the project",
+                "readOnly": true
+              }
+            }
+          },
+          "group": {
+            "description": "The group that the filter is shared with. For a request, specify the `name` property for the group.",
+            "type": "object",
+            "properties": {
+              "groupId": { "type": ["null", "string"] },
+              "name": { "type": "string", "description": "The name of group." },
+              "self": {
+                "type": "string",
+                "description": "The URL for these group details.",
+                "readOnly": true
+              }
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of a share permission for the filter."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "issue_custom_field_contexts",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "description": "The details of a custom field context.",
+        "properties": {
+          "id": {
+            "description": "The ID of the context.",
+            "type": ["null", "string"]
+          },
+          "fieldId": {
+            "description": "Id of the related field",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name of the context.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the context.",
+            "type": ["null", "string"]
+          },
+          "isGlobalContext": {
+            "description": "Whether the context is global.",
+            "type": ["null", "boolean"]
+          },
+          "isAnyIssueType": {
+            "description": "Whether the context applies to all issue types.",
+            "type": ["null", "boolean"]
+          },
+          "fieldType": {
+            "description": "The type of the related field",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "issue_custom_field_options",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "description": "Details of the custom field options for a context.",
+        "properties": {
+          "id": {
+            "description": "The ID of the custom field option.",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The value of the custom field option.",
+            "type": ["null", "string"]
+          },
+          "optionId": {
+            "description": "For cascading options, the ID of the custom field option containing the cascading option.",
+            "type": ["null", "string"]
+          },
+          "disabled": {
+            "description": "Whether the option is disabled.",
+            "type": ["null", "boolean"]
+          },
+          "fieldId": {
+            "description": "The ID of the custom field to which the option belongs.",
+            "type": ["null", "string"]
+          },
+          "contextId": {
+            "description": "The ID of the context to which the custom field option belongs.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "issue_properties",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "key": {
+            "description": "The key of the property. Required on create and update.",
+            "type": "string"
+          },
+          "issueId": {
+            "description": "Id of the related issue.",
+            "type": ["null", "string"],
+            "readOnly": true
+          },
+          "value": {
+            "description": "The value of the property. Required on create and update."
+          },
+          "isdefault": {
+            "description": "Indicates if the property is the default property.",
+            "type": ["null", "boolean"]
+          }
+        },
+        "description": "An entity property, for more information see [Entity properties](https://developer.atlassian.com/cloud/jira/platform/jira-entity-properties/)."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["key"]],
+      "is_resumable": false
+    },
+    {
+      "name": "issue_remote_links",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": { "description": "The ID of the link.", "type": "integer" },
+          "issueId": {
+            "description": "Id of the related issue.",
+            "type": ["null", "string"]
+          },
+          "self": { "description": "The URL of the link.", "type": "string" },
+          "globalId": {
+            "description": "The global ID of the link, such as the ID of the item on the remote system.",
+            "type": "string"
+          },
+          "application": {
+            "description": "Details of the remote application the linked item is in.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "description": "The name-spaced type of the application, used by registered rendering apps.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the application. Used in conjunction with the (remote) object icon title to display a tooltip for the link's icon. The tooltip takes the format \"[application name] icon title\". Blank items are excluded from the tooltip title. If both items are blank, the icon tooltop displays as \"Web Link\". Grouping and sorting of links may place links without an application name last.",
+                "type": "string"
+              }
+            }
+          },
+          "relationship": {
+            "description": "Description of the relationship between the issue and the linked item.",
+            "type": "string"
+          },
+          "object": {
+            "description": "Details of the item linked to.",
+            "type": "object",
+            "properties": {
+              "url": {
+                "description": "The URL of the item.",
+                "type": "string"
+              },
+              "title": {
+                "description": "The title of the item.",
+                "type": "string"
+              },
+              "summary": {
+                "description": "The summary details of the item.",
+                "type": "string"
+              },
+              "icon": {
+                "description": "Details of the icon for the item. If no icon is defined, the default link icon is used in Jira.",
+                "type": "object",
+                "properties": {
+                  "url16x16": {
+                    "description": "The URL of an icon that displays at 16x16 pixel in Jira.",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "The title of the icon. This is used as follows:\n\n *  For a status icon it is used as a tooltip on the icon. If not set, the status icon doesn't display a tooltip in Jira.\n *  For the remote object icon it is used in conjunction with the application name to display a tooltip for the link's icon. The tooltip takes the format \"[application name] icon title\". Blank itemsare excluded from the tooltip title. If both items are blank, the icon tooltop displays as \"Web Link\".",
+                    "type": "string"
+                  },
+                  "link": {
+                    "description": "The URL of the tooltip, used only for a status icon. If not set, the status icon in Jira is not clickable.",
+                    "type": "string"
+                  }
+                }
+              },
+              "status": {
+                "description": "The status of the item.",
+                "type": "object",
+                "properties": {
+                  "resolved": {
+                    "description": "Whether the item is resolved. If set to \"true\", the link to the issue is displayed in a strikethrough font, otherwise the link displays in normal font.",
+                    "type": "boolean"
+                  },
+                  "icon": {
+                    "description": "Details of the icon representing the status. If not provided, no status icon displays in Jira.",
+                    "type": "object",
+                    "properties": {
+                      "url16x16": {
+                        "description": "The URL of an icon that displays at 16x16 pixel in Jira.",
+                        "type": "string"
+                      },
+                      "title": {
+                        "description": "The title of the icon. This is used as follows:\n\n *  For a status icon it is used as a tooltip on the icon. If not set, the status icon doesn't display a tooltip in Jira.\n *  For the remote object icon it is used in conjunction with the application name to display a tooltip for the link's icon. The tooltip takes the format \"[application name] icon title\". Blank itemsare excluded from the tooltip title. If both items are blank, the icon tooltop displays as \"Web Link\".",
+                        "type": "string"
+                      },
+                      "link": {
+                        "description": "The URL of the tooltip, used only for a status icon. If not set, the status icon in Jira is not clickable.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of an issue remote link."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "issue_transitions",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "title": "Issue Transitions",
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "Represents the custom fields associated with the issue transition",
+            "type": ["null", "string"]
+          },
+          "hasScreen": {
+            "description": "Indicates if the transition has an associated screen",
+            "type": ["null", "boolean"]
+          },
+          "id": {
+            "description": "Unique identifier for the issue transition",
+            "type": ["null", "string"]
+          },
+          "issueId": {
+            "description": "Identifier of the issue associated with the transition",
+            "type": ["null", "string"]
+          },
+          "isAvailable": {
+            "description": "Indicates if the transition is available",
+            "type": ["null", "boolean"]
+          },
+          "isConditional": {
+            "description": "Indicates if the transition is conditional",
+            "type": ["null", "boolean"]
+          },
+          "isGlobal": {
+            "description": "Indicates if the transition is global",
+            "type": ["null", "boolean"]
+          },
+          "isInitial": {
+            "description": "Indicates if the transition is the initial transition",
+            "type": ["null", "boolean"]
+          },
+          "isLooped": {
+            "description": "Indicates if the transition is a loop transition",
+            "type": ["null", "boolean"]
+          },
+          "name": {
+            "description": "Name of the issue transition",
+            "type": ["null", "string"]
+          },
+          "to": {
+            "description": "Represents the destination status of the issue transition.",
+            "type": ["null", "object"],
+            "properties": {
+              "description": {
+                "description": "Description of the destination status",
+                "type": ["null", "string"]
+              },
+              "iconUrl": {
+                "description": "URL of the icon associated with the destination status",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "Unique identifier for the destination status",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Name of the destination status",
+                "type": ["null", "string"]
+              },
+              "self": {
+                "description": "Self URI for the destination status",
+                "type": ["null", "string"]
+              },
+              "statusCategory": {
+                "description": "Contains information about the category of the status.",
+                "type": ["null", "object"],
+                "properties": {
+                  "colorName": {
+                    "description": "Name of the color associated with the status category",
+                    "type": ["null", "string"]
+                  },
+                  "id": {
+                    "description": "Unique identifier for the status category",
+                    "type": ["null", "integer"]
+                  },
+                  "key": {
+                    "description": "Key of the status category",
+                    "type": ["null", "string"]
+                  },
+                  "name": {
+                    "description": "Name of the status category",
+                    "type": ["null", "string"]
+                  },
+                  "self": {
+                    "description": "Self URI for the status category",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["issueId"], ["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "issue_votes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of these issue vote details.",
+            "type": "string",
+            "readOnly": true
+          },
+          "issueId": {
+            "description": "Id of the related issue.",
+            "type": ["null", "string"],
+            "readOnly": true
+          },
+          "votes": {
+            "description": "The number of votes on the issue.",
+            "type": "integer",
+            "readOnly": true
+          },
+          "hasVoted": {
+            "description": "Whether the user making this request has voted on the issue.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "voters": {
+            "description": "List of the users who have voted on this issue. An empty list is returned when the calling user doesn't have the *View voters and watchers* project permission.",
+            "type": "array",
+            "readOnly": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "self": {
+                  "description": "The URL of the user.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "key": {
+                  "description": "This property is no longer available and will be removed from the documentation soon. See the deprecation notice for details.",
+                  "type": "string"
+                },
+                "accountId": {
+                  "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests.",
+                  "maxLength": 128,
+                  "type": "string"
+                },
+                "accountType": {
+                  "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                  "type": "string",
+                  "readOnly": true,
+                  "enum": ["atlassian", "app", "customer", "unknown"]
+                },
+                "name": {
+                  "description": "This property is no longer available and will be removed from the documentation soon. See the deprecation notice for details.",
+                  "type": "string"
+                },
+                "emailAddress": {
+                  "description": "The email address of the user. Depending on the user's privacy setting, this may be returned as null.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "avatarUrls": {
+                  "description": "The avatars of the user.",
+                  "readOnly": true,
+                  "type": "object",
+                  "properties": {
+                    "16x16": {
+                      "description": "The URL of the item's 16x16 pixel avatar.",
+                      "type": "string"
+                    },
+                    "24x24": {
+                      "description": "The URL of the item's 24x24 pixel avatar.",
+                      "type": "string"
+                    },
+                    "32x32": {
+                      "description": "The URL of the item's 32x32 pixel avatar.",
+                      "type": "string"
+                    },
+                    "48x48": {
+                      "description": "The URL of the item's 48x48 pixel avatar.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "displayName": {
+                  "description": "The display name of the user. Depending on the user's privacy setting, this may return an alternative value.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "active": {
+                  "description": "Whether the user is active.",
+                  "type": "boolean",
+                  "readOnly": true
+                },
+                "timeZone": {
+                  "description": "The time zone specified in the user's profile. Depending on the user's privacy setting, this may be returned as null.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "locale": {
+                  "description": "The locale of the user. Depending on the user's privacy setting, this may be returned as null.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "groups": {
+                  "description": "The groups that the user belongs to.",
+                  "readOnly": true,
+                  "type": "object",
+                  "properties": {
+                    "size": {
+                      "description": "Size XML information.",
+                      "type": "integer",
+                      "xml": { "attribute": true }
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "The name of group.",
+                            "type": "string"
+                          },
+                          "self": {
+                            "description": "The URL for these group details.",
+                            "type": "string",
+                            "readOnly": true
+                          }
+                        }
+                      }
+                    },
+                    "pagingCallback": {
+                      "description": "Paging callback.",
+                      "type": "object"
+                    },
+                    "callback": {
+                      "description": "Callback information.",
+                      "type": "object"
+                    },
+                    "max-results": {
+                      "description": "Max results related information.",
+                      "type": "integer",
+                      "xml": { "name": "max-results", "attribute": true }
+                    }
+                  }
+                },
+                "applicationRoles": {
+                  "description": "The application roles the user is assigned to.",
+                  "readOnly": true,
+                  "type": "object",
+                  "properties": {
+                    "size": {
+                      "description": "Size XML information.",
+                      "type": "integer",
+                      "xml": { "attribute": true }
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the application role.",
+                            "type": "string"
+                          },
+                          "groups": {
+                            "description": "The groups associated with the application role.",
+                            "uniqueItems": true,
+                            "type": "array",
+                            "items": { "type": "string" }
+                          },
+                          "name": {
+                            "description": "The display name of the application role.",
+                            "type": "string"
+                          },
+                          "defaultGroups": {
+                            "description": "The groups that are granted default access for this application role.",
+                            "uniqueItems": true,
+                            "type": "array",
+                            "items": { "type": "string" }
+                          },
+                          "selectedByDefault": {
+                            "description": "Determines whether this application role should be selected by default on user creation.",
+                            "type": "boolean"
+                          },
+                          "defined": {
+                            "description": "Deprecated.",
+                            "type": "boolean"
+                          },
+                          "numberOfSeats": {
+                            "description": "The maximum count of users on your license.",
+                            "type": "integer"
+                          },
+                          "remainingSeats": {
+                            "description": "The count of users remaining on your license.",
+                            "type": "integer"
+                          },
+                          "userCount": {
+                            "description": "The number of users counting against your license.",
+                            "type": "integer"
+                          },
+                          "userCountDescription": {
+                            "description": "The type of users being counted against your license.",
+                            "type": "string"
+                          },
+                          "hasUnlimitedSeats": {
+                            "description": "Indicates if there are unlimited seats for this application role.",
+                            "type": "boolean"
+                          },
+                          "platform": {
+                            "description": "Indicates if the application role belongs to Jira platform (`jira-core`).",
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    },
+                    "pagingCallback": {
+                      "description": "Paging callback.",
+                      "type": "object"
+                    },
+                    "callback": {
+                      "description": "Callback information.",
+                      "type": "object"
+                    },
+                    "max-results": {
+                      "description": "Max results related information.",
+                      "type": "integer",
+                      "xml": { "name": "max-results", "attribute": true }
+                    }
+                  }
+                },
+                "expand": {
+                  "description": "Expand options that include additional user details in the response.",
+                  "type": "string",
+                  "readOnly": true,
+                  "xml": { "attribute": true }
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "The details of votes on an issue."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "is_resumable": false
+    },
+    {
+      "name": "issue_watchers",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of these issue watcher details.",
+            "type": "string",
+            "readOnly": true
+          },
+          "issueId": {
+            "description": "Id of the related issue.",
+            "type": ["null", "string"]
+          },
+          "isWatching": {
+            "description": "Whether the calling user is watching this issue.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "watchCount": {
+            "description": "The number of users watching this issue.",
+            "type": "integer",
+            "readOnly": true
+          },
+          "watchers": {
+            "description": "Details of the users watching this issue.",
+            "type": "array",
+            "readOnly": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "self": {
+                  "description": "The URL of the user.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "name": {
+                  "description": "This property is no longer available and will be removed from the documentation soon. See the deprecation notice for details.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "key": {
+                  "description": "This property is no longer available and will be removed from the documentation soon. See the deprecation notice for details.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "accountId": {
+                  "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*.",
+                  "maxLength": 128,
+                  "type": "string"
+                },
+                "emailAddress": {
+                  "description": "The email address of the user. Depending on the user's privacy settings, this may be returned as null.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "avatarUrls": {
+                  "description": "The avatars of the user.",
+                  "readOnly": true,
+                  "type": "object",
+                  "properties": {
+                    "16x16": {
+                      "description": "The URL of the item's 16x16 pixel avatar.",
+                      "type": "string"
+                    },
+                    "24x24": {
+                      "description": "The URL of the item's 24x24 pixel avatar.",
+                      "type": "string"
+                    },
+                    "32x32": {
+                      "description": "The URL of the item's 32x32 pixel avatar.",
+                      "type": "string"
+                    },
+                    "48x48": {
+                      "description": "The URL of the item's 48x48 pixel avatar.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "displayName": {
+                  "description": "The display name of the user. Depending on the user's privacy settings, this may return an alternative value.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "active": {
+                  "description": "Whether the user is active.",
+                  "type": "boolean",
+                  "readOnly": true
+                },
+                "timeZone": {
+                  "description": "The time zone specified in the user's profile. Depending on the user's privacy settings, this may be returned as null.",
+                  "type": "string",
+                  "readOnly": true
+                },
+                "accountType": {
+                  "description": "The type of account represented by this user. This will be one of 'atlassian' (normal users), 'app' (application user) or 'customer' (Jira Service Desk customer user)",
+                  "type": "string",
+                  "readOnly": true
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "The details of watchers on an issue."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "is_resumable": false
+    },
+    {
+      "name": "project_avatars",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": { "description": "The ID of the avatar.", "type": "string" },
+          "projectId": {
+            "description": "Id of the related project.",
+            "type": ["null", "string"]
+          },
+          "owner": {
+            "description": "The owner of the avatar. For a system avatar the owner is null (and nothing is returned). For non-system avatars this is the appropriate identifier, such as the ID for a project or the account ID for a user.",
+            "type": "string",
+            "readOnly": true
+          },
+          "isSystemAvatar": {
+            "description": "Whether the avatar is a system avatar.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isSelected": {
+            "description": "Whether the avatar is used in Jira. For example, shown as a project's avatar.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isDeletable": {
+            "description": "Whether the avatar can be deleted.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "fileName": {
+            "description": "The file name of the avatar icon. Returned for system avatars.",
+            "type": "string",
+            "readOnly": true
+          },
+          "urls": {
+            "description": "The list of avatar icon URLs.",
+            "type": "object",
+            "additionalProperties": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": true,
+        "description": "List of project avatars."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "project_components",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the component.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "The unique identifier for the component.",
+            "type": "string",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The unique name for the component in the project. Required when creating a component. Optional when updating a component. The maximum length is 255 characters.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description for the component. Optional when creating or updating a component.",
+            "type": "string"
+          },
+          "lead": {
+            "description": "The user details for the component's lead user.",
+            "type": "object",
+            "properties": {
+              "self": {
+                "description": "The URL of the user.",
+                "type": "string",
+                "readOnly": true
+              },
+              "key": {
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                "type": "string"
+              },
+              "accountId": {
+                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests.",
+                "maxLength": 128,
+                "type": "string"
+              },
+              "accountType": {
+                "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                "type": "string",
+                "readOnly": true,
+                "enum": ["atlassian", "app", "customer", "unknown"]
+              },
+              "name": {
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                "type": "string"
+              },
+              "emailAddress": {
+                "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "avatarUrls": {
+                "description": "The avatars of the user.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "16x16": {
+                    "description": "The URL of the item's 16x16 pixel avatar.",
+                    "type": "string"
+                  },
+                  "24x24": {
+                    "description": "The URL of the item's 24x24 pixel avatar.",
+                    "type": "string"
+                  },
+                  "32x32": {
+                    "description": "The URL of the item's 32x32 pixel avatar.",
+                    "type": "string"
+                  },
+                  "48x48": {
+                    "description": "The URL of the item's 48x48 pixel avatar.",
+                    "type": "string"
+                  }
+                }
+              },
+              "displayName": {
+                "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                "type": "string",
+                "readOnly": true
+              },
+              "active": {
+                "description": "Whether the user is active.",
+                "type": "boolean",
+                "readOnly": true
+              },
+              "timeZone": {
+                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "locale": {
+                "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "groups": {
+                "description": "The groups that the user belongs to.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "size": { "type": "integer", "xml": { "attribute": true } },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "The name of group.",
+                          "type": "string"
+                        },
+                        "self": {
+                          "description": "The URL for these group details.",
+                          "type": "string",
+                          "readOnly": true
+                        }
+                      }
+                    }
+                  },
+                  "pagingCallback": { "type": "object" },
+                  "callback": { "type": "object" },
+                  "max-results": {
+                    "type": "integer",
+                    "xml": { "name": "max-results", "attribute": true }
+                  }
+                }
+              },
+              "applicationRoles": {
+                "description": "The application roles the user is assigned to.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "size": { "type": "integer", "xml": { "attribute": true } },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the application role.",
+                          "type": "string"
+                        },
+                        "groups": {
+                          "description": "The groups associated with the application role.",
+                          "uniqueItems": true,
+                          "type": "array",
+                          "items": { "type": "string" }
+                        },
+                        "name": {
+                          "description": "The display name of the application role.",
+                          "type": "string"
+                        },
+                        "defaultGroups": {
+                          "description": "The groups that are granted default access for this application role.",
+                          "uniqueItems": true,
+                          "type": "array",
+                          "items": { "type": "string" }
+                        },
+                        "selectedByDefault": {
+                          "description": "Determines whether this application role should be selected by default on user creation.",
+                          "type": "boolean"
+                        },
+                        "defined": {
+                          "description": "Deprecated.",
+                          "type": "boolean"
+                        },
+                        "numberOfSeats": {
+                          "description": "The maximum count of users on your license.",
+                          "type": "integer"
+                        },
+                        "remainingSeats": {
+                          "description": "The count of users remaining on your license.",
+                          "type": "integer"
+                        },
+                        "userCount": {
+                          "description": "The number of users counting against your license.",
+                          "type": "integer"
+                        },
+                        "userCountDescription": {
+                          "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license.",
+                          "type": "string"
+                        },
+                        "hasUnlimitedSeats": { "type": "boolean" },
+                        "platform": {
+                          "description": "Indicates if the application role belongs to Jira platform (`jira-core`).",
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  },
+                  "pagingCallback": { "type": "object" },
+                  "callback": { "type": "object" },
+                  "max-results": {
+                    "type": "integer",
+                    "xml": { "name": "max-results", "attribute": true }
+                  }
+                }
+              },
+              "expand": {
+                "description": "Expand options that include additional user details in the response.",
+                "type": "string",
+                "readOnly": true,
+                "xml": { "attribute": true }
+              }
+            }
+          },
+          "leadUserName": {
+            "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+            "type": ["string", "null"]
+          },
+          "leadAccountId": {
+            "description": "The accountId of the component's lead user. The accountId uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*.",
+            "maxLength": 128,
+            "type": ["string", "null"],
+            "writeOnly": true
+          },
+          "assigneeType": {
+            "description": "The nominal user type used to determine the assignee for issues created with this component. See `realAssigneeType` for details on how the type of the user, and hence the user, assigned to issues is determined. Can take the following values:\n\n *  `PROJECT_LEAD` the assignee to any issues created with this component is nominally the lead for the project the component is in.\n *  `COMPONENT_LEAD` the assignee to any issues created with this component is nominally the lead for the component.\n *  `UNASSIGNED` an assignee is not set for issues created with this component.\n *  `PROJECT_DEFAULT` the assignee to any issues created with this component is nominally the default assignee for the project that the component is in.\n\nDefault value: `PROJECT_DEFAULT`.  \nOptional when creating or updating a component.",
+            "type": "string",
+            "enum": [
+              "PROJECT_DEFAULT",
+              "COMPONENT_LEAD",
+              "PROJECT_LEAD",
+              "UNASSIGNED"
+            ]
+          },
+          "assignee": {
+            "description": "The details of the user associated with `assigneeType`, if any. See `realAssignee` for details of the user assigned to issues created with this component.",
+            "type": "object",
+            "properties": {
+              "self": {
+                "description": "The URL of the user.",
+                "type": "string",
+                "readOnly": true
+              },
+              "key": {
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                "type": ["string", "null"]
+              },
+              "accountId": {
+                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*. Required in requests.",
+                "maxLength": 128,
+                "type": "string"
+              },
+              "accountType": {
+                "description": "The user account type. Can take the following values:\n\n *  `atlassian` regular Atlassian user account\n *  `app` system account used for Connect applications and OAuth to represent external systems\n *  `customer` Jira Service Desk account representing an external service desk",
+                "type": "string",
+                "readOnly": true,
+                "enum": ["atlassian", "app", "customer", "unknown"]
+              },
+              "name": {
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                "type": "string"
+              },
+              "emailAddress": {
+                "description": "The email address of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "avatarUrls": {
+                "description": "The avatars of the user.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "16x16": {
+                    "description": "The URL of the item's 16x16 pixel avatar.",
+                    "type": "string"
+                  },
+                  "24x24": {
+                    "description": "The URL of the item's 24x24 pixel avatar.",
+                    "type": "string"
+                  },
+                  "32x32": {
+                    "description": "The URL of the item's 32x32 pixel avatar.",
+                    "type": "string"
+                  },
+                  "48x48": {
+                    "description": "The URL of the item's 48x48 pixel avatar.",
+                    "type": "string"
+                  }
+                }
+              },
+              "displayName": {
+                "description": "The display name of the user. Depending on the user\u2019s privacy setting, this may return an alternative value.",
+                "type": "string",
+                "readOnly": true
+              },
+              "active": {
+                "description": "Whether the user is active.",
+                "type": "boolean",
+                "readOnly": true
+              },
+              "timeZone": {
+                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "locale": {
+                "description": "The locale of the user. Depending on the user\u2019s privacy setting, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "groups": {
+                "description": "The groups that the user belongs to.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "size": { "type": "integer", "xml": { "attribute": true } },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "The name of group.",
+                          "type": "string"
+                        },
+                        "self": {
+                          "description": "The URL for these group details.",
+                          "type": "string",
+                          "readOnly": true
+                        }
+                      }
+                    }
+                  },
+                  "pagingCallback": { "type": "object" },
+                  "callback": { "type": "object" },
+                  "max-results": {
+                    "type": "integer",
+                    "xml": { "name": "max-results", "attribute": true }
+                  }
+                }
+              },
+              "applicationRoles": {
+                "description": "The application roles the user is assigned to.",
+                "readOnly": true,
+                "type": ["object", "null"],
+                "properties": {
+                  "size": { "type": "integer", "xml": { "attribute": true } },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the application role.",
+                          "type": "string"
+                        },
+                        "groups": {
+                          "description": "The groups associated with the application role.",
+                          "uniqueItems": true,
+                          "type": "array",
+                          "items": { "type": "string" }
+                        },
+                        "name": {
+                          "description": "The display name of the application role.",
+                          "type": "string"
+                        },
+                        "defaultGroups": {
+                          "description": "The groups that are granted default access for this application role.",
+                          "uniqueItems": true,
+                          "type": "array",
+                          "items": { "type": "string" }
+                        },
+                        "selectedByDefault": {
+                          "description": "Determines whether this application role should be selected by default on user creation.",
+                          "type": "boolean"
+                        },
+                        "defined": {
+                          "description": "Deprecated.",
+                          "type": "boolean"
+                        },
+                        "numberOfSeats": {
+                          "description": "The maximum count of users on your license.",
+                          "type": "integer"
+                        },
+                        "remainingSeats": {
+                          "description": "The count of users remaining on your license.",
+                          "type": "integer"
+                        },
+                        "userCount": {
+                          "description": "The number of users counting against your license.",
+                          "type": "integer"
+                        },
+                        "userCountDescription": {
+                          "description": "The [type of users](https://confluence.atlassian.com/x/lRW3Ng) being counted against your license.",
+                          "type": "string"
+                        },
+                        "hasUnlimitedSeats": { "type": "boolean" },
+                        "platform": {
+                          "description": "Indicates if the application role belongs to Jira platform (`jira-core`).",
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  },
+                  "pagingCallback": { "type": "object" },
+                  "callback": { "type": "object" },
+                  "max-results": {
+                    "type": "integer",
+                    "xml": { "name": "max-results", "attribute": true }
+                  }
+                }
+              },
+              "expand": {
+                "description": "Expand options that include additional user details in the response.",
+                "type": "string",
+                "readOnly": true,
+                "xml": { "attribute": true }
+              }
+            }
+          },
+          "realAssigneeType": {
+            "description": "The type of the assignee that is assigned to issues created with this component, when an assignee cannot be set from the `assigneeType`. For example, `assigneeType` is set to `COMPONENT_LEAD` but no component lead is set. This property is set to one of the following values:\n\n *  `PROJECT_LEAD` when `assigneeType` is `PROJECT_LEAD` and the project lead has permission to be assigned issues in the project that the component is in.\n *  `COMPONENT_LEAD` when `assignee`Type is `COMPONENT_LEAD` and the component lead has permission to be assigned issues in the project that the component is in.\n *  `UNASSIGNED` when `assigneeType` is `UNASSIGNED` and Jira is configured to allow unassigned issues.\n *  `PROJECT_DEFAULT` when none of the preceding cases are true.",
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "PROJECT_DEFAULT",
+              "COMPONENT_LEAD",
+              "PROJECT_LEAD",
+              "UNASSIGNED"
+            ]
+          },
+          "realAssignee": {
+            "description": "The user assigned to issues created with this component, when `assigneeType` does not identify a valid assignee.",
+            "readOnly": true,
+            "type": "object"
+          },
+          "isAssigneeTypeValid": {
+            "description": "Whether a user is associated with `assigneeType`. For example, if the `assigneeType` is set to `COMPONENT_LEAD` but the component lead is not set, then `false` is returned.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "project": {
+            "description": "The key of the project the component is assigned to. Required when creating a component. Can't be updated.",
+            "type": "string"
+          },
+          "projectId": {
+            "description": "The ID of the project the component is assigned to.",
+            "type": "integer",
+            "readOnly": true
+          },
+          "componentBean": {
+            "description": "Contains information about the component associated with the project.",
+            "type": ["null", "object"]
+          },
+          "issueCount": {
+            "description": "The total count of issues related to the project component.",
+            "type": ["null", "integer"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details about a project component.",
+        "xml": { "name": "component" }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "project_email",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "projectId": {
+            "description": "The unique identifier for the project.",
+            "type": "string"
+          },
+          "emailAddress": {
+            "description": "The email address of the project.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "description": "A project's sender email address."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["projectId"]],
+      "is_resumable": false
+    },
+    {
+      "name": "project_permission_schemes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the issue level security item.",
+            "type": ["null", "string"]
+          },
+          "projectId": {
+            "description": "Id of the related project.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The ID of the issue level security item.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the issue level security item.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name of the issue level security item.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details about a security scheme."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "project_versions",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "expand": {
+            "description": "Use expand parameter to include additional information about the version in the response. Optional field for creation and update. Expand options include operations and issuesstatus.",
+            "type": ["string", "null"],
+            "xml": { "attribute": true }
+          },
+          "self": {
+            "description": "The URL of the version.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "The unique ID of the version.",
+            "type": "string",
+            "readOnly": true
+          },
+          "description": {
+            "description": "The description of the version. Optional field for creating or updating a version.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The unique name assigned to the version. Required field for version creation, optional for version update. Maximum length is 255 characters.",
+            "type": "string"
+          },
+          "archived": {
+            "description": "Indicates whether the version is archived. Optional field for creating or updating a version.",
+            "type": "boolean"
+          },
+          "released": {
+            "description": "Indicates whether the version has been released. A request to release it again will be ignored. Not applicable during version creation. Optional field for version update.",
+            "type": "boolean"
+          },
+          "startDate": {
+            "description": "The start date of the version in ISO 8601 format (yyyy-mm-dd). Optional field for creating or updating a version.",
+            "type": "string",
+            "format": "date"
+          },
+          "releaseDate": {
+            "description": "The release date of the version in ISO 8601 format (yyyy-mm-dd). Optional field for creating or updating a version.",
+            "type": "string",
+            "format": "date"
+          },
+          "overdue": {
+            "description": "Indicates whether the version is overdue.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "userStartDate": {
+            "description": "The date when work on this version is expected to begin, expressed in the instance's Day/Month/Year format.",
+            "type": "string",
+            "readOnly": true
+          },
+          "userReleaseDate": {
+            "description": "The date when work on this version is expected to finish, expressed in the instance's Day/Month/Year format.",
+            "type": "string",
+            "readOnly": true
+          },
+          "project": {
+            "description": "Deprecated field. Use projectId instead.",
+            "type": "string"
+          },
+          "projectId": {
+            "description": "The ID of the project to which this version is connected. Required for version creation, not applicable for version update.",
+            "type": "integer"
+          },
+          "moveUnfixedIssuesTo": {
+            "description": "The URL of the self link to the version where all unfixed issues are moved when the version gets released. Not used during version creation. Optional field for version update.",
+            "type": "string"
+          },
+          "operations": {
+            "description": "If 'operations' is expanded, provides a list of available operations for this version.",
+            "type": "array",
+            "readOnly": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "description": "", "type": "string" },
+                "styleClass": { "description": "", "type": "string" },
+                "iconClass": { "description": "", "type": "string" },
+                "label": { "description": "", "type": "string" },
+                "title": { "description": "", "type": "string" },
+                "href": { "description": "", "type": "string" },
+                "weight": { "description": "", "type": "integer" }
+              }
+            }
+          },
+          "issuesStatusForFixVersion": {
+            "description": "If 'issuesstatus' is expanded, provides counts of issues in this version for status categories: to do, in progress, done, and unmapped.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "unmapped": {
+                "description": "Count of issues with a status other than to do, in progress, and done.",
+                "type": "integer",
+                "readOnly": true
+              },
+              "toDo": {
+                "description": "Count of issues marked as 'to do'.",
+                "type": "integer",
+                "readOnly": true
+              },
+              "inProgress": {
+                "description": "Count of issues marked as 'in progress'.",
+                "type": "integer",
+                "readOnly": true
+              },
+              "done": {
+                "description": "Count of issues marked as 'done'.",
+                "type": "integer",
+                "readOnly": true
+              }
+            }
+          }
+        },
+        "readOnly": true
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "screen_tabs",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the screen tab.",
+            "type": "integer",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the screen tab. The maximum length is 255 characters.",
+            "type": "string"
+          },
+          "screenId": {
+            "description": "Id of the related screen.",
+            "type": ["null", "integer"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "A screen tab."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "screen_tab_fields",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the screen tab field.",
+            "type": "string",
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the screen tab field. Required on create and update. The maximum length is 255 characters.",
+            "type": "string"
+          },
+          "screenId": {
+            "description": "ID of the related screen.",
+            "type": ["null", "integer"]
+          },
+          "tabId": {
+            "description": "ID of the related tab.",
+            "type": ["null", "integer"]
+          }
+        },
+        "additionalProperties": true,
+        "description": "A screen tab field."
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "sprints",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the sprint.",
+            "type": "integer"
+          },
+          "self": {
+            "description": "The URL link to fetch more details about the sprint.",
+            "type": "string"
+          },
+          "state": {
+            "description": "The current state/status of the sprint.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name or title of the sprint.",
+            "type": "string"
+          },
+          "startDate": {
+            "description": "The date and time when the sprint is scheduled to start.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "description": "The date and time when the sprint is expected to end.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "completeDate": {
+            "description": "The date and time when the sprint was completed.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "originBoardId": {
+            "description": "The original board ID the sprint belongs to.",
+            "type": "integer"
+          },
+          "boardId": {
+            "description": "Used to determine which board the sprint is a part of. (Not always the same as originBoardId)",
+            "type": "integer"
+          },
+          "goal": {
+            "description": "The goal or objective of the sprint.",
+            "type": "string"
+          },
+          "createdDate": {
+            "description": "The date and time when the sprint was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "users_groups_detailed",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the user.",
+            "type": "string",
+            "readOnly": true
+          },
+          "key": {
+            "description": "This property is no longer available and will be removed from the documentation soon. See the deprecation notice for details.",
+            "type": "string"
+          },
+          "accountId": {
+            "description": "The account ID of the user, uniquely identifying the user across all Atlassian products. Required in requests.",
+            "maxLength": 128,
+            "type": "string"
+          },
+          "accountType": {
+            "description": "The user account type. Possible values are 'atlassian' for regular Atlassian user account, 'app' for a system account used for Connect applications and OAuth, and 'customer' for a Jira Service Desk account representing an external service desk.",
+            "type": "string",
+            "readOnly": true,
+            "enum": ["atlassian", "app", "customer", "unknown"]
+          },
+          "name": {
+            "description": "This property is no longer available and will be removed from the documentation soon. See the deprecation notice for details.",
+            "type": "string"
+          },
+          "emailAddress": {
+            "description": "The email address of the user. Depending on the user's privacy setting, this may be returned as null.",
+            "type": "string",
+            "readOnly": true
+          },
+          "avatarUrls": {
+            "description": "The avatars of the user.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "16x16": {
+                "description": "The URL of the item's 16x16 pixel avatar.",
+                "type": "string"
+              },
+              "24x24": {
+                "description": "The URL of the item's 24x24 pixel avatar.",
+                "type": "string"
+              },
+              "32x32": {
+                "description": "The URL of the item's 32x32 pixel avatar.",
+                "type": "string"
+              },
+              "48x48": {
+                "description": "The URL of the item's 48x48 pixel avatar.",
+                "type": "string"
+              }
+            }
+          },
+          "displayName": {
+            "description": "The display name of the user. Depending on the user's privacy setting, this may return an alternative value.",
+            "type": "string",
+            "readOnly": true
+          },
+          "active": {
+            "description": "Indicates whether the user is active.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "timeZone": {
+            "description": "The time zone specified in the user's profile. Depending on the user's privacy setting, this may be returned as null.",
+            "type": "string",
+            "readOnly": true
+          },
+          "locale": {
+            "description": "The locale of the user. Depending on the user's privacy setting, this may be returned as null.",
+            "type": "string",
+            "readOnly": true
+          },
+          "groups": {
+            "description": "The groups that the user belongs to.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "size": { "type": "integer", "xml": { "attribute": true } },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "groupId": { "type": ["null", "string"] },
+                    "name": {
+                      "description": "The name of the group.",
+                      "type": "string"
+                    },
+                    "self": {
+                      "description": "The URL for these group details.",
+                      "type": "string",
+                      "readOnly": true
+                    }
+                  }
+                }
+              },
+              "pagingCallback": { "type": "object" },
+              "callback": { "type": "object" },
+              "max-results": {
+                "type": "integer",
+                "xml": { "name": "max-results", "attribute": true }
+              }
+            }
+          },
+          "applicationRoles": {
+            "description": "The application roles assigned to the user.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "size": { "type": "integer", "xml": { "attribute": true } },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the application role.",
+                      "type": "string"
+                    },
+                    "groups": {
+                      "description": "The groups associated with the application role.",
+                      "uniqueItems": true,
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "name": {
+                      "description": "The display name of the application role.",
+                      "type": "string"
+                    },
+                    "defaultGroups": {
+                      "description": "The groups granted default access for this application role.",
+                      "uniqueItems": true,
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "selectedByDefault": {
+                      "description": "Determines whether this application role should be selected by default on user creation.",
+                      "type": "boolean"
+                    },
+                    "defined": {
+                      "description": "Deprecated.",
+                      "type": "boolean"
+                    },
+                    "numberOfSeats": {
+                      "description": "The maximum count of users on your license.",
+                      "type": "integer"
+                    },
+                    "remainingSeats": {
+                      "description": "The count of users remaining on your license.",
+                      "type": "integer"
+                    },
+                    "userCount": {
+                      "description": "The number of users counting against your license.",
+                      "type": "integer"
+                    },
+                    "userCountDescription": {
+                      "description": "The type of users being counted against your license.",
+                      "type": "string"
+                    },
+                    "hasUnlimitedSeats": { "type": "boolean" },
+                    "platform": {
+                      "description": "Indicates if the application role belongs to Jira platform ('jira-core').",
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "pagingCallback": { "type": "object" },
+              "callback": { "type": "object" },
+              "max-results": {
+                "type": "integer",
+                "xml": { "name": "max-results", "attribute": true }
+              }
+            }
+          },
+          "expand": {
+            "description": "Expand options that include additional user details in the response.",
+            "type": "string",
+            "readOnly": true,
+            "xml": { "attribute": true }
+          }
+        },
+        "additionalProperties": true,
+        "description": "A user with details as permitted by the user's Atlassian Account privacy settings. However, be aware of these exceptions:\n\n *  User record deleted from Atlassian: This occurs as the result of a right to be forgotten request. In this case, `displayName` provides an indication and other parameters have default values or are blank (for example, email is blank).\n *  User record corrupted: This occurs as a results of events such as a server import and can only happen to deleted users. In this case, `accountId` returns *unknown* and all other parameters have fallback values.\n *  User record unavailable: This usually occurs due to an internal service outage. In this case, all parameters have fallback values.",
+        "xml": { "name": "user" }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["accountId"]],
+      "is_resumable": false
+    },
+    {
+      "name": "board_issues",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "expand": {
+            "description": "A parameter indicating the details to be included in the response",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique identifier of the issue",
+            "type": "string"
+          },
+          "self": { "description": "URL of the issue", "type": "string" },
+          "key": {
+            "description": "The unique key of the issue",
+            "type": "string"
+          },
+          "fields": {
+            "description": "Fields associated with the issues on the board",
+            "type": "object",
+            "properties": {
+              "flagged": {
+                "description": "Indicator if the issue is flagged for attention",
+                "type": ["null", "boolean"]
+              },
+              "sprint": {
+                "description": "Details of the sprint in which the issue resides",
+                "type": ["null", "object"]
+              },
+              "closedSprints": {
+                "description": "List of sprints that are closed related to the issue",
+                "type": ["null", "object"]
+              },
+              "description": {
+                "description": "Description of the issue",
+                "type": ["null", "string"]
+              },
+              "project": {
+                "description": "Details of the project to which the issue is associated",
+                "type": ["null", "object"]
+              },
+              "comment": {
+                "description": "Comments made on the issue",
+                "type": ["null", "array"],
+                "items": { "type": "object" }
+              },
+              "epic": {
+                "description": "Information about the epic the issue belongs to",
+                "type": ["null", "object"]
+              },
+              "worklog": {
+                "description": "Log of work done on the issue",
+                "type": ["null", "array"],
+                "items": { "type": "object" }
+              },
+              "created": {
+                "description": "The date and time when the issue was created",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "updated": {
+                "description": "The date and time when the issue was last updated",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "timetracking": {
+                "description": "Information related to time tracking for the issue",
+                "type": ["null", "object"]
+              }
+            }
+          },
+          "boardId": {
+            "description": "The unique identifier of the board where the issue belongs",
+            "type": "integer"
+          },
+          "created": {
+            "description": "The date and time when the issue was created",
+            "type": ["string", "null"],
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updated": {
+            "description": "The date and time when the issue was last updated",
+            "type": ["string", "null"],
+            "format": "date-time",
+            "readOnly": true
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issues",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "expand": {
+            "description": "Expand options that include additional issue details in the response.",
+            "type": "string",
+            "readOnly": true,
+            "xml": { "attribute": true }
+          },
+          "id": {
+            "description": "The unique ID of the issue.",
+            "type": "string",
+            "readOnly": true
+          },
+          "self": {
+            "description": "The URL of the issue details.",
+            "type": "string",
+            "readOnly": true
+          },
+          "key": {
+            "description": "The unique key of the issue.",
+            "type": "string",
+            "readOnly": true
+          },
+          "renderedFields": {
+            "description": "The rendered value of each field present on the issue.",
+            "type": "object",
+            "additionalProperties": true,
+            "readOnly": true,
+            "properties": {
+              "statuscategorychangedate": { "type": ["null", "string"] },
+              "issuetype": { "type": ["null", "string"] },
+              "timespent": { "type": ["null", "string"] },
+              "project": { "type": ["null", "string"] },
+              "fixVersions": { "type": ["null", "string"] },
+              "aggregatetimespent": { "type": ["null", "string"] },
+              "resolution": { "type": ["null", "string"] },
+              "resolutiondate": { "type": ["null", "string"] },
+              "workratio": { "type": ["null", "string"] },
+              "watches": { "type": ["null", "string"] },
+              "lastViewed": { "type": ["null", "string"] },
+              "issuerestriction": { "type": ["null", "string"] },
+              "created": { "type": ["null", "string"] },
+              "priority": { "type": ["null", "string"] },
+              "labels": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "timeestimate": { "type": ["null", "string"] },
+              "aggregatetimeoriginalestimate": { "type": ["null", "string"] },
+              "versions": { "type": ["null", "string"] },
+              "issuelinks": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "assignee": { "type": ["null", "string"] },
+              "updated": { "type": ["null", "string"] },
+              "status": { "type": ["null", "string"] },
+              "components": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "object"] }
+              },
+              "timeoriginalestimate": { "type": ["null", "string"] },
+              "description": { "type": ["null", "string"] },
+              "timetracking": { "type": ["null", "object"] },
+              "security": { "type": ["null", "string"] },
+              "aggregatetimeestimate": { "type": ["null", "string"] },
+              "attachment": { "type": ["null", "array"] },
+              "summary": { "type": ["null", "string"] },
+              "creator": { "type": ["null", "string"] },
+              "subtasks": { "type": ["null", "array"] },
+              "reporter": { "type": ["null", "string"] },
+              "aggregateprogress": { "type": ["null", "string"] },
+              "environment": { "type": ["null", "string"] },
+              "duedate": { "type": ["null", "string"] },
+              "progress": { "type": ["null", "string"] },
+              "comment": {
+                "description": "Details of comments on the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "comments": {
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "self": { "type": ["null", "string"] },
+                        "id": { "type": ["null", "string"] },
+                        "author": {
+                          "description": "Details of the author of the comment.",
+                          "type": ["null", "object"],
+                          "properties": {
+                            "self": { "type": ["null", "string"] },
+                            "accountId": { "type": ["null", "string"] },
+                            "emailAddress": { "type": ["null", "string"] },
+                            "avatarUrls": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "48x48": { "type": ["null", "string"] },
+                                "24x24": { "type": ["null", "string"] },
+                                "16x16": { "type": ["null", "string"] },
+                                "32x32": { "type": ["null", "string"] }
+                              }
+                            },
+                            "displayName": { "type": ["null", "string"] },
+                            "active": { "type": "boolean" },
+                            "timeZone": { "type": ["null", "string"] },
+                            "accountType": { "type": ["null", "string"] }
+                          }
+                        },
+                        "body": {
+                          "description": "Details of the body of the comment.",
+                          "type": ["null", "object"],
+                          "properties": {
+                            "version": { "type": ["null", "integer"] },
+                            "type": { "type": ["null", "string"] },
+                            "content": {
+                              "type": ["null", "array"],
+                              "items": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "type": { "type": ["null", "string"] },
+                                  "content": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": ["null", "object"],
+                                      "properties": {
+                                        "type": { "type": ["null", "string"] },
+                                        "text": { "type": ["null", "string"] }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "updateAuthor": {
+                          "description": "Details of the author who updated the comment.",
+                          "type": ["null", "object"],
+                          "properties": {
+                            "self": { "type": ["null", "string"] },
+                            "accountId": { "type": ["null", "string"] },
+                            "emailAddress": { "type": ["null", "string"] },
+                            "avatarUrls": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "48x48": { "type": ["null", "string"] },
+                                "24x24": { "type": ["null", "string"] },
+                                "16x16": { "type": ["null", "string"] },
+                                "32x32": { "type": ["null", "string"] }
+                              }
+                            },
+                            "displayName": { "type": ["null", "string"] },
+                            "active": { "type": "boolean" },
+                            "timeZone": { "type": ["null", "string"] },
+                            "accountType": { "type": ["null", "string"] }
+                          }
+                        },
+                        "created": { "type": ["null", "string"] },
+                        "updated": { "type": ["null", "string"] },
+                        "jsdPublic": { "type": "boolean" }
+                      }
+                    }
+                  },
+                  "self": { "type": ["null", "string"] },
+                  "maxResults": { "type": ["null", "integer"] },
+                  "total": { "type": ["null", "integer"] },
+                  "startAt": { "type": ["null", "integer"] }
+                }
+              },
+              "votes": { "type": ["null", "string"] },
+              "worklog": {
+                "type": ["null", "object"],
+                "properties": {
+                  "startAt": { "type": ["null", "integer"] },
+                  "maxResults": { "type": ["null", "integer"] },
+                  "total": { "type": "integer" },
+                  "worklogs": { "type": ["null", "array"] }
+                }
+              }
+            }
+          },
+          "properties": {
+            "description": "Details of the issue properties identified in the request.",
+            "type": "object",
+            "additionalProperties": true,
+            "readOnly": true
+          },
+          "names": {
+            "description": "The ID and name of each field present on the issue.",
+            "type": "object",
+            "additionalProperties": true,
+            "readOnly": true
+          },
+          "schema": {
+            "description": "The schema describing each field present on the issue.",
+            "type": "object",
+            "readOnly": true
+          },
+          "transitions": {
+            "description": "The transitions that can be performed on the issue.",
+            "type": "array",
+            "readOnly": true,
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "string"] },
+                "name": { "type": ["null", "string"] },
+                "to": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "self": { "type": ["null", "string"] },
+                    "description": { "type": ["null", "string"] },
+                    "iconUrl": { "type": ["null", "string"] },
+                    "name": { "type": ["null", "string"] },
+                    "id": { "type": ["null", "string"] },
+                    "statusCategory": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "self": { "type": ["null", "string"] },
+                        "id": { "type": ["null", "integer"] },
+                        "key": { "type": ["null", "string"] },
+                        "colorName": { "type": ["null", "string"] },
+                        "name": { "type": ["null", "string"] }
+                      }
+                    }
+                  }
+                },
+                "hasScreen": { "type": "boolean" },
+                "isGlobal": { "type": "boolean" },
+                "isInitial": { "type": "boolean" },
+                "isAvailable": { "type": "boolean" },
+                "isConditional": { "type": "boolean" },
+                "isLooped": { "type": "boolean" }
+              }
+            }
+          },
+          "operations": {
+            "description": "The operations that can be performed on the issue.",
+            "type": ["object", "null"],
+            "readOnly": true
+          },
+          "editmeta": {
+            "description": "The metadata for the fields on the issue that can be amended.",
+            "type": ["object", "null"],
+            "readOnly": true
+          },
+          "changelog": {
+            "description": "Details of changelogs associated with the issue.",
+            "type": ["object", "null"],
+            "readOnly": true,
+            "properties": {
+              "startAt": { "type": ["null", "integer"] },
+              "maxResults": { "type": ["null", "integer"] },
+              "total": { "type": ["null", "integer"] },
+              "histories": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": { "type": ["null", "string"] },
+                    "author": {
+                      "description": "Details of the author of the changelog.",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "self": { "type": ["null", "string"] },
+                        "accountId": { "type": ["null", "string"] },
+                        "emailAddress": { "type": ["null", "string"] },
+                        "avatarUrls": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "48x48": { "type": ["null", "string"] },
+                            "24x24": { "type": ["null", "string"] },
+                            "16x16": { "type": ["null", "string"] },
+                            "32x32": { "type": ["null", "string"] }
+                          }
+                        },
+                        "displayName": { "type": "string" },
+                        "active": { "type": "boolean" },
+                        "timeZone": { "type": ["null", "string"] },
+                        "accountType": { "type": ["null", "string"] }
+                      }
+                    },
+                    "created": { "type": ["null", "string"] },
+                    "items": {
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "fieldId": { "type": ["null", "string"] },
+                          "field": { "type": ["null", "string"] },
+                          "fieldtype": { "type": ["null", "string"] },
+                          "from": { "type": ["null", "string"] },
+                          "fromString": { "type": ["null", "string"] },
+                          "to": { "type": ["null", "string"] },
+                          "toString": { "type": ["null", "string"] },
+                          "tmpFromAccountId": { "type": ["null", "string"] },
+                          "tmpToAccountId": { "type": ["null", "string"] }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "versionedRepresentations": {
+            "description": "The versions of each field on the issue.",
+            "type": "object",
+            "additionalProperties": true,
+            "readOnly": true
+          },
+          "fieldsToInclude": {
+            "description": "Specify the fields to include in the fetched issues data. Use specific field names or 'all' to include all fields.",
+            "type": "object"
+          },
+          "fields": {
+            "description": "Details of various fields associated with the issue.",
+            "type": "object",
+            "properties": {
+              "created": {
+                "description": "The timestamp when the issue was created.",
+                "type": ["string", "null"],
+                "format": "date-time"
+              },
+              "updated": {
+                "description": "The timestamp when the issue was last updated.",
+                "type": ["string", "null"],
+                "format": "date-time"
+              },
+              "aggregateprogress": {
+                "description": "Details of the aggregate progress on the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "percent": { "type": ["null", "integer"] },
+                  "progress": { "type": ["null", "integer"] },
+                  "total": { "type": ["null", "integer"] }
+                }
+              },
+              "assignee": {
+                "description": "Details of the assignee of the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "accountId": { "type": ["null", "string"] },
+                  "accountType": { "type": ["null", "string"] },
+                  "active": { "type": ["null", "boolean"] },
+                  "avatarUrls": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "16x16": { "type": ["null", "string"] },
+                      "24x24": { "type": ["null", "string"] },
+                      "32x32": { "type": ["null", "string"] },
+                      "48x48": { "type": ["null", "string"] }
+                    }
+                  },
+                  "displayName": { "type": ["null", "string"] },
+                  "emailAddress": { "type": ["null", "string"] },
+                  "self": { "type": ["null", "string"] },
+                  "timeZone": { "type": ["null", "string"] }
+                }
+              },
+              "aggregatetimeestimate": { "type": ["null", "integer"] },
+              "aggregatetimeoriginalestimate": { "type": ["null", "integer"] },
+              "aggregatetimespent": { "type": ["null", "integer"] },
+              "attachment": { "type": ["null", "array"] },
+              "comment": {
+                "description": "Details of comments on the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "comments": { "type": ["null", "array"] },
+                  "maxResults": { "type": ["null", "integer"] },
+                  "self": { "type": ["null", "string"] },
+                  "startAt": { "type": ["null", "integer"] },
+                  "total": { "type": ["null", "integer"] }
+                }
+              },
+              "components": { "type": ["null", "array"] },
+              "creator": {
+                "description": "Details of the creator of the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "accountId": { "type": ["null", "string"] },
+                  "accountType": { "type": ["null", "string"] },
+                  "active": { "type": ["null", "boolean"] },
+                  "avatarUrls": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "16x16": { "type": ["null", "string"] },
+                      "24x24": { "type": ["null", "string"] },
+                      "32x32": { "type": ["null", "string"] },
+                      "48x48": { "type": ["null", "string"] }
+                    }
+                  },
+                  "displayName": { "type": ["null", "string"] },
+                  "emailAddress": { "type": ["null", "string"] },
+                  "self": { "type": ["null", "string"] },
+                  "timeZone": { "type": ["null", "string"] }
+                }
+              },
+              "description": {
+                "description": "Details of the description of the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "content": {
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "content": {
+                          "type": ["null", "array"],
+                          "items": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "text": { "type": ["null", "string"] },
+                              "type": { "type": ["null", "string"] }
+                            }
+                          }
+                        },
+                        "type": { "type": ["null", "string"] }
+                      }
+                    }
+                  },
+                  "type": { "type": ["null", "string"] },
+                  "version": { "type": ["null", "integer"] }
+                }
+              },
+              "fixVersions": { "type": ["null", "array"] },
+              "issuelinks": { "type": ["null", "array"] },
+              "issuerestriction": {
+                "description": "Details of the issue restriction.",
+                "type": ["null", "object"],
+                "properties": {
+                  "issuerestrictions": { "type": ["null", "object"] },
+                  "shouldDisplay": { "type": ["null", "boolean"] }
+                }
+              },
+              "issuetype": {
+                "description": "Details of the issue type.",
+                "type": ["null", "object"],
+                "properties": {
+                  "avatarId": { "type": ["null", "integer"] },
+                  "description": { "type": ["null", "string"] },
+                  "entityId": { "type": ["null", "string"] },
+                  "hierarchyLevel": { "type": ["null", "integer"] },
+                  "iconUrl": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "self": { "type": ["null", "string"] },
+                  "subtask": { "type": ["null", "boolean"] }
+                }
+              },
+              "labels": {
+                "description": "Details of labels attached to the issue.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "lastViewed": {
+                "description": "The timestamp when the issue was last viewed.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "priority": {
+                "description": "Details of the priority of the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "iconUrl": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "self": { "type": ["null", "string"] }
+                }
+              },
+              "progress": {
+                "description": "Details of the progress on the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "percent": { "type": ["null", "integer"] },
+                  "progress": { "type": ["null", "integer"] },
+                  "total": { "type": ["null", "integer"] }
+                }
+              },
+              "project": {
+                "description": "Details of the project associated with the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "avatarUrls": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "16x16": { "type": ["null", "string"] },
+                      "24x24": { "type": ["null", "string"] },
+                      "32x32": { "type": ["null", "string"] },
+                      "48x48": { "type": ["null", "string"] }
+                    }
+                  },
+                  "id": { "type": ["null", "string"] },
+                  "key": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "projectCategory": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "description": { "type": ["null", "string"] },
+                      "id": { "type": ["null", "string"] },
+                      "name": { "type": ["null", "string"] },
+                      "self": { "type": ["null", "string"] }
+                    }
+                  },
+                  "projectTypeKey": { "type": ["null", "string"] },
+                  "self": { "type": ["null", "string"] },
+                  "simplified": { "type": ["null", "boolean"] }
+                }
+              },
+              "reporter": {
+                "description": "Details of the reporter of the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "accountId": { "type": ["null", "string"] },
+                  "accountType": { "type": ["null", "string"] },
+                  "active": { "type": ["null", "boolean"] },
+                  "avatarUrls": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "16x16": { "type": ["null", "string"] },
+                      "24x24": { "type": ["null", "string"] },
+                      "32x32": { "type": ["null", "string"] },
+                      "48x48": { "type": ["null", "string"] }
+                    }
+                  },
+                  "displayName": { "type": ["null", "string"] },
+                  "emailAddress": { "type": ["null", "string"] },
+                  "self": { "type": ["null", "string"] },
+                  "timeZone": { "type": ["null", "string"] }
+                }
+              },
+              "resolution": {
+                "description": "Details of the resolution of the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "description": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "self": { "type": ["null", "string"] }
+                }
+              },
+              "resolutiondate": {
+                "description": "The timestamp when the issue was resolved.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "status": {
+                "description": "Details of the status of the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "description": { "type": ["null", "string"] },
+                  "iconUrl": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "self": { "type": ["null", "string"] },
+                  "statusCategory": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "self": { "type": ["null", "string"] },
+                      "id": { "type": ["null", "integer"] },
+                      "key": { "type": ["null", "string"] },
+                      "colorName": { "type": ["null", "string"] },
+                      "name": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              },
+              "statuscategorychangedate": {
+                "description": "The timestamp when the status category of the issue changed.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "subtasks": { "type": ["null", "array"] },
+              "summary": {
+                "description": "The summary of the issue.",
+                "type": ["null", "string"]
+              },
+              "timeestimate": { "type": ["null", "integer"] },
+              "timeoriginalestimate": { "type": ["null", "integer"] },
+              "timespent": { "type": ["null", "integer"] },
+              "timetracking": {
+                "description": "Details of time tracking on the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "remainingEstimate": { "type": ["null", "string"] },
+                  "remainingEstimateSeconds": { "type": ["null", "integer"] },
+                  "timeSpent": { "type": ["null", "string"] },
+                  "timeSpentSeconds": { "type": ["null", "integer"] },
+                  "originalEstimate": { "type": ["null", "string"] },
+                  "originalEstimateSeconds": { "type": ["null", "integer"] }
+                }
+              },
+              "versions": { "type": ["null", "array"] },
+              "votes": {
+                "description": "Details of votes on the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "hasVoted": { "type": ["null", "boolean"] },
+                  "self": { "type": ["null", "string"] },
+                  "votes": { "type": ["null", "integer"] }
+                }
+              },
+              "watches": {
+                "description": "Details of watchers on the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "isWatching": { "type": ["null", "boolean"] },
+                  "self": { "type": ["null", "string"] },
+                  "watchCount": { "type": ["null", "integer"] }
+                }
+              },
+              "worklog": {
+                "description": "Details of worklogs on the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "maxResults": { "type": ["null", "integer"] },
+                  "startAt": { "type": ["null", "integer"] },
+                  "total": { "type": ["null", "integer"] },
+                  "worklogs": {
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "author": {
+                          "description": "Details of the author of the worklog.",
+                          "type": ["null", "object"],
+                          "properties": {
+                            "accountId": { "type": ["null", "string"] },
+                            "accountType": { "type": ["null", "string"] },
+                            "active": { "type": ["null", "boolean"] },
+                            "avatarUrls": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "16x16": { "type": ["null", "string"] },
+                                "24x24": { "type": ["null", "string"] },
+                                "32x32": { "type": ["null", "string"] },
+                                "48x48": { "type": ["null", "string"] }
+                              }
+                            },
+                            "displayName": { "type": ["null", "string"] },
+                            "emailAddress": { "type": ["null", "string"] },
+                            "self": { "type": ["null", "string"] },
+                            "timeZone": { "type": ["null", "string"] }
+                          }
+                        },
+                        "comment": {
+                          "description": "Details of the comment in the worklog.",
+                          "type": ["null", "object"],
+                          "properties": {
+                            "version": { "type": ["null", "integer"] },
+                            "type": { "type": ["null", "string"] },
+                            "content": {
+                              "type": ["null", "array"],
+                              "items": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "type": { "type": ["null", "string"] },
+                                  "content": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": ["null", "object"],
+                                      "properties": {
+                                        "type": { "type": ["null", "string"] },
+                                        "text": { "type": ["null", "string"] }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "created": {
+                          "description": "The timestamp when the worklog was created.",
+                          "type": ["null", "string"],
+                          "format": "date-time"
+                        },
+                        "started": {
+                          "description": "The timestamp when the worklog was started.",
+                          "type": ["null", "string"],
+                          "format": "date-time"
+                        },
+                        "updated": {
+                          "description": "The timestamp when the worklog was last updated.",
+                          "type": ["null", "string"],
+                          "format": "date-time"
+                        },
+                        "id": { "type": ["null", "string"] },
+                        "issueId": { "type": ["null", "string"] },
+                        "self": { "type": ["null", "string"] },
+                        "timeSpent": { "type": ["null", "string"] },
+                        "timeSpentSeconds": { "type": ["null", "integer"] },
+                        "updateAuthor": {
+                          "description": "Details of the author who updated the worklog.",
+                          "type": ["null", "object"],
+                          "properties": {
+                            "accountId": { "type": ["null", "string"] },
+                            "accountType": { "type": ["null", "string"] },
+                            "active": { "type": ["null", "boolean"] },
+                            "avatarUrls": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "16x16": { "type": ["null", "string"] },
+                                "24x24": { "type": ["null", "string"] },
+                                "32x32": { "type": ["null", "string"] },
+                                "48x48": { "type": ["null", "string"] }
+                              }
+                            },
+                            "displayName": { "type": ["null", "string"] },
+                            "emailAddress": { "type": ["null", "string"] },
+                            "self": { "type": ["null", "string"] },
+                            "timeZone": { "type": ["null", "string"] }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "workratio": { "type": ["null", "integer"] }
+            },
+            "additionalProperties": true
+          },
+          "projectId": {
+            "description": "The ID of the project containing the issue.",
+            "type": "string",
+            "readOnly": true
+          },
+          "projectKey": {
+            "description": "The key of the project containing the issue.",
+            "type": "string",
+            "readOnly": true
+          },
+          "created": {
+            "description": "The timestamp when the issue was created.",
+            "type": ["string", "null"],
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updated": {
+            "description": "The timestamp when the issue was last updated.",
+            "type": ["string", "null"],
+            "format": "date-time",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "sprint_issues",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "expand": {
+            "description": "Expand options for the issue",
+            "type": "string"
+          },
+          "id": { "description": "ID of the issue", "type": "string" },
+          "self": { "description": "URL of the issue", "type": "string" },
+          "key": { "description": "Key of the issue", "type": "string" },
+          "fields": {
+            "description": "Contains various field values associated with the sprint issue",
+            "type": "object",
+            "properties": {
+              "flagged": {
+                "description": "Flag indicating if the issue is flagged",
+                "type": ["null", "boolean"]
+              },
+              "sprint": {
+                "description": "Sprint related to the issue",
+                "type": ["null", "object"]
+              },
+              "closedSprints": {
+                "description": "List of closed sprints related to the issue",
+                "type": ["null", "object"]
+              },
+              "description": {
+                "description": "Description of the issue",
+                "type": ["null", "string"]
+              },
+              "project": {
+                "description": "Project to which the issue belongs",
+                "type": ["null", "object"]
+              },
+              "comment": {
+                "description": "Comments added to the sprint issue",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Comments added to the issue",
+                  "type": "object"
+                }
+              },
+              "epic": {
+                "description": "Epic information associated with the issue",
+                "type": ["null", "object"]
+              },
+              "worklog": {
+                "description": "Work logs related to the sprint issue",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Work logs related to the issue",
+                  "type": "object"
+                }
+              },
+              "created": {
+                "description": "Date and time when the issue was created",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "updated": {
+                "description": "Date and time when the issue was last updated",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "timetracking": {
+                "description": "Time tracking information for the issue",
+                "type": ["null", "object"]
+              },
+              "status": {
+                "description": "Status details of the sprint issue",
+                "type": ["null", "object"],
+                "properties": {
+                  "description": {
+                    "description": "Description of the status",
+                    "type": ["null", "string"]
+                  },
+                  "iconUrl": {
+                    "description": "URL of the status icon",
+                    "type": ["null", "string"]
+                  },
+                  "id": {
+                    "description": "ID of the status",
+                    "type": ["null", "string"]
+                  },
+                  "name": {
+                    "description": "Name of the status",
+                    "type": ["null", "string"]
+                  },
+                  "self": {
+                    "description": "Status resource URL",
+                    "type": ["null", "string"]
+                  },
+                  "statusCategory": {
+                    "description": "Category of the status of the sprint issue",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "colorName": {
+                        "description": "Name of the color representing the status category",
+                        "type": ["null", "string"]
+                      },
+                      "id": {
+                        "description": "ID of the status category",
+                        "type": ["null", "integer"]
+                      },
+                      "key": {
+                        "description": "Key of the status category",
+                        "type": ["null", "string"]
+                      },
+                      "name": {
+                        "description": "Name of the status category",
+                        "type": ["null", "string"]
+                      },
+                      "self": {
+                        "description": "Status category resource URL",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "issueId": { "description": "ID of the issue", "type": "string" },
+          "sprintId": {
+            "description": "ID of the sprint associated with the issue",
+            "type": "integer"
+          },
+          "created": {
+            "description": "Date and time when the issue was created",
+            "type": ["string", "null"],
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updated": {
+            "description": "Date and time when the issue was last updated",
+            "type": ["string", "null"],
+            "format": "date-time",
+            "readOnly": true
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_comments",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the comment.",
+            "type": "string",
+            "readOnly": true
+          },
+          "id": {
+            "description": "The ID of the comment.",
+            "type": "string",
+            "readOnly": true
+          },
+          "issueId": {
+            "description": "Id of the related issue.",
+            "type": ["null", "string"],
+            "readOnly": true
+          },
+          "author": {
+            "description": "The ID of the user who created the comment.",
+            "readOnly": true
+          },
+          "body": {
+            "description": "The comment text in Atlassian Document Format.",
+            "type": "object"
+          },
+          "renderedBody": {
+            "description": "The rendered version of the comment.",
+            "type": "string",
+            "readOnly": true
+          },
+          "updateAuthor": {
+            "description": "The ID of the user who updated the comment last.",
+            "type": "object",
+            "additionalProperties": true,
+            "readOnly": true
+          },
+          "created": {
+            "description": "The date and time at which the comment was created.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updated": {
+            "description": "The date and time at which the comment was updated last.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "visibility": {
+            "description": "The group or role to which this item is visible.",
+            "type": ["object", "null"],
+            "properties": {
+              "type": {
+                "description": "Whether visibility of this item is restricted to a group or role.",
+                "type": "string",
+                "enum": ["group", "role"]
+              },
+              "value": {
+                "description": "The name of the group or role to which visibility of this item is restricted.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          "jsdPublic": {
+            "description": "Whether the comment is visible in Jira Service Desk. Defaults to true when comments are created in the Jira Cloud Platform.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "properties": {
+            "description": "A list of comment properties. Optional on create and update.",
+            "type": "array"
+          }
+        },
+        "additionalProperties": true,
+        "description": "A comment."
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_worklogs",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "The URL of the worklog item.",
+            "type": "string",
+            "readOnly": true
+          },
+          "author": {
+            "description": "Details of the user who created the worklog.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "self": {
+                "description": "The URL of the user.",
+                "type": "string",
+                "readOnly": true
+              },
+              "name": {
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                "type": "string",
+                "readOnly": true
+              },
+              "key": {
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                "type": "string",
+                "readOnly": true
+              },
+              "accountId": {
+                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*.",
+                "maxLength": 128,
+                "type": "string"
+              },
+              "emailAddress": {
+                "description": "The email address of the user. Depending on the user\u2019s privacy settings, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "avatarUrls": {
+                "description": "The avatars of the user.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "16x16": {
+                    "description": "The URL of the item's 16x16 pixel avatar.",
+                    "type": "string"
+                  },
+                  "24x24": {
+                    "description": "The URL of the item's 24x24 pixel avatar.",
+                    "type": "string"
+                  },
+                  "32x32": {
+                    "description": "The URL of the item's 32x32 pixel avatar.",
+                    "type": "string"
+                  },
+                  "48x48": {
+                    "description": "The URL of the item's 48x48 pixel avatar.",
+                    "type": "string"
+                  }
+                }
+              },
+              "displayName": {
+                "description": "The display name of the user. Depending on the user\u2019s privacy settings, this may return an alternative value.",
+                "type": "string",
+                "readOnly": true
+              },
+              "active": {
+                "description": "Whether the user is active.",
+                "type": "boolean",
+                "readOnly": true
+              },
+              "timeZone": {
+                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy settings, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "accountType": {
+                "description": "The type of account represented by this user. This will be one of 'atlassian' (normal users), 'app' (application user) or 'customer' (Jira Service Desk customer user)",
+                "type": "string",
+                "readOnly": true
+              }
+            }
+          },
+          "updateAuthor": {
+            "description": "Details of the user who last updated the worklog.",
+            "readOnly": true,
+            "type": "object",
+            "properties": {
+              "self": {
+                "description": "The URL of the user.",
+                "type": "string",
+                "readOnly": true
+              },
+              "name": {
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                "type": "string",
+                "readOnly": true
+              },
+              "key": {
+                "description": "This property is no longer available and will be removed from the documentation soon. See the [deprecation notice](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for details.",
+                "type": "string",
+                "readOnly": true
+              },
+              "accountId": {
+                "description": "The account ID of the user, which uniquely identifies the user across all Atlassian products. For example, *5b10ac8d82e05b22cc7d4ef5*.",
+                "maxLength": 128,
+                "type": "string"
+              },
+              "emailAddress": {
+                "description": "The email address of the user. Depending on the user\u2019s privacy settings, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "avatarUrls": {
+                "description": "The avatars of the user.",
+                "readOnly": true,
+                "type": "object",
+                "properties": {
+                  "16x16": {
+                    "description": "The URL of the item's 16x16 pixel avatar.",
+                    "type": "string"
+                  },
+                  "24x24": {
+                    "description": "The URL of the item's 24x24 pixel avatar.",
+                    "type": "string"
+                  },
+                  "32x32": {
+                    "description": "The URL of the item's 32x32 pixel avatar.",
+                    "type": "string"
+                  },
+                  "48x48": {
+                    "description": "The URL of the item's 48x48 pixel avatar.",
+                    "type": "string"
+                  }
+                }
+              },
+              "displayName": {
+                "description": "The display name of the user. Depending on the user\u2019s privacy settings, this may return an alternative value.",
+                "type": "string",
+                "readOnly": true
+              },
+              "active": {
+                "description": "Whether the user is active.",
+                "type": "boolean",
+                "readOnly": true
+              },
+              "timeZone": {
+                "description": "The time zone specified in the user's profile. Depending on the user\u2019s privacy settings, this may be returned as null.",
+                "type": "string",
+                "readOnly": true
+              },
+              "accountType": {
+                "description": "The type of account represented by this user. This will be one of 'atlassian' (normal users), 'app' (application user) or 'customer' (Jira Service Desk customer user)",
+                "type": "string",
+                "readOnly": true
+              }
+            }
+          },
+          "comment": {
+            "description": "A comment about the worklog in [Atlassian Document Format](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/). Optional when creating or updating a worklog.",
+            "type": "object"
+          },
+          "created": {
+            "description": "The datetime on which the worklog was created.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updated": {
+            "description": "The datetime on which the worklog was last updated.",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "visibility": {
+            "description": "Details about any restrictions in the visibility of the worklog. Optional when creating or updating a worklog.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "description": "Whether visibility of this item is restricted to a group or role.",
+                "type": "string",
+                "enum": ["group", "role"]
+              },
+              "value": {
+                "description": "The name of the group or role to which visibility of this item is restricted.",
+                "type": "string"
+              }
+            }
+          },
+          "started": {
+            "description": "The datetime on which the worklog effort was started. Required when creating a worklog. Optional when updating a worklog.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeSpent": {
+            "description": "The time spent working on the issue as days (#d), hours (#h), or minutes (#m or #). Required when creating a worklog if `timeSpentSeconds` isn't provided. Optional when updating a worklog. Cannot be provided if `timeSpentSecond` is provided.",
+            "type": "string"
+          },
+          "timeSpentSeconds": {
+            "description": "The time in seconds spent working on the issue. Required when creating a worklog if `timeSpent` isn't provided. Optional when updating a worklog. Cannot be provided if `timeSpent` is provided.",
+            "type": "integer"
+          },
+          "id": {
+            "description": "The ID of the worklog record.",
+            "type": "string",
+            "readOnly": true
+          },
+          "issueId": {
+            "description": "The ID of the issue this worklog is for.",
+            "type": "string",
+            "readOnly": true
+          },
+          "properties": {
+            "description": "Details of properties for the worklog. Optional when creating or updating a worklog.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "description": "The key of the property. Required on create and update.",
+                  "type": "string"
+                },
+                "value": {
+                  "description": "The value of the property. Required on create and update."
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": true,
+        "description": "Details of a worklog."
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-jira/erd/estimated_relationships.json
+++ b/airbyte-integrations/connectors/source-jira/erd/estimated_relationships.json
@@ -1,0 +1,266 @@
+{
+  "streams": [
+    {
+      "name": "application_roles",
+      "relations": {}
+    },
+    {
+      "name": "avatars",
+      "relations": {}
+    },
+    {
+      "name": "boards",
+      "relations": {
+        "projectId": "projects.id"
+      }
+    },
+    {
+      "name": "dashboards",
+      "relations": {}
+    },
+    {
+      "name": "filters",
+      "relations": {}
+    },
+    {
+      "name": "groups",
+      "relations": {}
+    },
+    {
+      "name": "issue_fields",
+      "relations": {}
+    },
+    {
+      "name": "issue_field_configurations",
+      "relations": {}
+    },
+    {
+      "name": "issue_link_types",
+      "relations": {}
+    },
+    {
+      "name": "issue_navigator_settings",
+      "relations": {}
+    },
+    {
+      "name": "issue_notification_schemes",
+      "relations": {}
+    },
+    {
+      "name": "issue_priorities",
+      "relations": {}
+    },
+    {
+      "name": "issue_resolutions",
+      "relations": {}
+    },
+    {
+      "name": "issue_security_schemes",
+      "relations": {}
+    },
+    {
+      "name": "issue_types",
+      "relations": {}
+    },
+    {
+      "name": "issue_type_schemes",
+      "relations": {}
+    },
+    {
+      "name": "issue_type_screen_schemes",
+      "relations": {}
+    },
+    {
+      "name": "jira_settings",
+      "relations": {}
+    },
+    {
+      "name": "labels",
+      "relations": {}
+    },
+    {
+      "name": "permissions",
+      "relations": {}
+    },
+    {
+      "name": "permission_schemes",
+      "relations": {}
+    },
+    {
+      "name": "projects",
+      "relations": {
+        "lead": "users.accountId",
+        "deletedBy": "users.accountId",
+        "archivedBy": "users.accountId"
+      }
+    },
+    {
+      "name": "project_categories",
+      "relations": {}
+    },
+    {
+      "name": "project_roles",
+      "relations": {}
+    },
+    {
+      "name": "project_types",
+      "relations": {}
+    },
+    {
+      "name": "screens",
+      "relations": {}
+    },
+    {
+      "name": "screen_schemes",
+      "relations": {}
+    },
+    {
+      "name": "time_tracking",
+      "relations": {}
+    },
+    {
+      "name": "users",
+      "relations": {}
+    },
+    {
+      "name": "workflows",
+      "relations": {}
+    },
+    {
+      "name": "workflow_schemes",
+      "relations": {}
+    },
+    {
+      "name": "workflow_statuses",
+      "relations": {}
+    },
+    {
+      "name": "workflow_status_categories",
+      "relations": {}
+    },
+    {
+      "name": "filter_sharing",
+      "relations": {}
+    },
+    {
+      "name": "issue_custom_field_contexts",
+      "relations": {}
+    },
+    {
+      "name": "issue_custom_field_options",
+      "relations": {}
+    },
+    {
+      "name": "issue_properties",
+      "relations": {}
+    },
+    {
+      "name": "issue_remote_links",
+      "relations": {}
+    },
+    {
+      "name": "issue_transitions",
+      "relations": {
+        "issueId": "issues.id"
+      }
+    },
+    {
+      "name": "issue_votes",
+      "relations": {
+        "issueId": "issues.id"
+      }
+    },
+    {
+      "name": "issue_watchers",
+      "relations": {
+        "issueId": "issues.id"
+      }
+    },
+    {
+      "name": "project_avatars",
+      "relations": {
+        "projectId": "projects.id"
+      }
+    },
+    {
+      "name": "project_components",
+      "relations": {
+        "projectId": "projects.id",
+        "leadAccountId": "users.accountId"
+      }
+    },
+    {
+      "name": "project_email",
+      "relations": {
+        "projectId": "projects.id"
+      }
+    },
+    {
+      "name": "project_permission_schemes",
+      "relations": {
+        "projectId": "projects.id"
+      }
+    },
+    {
+      "name": "project_versions",
+      "relations": {
+        "projectId": "projects.id"
+      }
+    },
+    {
+      "name": "screen_tabs",
+      "relations": {
+        "screenId": "screens.id"
+      }
+    },
+    {
+      "name": "screen_tab_fields",
+      "relations": {
+        "screenId": "screens.id",
+        "tabId": "screen_tabs.id"
+      }
+    },
+    {
+      "name": "sprints",
+      "relations": {
+        "originBoardId": "boards.id",
+        "boardId": "boards.id"
+      }
+    },
+    {
+      "name": "users_groups_detailed",
+      "relations": {}
+    },
+    {
+      "name": "board_issues",
+      "relations": {
+        "boardId": "boards.id"
+      }
+    },
+    {
+      "name": "issues",
+      "relations": {
+        "projectId": "projects.id"
+      }
+    },
+    {
+      "name": "sprint_issues",
+      "relations": {
+        "sprintId": "sprints.id"
+      }
+    },
+    {
+      "name": "issue_comments",
+      "relations": {
+        "issueId": "issues.id",
+        "author": "users.accountId"
+      }
+    },
+    {
+      "name": "issue_worklogs",
+      "relations": {
+        "issueId": "issues.id"
+      }
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-jira/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-jira/erd/source.dbml
@@ -1,0 +1,694 @@
+Table "application_roles" {
+    "key" string [pk]
+    "groups" array
+    "name" string
+    "defaultGroups" array
+    "selectedByDefault" boolean
+    "defined" boolean
+    "numberOfSeats" integer
+    "remainingSeats" integer
+    "userCount" integer
+    "userCountDescription" string
+    "hasUnlimitedSeats" boolean
+    "platform" boolean
+    "groupDetails" array
+    "defaultGroupsDetails" array
+}
+
+Table "avatars" {
+    "id" string [pk]
+    "owner" string
+    "isSystemAvatar" boolean
+    "isSelected" boolean
+    "isDeletable" boolean
+    "fileName" string
+    "urls" object
+}
+
+Table "boards" {
+    "id" integer [pk]
+    "self" string
+    "name" string
+    "type" string
+    "projectId" string
+    "projectKey" string
+    "location" object
+}
+
+Table "dashboards" {
+    "description" string
+    "id" string [pk]
+    "isFavourite" boolean
+    "name" string
+    "owner" object
+    "popularity" integer
+    "rank" integer
+    "self" string
+    "sharePermissions" array
+    "view" string
+    "editpermission" array
+    "isWritable" boolean
+    "systemDashboard" boolean
+    "editPermissions" array
+}
+
+Table "filters" {
+    "expand" string
+    "self" string
+    "id" string [pk]
+    "name" string
+    "description" string
+    "owner" object
+    "jql" string
+    "viewUrl" string
+    "searchUrl" string
+    "favourite" boolean
+    "favouritedCount" integer
+    "sharePermissions" array
+    "isWritable" boolean
+    "approximateLastUsed" string
+    "subscriptions" array
+}
+
+Table "groups" {
+    "name" string
+    "groupId" string [pk]
+}
+
+Table "issue_fields" {
+    "id" string [pk]
+    "key" string
+    "name" string
+    "custom" boolean
+    "orderable" boolean
+    "navigable" boolean
+    "searchable" boolean
+    "clauseNames" array
+    "scope" object
+    "schema" object
+    "untranslatedName" string
+}
+
+Table "issue_field_configurations" {
+    "id" integer [pk]
+    "name" string
+    "description" string
+    "isDefault" boolean
+}
+
+Table "issue_link_types" {
+    "id" string [pk]
+    "name" string
+    "inward" string
+    "outward" string
+    "self" string
+}
+
+Table "issue_navigator_settings" {
+    "label" string
+    "value" string
+}
+
+Table "issue_notification_schemes" {
+    "expand" string
+    "id" integer [pk]
+    "self" string
+    "name" string
+    "description" string
+    "notificationSchemeEvents" array
+    "scope" object
+}
+
+Table "issue_priorities" {
+    "self" string
+    "statusColor" string
+    "description" string
+    "iconUrl" string
+    "name" string
+    "id" string [pk]
+    "isDefault" boolean
+}
+
+Table "issue_resolutions" {
+    "self" string
+    "id" string [pk]
+    "description" string
+    "name" string
+    "isDefault" boolean
+}
+
+Table "issue_security_schemes" {
+    "self" string
+    "id" integer [pk]
+    "name" string
+    "description" string
+    "defaultSecurityLevelId" integer
+    "levels" array
+}
+
+Table "issue_types" {
+    "avatarId" integer
+    "description" string
+    "entityId" string
+    "hierarchyLevel" integer
+    "iconUrl" string
+    "id" string [pk]
+    "name" string
+    "self" string
+    "subtask" boolean
+    "scope" object
+    "untranslatedName" string
+}
+
+Table "issue_type_schemes" {
+    "id" string [pk]
+    "name" string
+    "description" string
+    "defaultIssueTypeId" string
+    "isDefault" boolean
+}
+
+Table "issue_type_screen_schemes" {
+    "id" string [pk]
+    "name" string
+    "description" string
+}
+
+Table "jira_settings" {
+    "id" string [pk]
+    "key" string
+    "value" string
+    "name" string
+    "desc" string
+    "type" string
+    "defaultValue" string
+    "example" string
+    "allowedValues" array
+}
+
+Table "labels" {
+    "label" string [pk]
+}
+
+Table "permissions" {
+    "key" string [pk]
+    "name" string
+    "type" string
+    "description" string
+}
+
+Table "permission_schemes" {
+    "expand" string
+    "id" integer [pk]
+    "self" string
+    "name" string
+    "description" string
+    "scope" object
+    "permissions" array
+}
+
+Table "projects" {
+    "expand" string
+    "self" string
+    "id" string [pk]
+    "key" string
+    "description" string
+    "components" array
+    "issueTypes" array
+    "url" string
+    "email" string
+    "assigneeType" string
+    "versions" array
+    "name" string
+    "roles" object
+    "projectTypeKey" string
+    "simplified" boolean
+    "style" string
+    "favourite" boolean
+    "isPrivate" boolean
+    "properties" object
+    "uuid" string
+    "deleted" boolean
+    "retentionTillDate" string
+    "deletedDate" string
+    "archived" boolean
+    "archivedDate" string
+    "entityId" string
+}
+
+Table "project_categories" {
+    "self" string
+    "id" string [pk]
+    "name" string
+    "description" string
+}
+
+Table "project_roles" {
+    "actors" array
+    "admin" boolean
+    "currentUserRole" boolean
+    "default" boolean
+    "description" string
+    "id" integer [pk]
+    "name" string
+    "roleConfigurable" boolean
+    "scope" object
+    "self" string
+    "translatedName" string
+}
+
+Table "project_types" {
+    "key" string
+    "formattedKey" string
+    "descriptionI18nKey" string
+    "icon" string
+    "color" string
+}
+
+Table "screens" {
+    "id" integer [pk]
+    "name" string
+    "description" string
+    "scope" object
+}
+
+Table "screen_schemes" {
+    "id" integer [pk]
+    "name" string
+    "description" string
+    "screens" object
+    "issueTypeScreenSchemes" object
+}
+
+Table "time_tracking" {
+    "key" string [pk]
+    "name" string
+    "url" string
+}
+
+Table "users" {
+    "self" string
+    "key" string
+    "accountId" string [pk]
+    "accountType" string
+    "name" string
+    "emailAddress" string
+    "avatarUrls" object
+    "displayName" string
+    "active" boolean
+    "timeZone" string
+    "locale" string
+    "groups" object
+    "applicationRoles" object
+    "expand" string
+}
+
+Table "workflows" {
+    "id" object
+    "entityId" string
+    "name" string
+    "description" string
+    "transitions" array
+    "statuses" array
+    "created" string
+    "updated" string
+
+    indexes {
+        (entityId, name) [pk]
+    }
+}
+
+Table "workflow_schemes" {
+    "id" integer [pk]
+    "name" string
+    "description" string
+    "defaultWorkflow" string
+    "issueTypeMappings" object
+    "originalDefaultWorkflow" string
+    "originalIssueTypeMappings" object
+    "draft" boolean
+    "lastModifiedUser" object
+    "lastModified" string
+    "self" string
+    "updateDraftIfNeeded" boolean
+    "issueTypes" object
+}
+
+Table "workflow_statuses" {
+    "self" string
+    "description" string
+    "iconUrl" string
+    "name" string
+    "id" string [pk]
+    "statusCategory" object
+    "scope" object
+    "untranslatedName" string
+}
+
+Table "workflow_status_categories" {
+    "self" string
+    "id" integer [pk]
+    "key" string
+    "colorName" string
+    "name" string
+}
+
+Table "filter_sharing" {
+    "id" integer [pk]
+    "filterId" string
+    "type" string
+    "project" object
+    "role" object
+    "group" object
+}
+
+Table "issue_custom_field_contexts" {
+    "id" string [pk]
+    "fieldId" string
+    "name" string
+    "description" string
+    "isGlobalContext" boolean
+    "isAnyIssueType" boolean
+    "fieldType" string
+}
+
+Table "issue_custom_field_options" {
+    "id" string [pk]
+    "value" string
+    "optionId" string
+    "disabled" boolean
+    "fieldId" string
+    "contextId" string
+}
+
+Table "issue_properties" {
+    "key" string [pk]
+    "issueId" string
+    "isdefault" boolean
+}
+
+Table "issue_remote_links" {
+    "id" integer [pk]
+    "issueId" string
+    "self" string
+    "globalId" string
+    "application" object
+    "relationship" string
+    "object" object
+}
+
+Table "issue_transitions" {
+    "fields" string
+    "hasScreen" boolean
+    "id" string
+    "issueId" string
+    "isAvailable" boolean
+    "isConditional" boolean
+    "isGlobal" boolean
+    "isInitial" boolean
+    "isLooped" boolean
+    "name" string
+    "to" object
+
+    indexes {
+        (issueId, id) [pk]
+    }
+}
+
+Table "issue_votes" {
+    "self" string
+    "issueId" string
+    "votes" integer
+    "hasVoted" boolean
+    "voters" array
+}
+
+Table "issue_watchers" {
+    "self" string
+    "issueId" string
+    "isWatching" boolean
+    "watchCount" integer
+    "watchers" array
+}
+
+Table "project_avatars" {
+    "id" string [pk]
+    "projectId" string
+    "owner" string
+    "isSystemAvatar" boolean
+    "isSelected" boolean
+    "isDeletable" boolean
+    "fileName" string
+    "urls" object
+}
+
+Table "project_components" {
+    "self" string
+    "id" string [pk]
+    "name" string
+    "description" string
+    "lead" object
+    "leadUserName" string
+    "leadAccountId" string
+    "assigneeType" string
+    "assignee" object
+    "realAssigneeType" string
+    "realAssignee" object
+    "isAssigneeTypeValid" boolean
+    "project" string
+    "projectId" integer
+    "componentBean" object
+    "issueCount" integer
+}
+
+Table "project_email" {
+    "projectId" string [pk]
+    "emailAddress" string
+}
+
+Table "project_permission_schemes" {
+    "self" string
+    "projectId" string
+    "id" string [pk]
+    "description" string
+    "name" string
+}
+
+Table "project_versions" {
+    "expand" string
+    "self" string
+    "id" string [pk]
+    "description" string
+    "name" string
+    "archived" boolean
+    "released" boolean
+    "startDate" string
+    "releaseDate" string
+    "overdue" boolean
+    "userStartDate" string
+    "userReleaseDate" string
+    "project" string
+    "projectId" integer
+    "moveUnfixedIssuesTo" string
+    "operations" array
+    "issuesStatusForFixVersion" object
+}
+
+Table "screen_tabs" {
+    "id" integer [pk]
+    "name" string
+    "screenId" integer
+}
+
+Table "screen_tab_fields" {
+    "id" string [pk]
+    "name" string
+    "screenId" integer
+    "tabId" integer
+}
+
+Table "sprints" {
+    "id" integer [pk]
+    "self" string
+    "state" string
+    "name" string
+    "startDate" string
+    "endDate" string
+    "completeDate" string
+    "originBoardId" integer
+    "boardId" integer
+    "goal" string
+    "createdDate" string
+}
+
+Table "users_groups_detailed" {
+    "self" string
+    "key" string
+    "accountId" string [pk]
+    "accountType" string
+    "name" string
+    "emailAddress" string
+    "avatarUrls" object
+    "displayName" string
+    "active" boolean
+    "timeZone" string
+    "locale" string
+    "groups" object
+    "applicationRoles" object
+    "expand" string
+}
+
+Table "board_issues" {
+    "expand" string
+    "id" string [pk]
+    "self" string
+    "key" string
+    "fields" object
+    "boardId" integer
+    "created" string
+    "updated" string
+}
+
+Table "issues" {
+    "expand" string
+    "id" string [pk]
+    "self" string
+    "key" string
+    "renderedFields" object
+    "properties" object
+    "names" object
+    "schema" object
+    "transitions" array
+    "operations" object
+    "editmeta" object
+    "changelog" object
+    "versionedRepresentations" object
+    "fieldsToInclude" object
+    "fields" object
+    "projectId" string
+    "projectKey" string
+    "created" string
+    "updated" string
+}
+
+Table "sprint_issues" {
+    "expand" string
+    "id" string [pk]
+    "self" string
+    "key" string
+    "fields" object
+    "issueId" string
+    "sprintId" integer
+    "created" string
+    "updated" string
+}
+
+Table "issue_comments" {
+    "self" string
+    "id" string [pk]
+    "issueId" string
+    "body" object
+    "renderedBody" string
+    "updateAuthor" object
+    "created" string
+    "updated" string
+    "visibility" object
+    "jsdPublic" boolean
+    "properties" array
+}
+
+Table "issue_worklogs" {
+    "self" string
+    "author" object
+    "updateAuthor" object
+    "comment" object
+    "created" string
+    "updated" string
+    "visibility" object
+    "started" string
+    "timeSpent" string
+    "timeSpentSeconds" integer
+    "id" string [pk]
+    "issueId" string
+    "properties" array
+}
+
+Ref {
+    "boards"."projectId" <> "projects"."id"
+}
+
+Ref {
+    "issue_transitions"."issueId" <> "issues"."id"
+}
+
+Ref {
+    "issue_votes"."issueId" <> "issues"."id"
+}
+
+Ref {
+    "issue_watchers"."issueId" <> "issues"."id"
+}
+
+Ref {
+    "project_avatars"."projectId" <> "projects"."id"
+}
+
+Ref {
+    "project_components"."projectId" <> "projects"."id"
+}
+
+Ref {
+    "project_components"."leadAccountId" <> "users"."accountId"
+}
+
+Ref {
+    "project_email"."projectId" <> "projects"."id"
+}
+
+Ref {
+    "project_permission_schemes"."projectId" <> "projects"."id"
+}
+
+Ref {
+    "project_versions"."projectId" <> "projects"."id"
+}
+
+Ref {
+    "screen_tabs"."screenId" <> "screens"."id"
+}
+
+Ref {
+    "screen_tab_fields"."screenId" <> "screens"."id"
+}
+
+Ref {
+    "screen_tab_fields"."tabId" <> "screen_tabs"."id"
+}
+
+Ref {
+    "sprints"."originBoardId" <> "boards"."id"
+}
+
+Ref {
+    "sprints"."boardId" <> "boards"."id"
+}
+
+Ref {
+    "board_issues"."boardId" <> "boards"."id"
+}
+
+Ref {
+    "issues"."projectId" <> "projects"."id"
+}
+
+Ref {
+    "sprint_issues"."sprintId" <> "sprints"."id"
+}
+
+Ref {
+    "issue_comments"."issueId" <> "issues"."id"
+}
+
+Ref {
+    "issue_worklogs"."issueId" <> "issues"."id"
+}

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -13,6 +13,7 @@ data:
   dockerImageTag: 3.1.1
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
+  erdUrl: https://dbdocs.io/airbyteio/source-jira?view=relationships
   githubIssueLabel: source-jira
   icon: jira.svg
   license: MIT


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/9173 for source-jira

## How
By running `airbyte-ci --name=source-jira generate-erd`

The publish has been done as part of the airbyte-ci command executed locally.

## User Impact
ERD is now available on https://dbdocs.io/airbyteio/source-jira

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌

