### PR TITLE
[ISSUE 9173] add ERD files for source-bing-ads

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-bing-ads/erd/discovered_catalog.json
@@ -1,0 +1,18605 @@
+{
+  "streams": [
+    {
+      "name": "accounts",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "Id": {
+            "description": "ID of the account",
+            "type": ["null", "number"]
+          },
+          "AccountFinancialStatus": {
+            "description": "The financial status of the account",
+            "type": ["null", "string"]
+          },
+          "AccountLifeCycleStatus": {
+            "description": "The life cycle status of the account",
+            "type": ["null", "string"]
+          },
+          "AutoTagType": {
+            "description": "The type of auto-tagging",
+            "type": ["null", "string"]
+          },
+          "AccountMode": {
+            "description": "The mode of the account",
+            "type": ["null", "string"]
+          },
+          "ForwardCompatibilityMap": {
+            "description": "Map for forward compatibility",
+            "type": ["null", "string"]
+          },
+          "PaymentMethodType": {
+            "description": "Type of the payment method",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language used in the account",
+            "type": ["null", "string"]
+          },
+          "LinkedAgencies": {
+            "description": "The agencies linked to the account for management purposes.",
+            "type": ["null", "object"],
+            "properties": {
+              "Id": {
+                "description": "ID of the linked agency",
+                "type": ["null", "integer"]
+              },
+              "Name": {
+                "description": "Name of the linked agency",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "TaxInformation": {
+            "description": "Tax information of the account",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used by the account",
+            "type": ["null", "string"]
+          },
+          "TimeZone": {
+            "description": "The time zone of the account",
+            "type": ["null", "string"]
+          },
+          "BusinessAddress": {
+            "description": "The business address associated with the account.",
+            "type": ["null", "object"],
+            "properties": {
+              "City": {
+                "description": "The city of the business address",
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "description": "The country code of the business address",
+                "type": ["null", "string"]
+              },
+              "Id": {
+                "description": "ID of the business address",
+                "type": ["null", "number"]
+              },
+              "Line1": {
+                "description": "Address line 1",
+                "type": ["null", "string"]
+              },
+              "Line2": {
+                "description": "Address line 2",
+                "type": ["null", "string"]
+              },
+              "Line3": {
+                "description": "Address line 3",
+                "type": ["null", "string"]
+              },
+              "Line4": {
+                "description": "Address line 4",
+                "type": ["null", "string"]
+              },
+              "PostalCode": {
+                "description": "The postal code of the business address",
+                "type": ["null", "string"]
+              },
+              "StateOrProvince": {
+                "description": "The state or province of the business address",
+                "type": ["null", "string"]
+              },
+              "TimeStamp": {
+                "description": "Timestamp of the business address",
+                "type": ["null", "string"]
+              },
+              "BusinessName": {
+                "description": "The business name",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "BackUpPaymentInstrumentId": {
+            "description": "ID of the backup payment instrument",
+            "type": ["null", "number"]
+          },
+          "BillingThresholdAmount": {
+            "description": "The threshold amount for billing",
+            "type": ["null", "number"]
+          },
+          "BillToCustomerId": {
+            "description": "Customer ID for billing",
+            "type": ["null", "number"]
+          },
+          "LastModifiedByUserId": {
+            "description": "ID of the user who last modified the account",
+            "type": ["null", "number"]
+          },
+          "LastModifiedTime": {
+            "description": "The date and time of the last modification",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_without_timezone"
+          },
+          "Name": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "Number": {
+            "description": "The account number",
+            "type": ["null", "string"]
+          },
+          "ParentCustomerId": {
+            "description": "ID of the parent customer",
+            "type": ["null", "number"]
+          },
+          "PauseReason": {
+            "description": "Reason for pausing the account",
+            "type": ["null", "number"]
+          },
+          "PaymentMethodId": {
+            "description": "ID of the payment method",
+            "type": ["null", "number"]
+          },
+          "PrimaryUserId": {
+            "description": "ID of the primary user",
+            "type": ["null", "number"]
+          },
+          "SalesHouseCustomerId": {
+            "description": "Customer ID for sales house",
+            "type": ["null", "number"]
+          },
+          "SoldToPaymentInstrumentId": {
+            "description": "ID of the payment instrument for sales",
+            "type": ["null", "number"]
+          },
+          "TimeStamp": {
+            "description": "Timestamp of the account",
+            "type": ["null", "string"]
+          },
+          "TaxCertificate": {
+            "type": ["null", "object"],
+            "properties": {
+              "TaxCertificateBlobContainerName": { "type": ["null", "string"] },
+              "Status": {
+                "type": ["null", "string"],
+                "enum": ["Invalid", "Pending", "Valid"]
+              },
+              "TaxCertificates": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "key": { "type": ["null", "string"] },
+                    "value": { "type": ["null", "string"] }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "ad_groups",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "CampaignId": {
+            "description": "The unique identifier of the campaign to which the ad group belongs.",
+            "type": ["null", "integer"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the account to which the ad group belongs.",
+            "type": ["null", "integer"]
+          },
+          "CustomerId": {
+            "description": "The unique identifier of the customer to which the ad group belongs.",
+            "type": ["null", "integer"]
+          },
+          "AdRotation": {
+            "description": "Defines how ads are rotated within the ad group.",
+            "type": ["null", "object"],
+            "properties": {
+              "EndDate": {
+                "description": "The end date for the ad rotation period.",
+                "type": ["null", "string"]
+              },
+              "StartDate": {
+                "description": "The start date for the ad rotation period.",
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "description": "The type of ad rotation strategy being used.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "AudienceAdsBidAdjustment": {
+            "description": "The bid adjustment for audience-based ads.",
+            "type": ["null", "number"]
+          },
+          "BiddingScheme": {
+            "description": "The bidding strategy used for the ad group.",
+            "type": ["null", "object"],
+            "properties": {
+              "Type": {
+                "description": "The type of bidding strategy being used.",
+                "type": ["null", "string"]
+              },
+              "InheritedBidStrategyType": {
+                "description": "The inherited bid strategy type from the parent campaign.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "CpcBid": {
+            "description": "The cost-per-click bid for the ad group.",
+            "type": ["null", "object"],
+            "properties": {
+              "Amount": {
+                "description": "The amount of the cost-per-click bid.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "CpvBid": {
+            "description": "The cost-per-view bid for the ad group.",
+            "type": ["null", "object"],
+            "properties": {
+              "Amount": {
+                "description": "The amount of the cost-per-view bid.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "CpmBid": {
+            "description": "The cost-per-thousand-impressions bid for the ad group.",
+            "type": ["null", "object"],
+            "properties": {
+              "Amount": {
+                "description": "The amount of the cost-per-thousand-impressions bid.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "EndDate": {
+            "description": "The end date of the ad group.",
+            "type": ["null", "object"],
+            "properties": {
+              "Day": {
+                "description": "The day part of the end date.",
+                "type": ["null", "integer"]
+              },
+              "Month": {
+                "description": "The month part of the end date.",
+                "type": ["null", "integer"]
+              },
+              "Year": {
+                "description": "The year part of the end date.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "FinalUrlSuffix": {
+            "description": "A string to append to the final URL.",
+            "type": ["null", "string"]
+          },
+          "ForwardCompatibilityMap": {
+            "description": "A map of key-value pairs for forward compatibility.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "key": {
+                  "description": "The key of the compatibility pair.",
+                  "type": ["null", "string"]
+                },
+                "value": {
+                  "description": "The value of the compatibility pair.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "Id": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "Language": {
+            "description": "The language targeting setting for the ad group.",
+            "type": ["null", "string"]
+          },
+          "Name": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network targeting setting for the ad group.",
+            "type": ["null", "string"]
+          },
+          "PrivacyStatus": {
+            "description": "The privacy status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "Settings": {
+            "description": "The settings associated with the ad group.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "Type": {
+                  "description": "The type of setting.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "StartDate": {
+            "description": "The start date of the ad group.",
+            "type": ["null", "object"],
+            "properties": {
+              "Day": {
+                "description": "The day part of the start date.",
+                "type": ["null", "integer"]
+              },
+              "Month": {
+                "description": "The month part of the start date.",
+                "type": ["null", "integer"]
+              },
+              "Year": {
+                "description": "The year part of the start date.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "Status": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "TrackingUrlTemplate": {
+            "description": "The tracking URL template for the ad group.",
+            "type": ["null", "string"]
+          },
+          "UrlCustomParameters": {
+            "description": "Custom parameters for tracking URLs.",
+            "type": ["null", "object"],
+            "properties": {
+              "Parameters": {
+                "description": "The list of custom parameters.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "key": {
+                      "description": "The key of the custom parameter.",
+                      "type": ["null", "string"]
+                    },
+                    "value": {
+                      "description": "The value of the custom parameter.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "AdScheduleUseSearcherTimeZone": {
+            "description": "Indicates whether ad scheduling uses the searcher's time zone.",
+            "type": ["null", "boolean"]
+          },
+          "AdGroupType": {
+            "description": "The type of the ad group (e.g., Search, Display, Video, etc).",
+            "type": ["null", "string"]
+          },
+          "MultimediaAdsBidAdjustment": {
+            "description": "The bid adjustment for multimedia ads.",
+            "type": ["null", "integer"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "ad_group_labels",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "Account Id": {
+            "description": "The unique identifier for the account to which the ad group belongs.",
+            "type": ["null", "integer"]
+          },
+          "Ad Group": {
+            "description": "The name or identifier of the ad group.",
+            "type": ["null", "string"]
+          },
+          "Campaign": {
+            "description": "The campaign to which the ad group is associated.",
+            "type": ["null", "string"]
+          },
+          "Client Id": {
+            "description": "The client identifier associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "Id": {
+            "description": "The unique identifier of the ad group label.",
+            "type": ["null", "integer"]
+          },
+          "Parent Id": {
+            "description": "The identifier of the parent entity, if applicable.",
+            "type": ["null", "integer"]
+          },
+          "Modified Time": {
+            "description": "The date and time when the ad group label was last modified.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "Status": {
+            "description": "The status of the ad group label.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Modified Time"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "app_install_ads",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "Ad Group": {
+            "description": "The name or ID of the ad group to which the app install ad belongs.",
+            "type": ["null", "string"]
+          },
+          "App Id": {
+            "description": "The unique identifier of the mobile app being promoted.",
+            "type": ["null", "integer"]
+          },
+          "Campaign": {
+            "description": "The name or ID of the advertising campaign associated with the app install ad.",
+            "type": ["null", "string"]
+          },
+          "Client Id": {
+            "description": "The unique identifier of the client or advertiser account.",
+            "type": ["null", "integer"]
+          },
+          "Custom Parameter": {
+            "description": "Optional custom parameters configured for tracking purposes.",
+            "type": ["null", "string"]
+          },
+          "Device Preference": {
+            "description": "Device preference targeting for the app install ad.",
+            "type": ["null", "string"]
+          },
+          "Editorial Appeal Status": {
+            "description": "The editorial appeal status of the ad.",
+            "type": ["null", "string"]
+          },
+          "Editorial Location": {
+            "description": "The editorial location where the ad is being reviewed.",
+            "type": ["null", "string"]
+          },
+          "Editorial Reason Code": {
+            "description": "The editorial reason code indicating the reason for disapproval of the ad.",
+            "type": ["null", "string"]
+          },
+          "Editorial Status": {
+            "description": "The editorial status of the ad (e.g., pending, approved, disapproved).",
+            "type": ["null", "string"]
+          },
+          "Editorial Term": {
+            "description": "The editorial term triggered in the review process.",
+            "type": ["null", "string"]
+          },
+          "Final Url": {
+            "description": "The final URL users are directed to after clicking the app install ad.",
+            "type": ["null", "string"]
+          },
+          "Final Url Suffix": {
+            "description": "Additional tracking information appended to the final URL.",
+            "type": ["null", "string"]
+          },
+          "Id": {
+            "description": "The unique identifier of the app install ad.",
+            "type": ["null", "integer"]
+          },
+          "Modified Time": {
+            "description": "The date and time when the app install ad was last modified.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "Parent Id": {
+            "description": "The ID of the parent object to which the app install ad belongs.",
+            "type": ["null", "integer"]
+          },
+          "Publisher Countries": {
+            "description": "List of countries targeted for publishing the app install ad.",
+            "type": ["null", "string"]
+          },
+          "Status": {
+            "description": "The status of the app install ad (e.g., enabled, paused, deleted).",
+            "type": ["null", "string"]
+          },
+          "Text": {
+            "description": "The text content of the app install ad.",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "The title of the app install ad.",
+            "type": ["null", "string"]
+          },
+          "Tracking Template": {
+            "description": "The tracking template URL for monitoring ad performance.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Modified Time"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "app_install_ad_labels",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "Account Id": {
+            "description": "The unique identifier for the account associated with the app install ad.",
+            "type": ["null", "integer"]
+          },
+          "Client Id": {
+            "description": "The unique identifier for the client associated with the app install ad.",
+            "type": ["null", "string"]
+          },
+          "Id": {
+            "description": "The unique identifier for the app install ad.",
+            "type": ["null", "integer"]
+          },
+          "Parent Id": {
+            "description": "The unique identifier for the parent resource that this app install ad belongs to.",
+            "type": ["null", "integer"]
+          },
+          "Modified Time": {
+            "description": "The date and time when the app install ad was last modified.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "Status": {
+            "description": "The current status of the app install ad.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Modified Time"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "ads",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the account associated with the ad",
+            "type": ["null", "integer"]
+          },
+          "CustomerId": {
+            "description": "The unique identifier for the customer associated with the ad",
+            "type": ["null", "integer"]
+          },
+          "AdFormatPreference": {
+            "description": "Preference for the ad format",
+            "type": ["null", "string"]
+          },
+          "DevicePreference": {
+            "description": "Preference for the device on which the ad should be displayed",
+            "type": ["null", "integer"]
+          },
+          "EditorialStatus": {
+            "description": "The editorial review status of the ad",
+            "type": ["null", "string"]
+          },
+          "BusinessName": {
+            "description": "The name of the business or entity associated with the ad",
+            "type": ["null", "string"]
+          },
+          "CallToAction": {
+            "description": "The call-to-action message for the ad",
+            "type": ["null", "string"]
+          },
+          "CallToActionLanguage": {
+            "description": "The language used for the call-to-action message",
+            "type": ["null", "string"]
+          },
+          "Headline": {
+            "description": "The headline of the ad",
+            "type": ["null", "string"]
+          },
+          "Images": {
+            "description": "Contains images for the ads",
+            "type": ["null", "object"],
+            "properties": {
+              "AssetLink": {
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Links to assets used in the images",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "Asset": {
+                      "description": "Defines the asset properties",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "Id": {
+                          "description": "The unique identifier for the asset",
+                          "type": ["null", "integer"]
+                        },
+                        "Name": {
+                          "description": "The name of the asset",
+                          "type": ["null", "string"]
+                        },
+                        "Type": {
+                          "description": "The type of the asset",
+                          "type": ["null", "string"]
+                        },
+                        "Text": {
+                          "description": "The text content of the asset",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "AssetPerformanceLabel": {
+                      "description": "Label indicating the performance of the asset",
+                      "type": ["null", "string"]
+                    },
+                    "EditorialStatus": {
+                      "description": "The editorial review status of the asset",
+                      "type": ["null", "string"]
+                    },
+                    "PinnedField": {
+                      "description": "Indicates if the field is pinned",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "Videos": {
+            "description": "Contains videos for the ads",
+            "type": ["null", "object"],
+            "properties": {
+              "AssetLink": {
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Links to assets used in the videos",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "Asset": {
+                      "description": "Defines the asset properties",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "Id": {
+                          "description": "The unique identifier for the asset",
+                          "type": ["null", "integer"]
+                        },
+                        "Name": {
+                          "description": "The name of the asset",
+                          "type": ["null", "string"]
+                        },
+                        "Type": {
+                          "description": "The type of the asset",
+                          "type": ["null", "string"]
+                        },
+                        "Text": {
+                          "description": "The text content of the asset",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "AssetPerformanceLabel": {
+                      "description": "Label indicating the performance of the asset",
+                      "type": ["null", "string"]
+                    },
+                    "EditorialStatus": {
+                      "description": "The editorial review status of the asset",
+                      "type": ["null", "string"]
+                    },
+                    "PinnedField": {
+                      "description": "Indicates if the field is pinned",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "LongHeadlines": {
+            "description": "Contains long headlines for the ads",
+            "type": ["null", "object"],
+            "properties": {
+              "AssetLink": {
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Links to assets used in the long headlines",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "Asset": {
+                      "description": "Defines the asset properties",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "Id": {
+                          "description": "The unique identifier for the asset",
+                          "type": ["null", "integer"]
+                        },
+                        "Name": {
+                          "description": "The name of the asset",
+                          "type": ["null", "string"]
+                        },
+                        "Type": {
+                          "description": "The type of the asset",
+                          "type": ["null", "string"]
+                        },
+                        "Text": {
+                          "description": "The text content of the asset",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "AssetPerformanceLabel": {
+                      "description": "Label indicating the performance of the asset",
+                      "type": ["null", "string"]
+                    },
+                    "EditorialStatus": {
+                      "description": "The editorial review status of the asset",
+                      "type": ["null", "string"]
+                    },
+                    "PinnedField": {
+                      "description": "Indicates if the field is pinned",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "LongHeadline": {
+            "description": "Long headline for the ads",
+            "type": ["null", "object"],
+            "properties": {
+              "Asset": {
+                "description": "Defines the asset properties for long headlines",
+                "type": ["null", "object"],
+                "properties": {
+                  "Id": {
+                    "description": "The unique identifier for the asset",
+                    "type": ["null", "integer"]
+                  },
+                  "Name": {
+                    "description": "The name of the asset",
+                    "type": ["null", "integer"]
+                  },
+                  "Type": {
+                    "description": "The type of the asset",
+                    "type": ["null", "integer"]
+                  }
+                }
+              },
+              "AssetPerformanceLabel": {
+                "description": "Label indicating the performance of the asset",
+                "type": ["null", "string"]
+              },
+              "EditorialStatus": {
+                "description": "The editorial review status of the asset",
+                "type": ["null", "string"]
+              },
+              "PinnedField": {
+                "description": "Indicates if the field is pinned",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "LongHeadlineString": {
+            "description": "The long headline content as a string",
+            "type": ["null", "string"]
+          },
+          "Text": {
+            "description": "The text content of the ad",
+            "type": ["null", "string"]
+          },
+          "TextPart2": {
+            "description": "The second part of the text content for the ad",
+            "type": ["null", "string"]
+          },
+          "TitlePart1": {
+            "description": "The first part of the ad title",
+            "type": ["null", "string"]
+          },
+          "TitlePart2": {
+            "description": "The second part of the ad title",
+            "type": ["null", "string"]
+          },
+          "TitlePart3": {
+            "description": "The third part of the ad title",
+            "type": ["null", "string"]
+          },
+          "FinalAppUrls": {
+            "description": "Final URLs for mobile app links",
+            "type": "null"
+          },
+          "FinalMobileUrls": {
+            "description": "Mobile final URLs for the ads",
+            "type": ["null", "object"],
+            "properties": {
+              "string": {
+                "description": "String properties for mobile URLs",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Final mobile URL",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "FinalUrlSuffix": {
+            "description": "Suffix to append to the final URL",
+            "type": ["null", "string"]
+          },
+          "FinalUrls": {
+            "description": "Final URLs for the ads",
+            "type": ["null", "object"],
+            "properties": {
+              "string": {
+                "description": "String properties for URLs",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Final URL",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "ForwardCompatibilityMap": {
+            "description": "Map for forward compatibility with future API changes",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "key": {
+                  "description": "Key for the compatibility map",
+                  "type": ["null", "string"]
+                },
+                "value": {
+                  "description": "Value for the compatibility map",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "Id": {
+            "description": "The unique identifier for the ad",
+            "type": ["null", "integer"]
+          },
+          "Status": {
+            "description": "The status of the ad",
+            "type": ["null", "string"]
+          },
+          "TrackingUrlTemplate": {
+            "description": "Template for tracking URLs",
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "description": "The type of ad",
+            "type": ["null", "string"]
+          },
+          "UrlCustomParameters": {
+            "description": "Custom URL parameters for the ads",
+            "type": ["null", "object"],
+            "properties": {
+              "Parameters": {
+                "description": "Defines the URL parameter properties",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "key": {
+                      "description": "Parameter key",
+                      "type": ["null", "string"]
+                    },
+                    "value": {
+                      "description": "Parameter value",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "Descriptions": {
+            "description": "Contains descriptions for the ads",
+            "type": ["null", "object"],
+            "properties": {
+              "AssetLink": {
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Links to assets used in the descriptions",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "Asset": {
+                      "description": "Defines the asset properties",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "Id": {
+                          "description": "The unique identifier for the asset",
+                          "type": ["null", "integer"]
+                        },
+                        "Name": {
+                          "description": "The name of the asset",
+                          "type": ["null", "string"]
+                        },
+                        "Type": {
+                          "description": "The type of the asset",
+                          "type": ["null", "string"]
+                        },
+                        "Text": {
+                          "description": "The text content of the asset",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "AssetPerformanceLabel": {
+                      "description": "Label indicating the performance of the asset",
+                      "type": ["null", "string"]
+                    },
+                    "EditorialStatus": {
+                      "description": "The editorial review status of the asset",
+                      "type": ["null", "string"]
+                    },
+                    "PinnedField": {
+                      "description": "Indicates if the field is pinned",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "Domain": {
+            "description": "The domain associated with the ad",
+            "type": ["null", "string"]
+          },
+          "Headlines": {
+            "description": "Contains headlines for the ads",
+            "type": ["null", "object"],
+            "properties": {
+              "AssetLink": {
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Links to assets used in the headlines",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "Asset": {
+                      "description": "Defines the asset properties",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "Id": {
+                          "description": "The unique identifier for the asset",
+                          "type": ["null", "integer"]
+                        },
+                        "Name": {
+                          "description": "The name of the asset",
+                          "type": ["null", "string"]
+                        },
+                        "Type": {
+                          "description": "The type of the asset",
+                          "type": ["null", "string"]
+                        },
+                        "Text": {
+                          "description": "The text content of the asset",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "AssetPerformanceLabel": {
+                      "description": "Label indicating the performance of the asset",
+                      "type": ["null", "string"]
+                    },
+                    "EditorialStatus": {
+                      "description": "The editorial review status of the asset",
+                      "type": ["null", "string"]
+                    },
+                    "PinnedField": {
+                      "description": "Indicates if the field is pinned",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "Path1": {
+            "description": "The first part of the display URL path",
+            "type": ["null", "string"]
+          },
+          "Path2": {
+            "description": "The second part of the display URL path",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "budget",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "Account Id": {
+            "description": "The unique identifier of the account associated with the budget.",
+            "type": ["null", "integer"]
+          },
+          "Type": {
+            "description": "The type of budget entity, such as campaign or ad group budget.",
+            "type": ["null", "string"]
+          },
+          "Status": {
+            "description": "The current status of the budget, such as active or paused.",
+            "type": ["null", "string"]
+          },
+          "Id": {
+            "description": "The unique identifier of the budget entity.",
+            "type": ["null", "integer"]
+          },
+          "Parent Id": {
+            "description": "The identifier of the parent entity to which the budget belongs, if applicable.",
+            "type": ["null", "integer"]
+          },
+          "Client Id": {
+            "description": "The unique identifier of the client associated with the budget.",
+            "type": ["null", "integer"]
+          },
+          "Modified Time": {
+            "description": "The date and time when the budget information was last modified.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "Budget Id": {
+            "description": "The unique identifier of the budget.",
+            "type": ["null", "integer"]
+          },
+          "Budget Name": {
+            "description": "The name assigned to the budget for easy identification.",
+            "type": ["null", "string"]
+          },
+          "Budget": {
+            "description": "The amount allocated for spending on advertising campaigns.",
+            "type": ["null", "number"]
+          },
+          "Budget Type": {
+            "description": "The type of budget allocation, such as daily or monthly.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Modified Time"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "campaigns",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier of the account associated with the campaign.",
+            "type": ["null", "integer"]
+          },
+          "CustomerId": {
+            "description": "The unique identifier of the customer associated with the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AudienceAdsBidAdjustment": {
+            "description": "Bid adjustment value for audience targeting ads.",
+            "type": ["null", "number"]
+          },
+          "BiddingScheme": {
+            "description": "Details of the bidding scheme for the campaign",
+            "type": ["null", "object"],
+            "properties": {
+              "Type": {
+                "description": "The type of bidding strategy used for the campaign.",
+                "type": ["null", "string"]
+              },
+              "MaxCpc": {
+                "description": "Details of the maximum cost-per-click bid",
+                "type": ["null", "object"],
+                "properties": {
+                  "Amount": {
+                    "description": "The maximum cost-per-click bid for the campaign.",
+                    "type": ["null", "number"]
+                  }
+                }
+              }
+            }
+          },
+          "BudgetType": {
+            "description": "The type of budget (e.g., daily, monthly) for the campaign.",
+            "type": ["null", "string"]
+          },
+          "MultimediaAdsBidAdjustment": {
+            "description": "Bid adjustment value for multimedia ads.",
+            "type": ["null", "number"]
+          },
+          "DailyBudget": {
+            "description": "The daily budget amount set for the campaign.",
+            "type": ["null", "number"]
+          },
+          "ExperimentId": {
+            "description": "The identifier of the experiment linked to the campaign.",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The final URL suffix appended to campaign URLs.",
+            "type": ["null", "string"]
+          },
+          "ForwardCompatibilityMap": {
+            "description": "Forward compatibility map for potential future enhancements",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "key": {
+                  "description": "The key identifying a forward compatibility setting.",
+                  "type": ["null", "string"]
+                },
+                "value": {
+                  "description": "The value associated with the forward compatibility setting.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "Id": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "number"]
+          },
+          "Name": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "Status": {
+            "description": "The status of the campaign (e.g., Active, Paused).",
+            "type": ["null", "string"]
+          },
+          "SubType": {
+            "description": "The subtype of the campaign, providing additional context.",
+            "type": ["null", "string"]
+          },
+          "TimeZone": {
+            "description": "The time zone setting for the campaign.",
+            "type": ["null", "string"]
+          },
+          "TrackingUrlTemplate": {
+            "description": "The tracking URL template used for the campaign.",
+            "type": ["null", "string"]
+          },
+          "UrlCustomParameters": {
+            "description": "Custom parameters for campaign URLs",
+            "type": ["null", "object"],
+            "properties": {
+              "Parameters": {
+                "description": "Specific URL parameters",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "Key": {
+                      "description": "The key parameter for URL customization.",
+                      "type": ["null", "string"]
+                    },
+                    "Value": {
+                      "description": "The value parameter for URL customization.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "CampaignType": {
+            "description": "The type of campaign (e.g., Search, Display, Video) being run.",
+            "type": ["null", "string"]
+          },
+          "Settings": {
+            "description": "Settings related to the campaign",
+            "type": ["null", "object"],
+            "properties": {
+              "Setting": {
+                "description": "Specific setting details",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "Type": {
+                      "description": "The type of setting applied to the campaign.",
+                      "type": ["null", "string"]
+                    },
+                    "Details": {
+                      "description": "Specific details of the setting",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "TargetSettingDetail": {
+                          "description": "Specific target setting details",
+                          "type": ["null", "array"],
+                          "items": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "CriterionTypeGroup": {
+                                "description": "The group type for targeting.",
+                                "type": ["null", "string"]
+                              },
+                              "TargetAndBid": {
+                                "description": "Indicates whether targeting is set to 'Bid only' or 'Target and bid'.",
+                                "type": ["null", "boolean"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "BudgetId": {
+            "description": "The identifier of the budget associated with the campaign.",
+            "type": ["null", "number"]
+          },
+          "Languages": {
+            "description": "Languages targeted in the campaign",
+            "type": ["null", "object"],
+            "properties": {
+              "string": {
+                "description": "The languages targeted by the campaign.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "AdScheduleUseSearcherTimeZone": {
+            "description": "Indicates whether ad schedules should be based on the searcher's time zone.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "budget_summary_report",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "Name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "Account number associated with the account",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "Unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "Unique identifier for the campaign",
+            "type": ["null", "integer"]
+          },
+          "CampaignName": {
+            "description": "Name of the campaign",
+            "type": ["null", "string"]
+          },
+          "Date": {
+            "description": "Date of the data record",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "MonthlyBudget": {
+            "description": "Budget amount set for the campaign for the entire month",
+            "type": ["null", "number"]
+          },
+          "DailySpend": {
+            "description": "Amount spent on the campaign on a daily basis",
+            "type": ["null", "number"]
+          },
+          "MonthToDateSpend": {
+            "description": "Total amount spent on the campaign from the beginning of the month",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Date"],
+      "source_defined_primary_key": [["Date"]],
+      "is_resumable": true
+    },
+    {
+      "name": "labels",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "Account Id": {
+            "description": "The unique identifier of the account associated with the label.",
+            "type": ["null", "integer"]
+          },
+          "Color": {
+            "description": "The color code or name associated with the label for visual identification purposes.",
+            "type": ["null", "string"]
+          },
+          "Client Id": {
+            "description": "The unique identifier of the client associated with the label.",
+            "type": ["null", "string"]
+          },
+          "Description": {
+            "description": "A brief description or notes related to the label.",
+            "type": ["null", "string"]
+          },
+          "Id": {
+            "description": "The unique identifier of the label.",
+            "type": ["null", "integer"]
+          },
+          "Label": {
+            "description": "The name or title given to the label for identification.",
+            "type": ["null", "string"]
+          },
+          "Modified Time": {
+            "description": "The date and time when the label was last modified.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "Status": {
+            "description": "The current status of the label, such as active, inactive, or archived.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Modified Time"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "keyword_labels",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "Account Id": {
+            "description": "Unique identifier for the account associated with the keyword label.",
+            "type": ["null", "integer"]
+          },
+          "Client Id": {
+            "description": "Unique identifier for the client associated with the keyword label.",
+            "type": ["null", "string"]
+          },
+          "Id": {
+            "description": "Unique identifier for the keyword label.",
+            "type": ["null", "integer"]
+          },
+          "Parent Id": {
+            "description": "Unique identifier for the parent entity related to the keyword label.",
+            "type": ["null", "integer"]
+          },
+          "Modified Time": {
+            "description": "Timestamp indicating when the keyword label was last modified.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "Status": {
+            "description": "Current status of the keyword label.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Modified Time"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "keywords",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "Account Id": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "Id": {
+            "description": "The unique identifier for the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Ad Group": {
+            "description": "The name of the ad group where the keyword belongs.",
+            "type": ["null", "string"]
+          },
+          "Bid": {
+            "description": "The bid amount set for the keyword.",
+            "type": ["null", "string"]
+          },
+          "Bid Strategy Type": {
+            "description": "The type of bid strategy used for the keyword.",
+            "type": ["null", "string"]
+          },
+          "Campaign": {
+            "description": "The campaign name where the keyword is associated.",
+            "type": ["null", "string"]
+          },
+          "Client Id": {
+            "description": "The client identifier linked to the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Custom Parameter": {
+            "description": "A custom parameter associated with the keyword.",
+            "type": ["null", "string"]
+          },
+          "Destination Url": {
+            "description": "The destination URL for the keyword.",
+            "type": ["null", "string"]
+          },
+          "Modified Time": {
+            "description": "The timestamp when the keyword was last modified.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "Editorial Appeal Status": {
+            "description": "The appeal status of the keyword during the editorial review process.",
+            "type": ["null", "string"]
+          },
+          "Editorial Location": {
+            "description": "The location of the editorial review for the keyword.",
+            "type": ["null", "string"]
+          },
+          "Editorial Reason Code": {
+            "description": "The reason code provided during the editorial review process.",
+            "type": ["null", "string"]
+          },
+          "Editorial Status": {
+            "description": "The editorial status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "Editorial Term": {
+            "description": "The term that was reviewed editorially.",
+            "type": ["null", "string"]
+          },
+          "Final Url": {
+            "description": "The final URL that the keyword points to.",
+            "type": ["null", "string"]
+          },
+          "Final Url Suffix": {
+            "description": "The URL suffix added to the final URL.",
+            "type": ["null", "string"]
+          },
+          "Inherited Bid Strategy Type": {
+            "description": "The bid strategy type inherited for the keyword.",
+            "type": ["null", "string"]
+          },
+          "Keyword": {
+            "description": "The keyword used for advertising.",
+            "type": ["null", "string"]
+          },
+          "Keyword Relevance": {
+            "description": "The relevance of the keyword to its ad group or campaign.",
+            "type": ["null", "string"]
+          },
+          "Landing Page Relevance": {
+            "description": "The relevance of the landing page to the keyword.",
+            "type": ["null", "string"]
+          },
+          "Landing Page User Experience": {
+            "description": "The user experience on the landing page related to the keyword.",
+            "type": ["null", "string"]
+          },
+          "Match Type": {
+            "description": "The match type of the keyword (e.g., exact, phrase, broad).",
+            "type": ["null", "string"]
+          },
+          "Mobile Final Url": {
+            "description": "The final URL for mobile devices.",
+            "type": ["null", "string"]
+          },
+          "Param1": {
+            "description": "Parameter 1 associated with the keyword.",
+            "type": ["null", "string"]
+          },
+          "Param2": {
+            "description": "Parameter 2 associated with the keyword.",
+            "type": ["null", "string"]
+          },
+          "Param3": {
+            "description": "Parameter 3 associated with the keyword.",
+            "type": ["null", "string"]
+          },
+          "Parent Id": {
+            "description": "The parent identifier to which the keyword belongs.",
+            "type": ["null", "string"]
+          },
+          "Publisher Countries": {
+            "description": "The countries targeted for publishing the keyword.",
+            "type": ["null", "string"]
+          },
+          "Quality Score": {
+            "description": "The quality score assigned to the keyword.",
+            "type": ["null", "string"]
+          },
+          "Status": {
+            "description": "The current status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "Tracking Template": {
+            "description": "The template used for tracking the performance of the keyword.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Modified Time"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "campaign_labels",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "Account Id": {
+            "description": "The unique identifier of the account associated with the campaign label.",
+            "type": ["null", "integer"]
+          },
+          "Campaign": {
+            "description": "The name or title of the campaign to which the label is applied.",
+            "type": ["null", "string"]
+          },
+          "Client Id": {
+            "description": "The unique identifier of the client associated with the campaign label.",
+            "type": ["null", "string"]
+          },
+          "Id": {
+            "description": "The unique identifier of the campaign label.",
+            "type": ["null", "integer"]
+          },
+          "Parent Id": {
+            "description": "The unique identifier of the parent item associated with the campaign label.",
+            "type": ["null", "integer"]
+          },
+          "Modified Time": {
+            "description": "The date and time when the campaign label was last modified.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "Status": {
+            "description": "The current status of the campaign label (e.g., active, paused, deleted).",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["Modified Time"],
+      "source_defined_primary_key": [["Id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "age_gender_audience_report_hourly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier of the account to which the data belongs.",
+            "type": ["null", "integer"]
+          },
+          "AgeGroup": {
+            "description": "The age group of the audience targeted by the campaign.",
+            "type": ["null", "string"]
+          },
+          "Gender": {
+            "description": "The gender of the audience targeted by the campaign.",
+            "type": ["null", "string"]
+          },
+          "TimePeriod": {
+            "description": "The specific date and time period for the collected data.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "AllConversions": {
+            "description": "Total number of all types of conversions.",
+            "type": ["null", "integer"]
+          },
+          "AccountName": {
+            "description": "The name of the account to which the data belongs.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the account.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign to which the data belongs.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign to which the data belongs.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group to which the data belongs.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group to which the data belongs.",
+            "type": ["null", "integer"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was displayed (search, display, etc.).",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the ad was displayed to users.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of times the ad was clicked on.",
+            "type": ["null", "integer"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions generated by the ad.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on running the ad campaign.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the ad campaign.",
+            "type": ["null", "number"]
+          },
+          "ExtendedCost": {
+            "description": "The total cost of running the ad campaign including all associated costs.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of times this ad appeared in a conversion path but was not the last click before the conversion.",
+            "type": ["null", "integer"]
+          },
+          "Language": {
+            "description": "The language targeting setting for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The unique identifier of the base campaign to which the data belongs.",
+            "type": ["null", "string"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated from all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of times users saw but did not interact with this ad and later converted.",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The objective or goal set for the campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal set for the campaign (e.g., clicks, conversions).",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times that your ad is shown at the top of the page, above the organic search results.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of times that your ad is shown at the top of the search results.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of conversions that meet specified criteria.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "Total number of all types of conversions that meet specified criteria.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions that meet specified criteria.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AgeGroup"],
+        ["Gender"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["Language"],
+        ["AdDistribution"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "age_gender_audience_report_daily",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The ID of the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "AgeGroup": {
+            "description": "The age group of the audience targeted by the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "Gender": {
+            "description": "The gender of the audience targeted by the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the data is reported.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AllConversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The ID of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The ID of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "AdDistribution": {
+            "description": "The type of ad distribution, such as search or content network.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The number of times the ad was displayed.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Conversions": {
+            "description": "The number of conversions.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on the ad campaign.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated from conversions.",
+            "type": ["null", "number"]
+          },
+          "ExtendedCost": {
+            "description": "The total cost extended due to possible monthly budget overspend.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists that contributed to conversions.",
+            "type": ["null", "integer"]
+          },
+          "Language": {
+            "description": "The language used in targeting the audience.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The ID of the base campaign.",
+            "type": ["null", "string"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal set for the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal set for the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times your ad was shown at the absolute top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of times your ad was shown above organic search results.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AgeGroup"],
+        ["Gender"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["Language"],
+        ["AdDistribution"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "age_gender_audience_report_weekly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The ID of the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "AgeGroup": {
+            "description": "The age group of the audience targeted by the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "Gender": {
+            "description": "The gender of the audience targeted by the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the data is reported.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AllConversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The ID of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The ID of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "AdDistribution": {
+            "description": "The type of ad distribution, such as search or content network.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The number of times the ad was displayed.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Conversions": {
+            "description": "The number of conversions.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on the ad campaign.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated from conversions.",
+            "type": ["null", "number"]
+          },
+          "ExtendedCost": {
+            "description": "The total cost extended due to possible monthly budget overspend.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists that contributed to conversions.",
+            "type": ["null", "integer"]
+          },
+          "Language": {
+            "description": "The language used in targeting the audience.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The ID of the base campaign.",
+            "type": ["null", "string"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal set for the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal set for the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times your ad was shown at the absolute top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of times your ad was shown above organic search results.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AgeGroup"],
+        ["Gender"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["Language"],
+        ["AdDistribution"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "age_gender_audience_report_monthly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The ID of the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "AgeGroup": {
+            "description": "The age group of the audience targeted by the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "Gender": {
+            "description": "The gender of the audience targeted by the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the data is reported.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AllConversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The ID of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The ID of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "AdDistribution": {
+            "description": "The type of ad distribution, such as search or content network.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The number of times the ad was displayed.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Conversions": {
+            "description": "The number of conversions.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on the ad campaign.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated from conversions.",
+            "type": ["null", "number"]
+          },
+          "ExtendedCost": {
+            "description": "The total cost extended due to possible monthly budget overspend.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists that contributed to conversions.",
+            "type": ["null", "integer"]
+          },
+          "Language": {
+            "description": "The language used in targeting the audience.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The ID of the base campaign.",
+            "type": ["null", "string"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal set for the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal set for the ad campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times your ad was shown at the absolute top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of times your ad was shown above organic search results.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AgeGroup"],
+        ["Gender"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["Language"],
+        ["AdDistribution"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "account_impression_performance_report_hourly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the data",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for the values",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution channel where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position where the ad was displayed",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The rate of conversions generated",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "The total number of low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "The percentage of low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "The total number of low-quality impressions",
+            "type": ["null", "integer"]
+          },
+          "LowQualityImpressionsPercent": {
+            "description": "The percentage of low-quality impressions",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversions": {
+            "description": "The total number of low-quality conversions",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "The conversion rate for low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "The type of device on which the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "PhoneImpressions": {
+            "description": "The total number of phone impressions",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The total number of phone calls generated",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone-through rate",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "The network on which the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The total number of assists (click assist impressions)",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "LowQualityGeneralClicks": {
+            "description": "The total number of low-quality general clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "The total number of low-quality sophisticated clicks",
+            "type": ["null", "integer"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The top impression rate percentage",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The rate of all conversions generated",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per each conversion",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per each conversion",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversionsQualified": {
+            "description": "The total number of qualified low-quality conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of qualified all conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of view-through conversions qualified",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The view-through revenue",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "The total number of video views",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "The view-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "The average cost per video view",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "The total number of video views at 25%",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "The total number of video views at 50%",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "The total number of video views at 75%",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "The total number of completed video views",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "The video completion rate",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "The total watch time in milliseconds",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "The average watch time per video view",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "The average watch time per impression",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The revenue per sale",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of installs",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per install",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The revenue per install",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "account_impression_performance_report_daily",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the account",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the data is being reported",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency used for the financial metrics",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ads were displayed (e.g., search, display)",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions on the ads",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ads",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate of the ad",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on advertisements",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on the search results page",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions tracked",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The rate at which conversions occur",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "The number of clicks considered of low quality",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "The percentage of clicks classified as low quality",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "The number of impressions classified as low quality",
+            "type": ["null", "integer"]
+          },
+          "LowQualityImpressionsPercent": {
+            "description": "The percentage of low-quality impressions",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversions": {
+            "description": "The total number of conversions from low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "The conversion rate attributed to low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "The type of device on which the ad was displayed (e.g., desktop, mobile)",
+            "type": ["null", "string"]
+          },
+          "ImpressionSharePercent": {
+            "description": "The percentage of impressions captured out of total available impressions",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToBudgetPercent": {
+            "description": "The percentage of impressions lost due to budget limitations",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToRankAggPercent": {
+            "description": "The percentage of impressions lost to ranking aggregation",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "The number of impressions on phone devices",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The total number of phone calls generated by the ads",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone-through rate of the ad",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "The advertising network where the ads were displayed",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists in contributing to conversions",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on investment from ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist in contributing to conversions",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue generated per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue generated per assist in conversions",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account (e.g., active, paused, etc.)",
+            "type": ["null", "string"]
+          },
+          "LowQualityGeneralClicks": {
+            "description": "The number of general clicks considered of low quality",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "The number of sophisticated clicks considered of low quality",
+            "type": ["null", "integer"]
+          },
+          "ExactMatchImpressionSharePercent": {
+            "description": "The percentage of exact match impressions captured",
+            "type": ["null", "number"]
+          },
+          "ClickSharePercent": {
+            "description": "The share of clicks received out of the total available clicks",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionSharePercent": {
+            "description": "The percentage of impressions received in the absolute top location on the search results page",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToRankPercent": {
+            "description": "The percentage of top impressions lost due to ad ranking",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of top impressions lost due to budget constraints",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToRankPercent": {
+            "description": "The percentage of absolute top impressions lost due to ad ranking",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of absolute top impressions lost due to budget constraints",
+            "type": ["null", "number"]
+          },
+          "TopImpressionSharePercent": {
+            "description": "The percentage of impressions received at the top position on the search results page",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of impressions that are shown in the absolute top position above the organic search results",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of impressions that appear at the top of search results",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions counted",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The rate of all conversions that occurred",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend generated by all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue generated per conversion from all conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of conversions attributed to view-through tracking",
+            "type": ["null", "integer"]
+          },
+          "AudienceImpressionSharePercent": {
+            "description": "The percentage of impressions captured for the targeted audience",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToRankPercent": {
+            "description": "The percentage of audience impressions lost due to ad ranking",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToBudgetPercent": {
+            "description": "The percentage of audience impressions lost due to budget restrictions",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversionsQualified": {
+            "description": "The number of qualified conversions from low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of qualified conversions of all types",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified conversions linked to view-through tracking",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "The total number of views of video ads",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "The rate at which view-through conversions occur",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "The average cost per view of video ads",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "The number of video views at 25% completion",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "The number of video views at 50% completion",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "The number of video views at 75% completion",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "The number of completed views of video ads",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "The rate of completed views of video ads",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "The total watch time in milliseconds for video ads",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "The average watch time per video view",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "The average watch time per impression for video ads",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales attributed to the ads",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The average revenue generated per sale",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of installations linked to the ads",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per installation",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The average revenue generated per installation",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "account_impression_performance_report_weekly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the account",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the data is being reported",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency used for the financial metrics",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ads were displayed (e.g., search, display)",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions on the ads",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ads",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate of the ad",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on advertisements",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on the search results page",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions tracked",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The rate at which conversions occur",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "The number of clicks considered of low quality",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "The percentage of clicks classified as low quality",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "The number of impressions classified as low quality",
+            "type": ["null", "integer"]
+          },
+          "LowQualityImpressionsPercent": {
+            "description": "The percentage of low-quality impressions",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversions": {
+            "description": "The total number of conversions from low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "The conversion rate attributed to low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "The type of device on which the ad was displayed (e.g., desktop, mobile)",
+            "type": ["null", "string"]
+          },
+          "ImpressionSharePercent": {
+            "description": "The percentage of impressions captured out of total available impressions",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToBudgetPercent": {
+            "description": "The percentage of impressions lost due to budget limitations",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToRankAggPercent": {
+            "description": "The percentage of impressions lost to ranking aggregation",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "The number of impressions on phone devices",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The total number of phone calls generated by the ads",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone-through rate of the ad",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "The advertising network where the ads were displayed",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists in contributing to conversions",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on investment from ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist in contributing to conversions",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue generated per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue generated per assist in conversions",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account (e.g., active, paused, etc.)",
+            "type": ["null", "string"]
+          },
+          "LowQualityGeneralClicks": {
+            "description": "The number of general clicks considered of low quality",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "The number of sophisticated clicks considered of low quality",
+            "type": ["null", "integer"]
+          },
+          "ExactMatchImpressionSharePercent": {
+            "description": "The percentage of exact match impressions captured",
+            "type": ["null", "number"]
+          },
+          "ClickSharePercent": {
+            "description": "The share of clicks received out of the total available clicks",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionSharePercent": {
+            "description": "The percentage of impressions received in the absolute top location on the search results page",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToRankPercent": {
+            "description": "The percentage of top impressions lost due to ad ranking",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of top impressions lost due to budget constraints",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToRankPercent": {
+            "description": "The percentage of absolute top impressions lost due to ad ranking",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of absolute top impressions lost due to budget constraints",
+            "type": ["null", "number"]
+          },
+          "TopImpressionSharePercent": {
+            "description": "The percentage of impressions received at the top position on the search results page",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of impressions that are shown in the absolute top position above the organic search results",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of impressions that appear at the top of search results",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions counted",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The rate of all conversions that occurred",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend generated by all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue generated per conversion from all conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of conversions attributed to view-through tracking",
+            "type": ["null", "integer"]
+          },
+          "AudienceImpressionSharePercent": {
+            "description": "The percentage of impressions captured for the targeted audience",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToRankPercent": {
+            "description": "The percentage of audience impressions lost due to ad ranking",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToBudgetPercent": {
+            "description": "The percentage of audience impressions lost due to budget restrictions",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversionsQualified": {
+            "description": "The number of qualified conversions from low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of qualified conversions of all types",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified conversions linked to view-through tracking",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "The total number of views of video ads",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "The rate at which view-through conversions occur",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "The average cost per view of video ads",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "The number of video views at 25% completion",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "The number of video views at 50% completion",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "The number of video views at 75% completion",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "The number of completed views of video ads",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "The rate of completed views of video ads",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "The total watch time in milliseconds for video ads",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "The average watch time per video view",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "The average watch time per impression for video ads",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales attributed to the ads",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The average revenue generated per sale",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of installations linked to the ads",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per installation",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The average revenue generated per installation",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "account_impression_performance_report_monthly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the account",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the data is being reported",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency used for the financial metrics",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ads were displayed (e.g., search, display)",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions on the ads",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ads",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate of the ad",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on advertisements",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on the search results page",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions tracked",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The rate at which conversions occur",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "The number of clicks considered of low quality",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "The percentage of clicks classified as low quality",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "The number of impressions classified as low quality",
+            "type": ["null", "integer"]
+          },
+          "LowQualityImpressionsPercent": {
+            "description": "The percentage of low-quality impressions",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversions": {
+            "description": "The total number of conversions from low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "The conversion rate attributed to low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "The type of device on which the ad was displayed (e.g., desktop, mobile)",
+            "type": ["null", "string"]
+          },
+          "ImpressionSharePercent": {
+            "description": "The percentage of impressions captured out of total available impressions",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToBudgetPercent": {
+            "description": "The percentage of impressions lost due to budget limitations",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToRankAggPercent": {
+            "description": "The percentage of impressions lost to ranking aggregation",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "The number of impressions on phone devices",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The total number of phone calls generated by the ads",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone-through rate of the ad",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "The advertising network where the ads were displayed",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists in contributing to conversions",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on investment from ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist in contributing to conversions",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue generated per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue generated per assist in conversions",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account (e.g., active, paused, etc.)",
+            "type": ["null", "string"]
+          },
+          "LowQualityGeneralClicks": {
+            "description": "The number of general clicks considered of low quality",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "The number of sophisticated clicks considered of low quality",
+            "type": ["null", "integer"]
+          },
+          "ExactMatchImpressionSharePercent": {
+            "description": "The percentage of exact match impressions captured",
+            "type": ["null", "number"]
+          },
+          "ClickSharePercent": {
+            "description": "The share of clicks received out of the total available clicks",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionSharePercent": {
+            "description": "The percentage of impressions received in the absolute top location on the search results page",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToRankPercent": {
+            "description": "The percentage of top impressions lost due to ad ranking",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of top impressions lost due to budget constraints",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToRankPercent": {
+            "description": "The percentage of absolute top impressions lost due to ad ranking",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of absolute top impressions lost due to budget constraints",
+            "type": ["null", "number"]
+          },
+          "TopImpressionSharePercent": {
+            "description": "The percentage of impressions received at the top position on the search results page",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of impressions that are shown in the absolute top position above the organic search results",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of impressions that appear at the top of search results",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions counted",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The rate of all conversions that occurred",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend generated by all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue generated per conversion from all conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of conversions attributed to view-through tracking",
+            "type": ["null", "integer"]
+          },
+          "AudienceImpressionSharePercent": {
+            "description": "The percentage of impressions captured for the targeted audience",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToRankPercent": {
+            "description": "The percentage of audience impressions lost due to ad ranking",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToBudgetPercent": {
+            "description": "The percentage of audience impressions lost due to budget restrictions",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversionsQualified": {
+            "description": "The number of qualified conversions from low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of qualified conversions of all types",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified conversions linked to view-through tracking",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "The total number of views of video ads",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "The rate at which view-through conversions occur",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "The average cost per view of video ads",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "The number of video views at 25% completion",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "The number of video views at 50% completion",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "The number of video views at 75% completion",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "The number of completed views of video ads",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "The rate of completed views of video ads",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "The total watch time in milliseconds for video ads",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "The average watch time per video view",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "The average watch time per impression for video ads",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales attributed to the ads",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The average revenue generated per sale",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of installations linked to the ads",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per installation",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The average revenue generated per installation",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "account_performance_report_hourly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network for the ad (search partners, audience network, etc.)",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device on which the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network on which the ad appeared (e.g., Bing, AOL)",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type for the delivered ad",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device on which the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Indicates whether the ad appeared at the top or other positions",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type for which the bid was set",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "PhoneImpressions": {
+            "description": "The number of impressions that included a phone number",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The number of phone calls generated by the ad",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate for the ad",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend on the ad campaign",
+            "type": ["null", "number"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions generated by the ad",
+            "type": ["null", "integer"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion generated by the ad",
+            "type": ["null", "number"]
+          },
+          "Ptr": {
+            "description": "The phone-through rate for the ad",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists generated by the ad",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend (ROAS) for the ad campaign",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist generated by the ad",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click for the ad",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position where the ad appeared on the search results page",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions for the ad",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions generated by the ad",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of conversions that met certain criteria",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The rate at which clicks on the ad led to conversions",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "The number of low-quality clicks on the ad",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "The percentage of low-quality clicks out of total clicks",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "The number of low-quality impressions generated by the ad",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "The number of sophisticated clicks recognized as low-quality",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversions": {
+            "description": "The number of conversions from low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "The conversion rate for low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the ad",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion generated by the ad",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist generated by the ad",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "account_performance_report_daily",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "Unique identifier for the Bing Ads account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "Time period for the report",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "Currency code used for reporting",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "Type of ad distribution (search, content, both)",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "Type of device used",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "Type of network (search, audience)",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "Type of match in ad delivery",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "Operating system of the device",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Performance comparison between top and other ad positions",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "Type of bidding match (exact, phrase, broad)",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "Name of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "Numeric account number",
+            "type": ["null", "string"]
+          },
+          "PhoneImpressions": {
+            "description": "Number of ad impressions on phone devices",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Number of phone calls generated",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total spend on ad campaigns",
+            "type": ["null", "number"]
+          },
+          "Impressions": {
+            "description": "Total number of ad impressions",
+            "type": ["null", "integer"]
+          },
+          "CostPerConversion": {
+            "description": "Cost per conversion",
+            "type": ["null", "number"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Number of assist conversions",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "Return on ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Cost per assist conversion",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "Average ad position",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "Percentage of conversions from clicks",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "Number of low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "Percentage of low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "Number of low-quality impressions",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "Number of sophisticated low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversions": {
+            "description": "Total number of low-quality conversions",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "Conversion rate for low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Revenue per assist conversion",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "account_performance_report_weekly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "Unique identifier for the Bing Ads account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "Time period for the report",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "Currency code used for reporting",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "Type of ad distribution (search, content, both)",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "Type of device used",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "Type of network (search, audience)",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "Type of match in ad delivery",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "Operating system of the device",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Performance comparison between top and other ad positions",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "Type of bidding match (exact, phrase, broad)",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "Name of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "Numeric account number",
+            "type": ["null", "string"]
+          },
+          "PhoneImpressions": {
+            "description": "Number of ad impressions on phone devices",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Number of phone calls generated",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total spend on ad campaigns",
+            "type": ["null", "number"]
+          },
+          "Impressions": {
+            "description": "Total number of ad impressions",
+            "type": ["null", "integer"]
+          },
+          "CostPerConversion": {
+            "description": "Cost per conversion",
+            "type": ["null", "number"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Number of assist conversions",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "Return on ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Cost per assist conversion",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "Average ad position",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "Percentage of conversions from clicks",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "Number of low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "Percentage of low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "Number of low-quality impressions",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "Number of sophisticated low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversions": {
+            "description": "Total number of low-quality conversions",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "Conversion rate for low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Revenue per assist conversion",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "account_performance_report_monthly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "Unique identifier for the Bing Ads account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "Time period for the report",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "Currency code used for reporting",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "Type of ad distribution (search, content, both)",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "Type of device used",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "Type of network (search, audience)",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "Type of match in ad delivery",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "Operating system of the device",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Performance comparison between top and other ad positions",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "Type of bidding match (exact, phrase, broad)",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "Name of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "Numeric account number",
+            "type": ["null", "string"]
+          },
+          "PhoneImpressions": {
+            "description": "Number of ad impressions on phone devices",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Number of phone calls generated",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total spend on ad campaigns",
+            "type": ["null", "number"]
+          },
+          "Impressions": {
+            "description": "Total number of ad impressions",
+            "type": ["null", "integer"]
+          },
+          "CostPerConversion": {
+            "description": "Cost per conversion",
+            "type": ["null", "number"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Number of assist conversions",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "Return on ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Cost per assist conversion",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "Average ad position",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "Percentage of conversions from clicks",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "Number of low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "Percentage of low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "Number of low-quality impressions",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "Number of sophisticated low-quality clicks",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversions": {
+            "description": "Total number of low-quality conversions",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "Conversion rate for low-quality clicks",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Revenue per assist conversion",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "audience_performance_report_hourly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period associated with the data.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "AudienceId": {
+            "description": "The unique identifier for the audience.",
+            "type": ["null", "integer"]
+          },
+          "AudienceName": {
+            "description": "The name of the audience.",
+            "type": ["null", "string"]
+          },
+          "AssociationStatus": {
+            "description": "The status of the association.",
+            "type": ["null", "string"]
+          },
+          "BidAdjustment": {
+            "description": "The bid adjustment value.",
+            "type": ["null", "number"]
+          },
+          "TargetingSetting": {
+            "description": "The targeting setting used for the data.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of ad impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of specific conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for specific conversions.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per specific conversion.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per specific conversion.",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AudienceType": {
+            "description": "The type of audience.",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The unique identifier for the base campaign.",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AssociationId": {
+            "description": "The unique identifier for the association.",
+            "type": ["null", "integer"]
+          },
+          "AssociationLevel": {
+            "description": "The level of association for the data.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal associated with the data.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions out of the total eligible impressions.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions out of the total eligible impressions.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified specific conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of all qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AudienceId"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "audience_performance_report_daily",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period of the report",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group",
+            "type": ["null", "integer"]
+          },
+          "AudienceId": {
+            "description": "The unique identifier for the audience",
+            "type": ["null", "integer"]
+          },
+          "AudienceName": {
+            "description": "The name of the audience",
+            "type": ["null", "string"]
+          },
+          "AssociationStatus": {
+            "description": "The status of the association",
+            "type": ["null", "string"]
+          },
+          "BidAdjustment": {
+            "description": "The bid adjustment value",
+            "type": ["null", "number"]
+          },
+          "TargetingSetting": {
+            "description": "The targeting settings used",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The rate of conversions",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group",
+            "type": ["null", "string"]
+          },
+          "AudienceType": {
+            "description": "The type of the audience",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign's ID",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The rate of all conversions generated",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per all conversion",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per all conversion",
+            "type": ["null", "number"]
+          },
+          "AssociationId": {
+            "description": "The unique identifier for the association",
+            "type": ["null", "integer"]
+          },
+          "AssociationLevel": {
+            "description": "The level of the association",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal of the report",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions compared to total impressions",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions compared to total impressions",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of conversions qualified",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of all conversions qualified",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions qualified",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AudienceId"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "audience_performance_report_weekly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period of the report",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group",
+            "type": ["null", "integer"]
+          },
+          "AudienceId": {
+            "description": "The unique identifier for the audience",
+            "type": ["null", "integer"]
+          },
+          "AudienceName": {
+            "description": "The name of the audience",
+            "type": ["null", "string"]
+          },
+          "AssociationStatus": {
+            "description": "The status of the association",
+            "type": ["null", "string"]
+          },
+          "BidAdjustment": {
+            "description": "The bid adjustment value",
+            "type": ["null", "number"]
+          },
+          "TargetingSetting": {
+            "description": "The targeting settings used",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The rate of conversions",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group",
+            "type": ["null", "string"]
+          },
+          "AudienceType": {
+            "description": "The type of the audience",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign's ID",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The rate of all conversions generated",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per all conversion",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per all conversion",
+            "type": ["null", "number"]
+          },
+          "AssociationId": {
+            "description": "The unique identifier for the association",
+            "type": ["null", "integer"]
+          },
+          "AssociationLevel": {
+            "description": "The level of the association",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal of the report",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions compared to total impressions",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions compared to total impressions",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of conversions qualified",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of all conversions qualified",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions qualified",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AudienceId"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "audience_performance_report_monthly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period of the report",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group",
+            "type": ["null", "integer"]
+          },
+          "AudienceId": {
+            "description": "The unique identifier for the audience",
+            "type": ["null", "integer"]
+          },
+          "AudienceName": {
+            "description": "The name of the audience",
+            "type": ["null", "string"]
+          },
+          "AssociationStatus": {
+            "description": "The status of the association",
+            "type": ["null", "string"]
+          },
+          "BidAdjustment": {
+            "description": "The bid adjustment value",
+            "type": ["null", "number"]
+          },
+          "TargetingSetting": {
+            "description": "The targeting settings used",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The rate of conversions",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group",
+            "type": ["null", "string"]
+          },
+          "AudienceType": {
+            "description": "The type of the audience",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign's ID",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The rate of all conversions generated",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per all conversion",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per all conversion",
+            "type": ["null", "number"]
+          },
+          "AssociationId": {
+            "description": "The unique identifier for the association",
+            "type": ["null", "integer"]
+          },
+          "AssociationLevel": {
+            "description": "The level of the association",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal of the report",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions compared to total impressions",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions compared to total impressions",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of conversions qualified",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of all conversions qualified",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions qualified",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AudienceId"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "keyword_performance_report_hourly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier for the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Keyword": {
+            "description": "The keyword for the ad.",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "The unique identifier for the ad.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period the data represents.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CurrencyCode": {
+            "description": "The currency code.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type that generated the impression.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The ad distribution type.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language of the ads.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The device operating system.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Indicates if the ad was displayed on the top or other positions.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type for which the bid applies.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "CurrentMaxCpc": {
+            "description": "The current maximum cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total cost.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "The relevance score of the ad.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "The landing page experience score.",
+            "type": ["null", "number"]
+          },
+          "QualityImpact": {
+            "description": "The impact of quality on ad performance.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "FinalAppUrl": {
+            "description": "The final app URL.",
+            "type": ["null", "string"]
+          },
+          "Mainline1Bid": {
+            "description": "The bid for the mainline position 1.",
+            "type": ["null", "number"]
+          },
+          "MainlineBid": {
+            "description": "The bid for all mainline positions.",
+            "type": ["null", "number"]
+          },
+          "FirstPageBid": {
+            "description": "The first page bid.",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The final URL suffix.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The overall cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The overall return on ad spend.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The overall conversion rate.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The overall revenue per conversion.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The revenue generated.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist.",
+            "type": ["null", "number"]
+          },
+          "CampaignStatus": { "type": ["null", "string"] },
+          "TopImpressionRatePercent": { "type": ["null", "number"] },
+          "AdGroupStatus": { "type": ["null", "string"] },
+          "TrackingTemplate": { "type": ["null", "string"] },
+          "BidStrategyType": { "type": ["null", "string"] },
+          "AccountStatus": { "type": ["null", "string"] },
+          "FinalUrl": { "type": ["null", "string"] },
+          "AdType": { "type": ["null", "string"] },
+          "KeywordLabels": { "type": ["null", "string"] },
+          "FinalMobileUrl": { "type": ["null", "string"] },
+          "Goal": { "type": ["null", "string"] },
+          "GoalType": { "type": ["null", "string"] },
+          "AbsoluteTopImpressionRatePercent": { "type": ["null", "number"] },
+          "BaseCampaignId": { "type": ["null", "integer"] },
+          "AccountNumber": { "type": ["null", "string"] },
+          "DestinationUrl": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["KeywordId"],
+        ["AdId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["DeliveredMatchType"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Language"],
+        ["Network"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "keyword_performance_report_daily",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier of the Bing Ads account",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group",
+            "type": ["null", "integer"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier of the keyword",
+            "type": ["null", "integer"]
+          },
+          "Keyword": {
+            "description": "The keyword for the performance data",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "The unique identifier of the ad",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The date for which the performance data is reported",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "Currency code used",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "Match type of the delivered ad",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The ad distribution mechanism for the keyword",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "Type of device",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "Language used in the ad or campaign",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "Network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "Operating system of the device",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Comparison of top vs. other ad placements",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "Match type of the bid",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "Status of the keyword",
+            "type": ["null", "string"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "Historical expected click-through rate",
+            "type": ["null", "number"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "Historical relevance score of the ad",
+            "type": ["null", "number"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "Historical landing page experience score",
+            "type": ["null", "number"]
+          },
+          "HistoricalQualityScore": {
+            "description": "Historical quality score of the keyword",
+            "type": ["null", "number"]
+          },
+          "Impressions": {
+            "description": "Total number of ad impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate",
+            "type": ["null", "number"]
+          },
+          "CurrentMaxCpc": {
+            "description": "Current maximum cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total cost incurred for advertising",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "Cost per specific conversion",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "Quality score of the keyword",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "Expected click-through rate",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "Relevance score of the ad",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "Landing page experience score",
+            "type": ["null", "number"]
+          },
+          "QualityImpact": {
+            "description": "Impact of quality score on performance",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Number of assists for conversions",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "Return on ad spend for specific conversions",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Cost per assist for conversions",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters used",
+            "type": ["null", "string"]
+          },
+          "FinalAppUrl": {
+            "description": "Final URL linking to the app",
+            "type": ["null", "string"]
+          },
+          "Mainline1Bid": {
+            "description": "Bid required for mainline placement 1",
+            "type": ["null", "number"]
+          },
+          "MainlineBid": {
+            "description": "Bid required for mainline placement",
+            "type": ["null", "number"]
+          },
+          "FirstPageBid": {
+            "description": "Bid required for first page placement",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "Additional URL suffix",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "Number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "Number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "Total cost per all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "Return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of specific conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "Conversion rate for specific conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "Average position of the ad",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "Total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "Conversion rate for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "Revenue per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Revenue per specific conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Revenue per assist for conversions",
+            "type": ["null", "number"]
+          },
+          "CampaignStatus": { "type": ["null", "string"] },
+          "TopImpressionRatePercent": { "type": ["null", "number"] },
+          "AdGroupStatus": { "type": ["null", "string"] },
+          "TrackingTemplate": { "type": ["null", "string"] },
+          "BidStrategyType": { "type": ["null", "string"] },
+          "AccountStatus": { "type": ["null", "string"] },
+          "FinalUrl": { "type": ["null", "string"] },
+          "AdType": { "type": ["null", "string"] },
+          "KeywordLabels": { "type": ["null", "string"] },
+          "FinalMobileUrl": { "type": ["null", "string"] },
+          "Goal": { "type": ["null", "string"] },
+          "GoalType": { "type": ["null", "string"] },
+          "AbsoluteTopImpressionRatePercent": { "type": ["null", "number"] },
+          "BaseCampaignId": { "type": ["null", "integer"] },
+          "AccountNumber": { "type": ["null", "string"] },
+          "DestinationUrl": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["KeywordId"],
+        ["AdId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["DeliveredMatchType"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Language"],
+        ["Network"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "keyword_performance_report_weekly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the account to which the data belongs.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign to which the keyword belongs.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group to which the keyword belongs.",
+            "type": ["null", "integer"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier for the keyword being reported.",
+            "type": ["null", "integer"]
+          },
+          "Keyword": {
+            "description": "The keyword that triggered the ad and is being reported.",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "The unique identifier for the ad responsible for the keyword's performance.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the performance data is reported.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values in the data.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type that delivered the keyword's ad.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The type of ad distribution for the performance data.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device on which the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeting for the keyword's ad.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed (e.g., search, display).",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device on which the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The comparison between the top ad positions and other ad positions.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type used for the keyword's bid.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account to which the data belongs.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign to which the keyword belongs.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group to which the keyword belongs.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword (e.g., active, paused).",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the keyword's ad was shown.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the keyword's ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate for the keyword.",
+            "type": ["null", "number"]
+          },
+          "CurrentMaxCpc": {
+            "description": "The current maximum cost per click bid for the keyword.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total cost spent on displaying the ad for the keyword.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The average cost per conversion for the keyword.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The relevance and quality of the keyword's ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate for the keyword based on historical data.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "The relevance score of the ad associated with the keyword.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "The evaluation of the landing page experience for the keyword.",
+            "type": ["null", "number"]
+          },
+          "QualityImpact": {
+            "description": "The impact of quality score changes on ad performance.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists (interactions before a conversion) that the keyword contributed to.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend specific to the keyword.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The average cost per assist for the keyword.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Any custom parameters associated with the keyword.",
+            "type": ["null", "string"]
+          },
+          "FinalAppUrl": {
+            "description": "The final URL for the app download destination.",
+            "type": ["null", "string"]
+          },
+          "Mainline1Bid": {
+            "description": "The bid needed to appear in the first mainline position.",
+            "type": ["null", "number"]
+          },
+          "MainlineBid": {
+            "description": "The bid needed to appear in the mainline positions.",
+            "type": ["null", "number"]
+          },
+          "FirstPageBid": {
+            "description": "The bid needed to appear on the first page of search results.",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The suffix added to the final URL for tracking purposes.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions for the keyword.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions for the keyword.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The average cost per conversion for all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend considering all conversions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions generated by the keyword.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate specific to the keyword.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions from the keyword.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click for the keyword.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position where the ad was shown for the keyword.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions for the keyword.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all types of conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The overall conversion rate considering all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the keyword.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue per conversion for the keyword.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue per assist for the keyword.",
+            "type": ["null", "number"]
+          },
+          "CampaignStatus": { "type": ["null", "string"] },
+          "TopImpressionRatePercent": { "type": ["null", "number"] },
+          "AdGroupStatus": { "type": ["null", "string"] },
+          "TrackingTemplate": { "type": ["null", "string"] },
+          "BidStrategyType": { "type": ["null", "string"] },
+          "AccountStatus": { "type": ["null", "string"] },
+          "FinalUrl": { "type": ["null", "string"] },
+          "AdType": { "type": ["null", "string"] },
+          "KeywordLabels": { "type": ["null", "string"] },
+          "FinalMobileUrl": { "type": ["null", "string"] },
+          "Goal": { "type": ["null", "string"] },
+          "GoalType": { "type": ["null", "string"] },
+          "AbsoluteTopImpressionRatePercent": { "type": ["null", "number"] },
+          "BaseCampaignId": { "type": ["null", "integer"] },
+          "AccountNumber": { "type": ["null", "string"] },
+          "DestinationUrl": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["KeywordId"],
+        ["AdId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["DeliveredMatchType"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Language"],
+        ["Network"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "keyword_performance_report_monthly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the account to which the data belongs.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign to which the keyword belongs.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group to which the keyword belongs.",
+            "type": ["null", "integer"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier for the keyword being reported.",
+            "type": ["null", "integer"]
+          },
+          "Keyword": {
+            "description": "The keyword that triggered the ad and is being reported.",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "The unique identifier for the ad responsible for the keyword's performance.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the performance data is reported.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values in the data.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type that delivered the keyword's ad.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The type of ad distribution for the performance data.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device on which the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeting for the keyword's ad.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed (e.g., search, display).",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device on which the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The comparison between the top ad positions and other ad positions.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type used for the keyword's bid.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account to which the data belongs.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign to which the keyword belongs.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group to which the keyword belongs.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword (e.g., active, paused).",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the keyword's ad was shown.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the keyword's ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate for the keyword.",
+            "type": ["null", "number"]
+          },
+          "CurrentMaxCpc": {
+            "description": "The current maximum cost per click bid for the keyword.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total cost spent on displaying the ad for the keyword.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The average cost per conversion for the keyword.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The relevance and quality of the keyword's ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate for the keyword based on historical data.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "The relevance score of the ad associated with the keyword.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "The evaluation of the landing page experience for the keyword.",
+            "type": ["null", "number"]
+          },
+          "QualityImpact": {
+            "description": "The impact of quality score changes on ad performance.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists (interactions before a conversion) that the keyword contributed to.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend specific to the keyword.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The average cost per assist for the keyword.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Any custom parameters associated with the keyword.",
+            "type": ["null", "string"]
+          },
+          "FinalAppUrl": {
+            "description": "The final URL for the app download destination.",
+            "type": ["null", "string"]
+          },
+          "Mainline1Bid": {
+            "description": "The bid needed to appear in the first mainline position.",
+            "type": ["null", "number"]
+          },
+          "MainlineBid": {
+            "description": "The bid needed to appear in the mainline positions.",
+            "type": ["null", "number"]
+          },
+          "FirstPageBid": {
+            "description": "The bid needed to appear on the first page of search results.",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The suffix added to the final URL for tracking purposes.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions for the keyword.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions for the keyword.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The average cost per conversion for all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend considering all conversions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions generated by the keyword.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate specific to the keyword.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions from the keyword.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click for the keyword.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position where the ad was shown for the keyword.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions for the keyword.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all types of conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The overall conversion rate considering all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the keyword.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue per conversion for the keyword.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue per assist for the keyword.",
+            "type": ["null", "number"]
+          },
+          "CampaignStatus": { "type": ["null", "string"] },
+          "TopImpressionRatePercent": { "type": ["null", "number"] },
+          "AdGroupStatus": { "type": ["null", "string"] },
+          "TrackingTemplate": { "type": ["null", "string"] },
+          "BidStrategyType": { "type": ["null", "string"] },
+          "AccountStatus": { "type": ["null", "string"] },
+          "FinalUrl": { "type": ["null", "string"] },
+          "AdType": { "type": ["null", "string"] },
+          "KeywordLabels": { "type": ["null", "string"] },
+          "FinalMobileUrl": { "type": ["null", "string"] },
+          "Goal": { "type": ["null", "string"] },
+          "GoalType": { "type": ["null", "string"] },
+          "AbsoluteTopImpressionRatePercent": { "type": ["null", "number"] },
+          "BaseCampaignId": { "type": ["null", "integer"] },
+          "AccountNumber": { "type": ["null", "string"] },
+          "DestinationUrl": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["KeywordId"],
+        ["AdId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["DeliveredMatchType"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Language"],
+        ["Network"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_group_performance_report_hourly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "Unique identifier for the account where the ad group belongs.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "Unique identifier for the campaign where the ad group belongs.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "Unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "Date and time when the data was recorded.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CurrencyCode": {
+            "description": "Currency code used for reporting.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The types of distribution networks where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "Type of device where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "Type of advertising network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "Type of match bid used for the keyword delivered with the ad.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "Operating system of the device where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Performance comparison of top ad placements versus other placements.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "Type of match bid used for the keyword triggering the ad.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "Language settings targeting for the ad.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "Name of the account where the ad group belongs.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "Name of the campaign where the ad group belongs.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "Type of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "Name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupType": {
+            "description": "Type of the ad group.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Number of times the ad was shown.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate for the ad.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total spend on the ad.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "Average cost per conversion for specific actions.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "Quality score for the ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "Expected click-through rate for the ad.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "Quality score reflecting how relevant the ad is to the audience.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "Quality score for the landing page experience.",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "Number of times the phone number was shown in the ad.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Number of phone calls driven by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate for the ad.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Number of assist impressions for the ad.",
+            "type": ["null", "integer"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost per assist for the ad.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "FinalUrlSuffix": {
+            "description": "Suffix added to the final URL for tracking purposes.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "Number of view-through conversions attributed to the ad.",
+            "type": ["null", "integer"]
+          },
+          "AllCostPerConversion": {
+            "description": "Average cost per all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "Return on investment for all actions taken as a result of the ad.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "Total number of all conversions from the ad.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "Overall conversion rate for all actions taken as a result of the ad.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "Average revenue generated per all conversion.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click for the ad.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad when shown.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions for specific actions from the ad.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "Conversion rate for specific actions taken as a result of the ad.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of qualified conversions from the ad.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated from specific actions as a result of the ad.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Average revenue per conversion for specific actions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue per assist.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"],
+        ["Language"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_group_performance_report_daily",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for the data.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type when ads are shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The performance in top positions versus other positions.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type of the bid.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language used in the ad.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign, like search or shopping.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupType": {
+            "description": "The type of ad group, like product ads or audience ads.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend for the specified period.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per specified goal conversion.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate based on historical data.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "The relevance of the ad to its targeted keywords.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "The landing page experience score.",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "The number of times phone number was shown.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The number of phone calls made as a result of the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone-through rate.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists for conversions.",
+            "type": ["null", "integer"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist for conversions.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Any custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The suffix added to the final URL.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of view-through conversions recorded.",
+            "type": ["null", "integer"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad when shown.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of specified goal conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for a specific goal.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "HistoricalQualityScore": {
+            "description": "The historical quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "The historically expected click-through rate.",
+            "type": ["null", "number"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "The historical relevance of the ad.",
+            "type": ["null", "number"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "The historical landing page experience.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per specified goal conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist for conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"],
+        ["Language"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_group_performance_report_weekly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for the data.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type when ads are shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The performance in top positions versus other positions.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type of the bid.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language used in the ad.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign, like search or shopping.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupType": {
+            "description": "The type of ad group, like product ads or audience ads.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend for the specified period.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per specified goal conversion.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate based on historical data.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "The relevance of the ad to its targeted keywords.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "The landing page experience score.",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "The number of times phone number was shown.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The number of phone calls made as a result of the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone-through rate.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists for conversions.",
+            "type": ["null", "integer"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist for conversions.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Any custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The suffix added to the final URL.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of view-through conversions recorded.",
+            "type": ["null", "integer"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad when shown.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of specified goal conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for a specific goal.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "HistoricalQualityScore": {
+            "description": "The historical quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "The historically expected click-through rate.",
+            "type": ["null", "number"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "The historical relevance of the ad.",
+            "type": ["null", "number"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "The historical landing page experience.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per specified goal conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist for conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"],
+        ["Language"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_group_performance_report_monthly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for the data.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type when ads are shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The performance in top positions versus other positions.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type of the bid.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language used in the ad.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign, like search or shopping.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupType": {
+            "description": "The type of ad group, like product ads or audience ads.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend for the specified period.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per specified goal conversion.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate based on historical data.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "The relevance of the ad to its targeted keywords.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "The landing page experience score.",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "The number of times phone number was shown.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The number of phone calls made as a result of the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone-through rate.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists for conversions.",
+            "type": ["null", "integer"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist for conversions.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Any custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The suffix added to the final URL.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of view-through conversions recorded.",
+            "type": ["null", "integer"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion across all conversions.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad when shown.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of specified goal conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for a specific goal.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "HistoricalQualityScore": {
+            "description": "The historical quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "The historically expected click-through rate.",
+            "type": ["null", "number"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "The historical relevance of the ad.",
+            "type": ["null", "number"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "The historical landing page experience.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per specified goal conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist for conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"],
+        ["Language"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_performance_report_hourly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the account to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "AdId": {
+            "description": "The unique identifier for the ad",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period to which the data corresponds",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution channel for the ad (e.g., Search, Audience Network)",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device on which the ad was displayed (e.g., Desktop, Mobile)",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeting of the ad",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed (e.g., Bing, AOL)",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device on which the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The performance comparison of top positions vs. other positions",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of keyword match (e.g., Broad, Phrase, Exact) for the bid",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of keyword match for which the ad has been delivered",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign (e.g., Search, Audience Network)",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the ad was shown",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on the ad campaign",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per specific conversion",
+            "type": ["null", "number"]
+          },
+          "DestinationUrl": {
+            "description": "The destination URL of the ad",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists (when an ad indirectly results in a conversion)",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for specific conversions",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist (indirect conversion)",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Any custom parameters set for the ad",
+            "type": ["null", "string"]
+          },
+          "FinalAppUrl": {
+            "description": "The final URL shown in the ad for app installations",
+            "type": ["null", "string"]
+          },
+          "AdDescription": {
+            "description": "The text of the first description line in the ad",
+            "type": ["null", "string"]
+          },
+          "AdDescription2": {
+            "description": "The text of the second description line in the ad",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of specific conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for specific conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on the search results page",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per 1,000 impressions",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue from all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the ad",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per specific conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist (indirect conversion)",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["AdId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Language"],
+        ["Network"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"],
+        ["DeliveredMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_performance_report_daily",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique ID of the account to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique ID of the campaign to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The ID of the ad group to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "AdId": {
+            "description": "The unique ID of the ad",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times your ad is shown in the absolute top location",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of times your ad is shown either at the top or absolute top location",
+            "type": ["null", "number"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was shown",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was displayed (Desktop, Mobile, Tablet)",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeting of the ad",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed (Bing, Syndicated search partners)",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The comparison between showing at the top or other positions",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type of the keyword that triggered the ad",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type of the keyword that was matched to deliver the ad",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign (Search, Display, etc.)",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the ad was shown",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total cost spent on the ad",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "DestinationUrl": {
+            "description": "The URL where the user is directed when clicking the ad",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assist conversions generated",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist conversion",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters passed in the ad URL",
+            "type": ["null", "string"]
+          },
+          "FinalAppUrl": {
+            "description": "The final URL for specific apps in the ad",
+            "type": ["null", "string"]
+          },
+          "AdDescription": {
+            "description": "The description text of the ad",
+            "type": ["null", "string"]
+          },
+          "AdDescription2": {
+            "description": "The second description line of the ad",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position in which the ad appeared",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversion actions",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversion actions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the ad",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist conversion",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["AdId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Language"],
+        ["Network"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"],
+        ["DeliveredMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_performance_report_weekly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique ID of the account to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique ID of the campaign to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The ID of the ad group to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "AdId": {
+            "description": "The unique ID of the ad",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times your ad is shown in the absolute top location",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of times your ad is shown either at the top or absolute top location",
+            "type": ["null", "number"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was shown",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was displayed (Desktop, Mobile, Tablet)",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeting of the ad",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed (Bing, Syndicated search partners)",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The comparison between showing at the top or other positions",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type of the keyword that triggered the ad",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type of the keyword that was matched to deliver the ad",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign (Search, Display, etc.)",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the ad was shown",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total cost spent on the ad",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "DestinationUrl": {
+            "description": "The URL where the user is directed when clicking the ad",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assist conversions generated",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist conversion",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters passed in the ad URL",
+            "type": ["null", "string"]
+          },
+          "FinalAppUrl": {
+            "description": "The final URL for specific apps in the ad",
+            "type": ["null", "string"]
+          },
+          "AdDescription": {
+            "description": "The description text of the ad",
+            "type": ["null", "string"]
+          },
+          "AdDescription2": {
+            "description": "The second description line of the ad",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position in which the ad appeared",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversion actions",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversion actions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the ad",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist conversion",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["AdId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Language"],
+        ["Network"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"],
+        ["DeliveredMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_performance_report_monthly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique ID of the account to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique ID of the campaign to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The ID of the ad group to which the ad belongs",
+            "type": ["null", "integer"]
+          },
+          "AdId": {
+            "description": "The unique ID of the ad",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times your ad is shown in the absolute top location",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of times your ad is shown either at the top or absolute top location",
+            "type": ["null", "number"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was shown",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was displayed (Desktop, Mobile, Tablet)",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeting of the ad",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed (Bing, Syndicated search partners)",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The comparison between showing at the top or other positions",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type of the keyword that triggered the ad",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type of the keyword that was matched to deliver the ad",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign (Search, Display, etc.)",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group to which the ad belongs",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the ad was shown",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total cost spent on the ad",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "DestinationUrl": {
+            "description": "The URL where the user is directed when clicking the ad",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assist conversions generated",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist conversion",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters passed in the ad URL",
+            "type": ["null", "string"]
+          },
+          "FinalAppUrl": {
+            "description": "The final URL for specific apps in the ad",
+            "type": ["null", "string"]
+          },
+          "AdDescription": {
+            "description": "The description text of the ad",
+            "type": ["null", "string"]
+          },
+          "AdDescription2": {
+            "description": "The second description line of the ad",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position in which the ad appeared",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversion actions",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversion actions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all conversion actions",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the ad",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist conversion",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["AdGroupId"],
+        ["AdId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Language"],
+        ["Network"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"],
+        ["DeliveredMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_group_impression_performance_report_hourly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the account associated with the ad group.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "Status": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign associated with the ad group.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad is displayed.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the ad was displayed.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate in percentage.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on the ad.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad shown.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total count of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The rate of conversions divided by clicks.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The average cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad is displayed.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeting of the ad group.",
+            "type": ["null", "string"]
+          },
+          "QualityScore": {
+            "description": "A score reflecting the quality of the ad and landing page experience.",
+            "type": ["null", "integer"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate based on historical data.",
+            "type": ["null", "number"]
+          },
+          "AdRelevance": {
+            "description": "A score that reflects how relevant the ad is to the audience.",
+            "type": ["null", "integer"]
+          },
+          "LandingPageExperience": {
+            "description": "The user experience of the landing page.",
+            "type": ["null", "integer"]
+          },
+          "PhoneImpressions": {
+            "description": "The total number of phone impressions.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The total number of phone calls generated.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone-through rate in percentage.",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "The network where the ad is displayed.",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists (secondary conversions).",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for conversions.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The average cost per assist (secondary conversion).",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue per assist (secondary conversion).",
+            "type": ["null", "number"]
+          },
+          "TrackingTemplate": {
+            "description": "The tracking template URL for advanced tracking.",
+            "type": ["null", "string"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupLabels": {
+            "description": "Labels assigned to the ad group.",
+            "type": ["null", "string"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The final URL suffix for tracking purposes.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "TopImpressionSharePercent": {
+            "description": "The percentage of times the ad is shown in the top position.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times the ad is shown at the absolute top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of times the ad is shown at the top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "BaseCampaignId": {
+            "description": "The unique identifier for the base campaign.",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total count of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The rate of all conversions divided by all clicks.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The average cost per all conversion.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per all conversion.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total count of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupType": {
+            "description": "The type of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The count of conversions that meet qualification criteria.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The count of all conversions that meet qualification criteria.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The count of view-through conversions that meet qualification criteria.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "The total count of video views.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "The rate of view-through conversions divided by impressions.",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "The average cost per video view.",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "The total count of video views at 25% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "The total count of video views at 50% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "The total count of video views at 75% completion.",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "The total count of completed video views.",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "The rate of video completions divided by video views.",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "The total watch time in milliseconds.",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "The average watch time per video view.",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "The average watch time per impression.",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total count of sales generated.",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The average cost per sale.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The average revenue per sale.",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total count of installs generated.",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The average cost per install.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The average revenue per install.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["TimePeriod"],
+        ["Network"],
+        ["DeviceType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_group_impression_performance_report_daily",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period covered by the report.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "Status": {
+            "description": "The status of the ad (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "Where the ad was displayed (search, content, etc.).",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions received by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost-per-click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on the ad.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on the search result page.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for the ad.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "The type of device (desktop, mobile, tablet) on which the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeting for the ad.",
+            "type": ["null", "string"]
+          },
+          "ImpressionSharePercent": {
+            "description": "The percentage of impressions achieved by the ad compared to the total available impressions.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToBudgetPercent": {
+            "description": "The percentage of impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToRankAggPercent": {
+            "description": "The percentage of impressions lost due to rank aggregation.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The quality score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate based on targeting settings.",
+            "type": ["null", "number"]
+          },
+          "AdRelevance": {
+            "description": "The relevance of the ad to the search query.",
+            "type": ["null", "integer"]
+          },
+          "LandingPageExperience": {
+            "description": "The quality of the landing page experience.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalQualityScore": {
+            "description": "The historical quality score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "The historical expected click-through rate score.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "The historical ad relevance score.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "The historical landing page experience score.",
+            "type": ["null", "integer"]
+          },
+          "PhoneImpressions": {
+            "description": "The total number of phone impressions.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The total number of phone calls generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone through rate (PTR) for phone calls.",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed (search, display, etc.).",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the ad.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for the ad.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue generated per assist.",
+            "type": ["null", "number"]
+          },
+          "TrackingTemplate": {
+            "description": "The tracking template URL used for campaign tracking.",
+            "type": ["null", "string"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "AdGroupLabels": {
+            "description": "Labels associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "ExactMatchImpressionSharePercent": {
+            "description": "The percentage of exact match impressions achieved by the ad.",
+            "type": ["null", "number"]
+          },
+          "ClickSharePercent": {
+            "description": "The percentage of eligible clicks the ad received out of the total available clicks.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionSharePercent": {
+            "description": "The percentage of absolute top impressions achieved by the ad compared to the total available absolute top impressions.",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The final URL suffix added to the displayed URL.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign (search, shopping, video, etc.).",
+            "type": ["null", "string"]
+          },
+          "TopImpressionShareLostToRankPercent": {
+            "description": "The percentage of top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToRankPercent": {
+            "description": "The percentage of absolute top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of absolute top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionSharePercent": {
+            "description": "The percentage of top impressions achieved by the ad compared to the total available top impressions.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions divided by the total impressions in the search result page.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions divided by the total impressions in the search result page.",
+            "type": ["null", "number"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign identifier.",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "AudienceImpressionSharePercent": {
+            "description": "The percentage of audience impressions achieved by the ad compared to the total available audience impressions.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToRankPercent": {
+            "description": "The percentage of audience impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToBudgetPercent": {
+            "description": "The percentage of audience impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "RelativeCtr": {
+            "description": "The relative click-through rate performance compared to other ads.",
+            "type": ["null", "number"]
+          },
+          "AdGroupType": {
+            "description": "The type of ad group (standard, dynamic, remarketing, etc.).",
+            "type": ["null", "string"]
+          },
+          "AverageCpm": {
+            "description": "The average cost-per-thousand-impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "The total number of video views.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "The percentage of view-through conversions out of total viewable impressions.",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "The average cost-per-view for video ads.",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "The total number of video views at 25% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "The total number of video views at 50% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "The total number of video views at 75% completion.",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "The total number of completed video views for video ads.",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "The percentage of video views that were completed.",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "The total watch time in milliseconds for video ads.",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "The average watch time per video view for video ads.",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "The average watch time per impression for video ads.",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The average revenue generated per sale.",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of app installs.",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per app install.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The average revenue generated per app install.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["TimePeriod"],
+        ["Network"],
+        ["DeviceType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_group_impression_performance_report_weekly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period covered by the report.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "Status": {
+            "description": "The status of the ad (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "Where the ad was displayed (search, content, etc.).",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions received by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost-per-click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on the ad.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on the search result page.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for the ad.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "The type of device (desktop, mobile, tablet) on which the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeting for the ad.",
+            "type": ["null", "string"]
+          },
+          "ImpressionSharePercent": {
+            "description": "The percentage of impressions achieved by the ad compared to the total available impressions.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToBudgetPercent": {
+            "description": "The percentage of impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToRankAggPercent": {
+            "description": "The percentage of impressions lost due to rank aggregation.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The quality score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate based on targeting settings.",
+            "type": ["null", "number"]
+          },
+          "AdRelevance": {
+            "description": "The relevance of the ad to the search query.",
+            "type": ["null", "integer"]
+          },
+          "LandingPageExperience": {
+            "description": "The quality of the landing page experience.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalQualityScore": {
+            "description": "The historical quality score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "The historical expected click-through rate score.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "The historical ad relevance score.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "The historical landing page experience score.",
+            "type": ["null", "integer"]
+          },
+          "PhoneImpressions": {
+            "description": "The total number of phone impressions.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The total number of phone calls generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone through rate (PTR) for phone calls.",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed (search, display, etc.).",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the ad.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for the ad.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue generated per assist.",
+            "type": ["null", "number"]
+          },
+          "TrackingTemplate": {
+            "description": "The tracking template URL used for campaign tracking.",
+            "type": ["null", "string"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "AdGroupLabels": {
+            "description": "Labels associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "ExactMatchImpressionSharePercent": {
+            "description": "The percentage of exact match impressions achieved by the ad.",
+            "type": ["null", "number"]
+          },
+          "ClickSharePercent": {
+            "description": "The percentage of eligible clicks the ad received out of the total available clicks.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionSharePercent": {
+            "description": "The percentage of absolute top impressions achieved by the ad compared to the total available absolute top impressions.",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The final URL suffix added to the displayed URL.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign (search, shopping, video, etc.).",
+            "type": ["null", "string"]
+          },
+          "TopImpressionShareLostToRankPercent": {
+            "description": "The percentage of top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToRankPercent": {
+            "description": "The percentage of absolute top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of absolute top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionSharePercent": {
+            "description": "The percentage of top impressions achieved by the ad compared to the total available top impressions.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions divided by the total impressions in the search result page.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions divided by the total impressions in the search result page.",
+            "type": ["null", "number"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign identifier.",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "AudienceImpressionSharePercent": {
+            "description": "The percentage of audience impressions achieved by the ad compared to the total available audience impressions.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToRankPercent": {
+            "description": "The percentage of audience impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToBudgetPercent": {
+            "description": "The percentage of audience impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "RelativeCtr": {
+            "description": "The relative click-through rate performance compared to other ads.",
+            "type": ["null", "number"]
+          },
+          "AdGroupType": {
+            "description": "The type of ad group (standard, dynamic, remarketing, etc.).",
+            "type": ["null", "string"]
+          },
+          "AverageCpm": {
+            "description": "The average cost-per-thousand-impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "The total number of video views.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "The percentage of view-through conversions out of total viewable impressions.",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "The average cost-per-view for video ads.",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "The total number of video views at 25% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "The total number of video views at 50% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "The total number of video views at 75% completion.",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "The total number of completed video views for video ads.",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "The percentage of video views that were completed.",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "The total watch time in milliseconds for video ads.",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "The average watch time per video view for video ads.",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "The average watch time per impression for video ads.",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The average revenue generated per sale.",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of app installs.",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per app install.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The average revenue generated per app install.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["TimePeriod"],
+        ["Network"],
+        ["DeviceType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "ad_group_impression_performance_report_monthly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period covered by the report.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "Status": {
+            "description": "The status of the ad (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "Where the ad was displayed (search, content, etc.).",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions received by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost-per-click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on the ad.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on the search result page.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for the ad.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "The type of device (desktop, mobile, tablet) on which the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeting for the ad.",
+            "type": ["null", "string"]
+          },
+          "ImpressionSharePercent": {
+            "description": "The percentage of impressions achieved by the ad compared to the total available impressions.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToBudgetPercent": {
+            "description": "The percentage of impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToRankAggPercent": {
+            "description": "The percentage of impressions lost due to rank aggregation.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The quality score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate based on targeting settings.",
+            "type": ["null", "number"]
+          },
+          "AdRelevance": {
+            "description": "The relevance of the ad to the search query.",
+            "type": ["null", "integer"]
+          },
+          "LandingPageExperience": {
+            "description": "The quality of the landing page experience.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalQualityScore": {
+            "description": "The historical quality score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "The historical expected click-through rate score.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "The historical ad relevance score.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "The historical landing page experience score.",
+            "type": ["null", "integer"]
+          },
+          "PhoneImpressions": {
+            "description": "The total number of phone impressions.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The total number of phone calls generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone through rate (PTR) for phone calls.",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed (search, display, etc.).",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the ad.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for the ad.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue generated per assist.",
+            "type": ["null", "number"]
+          },
+          "TrackingTemplate": {
+            "description": "The tracking template URL used for campaign tracking.",
+            "type": ["null", "string"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign (active, paused, etc.).",
+            "type": ["null", "string"]
+          },
+          "AdGroupLabels": {
+            "description": "Labels associated with the ad group.",
+            "type": ["null", "string"]
+          },
+          "ExactMatchImpressionSharePercent": {
+            "description": "The percentage of exact match impressions achieved by the ad.",
+            "type": ["null", "number"]
+          },
+          "ClickSharePercent": {
+            "description": "The percentage of eligible clicks the ad received out of the total available clicks.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionSharePercent": {
+            "description": "The percentage of absolute top impressions achieved by the ad compared to the total available absolute top impressions.",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The final URL suffix added to the displayed URL.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign (search, shopping, video, etc.).",
+            "type": ["null", "string"]
+          },
+          "TopImpressionShareLostToRankPercent": {
+            "description": "The percentage of top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToRankPercent": {
+            "description": "The percentage of absolute top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of absolute top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionSharePercent": {
+            "description": "The percentage of top impressions achieved by the ad compared to the total available top impressions.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions divided by the total impressions in the search result page.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions divided by the total impressions in the search result page.",
+            "type": ["null", "number"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign identifier.",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "AudienceImpressionSharePercent": {
+            "description": "The percentage of audience impressions achieved by the ad compared to the total available audience impressions.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToRankPercent": {
+            "description": "The percentage of audience impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToBudgetPercent": {
+            "description": "The percentage of audience impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "RelativeCtr": {
+            "description": "The relative click-through rate performance compared to other ads.",
+            "type": ["null", "number"]
+          },
+          "AdGroupType": {
+            "description": "The type of ad group (standard, dynamic, remarketing, etc.).",
+            "type": ["null", "string"]
+          },
+          "AverageCpm": {
+            "description": "The average cost-per-thousand-impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "The total number of video views.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "The percentage of view-through conversions out of total viewable impressions.",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "The average cost-per-view for video ads.",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "The total number of video views at 25% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "The total number of video views at 50% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "The total number of video views at 75% completion.",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "The total number of completed video views for video ads.",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "The percentage of video views that were completed.",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "The total watch time in milliseconds for video ads.",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "The average watch time per video view for video ads.",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "The average watch time per impression for video ads.",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The average revenue generated per sale.",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of app installs.",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per app install.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The average revenue generated per app install.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["TimePeriod"],
+        ["Network"],
+        ["DeviceType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "campaign_performance_report_hourly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "Unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period covered by the reported data.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CurrencyCode": {
+            "description": "Currency used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "Where the ads were displayed, e.g., search, audience network, native, etc.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "Type of device where the ad was displayed, e.g., mobile, desktop, etc.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "Network where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "Type of the match for delivered ads.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "Operating system of the device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Performance comparison between top and other ad positions.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of bid match used, e.g., exact, broad, etc.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "Name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "Type of the campaign, e.g., search, shopping, etc.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "Status of the campaign, e.g., active, paused, etc.",
+            "type": ["null", "string"]
+          },
+          "CampaignLabels": {
+            "description": "Labels associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total amount spent on the campaign.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "Average cost per tracked conversion.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "Quality score of the ad shown.",
+            "type": ["null", "number"]
+          },
+          "AdRelevance": {
+            "description": "Relevance score of the ad shown.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "User experience of the landing page.",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "Number of impressions with a phone number shown.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Number of phone calls generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Number of assists provided in the conversion path.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "Return on ad spend for tracked conversions.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost per assist.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "Number of view-through conversions recorded.",
+            "type": ["null", "integer"]
+          },
+          "AllCostPerConversion": {
+            "description": "Average cost per all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "Return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "Total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "Overall conversion rate for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "Average revenue per all conversions.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "Average position of the ad when displayed.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of tracked conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "Conversion rate for tracked conversions.",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "Number of clicks on low-quality traffic sources.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "Percentage of low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "Number of impressions from low-quality traffic sources.",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "Number of sophisticated clicks on low-quality traffic sources.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversions": {
+            "description": "Number of conversions from low-quality clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "Conversion rate for low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated from tracked conversions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Average revenue per tracked conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue per assist.",
+            "type": ["null", "number"]
+          },
+          "BudgetName": {
+            "description": "Name of the budget associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "BudgetStatus": {
+            "description": "Status of the budget, e.g., active, paused, etc.",
+            "type": ["null", "string"]
+          },
+          "BudgetAssociationStatus": {
+            "description": "Status of the budget association.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "campaign_performance_report_daily",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique ID of the account to which the campaign belongs.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique ID of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the data is reported.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution channels where the ads were displayed.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was displayed (e.g., mobile, desktop).",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The advertising network where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of match used for delivering ads.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Comparison of the ad position with top vs. other placements.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of bid matching used for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account to which the campaign belongs.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type/category of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignLabels": {
+            "description": "Any labels associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of times the ad was displayed.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total amount spent on the campaign.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The average cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "AdRelevance": {
+            "description": "The relevance score of the ad in relation to the target audience.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "The landing page experience of the ad.",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "Number of impressions on phone devices.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Number of phone calls generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Number of assists in the conversion process.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for conversions.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost per assist in the conversion process.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Any custom parameters associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "Number of view-through conversions generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "AllCostPerConversion": {
+            "description": "The average cost per conversion for all conversion types.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "Total number of all types of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "Conversion rate considering all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated from all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue generated per conversion for all conversion types.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad in search results.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The overall conversion rate.",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "Number of clicks categorized as low quality.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "Percentage of clicks categorized as low quality.",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "Number of impressions categorized as low quality.",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "Number of sophisticated clicks categorized as low quality.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversions": {
+            "description": "Number of conversions from low-quality clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "Conversion rate of low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "HistoricalQualityScore": {
+            "description": "Historical quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "Historical expected click-through rate.",
+            "type": ["null", "number"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "Historical ad relevance score.",
+            "type": ["null", "number"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "Historical landing page experience score.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated from conversions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue generated per assist in the conversion process.",
+            "type": ["null", "number"]
+          },
+          "BudgetName": {
+            "description": "The name of the budget associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "BudgetStatus": {
+            "description": "The status of the budget associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "BudgetAssociationStatus": {
+            "description": "The status of the campaign's budget association.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "campaign_performance_report_weekly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique ID of the account to which the campaign belongs.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique ID of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the data is reported.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution channels where the ads were displayed.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was displayed (e.g., mobile, desktop).",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The advertising network where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of match used for delivering ads.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Comparison of the ad position with top vs. other placements.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of bid matching used for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account to which the campaign belongs.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type/category of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignLabels": {
+            "description": "Any labels associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of times the ad was displayed.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total amount spent on the campaign.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The average cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "AdRelevance": {
+            "description": "The relevance score of the ad in relation to the target audience.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "The landing page experience of the ad.",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "Number of impressions on phone devices.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Number of phone calls generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Number of assists in the conversion process.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for conversions.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost per assist in the conversion process.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Any custom parameters associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "Number of view-through conversions generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "AllCostPerConversion": {
+            "description": "The average cost per conversion for all conversion types.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "Total number of all types of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "Conversion rate considering all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated from all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue generated per conversion for all conversion types.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad in search results.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The overall conversion rate.",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "Number of clicks categorized as low quality.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "Percentage of clicks categorized as low quality.",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "Number of impressions categorized as low quality.",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "Number of sophisticated clicks categorized as low quality.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversions": {
+            "description": "Number of conversions from low-quality clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "Conversion rate of low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "HistoricalQualityScore": {
+            "description": "Historical quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "Historical expected click-through rate.",
+            "type": ["null", "number"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "Historical ad relevance score.",
+            "type": ["null", "number"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "Historical landing page experience score.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated from conversions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue generated per assist in the conversion process.",
+            "type": ["null", "number"]
+          },
+          "BudgetName": {
+            "description": "The name of the budget associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "BudgetStatus": {
+            "description": "The status of the budget associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "BudgetAssociationStatus": {
+            "description": "The status of the campaign's budget association.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "campaign_performance_report_monthly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique ID of the account to which the campaign belongs.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique ID of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for which the data is reported.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for monetary values.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution channels where the ads were displayed.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was displayed (e.g., mobile, desktop).",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The advertising network where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of match used for delivering ads.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Comparison of the ad position with top vs. other placements.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of bid matching used for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account to which the campaign belongs.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type/category of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignLabels": {
+            "description": "Any labels associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of times the ad was displayed.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total amount spent on the campaign.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The average cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "The quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "AdRelevance": {
+            "description": "The relevance score of the ad in relation to the target audience.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "The landing page experience of the ad.",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "Number of impressions on phone devices.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Number of phone calls generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Number of assists in the conversion process.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for conversions.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost per assist in the conversion process.",
+            "type": ["null", "number"]
+          },
+          "CustomParameters": {
+            "description": "Any custom parameters associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "Number of view-through conversions generated by the ad.",
+            "type": ["null", "integer"]
+          },
+          "AllCostPerConversion": {
+            "description": "The average cost per conversion for all conversion types.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "Total number of all types of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "Conversion rate considering all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated from all types of conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue generated per conversion for all conversion types.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad in search results.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The overall conversion rate.",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "Number of clicks categorized as low quality.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "Percentage of clicks categorized as low quality.",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "Number of impressions categorized as low quality.",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "Number of sophisticated clicks categorized as low quality.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversions": {
+            "description": "Number of conversions from low-quality clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "Conversion rate of low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "HistoricalQualityScore": {
+            "description": "Historical quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "Historical expected click-through rate.",
+            "type": ["null", "number"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "Historical ad relevance score.",
+            "type": ["null", "number"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "Historical landing page experience score.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated from conversions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue generated per assist in the conversion process.",
+            "type": ["null", "number"]
+          },
+          "BudgetName": {
+            "description": "The name of the budget associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "BudgetStatus": {
+            "description": "The status of the budget associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "BudgetAssociationStatus": {
+            "description": "The status of the campaign's budget association.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["CampaignId"],
+        ["TimePeriod"],
+        ["CurrencyCode"],
+        ["AdDistribution"],
+        ["DeviceType"],
+        ["Network"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["TopVsOther"],
+        ["BidMatchType"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "campaign_impression_performance_report_hourly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the account associated with the campaign.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The specific date and time period the data corresponds to.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network of the ad.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions for the ad.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate for the campaign.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click of the ad.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on the campaign.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad in search results.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for the campaign.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion for the campaign.",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "The total number of low-quality clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "The percentage of low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "The total number of low-quality impressions.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityImpressionsPercent": {
+            "description": "The percentage of low-quality impressions.",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversions": {
+            "description": "The total number of conversions from low-quality clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "The conversion rate for low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "QualityScore": {
+            "description": "The quality score assigned to the ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "The expected click-through rate for the ad.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "The relevance score of the ad.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "The landing page experience score.",
+            "type": ["null", "number"]
+          },
+          "PhoneImpressions": {
+            "description": "The total number of impressions on phones.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "The total number of phone calls generated.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "The phone-through rate for the ad.",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists in the conversion process.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated by the campaign.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for the campaign.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist in the conversion process.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion for the campaign.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist in the conversion process.",
+            "type": ["null", "number"]
+          },
+          "TrackingTemplate": {
+            "description": "The tracking template used for the ad.",
+            "type": ["null", "string"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters for tracking purposes.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "LowQualityGeneralClicks": {
+            "description": "The total number of general clicks from low-quality sources.",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "The total number of sophisticated clicks from low-quality sources.",
+            "type": ["null", "integer"]
+          },
+          "CampaignLabels": {
+            "description": "Labels associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "FinalUrlSuffix": {
+            "description": "The final URL suffix for the ad.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions for the campaign.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions for the campaign.",
+            "type": ["null", "number"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign identifier.",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The overall conversion rate for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions of the ad.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions for the campaign.",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversionsQualified": {
+            "description": "The number of qualified conversions from low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of qualified conversions for all conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified view-through conversions for the campaign.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions for the campaign.",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "The total number of video views.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "The view-through rate for the campaign.",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "The average cost per view of the ad.",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "The total number of video views at 25% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "The total number of video views at 50% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "The total number of video views at 75% completion.",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "The total number of completed video views.",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "The completion rate for video ads.",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "The total watch time in milliseconds for video ads.",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "The average watch time per video view.",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "The average watch time per impression for video ads.",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales generated.",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale for the campaign.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The revenue per sale for the campaign.",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of app installs generated.",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per install for the campaign.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The revenue per install for the campaign.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "campaign_impression_performance_report_daily",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "Name of the account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "Number assigned to the account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "Unique identifier of the account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "Time period to which the data corresponds.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignStatus": {
+            "description": "Status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "Name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "Unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "CurrencyCode": {
+            "description": "Code of the currency used.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "Distribution network where the ad has been displayed.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total amount spent on ads.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "Average position of the ad.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "Percentage of conversions compared to total clicks.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "Average cost for each conversion.",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "Total number of low-quality clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "Percentage of low-quality clicks compared to total clicks.",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "Total number of low-quality impressions.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityImpressionsPercent": {
+            "description": "Percentage of low-quality impressions compared to total impressions.",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversions": {
+            "description": "Total number of low-quality conversions.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "Conversion rate of low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "Type of device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "ImpressionSharePercent": {
+            "description": "The percentage of impressions divided by the total available impressions.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToBudgetPercent": {
+            "description": "Percentage of impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToRankAggPercent": {
+            "description": "Percentage of impressions lost due to aggregated rank constraints.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "Quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "Expected click-through rate.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "Relevance score of the ad.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "Score of the landing page experience.",
+            "type": ["null", "number"]
+          },
+          "HistoricalQualityScore": {
+            "description": "Historical quality score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "Historical expected click-through rate.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "Historical relevance score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "Historical landing page experience score.",
+            "type": ["null", "integer"]
+          },
+          "PhoneImpressions": {
+            "description": "Total number of impressions on phones.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Total number of phone calls generated from the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate.",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "Network where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "Total assists in conversions.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "Revenue generated for each unit of currency spent on ads.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost for each assist in conversions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue generated per assist in conversions.",
+            "type": ["null", "number"]
+          },
+          "TrackingTemplate": {
+            "description": "Template used for tracking purposes.",
+            "type": ["null", "string"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "Status of the account.",
+            "type": ["null", "string"]
+          },
+          "LowQualityGeneralClicks": {
+            "description": "Total number of low-quality general clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "Total number of low-quality sophisticated clicks.",
+            "type": ["null", "integer"]
+          },
+          "CampaignLabels": {
+            "description": "Labels associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "ExactMatchImpressionSharePercent": {
+            "description": "The percentage of exact match impressions divided by the total available exact match impressions.",
+            "type": ["null", "number"]
+          },
+          "ClickSharePercent": {
+            "description": "Percentage of available clicks compared to total clicks.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionSharePercent": {
+            "description": "The percentage of absolute top impressions divided by the total available absolute top impressions.",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "Suffix added to the final URL of the ad.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "Type of the campaign.",
+            "type": ["null", "string"]
+          },
+          "TopImpressionShareLostToRankPercent": {
+            "description": "The percentage of top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToRankPercent": {
+            "description": "The percentage of absolute top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of absolute top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionSharePercent": {
+            "description": "The percentage of top impressions divided by the total available top impressions.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions divided by the total available absolute top impressions.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions divided by the total available top impressions.",
+            "type": ["null", "number"]
+          },
+          "BaseCampaignId": {
+            "description": "Base identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "Total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "Percentage of conversions compared to all clicks.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "Average cost for each conversion.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "Revenue earned for each unit of currency spent on ads.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "Average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "Conversions that occur after a view-through impression.",
+            "type": ["null", "integer"]
+          },
+          "AudienceImpressionSharePercent": {
+            "description": "The percentage of audience impressions divided by the total available audience impressions.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToRankPercent": {
+            "description": "Percentage of audience impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToBudgetPercent": {
+            "description": "Percentage of audience impressions lost due to budget limitations.",
+            "type": ["null", "number"]
+          },
+          "RelativeCtr": {
+            "description": "Relative click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Qualified total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversionsQualified": {
+            "description": "Qualified total number of low-quality conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "Qualified total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "Qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "Revenue generated from view-through impressions.",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "Total number of video views.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "Rate of view-through impressions compared to total impressions.",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "Average cost per video view.",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "Total number of video views at 25% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "Total number of video views at 50% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "Total number of video views at 75% completion.",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "Total number of video views that were completed.",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "Rate at which viewers complete watching the video.",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "Total watch time in milliseconds.",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "Average watch time per video view.",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "Average watch time per impression.",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "Total number of sales.",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "Average cost for each sale.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "Average revenue generated per sale.",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "Total number of app installations.",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "Average cost for each install.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "Average revenue generated per install.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "campaign_impression_performance_report_weekly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "Name of the account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "Number assigned to the account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "Unique identifier of the account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "Time period to which the data corresponds.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignStatus": {
+            "description": "Status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "Name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "Unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "CurrencyCode": {
+            "description": "Code of the currency used.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "Distribution network where the ad has been displayed.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total amount spent on ads.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "Average position of the ad.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "Percentage of conversions compared to total clicks.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "Average cost for each conversion.",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "Total number of low-quality clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "Percentage of low-quality clicks compared to total clicks.",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "Total number of low-quality impressions.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityImpressionsPercent": {
+            "description": "Percentage of low-quality impressions compared to total impressions.",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversions": {
+            "description": "Total number of low-quality conversions.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "Conversion rate of low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "Type of device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "ImpressionSharePercent": {
+            "description": "The percentage of impressions divided by the total available impressions.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToBudgetPercent": {
+            "description": "Percentage of impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToRankAggPercent": {
+            "description": "Percentage of impressions lost due to aggregated rank constraints.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "Quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "Expected click-through rate.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "Relevance score of the ad.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "Score of the landing page experience.",
+            "type": ["null", "number"]
+          },
+          "HistoricalQualityScore": {
+            "description": "Historical quality score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "Historical expected click-through rate.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "Historical relevance score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "Historical landing page experience score.",
+            "type": ["null", "integer"]
+          },
+          "PhoneImpressions": {
+            "description": "Total number of impressions on phones.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Total number of phone calls generated from the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate.",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "Network where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "Total assists in conversions.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "Revenue generated for each unit of currency spent on ads.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost for each assist in conversions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue generated per assist in conversions.",
+            "type": ["null", "number"]
+          },
+          "TrackingTemplate": {
+            "description": "Template used for tracking purposes.",
+            "type": ["null", "string"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "Status of the account.",
+            "type": ["null", "string"]
+          },
+          "LowQualityGeneralClicks": {
+            "description": "Total number of low-quality general clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "Total number of low-quality sophisticated clicks.",
+            "type": ["null", "integer"]
+          },
+          "CampaignLabels": {
+            "description": "Labels associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "ExactMatchImpressionSharePercent": {
+            "description": "The percentage of exact match impressions divided by the total available exact match impressions.",
+            "type": ["null", "number"]
+          },
+          "ClickSharePercent": {
+            "description": "Percentage of available clicks compared to total clicks.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionSharePercent": {
+            "description": "The percentage of absolute top impressions divided by the total available absolute top impressions.",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "Suffix added to the final URL of the ad.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "Type of the campaign.",
+            "type": ["null", "string"]
+          },
+          "TopImpressionShareLostToRankPercent": {
+            "description": "The percentage of top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToRankPercent": {
+            "description": "The percentage of absolute top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of absolute top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionSharePercent": {
+            "description": "The percentage of top impressions divided by the total available top impressions.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions divided by the total available absolute top impressions.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions divided by the total available top impressions.",
+            "type": ["null", "number"]
+          },
+          "BaseCampaignId": {
+            "description": "Base identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "Total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "Percentage of conversions compared to all clicks.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "Average cost for each conversion.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "Revenue earned for each unit of currency spent on ads.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "Average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "Conversions that occur after a view-through impression.",
+            "type": ["null", "integer"]
+          },
+          "AudienceImpressionSharePercent": {
+            "description": "The percentage of audience impressions divided by the total available audience impressions.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToRankPercent": {
+            "description": "Percentage of audience impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToBudgetPercent": {
+            "description": "Percentage of audience impressions lost due to budget limitations.",
+            "type": ["null", "number"]
+          },
+          "RelativeCtr": {
+            "description": "Relative click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Qualified total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversionsQualified": {
+            "description": "Qualified total number of low-quality conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "Qualified total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "Qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "Revenue generated from view-through impressions.",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "Total number of video views.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "Rate of view-through impressions compared to total impressions.",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "Average cost per video view.",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "Total number of video views at 25% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "Total number of video views at 50% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "Total number of video views at 75% completion.",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "Total number of video views that were completed.",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "Rate at which viewers complete watching the video.",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "Total watch time in milliseconds.",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "Average watch time per video view.",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "Average watch time per impression.",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "Total number of sales.",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "Average cost for each sale.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "Average revenue generated per sale.",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "Total number of app installations.",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "Average cost for each install.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "Average revenue generated per install.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "campaign_impression_performance_report_monthly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "Name of the account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "Number assigned to the account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "Unique identifier of the account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "Time period to which the data corresponds.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignStatus": {
+            "description": "Status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "Name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "Unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "CurrencyCode": {
+            "description": "Code of the currency used.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "Distribution network where the ad has been displayed.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total amount spent on ads.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "Average position of the ad.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "Percentage of conversions compared to total clicks.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "Average cost for each conversion.",
+            "type": ["null", "number"]
+          },
+          "LowQualityClicks": {
+            "description": "Total number of low-quality clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityClicksPercent": {
+            "description": "Percentage of low-quality clicks compared to total clicks.",
+            "type": ["null", "number"]
+          },
+          "LowQualityImpressions": {
+            "description": "Total number of low-quality impressions.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityImpressionsPercent": {
+            "description": "Percentage of low-quality impressions compared to total impressions.",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversions": {
+            "description": "Total number of low-quality conversions.",
+            "type": ["null", "integer"]
+          },
+          "LowQualityConversionRate": {
+            "description": "Conversion rate of low-quality clicks.",
+            "type": ["null", "number"]
+          },
+          "DeviceType": {
+            "description": "Type of device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "ImpressionSharePercent": {
+            "description": "The percentage of impressions divided by the total available impressions.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToBudgetPercent": {
+            "description": "Percentage of impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "ImpressionLostToRankAggPercent": {
+            "description": "Percentage of impressions lost due to aggregated rank constraints.",
+            "type": ["null", "number"]
+          },
+          "QualityScore": {
+            "description": "Quality score of the ad.",
+            "type": ["null", "number"]
+          },
+          "ExpectedCtr": {
+            "description": "Expected click-through rate.",
+            "type": ["null", "string"]
+          },
+          "AdRelevance": {
+            "description": "Relevance score of the ad.",
+            "type": ["null", "number"]
+          },
+          "LandingPageExperience": {
+            "description": "Score of the landing page experience.",
+            "type": ["null", "number"]
+          },
+          "HistoricalQualityScore": {
+            "description": "Historical quality score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalExpectedCtr": {
+            "description": "Historical expected click-through rate.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalAdRelevance": {
+            "description": "Historical relevance score of the ad.",
+            "type": ["null", "integer"]
+          },
+          "HistoricalLandingPageExperience": {
+            "description": "Historical landing page experience score.",
+            "type": ["null", "integer"]
+          },
+          "PhoneImpressions": {
+            "description": "Total number of impressions on phones.",
+            "type": ["null", "integer"]
+          },
+          "PhoneCalls": {
+            "description": "Total number of phone calls generated from the ad.",
+            "type": ["null", "integer"]
+          },
+          "Ptr": {
+            "description": "Phone-through rate.",
+            "type": ["null", "number"]
+          },
+          "Network": {
+            "description": "Network where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "Total assists in conversions.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "Revenue generated for each unit of currency spent on ads.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost for each assist in conversions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue generated per assist in conversions.",
+            "type": ["null", "number"]
+          },
+          "TrackingTemplate": {
+            "description": "Template used for tracking purposes.",
+            "type": ["null", "string"]
+          },
+          "CustomParameters": {
+            "description": "Custom parameters associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "Status of the account.",
+            "type": ["null", "string"]
+          },
+          "LowQualityGeneralClicks": {
+            "description": "Total number of low-quality general clicks.",
+            "type": ["null", "integer"]
+          },
+          "LowQualitySophisticatedClicks": {
+            "description": "Total number of low-quality sophisticated clicks.",
+            "type": ["null", "integer"]
+          },
+          "CampaignLabels": {
+            "description": "Labels associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "ExactMatchImpressionSharePercent": {
+            "description": "The percentage of exact match impressions divided by the total available exact match impressions.",
+            "type": ["null", "number"]
+          },
+          "ClickSharePercent": {
+            "description": "Percentage of available clicks compared to total clicks.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionSharePercent": {
+            "description": "The percentage of absolute top impressions divided by the total available absolute top impressions.",
+            "type": ["null", "number"]
+          },
+          "FinalUrlSuffix": {
+            "description": "Suffix added to the final URL of the ad.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "Type of the campaign.",
+            "type": ["null", "string"]
+          },
+          "TopImpressionShareLostToRankPercent": {
+            "description": "The percentage of top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToRankPercent": {
+            "description": "The percentage of absolute top impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionShareLostToBudgetPercent": {
+            "description": "The percentage of absolute top impressions lost due to budget constraints.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionSharePercent": {
+            "description": "The percentage of top impressions divided by the total available top impressions.",
+            "type": ["null", "number"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions divided by the total available absolute top impressions.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions divided by the total available top impressions.",
+            "type": ["null", "number"]
+          },
+          "BaseCampaignId": {
+            "description": "Base identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "Total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "Percentage of conversions compared to all clicks.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "Average cost for each conversion.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "Revenue earned for each unit of currency spent on ads.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "Average revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "Conversions that occur after a view-through impression.",
+            "type": ["null", "integer"]
+          },
+          "AudienceImpressionSharePercent": {
+            "description": "The percentage of audience impressions divided by the total available audience impressions.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToRankPercent": {
+            "description": "Percentage of audience impressions lost due to rank constraints.",
+            "type": ["null", "number"]
+          },
+          "AudienceImpressionLostToBudgetPercent": {
+            "description": "Percentage of audience impressions lost due to budget limitations.",
+            "type": ["null", "number"]
+          },
+          "RelativeCtr": {
+            "description": "Relative click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Qualified total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "LowQualityConversionsQualified": {
+            "description": "Qualified total number of low-quality conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "Qualified total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "Qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "Revenue generated from view-through impressions.",
+            "type": ["null", "number"]
+          },
+          "VideoViews": {
+            "description": "Total number of video views.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughRate": {
+            "description": "Rate of view-through impressions compared to total impressions.",
+            "type": ["null", "number"]
+          },
+          "AverageCPV": {
+            "description": "Average cost per video view.",
+            "type": ["null", "number"]
+          },
+          "VideoViewsAt25Percent": {
+            "description": "Total number of video views at 25% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt50Percent": {
+            "description": "Total number of video views at 50% completion.",
+            "type": ["null", "integer"]
+          },
+          "VideoViewsAt75Percent": {
+            "description": "Total number of video views at 75% completion.",
+            "type": ["null", "integer"]
+          },
+          "CompletedVideoViews": {
+            "description": "Total number of video views that were completed.",
+            "type": ["null", "integer"]
+          },
+          "VideoCompletionRate": {
+            "description": "Rate at which viewers complete watching the video.",
+            "type": ["null", "number"]
+          },
+          "TotalWatchTimeInMS": {
+            "description": "Total watch time in milliseconds.",
+            "type": ["null", "integer"]
+          },
+          "AverageWatchTimePerVideoView": {
+            "description": "Average watch time per video view.",
+            "type": ["null", "number"]
+          },
+          "AverageWatchTimePerImpression": {
+            "description": "Average watch time per impression.",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "Total number of sales.",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "Average cost for each sale.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "Average revenue generated per sale.",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "Total number of app installations.",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "Average cost for each install.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "Average revenue generated per install.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "geographic_performance_report_hourly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the data, formatted as date-time.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "Country": {
+            "description": "The country where the ad interactions occurred.",
+            "type": ["null", "string"]
+          },
+          "State": {
+            "description": "The state where the ad interactions occurred.",
+            "type": ["null", "string"]
+          },
+          "MetroArea": {
+            "description": "The metropolitan area where the ad interactions occurred.",
+            "type": ["null", "string"]
+          },
+          "City": {
+            "description": "The city where the ad interactions occurred.",
+            "type": ["null", "string"]
+          },
+          "ProximityTargetLocation": {
+            "description": "The target location for proximity targeting.",
+            "type": ["null", "string"]
+          },
+          "Radius": {
+            "description": "The radius set for proximity targeting.",
+            "type": ["null", "string"]
+          },
+          "LocationType": {
+            "description": "The type of location where the ad interactions occurred.",
+            "type": ["null", "string"]
+          },
+          "MostSpecificLocation": {
+            "description": "The most specific location where the ad interactions occurred.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "County": {
+            "description": "The county where the ad interactions occurred.",
+            "type": ["null", "string"]
+          },
+          "PostalCode": {
+            "description": "The postal code of the location where the ad interactions occurred.",
+            "type": ["null", "string"]
+          },
+          "LocationId": {
+            "description": "The unique identifier for the location.",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign identifier.",
+            "type": ["null", "string"]
+          },
+          "Goal": {
+            "description": "The goal set for the campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal set for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions in relation to total impressions.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions in relation to total impressions.",
+            "type": ["null", "string"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of qualified conversions for all interactions.",
+            "type": ["null", "string"]
+          },
+          "Neighborhood": {
+            "description": "The neighborhood where the ad interactions occurred.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier for the asset group.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupStatus": {
+            "description": "The status of the asset group.",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for reporting.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type of the delivered ad.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad was interacted with.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language setting of the user interacting with the ad.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network used for ad distribution.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system on the device where the ad was interacted with.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The comparison of top impressions versus other impression types.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type used for bidding.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the ad was shown.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on ad interactions.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost incurred per conversion.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists in conversions.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for interactions.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost incurred per assist in a conversion.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost incurred per all conversion.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all interactions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The rate of conversions in relation to total interactions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad when shown.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The rate of all conversions in relation to total interactions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all interactions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue generated per all conversion.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated from interactions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue generated per assist in a conversion.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "geographic_performance_report_daily",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier of the account associated with the data.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AccountNumber": {
+            "description": "The number of the account associated with the data.",
+            "type": ["null", "string"]
+          },
+          "Country": {
+            "description": "The country where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "State": {
+            "description": "The state where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "MetroArea": {
+            "description": "The metro area where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "City": {
+            "description": "The city where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "ProximityTargetLocation": {
+            "description": "The target location for proximity targeting.",
+            "type": ["null", "string"]
+          },
+          "Radius": {
+            "description": "The radius used for proximity targeting.",
+            "type": ["null", "string"]
+          },
+          "LocationType": {
+            "description": "The type of location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "MostSpecificLocation": {
+            "description": "The most specific location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "County": {
+            "description": "The county where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "PostalCode": {
+            "description": "The postal code of the location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "LocationId": {
+            "description": "The unique identifier of the location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign's unique identifier.",
+            "type": ["null", "string"]
+          },
+          "Goal": {
+            "description": "The goal set for the campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal set for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions divided by the total number of impressions.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions divided by the total number of impressions.",
+            "type": ["null", "string"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of all conversions that are qualified.",
+            "type": ["null", "string"]
+          },
+          "Neighborhood": {
+            "description": "The neighborhood where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue from view-through conversions.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier of the asset group.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupStatus": {
+            "description": "The status of the asset group.",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for financial data.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of matching used for the delivered ad.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device used to view the ad.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeted by the ad.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The performance comparison of the top positions vs. other positions.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of matching used for the bid.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account associated with the data.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists for conversions.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist for conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions that are qualified.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per all conversion.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The rate at which conversions occur.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of conversions that are qualified.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The rate at which all conversions occur.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist for conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "geographic_performance_report_weekly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier of the account associated with the data.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AccountNumber": {
+            "description": "The number of the account associated with the data.",
+            "type": ["null", "string"]
+          },
+          "Country": {
+            "description": "The country where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "State": {
+            "description": "The state where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "MetroArea": {
+            "description": "The metro area where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "City": {
+            "description": "The city where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "ProximityTargetLocation": {
+            "description": "The target location for proximity targeting.",
+            "type": ["null", "string"]
+          },
+          "Radius": {
+            "description": "The radius used for proximity targeting.",
+            "type": ["null", "string"]
+          },
+          "LocationType": {
+            "description": "The type of location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "MostSpecificLocation": {
+            "description": "The most specific location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "County": {
+            "description": "The county where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "PostalCode": {
+            "description": "The postal code of the location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "LocationId": {
+            "description": "The unique identifier of the location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign's unique identifier.",
+            "type": ["null", "string"]
+          },
+          "Goal": {
+            "description": "The goal set for the campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal set for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions divided by the total number of impressions.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions divided by the total number of impressions.",
+            "type": ["null", "string"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of all conversions that are qualified.",
+            "type": ["null", "string"]
+          },
+          "Neighborhood": {
+            "description": "The neighborhood where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue from view-through conversions.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier of the asset group.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupStatus": {
+            "description": "The status of the asset group.",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for financial data.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of matching used for the delivered ad.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device used to view the ad.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeted by the ad.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The performance comparison of the top positions vs. other positions.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of matching used for the bid.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account associated with the data.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists for conversions.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist for conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions that are qualified.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per all conversion.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The rate at which conversions occur.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of conversions that are qualified.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The rate at which all conversions occur.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist for conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "geographic_performance_report_monthly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier of the account associated with the data.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AccountNumber": {
+            "description": "The number of the account associated with the data.",
+            "type": ["null", "string"]
+          },
+          "Country": {
+            "description": "The country where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "State": {
+            "description": "The state where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "MetroArea": {
+            "description": "The metro area where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "City": {
+            "description": "The city where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "ProximityTargetLocation": {
+            "description": "The target location for proximity targeting.",
+            "type": ["null", "string"]
+          },
+          "Radius": {
+            "description": "The radius used for proximity targeting.",
+            "type": ["null", "string"]
+          },
+          "LocationType": {
+            "description": "The type of location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "MostSpecificLocation": {
+            "description": "The most specific location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "County": {
+            "description": "The county where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "PostalCode": {
+            "description": "The postal code of the location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "LocationId": {
+            "description": "The unique identifier of the location where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "BaseCampaignId": {
+            "description": "The base campaign's unique identifier.",
+            "type": ["null", "string"]
+          },
+          "Goal": {
+            "description": "The goal set for the campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal set for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impressions divided by the total number of impressions.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impressions divided by the total number of impressions.",
+            "type": ["null", "string"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of all conversions that are qualified.",
+            "type": ["null", "string"]
+          },
+          "Neighborhood": {
+            "description": "The neighborhood where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue from view-through conversions.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier of the asset group.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupStatus": {
+            "description": "The status of the asset group.",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for financial data.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of matching used for the delivered ad.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device used to view the ad.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language targeted by the ad.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was shown.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The performance comparison of the top positions vs. other positions.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of matching used for the bid.",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "The name of the account associated with the data.",
+            "type": ["null", "string"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "The number of assists for conversions.",
+            "type": ["null", "integer"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist for conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions that are qualified.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per all conversion.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "number"]
+          },
+          "ConversionRate": {
+            "description": "The rate at which conversions occur.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of conversions that are qualified.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionRate": {
+            "description": "The rate at which all conversions occur.",
+            "type": ["null", "number"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist for conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "goals_and_funnels_report_hourly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account associated with the data.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number assigned to the account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the account associated with the data.",
+            "type": ["null", "string"]
+          },
+          "TimePeriod": {
+            "description": "The time period the data corresponds to.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "Keyword": {
+            "description": "The keyword triggered in the process.",
+            "type": ["null", "string"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier of the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal achieved.",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "Total number of conversions recorded.",
+            "type": ["null", "integer"]
+          },
+          "Assists": {
+            "description": "Number of assists in the conversion process.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "GoalId": {
+            "description": "The unique identifier of the goal.",
+            "type": ["null", "integer"]
+          },
+          "DeviceType": {
+            "description": "The type of device used.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal achieved.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "Number of view-through conversions recorded.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionsQualified": {
+            "description": "Number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "Number of qualified view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "Total revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["GoalId"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["AdGroupId"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "goals_and_funnels_report_daily",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "Keyword": {
+            "description": "The keyword associated with the report data.",
+            "type": ["null", "string"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier for the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal achieved in the report.",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "Assists": {
+            "description": "The number of conversions in which the keyword assisted.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "GoalId": {
+            "description": "The unique identifier for the goal.",
+            "type": ["null", "integer"]
+          },
+          "DeviceType": {
+            "description": "The type of device used when the event occurred.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device used when the event occurred.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal achieved.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of conversions that meet specific qualification criteria.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions that meet specific qualification criteria.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["GoalId"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["AdGroupId"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "goals_and_funnels_report_weekly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "Keyword": {
+            "description": "The keyword associated with the report data.",
+            "type": ["null", "string"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier for the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal achieved in the report.",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "Assists": {
+            "description": "The number of conversions in which the keyword assisted.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "GoalId": {
+            "description": "The unique identifier for the goal.",
+            "type": ["null", "integer"]
+          },
+          "DeviceType": {
+            "description": "The type of device used when the event occurred.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device used when the event occurred.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal achieved.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of conversions that meet specific qualification criteria.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions that meet specific qualification criteria.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["GoalId"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["AdGroupId"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "goals_and_funnels_report_monthly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the report data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "Keyword": {
+            "description": "The keyword associated with the report data.",
+            "type": ["null", "string"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier for the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal achieved in the report.",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "Assists": {
+            "description": "The number of conversions in which the keyword assisted.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "GoalId": {
+            "description": "The unique identifier for the goal.",
+            "type": ["null", "integer"]
+          },
+          "DeviceType": {
+            "description": "The type of device used when the event occurred.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device used when the event occurred.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal achieved.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of conversions that meet specific qualification criteria.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions that meet specific qualification criteria.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The total revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["GoalId"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["AdGroupId"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "product_dimension_performance_report_hourly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier for the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The date and time for the report data.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group.",
+            "type": ["null", "integer"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad is displayed.",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "The unique identifier for the ad.",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign.",
+            "type": ["null", "integer"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used for transactions.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device used to view the ad.",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language used in the campaign.",
+            "type": ["null", "string"]
+          },
+          "MerchantProductId": {
+            "description": "The unique identifier of the product set by the merchant.",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "The title of the ad or product.",
+            "type": ["null", "string"]
+          },
+          "Condition": {
+            "description": "The condition of the product.",
+            "type": ["null", "string"]
+          },
+          "Brand": {
+            "description": "The brand associated with the product.",
+            "type": ["null", "string"]
+          },
+          "Price": {
+            "description": "The price of the product.",
+            "type": ["null", "number"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent on advertising.",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The overall conversion rate.",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue generated per conversion.",
+            "type": ["null", "number"]
+          },
+          "SellerName": {
+            "description": "The name of the product seller.",
+            "type": ["null", "string"]
+          },
+          "OfferLanguage": {
+            "description": "The language used in the product offer.",
+            "type": ["null", "string"]
+          },
+          "CountryOfSale": {
+            "description": "The country where the sale occurred.",
+            "type": ["null", "string"]
+          },
+          "AdStatus": {
+            "description": "The status of the ad.",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad is displayed.",
+            "type": ["null", "string"]
+          },
+          "ClickTypeId": {
+            "description": "The unique identifier for the click type.",
+            "type": ["null", "string"]
+          },
+          "TotalClicksOnAdElements": {
+            "description": "The total number of clicks on ad elements.",
+            "type": ["null", "number"]
+          },
+          "ClickType": {
+            "description": "The type of click.",
+            "type": ["null", "string"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for specific conversions.",
+            "type": ["null", "number"]
+          },
+          "BidStrategyType": {
+            "description": "The type of bid strategy used.",
+            "type": ["null", "string"]
+          },
+          "LocalStoreCode": {
+            "description": "The local store code of the product.",
+            "type": ["null", "string"]
+          },
+          "StoreId": {
+            "description": "The unique identifier for the store.",
+            "type": ["null", "string"]
+          },
+          "AssistedClicks": {
+            "description": "The number of assisted clicks.",
+            "type": ["null", "string"]
+          },
+          "AssistedConversions": {
+            "description": "The total number of assisted conversions.",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions.",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal of the campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal set for the campaign.",
+            "type": ["null", "string"]
+          },
+          "ProductBought": {
+            "description": "The product purchased.",
+            "type": ["null", "string"]
+          },
+          "QuantityBought": {
+            "description": "The quantity of the purchased product.",
+            "type": ["null", "string"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AssistedConversionsQualified": {
+            "description": "The number of assisted conversions that are qualified.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of view-through conversions that are qualified.",
+            "type": ["null", "number"]
+          },
+          "ProductBoughtTitle": {
+            "description": "The title of the purchased product.",
+            "type": ["null", "string"]
+          },
+          "GTIN": {
+            "description": "The Global Trade Item Number for the product.",
+            "type": ["null", "string"]
+          },
+          "MPN": {
+            "description": "The Manufacturer Part Number of the product.",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions.",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales.",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The revenue generated per sale.",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of installs.",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per install.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The revenue generated per install.",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier for the asset group.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group.",
+            "type": ["null", "string"]
+          },
+          "AssetGroupStatus": {
+            "description": "The status of the asset group.",
+            "type": ["null", "string"]
+          },
+          "CustomLabel0": {
+            "description": "Custom label 0 for product categorization.",
+            "type": ["null", "string"]
+          },
+          "CustomLabel1": {
+            "description": "Custom label 1 for product categorization.",
+            "type": ["null", "string"]
+          },
+          "CustomLabel2": {
+            "description": "Custom label 2 for product categorization.",
+            "type": ["null", "string"]
+          },
+          "CustomLabel3": {
+            "description": "Custom label 3 for product categorization.",
+            "type": ["null", "string"]
+          },
+          "CustomLabel4": {
+            "description": "Custom label 4 for product categorization.",
+            "type": ["null", "string"]
+          },
+          "ProductType1": {
+            "description": "Product type level 1 for categorization.",
+            "type": ["null", "string"]
+          },
+          "ProductType2": {
+            "description": "Product type level 2 for categorization.",
+            "type": ["null", "string"]
+          },
+          "ProductType3": {
+            "description": "Product type level 3 for categorization.",
+            "type": ["null", "string"]
+          },
+          "ProductType4": {
+            "description": "Product type level 4 for categorization.",
+            "type": ["null", "string"]
+          },
+          "ProductType5": {
+            "description": "Product type level 5 for categorization.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "product_dimension_performance_report_daily",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier of the Bing Ads account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period in date format",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group",
+            "type": ["null", "integer"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "The unique identifier of the ad",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign",
+            "type": ["null", "integer"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device used",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language used",
+            "type": ["null", "string"]
+          },
+          "MerchantProductId": {
+            "description": "The unique identifier of the product",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "The title of the ad or product",
+            "type": ["null", "string"]
+          },
+          "Condition": {
+            "description": "The condition of the product",
+            "type": ["null", "string"]
+          },
+          "Brand": {
+            "description": "The brand associated with the product",
+            "type": ["null", "string"]
+          },
+          "Price": {
+            "description": "The price of the product",
+            "type": ["null", "number"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The overall conversion rate",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "SellerName": {
+            "description": "The name of the seller",
+            "type": ["null", "string"]
+          },
+          "OfferLanguage": {
+            "description": "The language of the product offer",
+            "type": ["null", "string"]
+          },
+          "CountryOfSale": {
+            "description": "The country where the purchase was made",
+            "type": ["null", "string"]
+          },
+          "AdStatus": {
+            "description": "The status of the ad",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "ClickTypeId": {
+            "description": "The unique identifier of the click type",
+            "type": ["null", "string"]
+          },
+          "TotalClicksOnAdElements": {
+            "description": "The total number of clicks on ad elements",
+            "type": ["null", "number"]
+          },
+          "ClickType": {
+            "description": "The type of click",
+            "type": ["null", "string"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "BidStrategyType": {
+            "description": "The type of bid strategy used",
+            "type": ["null", "string"]
+          },
+          "LocalStoreCode": {
+            "description": "The local store code",
+            "type": ["null", "string"]
+          },
+          "StoreId": {
+            "description": "The unique identifier of the store",
+            "type": ["null", "string"]
+          },
+          "AssistedClicks": {
+            "description": "The number of assisted clicks",
+            "type": ["null", "string"]
+          },
+          "AssistedConversions": {
+            "description": "The total number of assisted conversions",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal associated with the conversion",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal",
+            "type": ["null", "string"]
+          },
+          "ProductBought": {
+            "description": "The product bought",
+            "type": ["null", "string"]
+          },
+          "QuantityBought": {
+            "description": "The quantity of the product bought",
+            "type": ["null", "string"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AssistedConversionsQualified": {
+            "description": "The total number of qualified assisted conversions",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "ProductBoughtTitle": {
+            "description": "The title of the product bought",
+            "type": ["null", "string"]
+          },
+          "GTIN": {
+            "description": "The Global Trade Item Number",
+            "type": ["null", "string"]
+          },
+          "MPN": {
+            "description": "The Manufacturer Part Number",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue from view-through conversions",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The revenue per sale",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of installs",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per install",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The revenue per install",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier of the asset group",
+            "type": ["null", "string"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group",
+            "type": ["null", "string"]
+          },
+          "AssetGroupStatus": {
+            "description": "The status of the asset group",
+            "type": ["null", "string"]
+          },
+          "CustomLabel0": {
+            "description": "Custom label 0",
+            "type": ["null", "string"]
+          },
+          "CustomLabel1": {
+            "description": "Custom label 1",
+            "type": ["null", "string"]
+          },
+          "CustomLabel2": {
+            "description": "Custom label 2",
+            "type": ["null", "string"]
+          },
+          "CustomLabel3": {
+            "description": "Custom label 3",
+            "type": ["null", "string"]
+          },
+          "CustomLabel4": {
+            "description": "Custom label 4",
+            "type": ["null", "string"]
+          },
+          "ProductType1": {
+            "description": "Product Type 1",
+            "type": ["null", "string"]
+          },
+          "ProductType2": {
+            "description": "Product Type 2",
+            "type": ["null", "string"]
+          },
+          "ProductType3": {
+            "description": "Product Type 3",
+            "type": ["null", "string"]
+          },
+          "ProductType4": {
+            "description": "Product Type 4",
+            "type": ["null", "string"]
+          },
+          "ProductType5": {
+            "description": "Product Type 5",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "product_dimension_performance_report_weekly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier of the Bing Ads account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period in date format",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group",
+            "type": ["null", "integer"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "The unique identifier of the ad",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign",
+            "type": ["null", "integer"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device used",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language used",
+            "type": ["null", "string"]
+          },
+          "MerchantProductId": {
+            "description": "The unique identifier of the product",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "The title of the ad or product",
+            "type": ["null", "string"]
+          },
+          "Condition": {
+            "description": "The condition of the product",
+            "type": ["null", "string"]
+          },
+          "Brand": {
+            "description": "The brand associated with the product",
+            "type": ["null", "string"]
+          },
+          "Price": {
+            "description": "The price of the product",
+            "type": ["null", "number"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The overall conversion rate",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "SellerName": {
+            "description": "The name of the seller",
+            "type": ["null", "string"]
+          },
+          "OfferLanguage": {
+            "description": "The language of the product offer",
+            "type": ["null", "string"]
+          },
+          "CountryOfSale": {
+            "description": "The country where the purchase was made",
+            "type": ["null", "string"]
+          },
+          "AdStatus": {
+            "description": "The status of the ad",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "ClickTypeId": {
+            "description": "The unique identifier of the click type",
+            "type": ["null", "string"]
+          },
+          "TotalClicksOnAdElements": {
+            "description": "The total number of clicks on ad elements",
+            "type": ["null", "number"]
+          },
+          "ClickType": {
+            "description": "The type of click",
+            "type": ["null", "string"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "BidStrategyType": {
+            "description": "The type of bid strategy used",
+            "type": ["null", "string"]
+          },
+          "LocalStoreCode": {
+            "description": "The local store code",
+            "type": ["null", "string"]
+          },
+          "StoreId": {
+            "description": "The unique identifier of the store",
+            "type": ["null", "string"]
+          },
+          "AssistedClicks": {
+            "description": "The number of assisted clicks",
+            "type": ["null", "string"]
+          },
+          "AssistedConversions": {
+            "description": "The total number of assisted conversions",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal associated with the conversion",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal",
+            "type": ["null", "string"]
+          },
+          "ProductBought": {
+            "description": "The product bought",
+            "type": ["null", "string"]
+          },
+          "QuantityBought": {
+            "description": "The quantity of the product bought",
+            "type": ["null", "string"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AssistedConversionsQualified": {
+            "description": "The total number of qualified assisted conversions",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "ProductBoughtTitle": {
+            "description": "The title of the product bought",
+            "type": ["null", "string"]
+          },
+          "GTIN": {
+            "description": "The Global Trade Item Number",
+            "type": ["null", "string"]
+          },
+          "MPN": {
+            "description": "The Manufacturer Part Number",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue from view-through conversions",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The revenue per sale",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of installs",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per install",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The revenue per install",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier of the asset group",
+            "type": ["null", "string"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group",
+            "type": ["null", "string"]
+          },
+          "AssetGroupStatus": {
+            "description": "The status of the asset group",
+            "type": ["null", "string"]
+          },
+          "CustomLabel0": {
+            "description": "Custom label 0",
+            "type": ["null", "string"]
+          },
+          "CustomLabel1": {
+            "description": "Custom label 1",
+            "type": ["null", "string"]
+          },
+          "CustomLabel2": {
+            "description": "Custom label 2",
+            "type": ["null", "string"]
+          },
+          "CustomLabel3": {
+            "description": "Custom label 3",
+            "type": ["null", "string"]
+          },
+          "CustomLabel4": {
+            "description": "Custom label 4",
+            "type": ["null", "string"]
+          },
+          "ProductType1": {
+            "description": "Product Type 1",
+            "type": ["null", "string"]
+          },
+          "ProductType2": {
+            "description": "Product Type 2",
+            "type": ["null", "string"]
+          },
+          "ProductType3": {
+            "description": "Product Type 3",
+            "type": ["null", "string"]
+          },
+          "ProductType4": {
+            "description": "Product Type 4",
+            "type": ["null", "string"]
+          },
+          "ProductType5": {
+            "description": "Product Type 5",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "product_dimension_performance_report_monthly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountId": {
+            "description": "The unique identifier of the Bing Ads account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period in date format",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AccountName": {
+            "description": "The name of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group",
+            "type": ["null", "integer"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign",
+            "type": ["null", "string"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "The unique identifier of the ad",
+            "type": ["null", "integer"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign",
+            "type": ["null", "integer"]
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device used",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "The language used",
+            "type": ["null", "string"]
+          },
+          "MerchantProductId": {
+            "description": "The unique identifier of the product",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "The title of the ad or product",
+            "type": ["null", "string"]
+          },
+          "Condition": {
+            "description": "The condition of the product",
+            "type": ["null", "string"]
+          },
+          "Brand": {
+            "description": "The brand associated with the product",
+            "type": ["null", "string"]
+          },
+          "Price": {
+            "description": "The price of the product",
+            "type": ["null", "number"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The overall conversion rate",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "SellerName": {
+            "description": "The name of the seller",
+            "type": ["null", "string"]
+          },
+          "OfferLanguage": {
+            "description": "The language of the product offer",
+            "type": ["null", "string"]
+          },
+          "CountryOfSale": {
+            "description": "The country where the purchase was made",
+            "type": ["null", "string"]
+          },
+          "AdStatus": {
+            "description": "The status of the ad",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "ClickTypeId": {
+            "description": "The unique identifier of the click type",
+            "type": ["null", "string"]
+          },
+          "TotalClicksOnAdElements": {
+            "description": "The total number of clicks on ad elements",
+            "type": ["null", "number"]
+          },
+          "ClickType": {
+            "description": "The type of click",
+            "type": ["null", "string"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "BidStrategyType": {
+            "description": "The type of bid strategy used",
+            "type": ["null", "string"]
+          },
+          "LocalStoreCode": {
+            "description": "The local store code",
+            "type": ["null", "string"]
+          },
+          "StoreId": {
+            "description": "The unique identifier of the store",
+            "type": ["null", "string"]
+          },
+          "AssistedClicks": {
+            "description": "The number of assisted clicks",
+            "type": ["null", "string"]
+          },
+          "AssistedConversions": {
+            "description": "The total number of assisted conversions",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The total number of view-through conversions",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal associated with the conversion",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal",
+            "type": ["null", "string"]
+          },
+          "ProductBought": {
+            "description": "The product bought",
+            "type": ["null", "string"]
+          },
+          "QuantityBought": {
+            "description": "The quantity of the product bought",
+            "type": ["null", "string"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AssistedConversionsQualified": {
+            "description": "The total number of qualified assisted conversions",
+            "type": ["null", "string"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The total number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "ProductBoughtTitle": {
+            "description": "The title of the product bought",
+            "type": ["null", "string"]
+          },
+          "GTIN": {
+            "description": "The Global Trade Item Number",
+            "type": ["null", "string"]
+          },
+          "MPN": {
+            "description": "The Manufacturer Part Number",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue from view-through conversions",
+            "type": ["null", "number"]
+          },
+          "Sales": {
+            "description": "The total number of sales",
+            "type": ["null", "integer"]
+          },
+          "CostPerSale": {
+            "description": "The cost per sale",
+            "type": ["null", "number"]
+          },
+          "RevenuePerSale": {
+            "description": "The revenue per sale",
+            "type": ["null", "number"]
+          },
+          "Installs": {
+            "description": "The total number of installs",
+            "type": ["null", "integer"]
+          },
+          "CostPerInstall": {
+            "description": "The cost per install",
+            "type": ["null", "number"]
+          },
+          "RevenuePerInstall": {
+            "description": "The revenue per install",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier of the asset group",
+            "type": ["null", "string"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group",
+            "type": ["null", "string"]
+          },
+          "AssetGroupStatus": {
+            "description": "The status of the asset group",
+            "type": ["null", "string"]
+          },
+          "CustomLabel0": {
+            "description": "Custom label 0",
+            "type": ["null", "string"]
+          },
+          "CustomLabel1": {
+            "description": "Custom label 1",
+            "type": ["null", "string"]
+          },
+          "CustomLabel2": {
+            "description": "Custom label 2",
+            "type": ["null", "string"]
+          },
+          "CustomLabel3": {
+            "description": "Custom label 3",
+            "type": ["null", "string"]
+          },
+          "CustomLabel4": {
+            "description": "Custom label 4",
+            "type": ["null", "string"]
+          },
+          "ProductType1": {
+            "description": "Product Type 1",
+            "type": ["null", "string"]
+          },
+          "ProductType2": {
+            "description": "Product Type 2",
+            "type": ["null", "string"]
+          },
+          "ProductType3": {
+            "description": "Product Type 3",
+            "type": ["null", "string"]
+          },
+          "ProductType4": {
+            "description": "Product Type 4",
+            "type": ["null", "string"]
+          },
+          "ProductType5": {
+            "description": "Product Type 5",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "is_resumable": true
+    },
+    {
+      "name": "product_search_query_performance_report_hourly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "TimePeriod": {
+            "description": "The time period of the report",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "AccountId": {
+            "description": "ID of the account associated with the data",
+            "type": ["null", "integer"]
+          },
+          "AccountNumber": {
+            "description": "Number of the account associated with the data",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "Name of the account associated with the data",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "ID of the ad",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "ID of the ad group",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "Name of the ad group",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "ID of the campaign",
+            "type": ["null", "integer"]
+          },
+          "CampaignName": {
+            "description": "Name of the campaign",
+            "type": ["null", "string"]
+          },
+          "DestinationUrl": {
+            "description": "URL where the ad directs the user",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "Type of device used",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "Operating system of the device",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "Language targeting for the ad",
+            "type": ["null", "string"]
+          },
+          "SearchQuery": {
+            "description": "The search query entered by the user",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "MerchantProductId": {
+            "description": "ID of the merchant product",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "Title of the ad",
+            "type": ["null", "string"]
+          },
+          "ClickTypeId": {
+            "description": "ID of the click type",
+            "type": ["null", "string"]
+          },
+          "TotalClicksOnAdElements": {
+            "description": "Total number of clicks on elements within the ad",
+            "type": ["null", "number"]
+          },
+          "ClickType": {
+            "description": "Type of click",
+            "type": ["null", "string"]
+          },
+          "AdGroupCriterionId": {
+            "description": "Unique ID for the ad group criterion",
+            "type": ["null", "string"]
+          },
+          "ProductGroup": {
+            "description": "Grouping of products",
+            "type": ["null", "string"]
+          },
+          "PartitionType": {
+            "description": "Type of partition",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of times the ad was shown",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks on the ad",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate of the ad",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click for the ad",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total amount spent on the ad",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of times the ad resulted in a conversion",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for the ad",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Number of times the ad assisted in converting a customer",
+            "type": ["null", "integer"]
+          },
+          "CostPerAssist": {
+            "description": "Cost per assist where the ad assisted in converting a customer",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated by the ad",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "Cost per conversion for the ad",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Average revenue per conversion for the ad",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue per assist where the ad assisted in converting a customer",
+            "type": ["null", "number"]
+          },
+          "CustomerId": {
+            "description": "ID of the customer",
+            "type": ["null", "integer"]
+          },
+          "CustomerName": {
+            "description": "Name of the customer",
+            "type": ["null", "string"]
+          },
+          "AssistedImpressions": {
+            "description": "Number of times the ad appeared in a measured position on the search results page but wasn't clicked",
+            "type": ["null", "integer"]
+          },
+          "AssistedClicks": {
+            "description": "Number of clicks in which the ad appeared in a measured position on the search results page but wasn't clicked",
+            "type": ["null", "integer"]
+          },
+          "AssistedConversions": {
+            "description": "Number of conversions in which the ad appeared in a measured position on the search results page but wasn't clicked",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "Total number of all types of conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated from all types of conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The overall conversion rate for all types of conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "Total cost per conversion for all types of conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "Average revenue earned per conversion for all types of conversions",
+            "type": ["null", "number"]
+          },
+          "Goal": {
+            "description": "The goal associated with the ad",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "Type of goal",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times this ad was shown in the top position on the search results page",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of conversions that meet certain criteria",
+            "type": ["null", "number"]
+          },
+          "AssistedConversionsQualified": {
+            "description": "Number of conversions that meet certain criteria in which the ad appeared in a measured position on the search results page but wasn't clicked",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "Number of all types of conversions that meet certain criteria",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "Type of the campaign",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "ID of the asset group",
+            "type": ["null", "integer"]
+          },
+          "AssetGroupName": {
+            "description": "Name of the asset group",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["TimePeriod"],
+        ["CampaignId"],
+        ["AdId"],
+        ["AdGroupId"],
+        ["SearchQuery"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["Language"],
+        ["Network"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "product_search_query_performance_report_daily",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "TimePeriod": {
+            "description": "Time period for the data",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AccountId": {
+            "description": "Unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "AccountNumber": {
+            "description": "Account number associated with the account",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "Name of the account",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "ID of the ad",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "ID of the ad group",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "Name of the ad group",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "ID of the campaign",
+            "type": ["null", "integer"]
+          },
+          "CampaignName": {
+            "description": "Name of the campaign",
+            "type": ["null", "string"]
+          },
+          "DestinationUrl": {
+            "description": "URL of the landing page",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "Type of device",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "Operating system of the device",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "Language targeting of the ad",
+            "type": ["null", "string"]
+          },
+          "SearchQuery": {
+            "description": "Search query that triggered the ad",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "Network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "MerchantProductId": {
+            "description": "ID of the merchant product",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "Title of the ad",
+            "type": ["null", "string"]
+          },
+          "ClickTypeId": {
+            "description": "ID of the click type",
+            "type": ["null", "string"]
+          },
+          "TotalClicksOnAdElements": {
+            "description": "Total clicks on ad elements (e.g., sitelinks)",
+            "type": ["null", "number"]
+          },
+          "ClickType": {
+            "description": "Type of click (e.g., headline, sitelink)",
+            "type": ["null", "string"]
+          },
+          "AdGroupCriterionId": {
+            "description": "ID of the ad group criterion",
+            "type": ["null", "string"]
+          },
+          "ProductGroup": {
+            "description": "Grouping of products",
+            "type": ["null", "string"]
+          },
+          "PartitionType": {
+            "description": "Type of the partition",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total spend on the ad",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "Percentage of conversions over clicks",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Total number of assists",
+            "type": ["null", "integer"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost per assist",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "Average cost per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Average revenue generated per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue generated per assist",
+            "type": ["null", "number"]
+          },
+          "CustomerId": {
+            "description": "Unique identifier for the customer",
+            "type": ["null", "integer"]
+          },
+          "CustomerName": {
+            "description": "Name of the customer",
+            "type": ["null", "string"]
+          },
+          "AssistedImpressions": {
+            "description": "Number of impressions in which the ad was assisted",
+            "type": ["null", "integer"]
+          },
+          "AssistedClicks": {
+            "description": "Number of assisted clicks",
+            "type": ["null", "integer"]
+          },
+          "AssistedConversions": {
+            "description": "Number of assisted conversions",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "Total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "Percentage of conversions over all clicks",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "Average cost per conversion",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "Average revenue generated per conversion",
+            "type": ["null", "number"]
+          },
+          "Goal": {
+            "description": "Specific goal targeted by the ad",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "Type of goal",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times the ad showed at the absolute top of the search results",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of conversions that meet specific criteria",
+            "type": ["null", "number"]
+          },
+          "AssistedConversionsQualified": {
+            "description": "Number of assisted conversions that meet specific criteria",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "Number of conversions that meet specific criteria",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "Type of the campaign",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "ID of the asset group",
+            "type": ["null", "integer"]
+          },
+          "AssetGroupName": {
+            "description": "Name of the asset group",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["TimePeriod"],
+        ["CampaignId"],
+        ["AdId"],
+        ["AdGroupId"],
+        ["SearchQuery"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["Language"],
+        ["Network"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "product_search_query_performance_report_weekly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "TimePeriod": {
+            "description": "Time period for the data",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AccountId": {
+            "description": "Unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "AccountNumber": {
+            "description": "Account number associated with the account",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "Name of the account",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "ID of the ad",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "ID of the ad group",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "Name of the ad group",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "ID of the campaign",
+            "type": ["null", "integer"]
+          },
+          "CampaignName": {
+            "description": "Name of the campaign",
+            "type": ["null", "string"]
+          },
+          "DestinationUrl": {
+            "description": "URL of the landing page",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "Type of device",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "Operating system of the device",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "Language targeting of the ad",
+            "type": ["null", "string"]
+          },
+          "SearchQuery": {
+            "description": "Search query that triggered the ad",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "Network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "MerchantProductId": {
+            "description": "ID of the merchant product",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "Title of the ad",
+            "type": ["null", "string"]
+          },
+          "ClickTypeId": {
+            "description": "ID of the click type",
+            "type": ["null", "string"]
+          },
+          "TotalClicksOnAdElements": {
+            "description": "Total clicks on ad elements (e.g., sitelinks)",
+            "type": ["null", "number"]
+          },
+          "ClickType": {
+            "description": "Type of click (e.g., headline, sitelink)",
+            "type": ["null", "string"]
+          },
+          "AdGroupCriterionId": {
+            "description": "ID of the ad group criterion",
+            "type": ["null", "string"]
+          },
+          "ProductGroup": {
+            "description": "Grouping of products",
+            "type": ["null", "string"]
+          },
+          "PartitionType": {
+            "description": "Type of the partition",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total spend on the ad",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "Percentage of conversions over clicks",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Total number of assists",
+            "type": ["null", "integer"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost per assist",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "Average cost per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Average revenue generated per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue generated per assist",
+            "type": ["null", "number"]
+          },
+          "CustomerId": {
+            "description": "Unique identifier for the customer",
+            "type": ["null", "integer"]
+          },
+          "CustomerName": {
+            "description": "Name of the customer",
+            "type": ["null", "string"]
+          },
+          "AssistedImpressions": {
+            "description": "Number of impressions in which the ad was assisted",
+            "type": ["null", "integer"]
+          },
+          "AssistedClicks": {
+            "description": "Number of assisted clicks",
+            "type": ["null", "integer"]
+          },
+          "AssistedConversions": {
+            "description": "Number of assisted conversions",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "Total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "Percentage of conversions over all clicks",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "Average cost per conversion",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "Average revenue generated per conversion",
+            "type": ["null", "number"]
+          },
+          "Goal": {
+            "description": "Specific goal targeted by the ad",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "Type of goal",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times the ad showed at the absolute top of the search results",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of conversions that meet specific criteria",
+            "type": ["null", "number"]
+          },
+          "AssistedConversionsQualified": {
+            "description": "Number of assisted conversions that meet specific criteria",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "Number of conversions that meet specific criteria",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "Type of the campaign",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "ID of the asset group",
+            "type": ["null", "integer"]
+          },
+          "AssetGroupName": {
+            "description": "Name of the asset group",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["TimePeriod"],
+        ["CampaignId"],
+        ["AdId"],
+        ["AdGroupId"],
+        ["SearchQuery"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["Language"],
+        ["Network"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "product_search_query_performance_report_monthly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "TimePeriod": {
+            "description": "Time period for the data",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "AccountId": {
+            "description": "Unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "AccountNumber": {
+            "description": "Account number associated with the account",
+            "type": ["null", "string"]
+          },
+          "AccountName": {
+            "description": "Name of the account",
+            "type": ["null", "string"]
+          },
+          "AdId": {
+            "description": "ID of the ad",
+            "type": ["null", "integer"]
+          },
+          "AdGroupId": {
+            "description": "ID of the ad group",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "Name of the ad group",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "ID of the campaign",
+            "type": ["null", "integer"]
+          },
+          "CampaignName": {
+            "description": "Name of the campaign",
+            "type": ["null", "string"]
+          },
+          "DestinationUrl": {
+            "description": "URL of the landing page",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "Type of device",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "Operating system of the device",
+            "type": ["null", "string"]
+          },
+          "Language": {
+            "description": "Language targeting of the ad",
+            "type": ["null", "string"]
+          },
+          "SearchQuery": {
+            "description": "Search query that triggered the ad",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "Network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "MerchantProductId": {
+            "description": "ID of the merchant product",
+            "type": ["null", "string"]
+          },
+          "Title": {
+            "description": "Title of the ad",
+            "type": ["null", "string"]
+          },
+          "ClickTypeId": {
+            "description": "ID of the click type",
+            "type": ["null", "string"]
+          },
+          "TotalClicksOnAdElements": {
+            "description": "Total clicks on ad elements (e.g., sitelinks)",
+            "type": ["null", "number"]
+          },
+          "ClickType": {
+            "description": "Type of click (e.g., headline, sitelink)",
+            "type": ["null", "string"]
+          },
+          "AdGroupCriterionId": {
+            "description": "ID of the ad group criterion",
+            "type": ["null", "string"]
+          },
+          "ProductGroup": {
+            "description": "Grouping of products",
+            "type": ["null", "string"]
+          },
+          "PartitionType": {
+            "description": "Type of the partition",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "Total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "Total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "Click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "Average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "Total spend on the ad",
+            "type": ["null", "number"]
+          },
+          "Conversions": {
+            "description": "Total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "Percentage of conversions over clicks",
+            "type": ["null", "number"]
+          },
+          "Assists": {
+            "description": "Total number of assists",
+            "type": ["null", "integer"]
+          },
+          "CostPerAssist": {
+            "description": "Average cost per assist",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "Total revenue generated",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "Average cost per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "Average revenue generated per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "Average revenue generated per assist",
+            "type": ["null", "number"]
+          },
+          "CustomerId": {
+            "description": "Unique identifier for the customer",
+            "type": ["null", "integer"]
+          },
+          "CustomerName": {
+            "description": "Name of the customer",
+            "type": ["null", "string"]
+          },
+          "AssistedImpressions": {
+            "description": "Number of impressions in which the ad was assisted",
+            "type": ["null", "integer"]
+          },
+          "AssistedClicks": {
+            "description": "Number of assisted clicks",
+            "type": ["null", "integer"]
+          },
+          "AssistedConversions": {
+            "description": "Number of assisted conversions",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "Total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "Total revenue generated",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "Percentage of conversions over all clicks",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "Average cost per conversion",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "Average revenue generated per conversion",
+            "type": ["null", "number"]
+          },
+          "Goal": {
+            "description": "Specific goal targeted by the ad",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "Type of goal",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times the ad showed at the absolute top of the search results",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "Average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "Number of conversions that meet specific criteria",
+            "type": ["null", "number"]
+          },
+          "AssistedConversionsQualified": {
+            "description": "Number of assisted conversions that meet specific criteria",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "Number of conversions that meet specific criteria",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "Type of the campaign",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "ID of the asset group",
+            "type": ["null", "integer"]
+          },
+          "AssetGroupName": {
+            "description": "Name of the asset group",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["TimePeriod"],
+        ["CampaignId"],
+        ["AdId"],
+        ["AdGroupId"],
+        ["SearchQuery"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["Language"],
+        ["Network"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "search_query_performance_report_hourly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The number associated with the account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period for the data.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "AdId": {
+            "description": "The unique identifier of the ad.",
+            "type": ["null", "integer"]
+          },
+          "AdType": {
+            "description": "The type of the ad.",
+            "type": ["null", "string"]
+          },
+          "DestinationUrl": {
+            "description": "The URL where the user is directed to upon clicking.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of bid match.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of delivered match.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdStatus": {
+            "description": "The status of the ad.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad.",
+            "type": ["null", "number"]
+          },
+          "SearchQuery": {
+            "description": "The search query used by the user.",
+            "type": ["null", "string"]
+          },
+          "Keyword": {
+            "description": "The keyword associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "AdGroupCriterionId": {
+            "description": "The unique identifier of the ad group criterion.",
+            "type": ["null", "string"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for conversions.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "Language": {
+            "description": "The language of the ad.",
+            "type": ["null", "string"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier of the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Network": {
+            "description": "The network where the ad is displayed.",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "The comparison of top impression share versus other positions.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad is displayed.",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device.",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assist conversions.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist conversion.",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the account.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CustomerId": {
+            "description": "The unique identifier of the customer.",
+            "type": ["null", "integer"]
+          },
+          "CustomerName": {
+            "description": "The name of the customer.",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "Goal": {
+            "description": "The goal for the conversion.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal for the conversion.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of absolute top impression share for the ad.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of top impression share for the ad.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of all qualified conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["SearchQuery"],
+        ["Keyword"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["Language"],
+        ["DeliveredMatchType"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["TopVsOther"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "search_query_performance_report_daily",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period of the data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "AdId": {
+            "description": "The unique identifier of the ad.",
+            "type": ["null", "integer"]
+          },
+          "AdType": {
+            "description": "The type of ad (text ad, responsive ad, etc.).",
+            "type": ["null", "string"]
+          },
+          "DestinationUrl": {
+            "description": "The URL where the ad directs traffic.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of match (bidded, auto, etc.) for the keyword bid.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of match (exact, broad, etc.) for the keyword delivery.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdStatus": {
+            "description": "The status of the ad.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the ad was shown.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend on the ad.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on search results pages.",
+            "type": ["null", "number"]
+          },
+          "SearchQuery": {
+            "description": "The search query that triggered the ad.",
+            "type": ["null", "string"]
+          },
+          "Keyword": {
+            "description": "The keyword associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "AdGroupCriterionId": {
+            "description": "The unique identifier of the ad group criterion.",
+            "type": ["null", "string"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The percentage of clicks that resulted in a conversion.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "Language": {
+            "description": "The language setting targeted by the ad.",
+            "type": ["null", "string"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier of the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Network": {
+            "description": "The network where the ad was shown (Bing, partner sites, etc.).",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Indicates if the ad was shown in the top position or elsewhere.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device (desktop, mobile, tablet, etc.).",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists on conversions.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist on conversions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue per assist.",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign (search, display, etc.).",
+            "type": ["null", "string"]
+          },
+          "CustomerId": {
+            "description": "The unique identifier of the customer.",
+            "type": ["null", "integer"]
+          },
+          "CustomerName": {
+            "description": "The name of the customer.",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The percentage of all clicks that resulted in a conversion.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "Goal": {
+            "description": "The goal associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal (e.g., ROAS, CPA) for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the absolute top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["SearchQuery"],
+        ["Keyword"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["Language"],
+        ["DeliveredMatchType"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["TopVsOther"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "search_query_performance_report_weekly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period of the data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "AdId": {
+            "description": "The unique identifier of the ad.",
+            "type": ["null", "integer"]
+          },
+          "AdType": {
+            "description": "The type of ad (text ad, responsive ad, etc.).",
+            "type": ["null", "string"]
+          },
+          "DestinationUrl": {
+            "description": "The URL where the ad directs traffic.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of match (bidded, auto, etc.) for the keyword bid.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of match (exact, broad, etc.) for the keyword delivery.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdStatus": {
+            "description": "The status of the ad.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the ad was shown.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend on the ad.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on search results pages.",
+            "type": ["null", "number"]
+          },
+          "SearchQuery": {
+            "description": "The search query that triggered the ad.",
+            "type": ["null", "string"]
+          },
+          "Keyword": {
+            "description": "The keyword associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "AdGroupCriterionId": {
+            "description": "The unique identifier of the ad group criterion.",
+            "type": ["null", "string"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The percentage of clicks that resulted in a conversion.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "Language": {
+            "description": "The language setting targeted by the ad.",
+            "type": ["null", "string"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier of the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Network": {
+            "description": "The network where the ad was shown (Bing, partner sites, etc.).",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Indicates if the ad was shown in the top position or elsewhere.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device (desktop, mobile, tablet, etc.).",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists on conversions.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist on conversions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue per assist.",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign (search, display, etc.).",
+            "type": ["null", "string"]
+          },
+          "CustomerId": {
+            "description": "The unique identifier of the customer.",
+            "type": ["null", "integer"]
+          },
+          "CustomerName": {
+            "description": "The name of the customer.",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The percentage of all clicks that resulted in a conversion.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "Goal": {
+            "description": "The goal associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal (e.g., ROAS, CPA) for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the absolute top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["SearchQuery"],
+        ["Keyword"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["Language"],
+        ["DeliveredMatchType"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["TopVsOther"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "search_query_performance_report_monthly",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier of the Bing Ads account.",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period of the data.",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group.",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier of the ad group.",
+            "type": ["null", "integer"]
+          },
+          "AdId": {
+            "description": "The unique identifier of the ad.",
+            "type": ["null", "integer"]
+          },
+          "AdType": {
+            "description": "The type of ad (text ad, responsive ad, etc.).",
+            "type": ["null", "string"]
+          },
+          "DestinationUrl": {
+            "description": "The URL where the ad directs traffic.",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of match (bidded, auto, etc.) for the keyword bid.",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of match (exact, broad, etc.) for the keyword delivery.",
+            "type": ["null", "string"]
+          },
+          "CampaignStatus": {
+            "description": "The status of the campaign.",
+            "type": ["null", "string"]
+          },
+          "AdStatus": {
+            "description": "The status of the ad.",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of times the ad was shown.",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks.",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate.",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click.",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total spend on the ad.",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on search results pages.",
+            "type": ["null", "number"]
+          },
+          "SearchQuery": {
+            "description": "The search query that triggered the ad.",
+            "type": ["null", "string"]
+          },
+          "Keyword": {
+            "description": "The keyword associated with the ad.",
+            "type": ["null", "string"]
+          },
+          "AdGroupCriterionId": {
+            "description": "The unique identifier of the ad group criterion.",
+            "type": ["null", "string"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions.",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The percentage of clicks that resulted in a conversion.",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion.",
+            "type": ["null", "number"]
+          },
+          "Language": {
+            "description": "The language setting targeted by the ad.",
+            "type": ["null", "string"]
+          },
+          "KeywordId": {
+            "description": "The unique identifier of the keyword.",
+            "type": ["null", "integer"]
+          },
+          "Network": {
+            "description": "The network where the ad was shown (Bing, partner sites, etc.).",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Indicates if the ad was shown in the top position or elsewhere.",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device (desktop, mobile, tablet, etc.).",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device where the ad was displayed.",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists on conversions.",
+            "type": ["null", "integer"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated.",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend.",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist on conversions.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The average revenue per conversion.",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The average revenue per assist.",
+            "type": ["null", "number"]
+          },
+          "AccountStatus": {
+            "description": "The status of the Bing Ads account.",
+            "type": ["null", "string"]
+          },
+          "AdGroupStatus": {
+            "description": "The status of the ad group.",
+            "type": ["null", "string"]
+          },
+          "KeywordStatus": {
+            "description": "The status of the keyword.",
+            "type": ["null", "string"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign (search, display, etc.).",
+            "type": ["null", "string"]
+          },
+          "CustomerId": {
+            "description": "The unique identifier of the customer.",
+            "type": ["null", "integer"]
+          },
+          "CustomerName": {
+            "description": "The name of the customer.",
+            "type": ["null", "string"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions.",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated from all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The percentage of all clicks that resulted in a conversion.",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions.",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The average revenue per conversion for all conversions.",
+            "type": ["null", "number"]
+          },
+          "Goal": {
+            "description": "The goal associated with the campaign.",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal (e.g., ROAS, CPA) for the campaign.",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the absolute top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the top of the search results page.",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions.",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The total number of qualified conversions.",
+            "type": ["null", "number"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["SearchQuery"],
+        ["Keyword"],
+        ["TimePeriod"],
+        ["AccountId"],
+        ["CampaignId"],
+        ["Language"],
+        ["DeliveredMatchType"],
+        ["DeviceType"],
+        ["DeviceOS"],
+        ["TopVsOther"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "user_location_performance_report_hourly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number associated with the account",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period covered in the report",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group",
+            "type": ["null", "integer"]
+          },
+          "Country": {
+            "description": "The country where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "State": {
+            "description": "The state where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "MetroArea": {
+            "description": "The metropolitan area where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used in the report",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution channel where the ad was shown",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of ad impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks on the ad",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total cost incurred for running the ad campaign",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position of the ad on the search results page",
+            "type": ["null", "number"]
+          },
+          "ProximityTargetLocation": {
+            "description": "The target location for proximity targeting",
+            "type": ["null", "string"]
+          },
+          "Radius": {
+            "description": "The radius for proximity targeting",
+            "type": ["null", "integer"]
+          },
+          "Language": {
+            "description": "The language targeted for the ad campaign",
+            "type": ["null", "string"]
+          },
+          "City": {
+            "description": "The city where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCountry": {
+            "description": "The country from query intent",
+            "type": ["null", "string"]
+          },
+          "QueryIntentState": {
+            "description": "The state from query intent",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCity": {
+            "description": "The city from query intent",
+            "type": ["null", "string"]
+          },
+          "QueryIntentDMA": {
+            "description": "The Designated Market Area from query intent",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The type of match that triggered the ad to show",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The type of match that delivered the ad in the search results",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The advertising network where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Comparison of the top positions with other positions in displaying the ad",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device on which the ad was displayed (e.g., Desktop, Mobile)",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device on which the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists for conversions",
+            "type": ["null", "integer"]
+          },
+          "Conversions": {
+            "description": "The total number of a specific type of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate for a specific type of conversion",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated for a specific type of conversion",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend for a specific type of conversion",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion for a specific type of conversion",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist for conversions",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue generated per conversion for a specific type of conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue generated per assist for conversions",
+            "type": ["null", "number"]
+          },
+          "County": {
+            "description": "The county where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "PostalCode": {
+            "description": "The postal code where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCounty": {
+            "description": "The county from query intent",
+            "type": ["null", "string"]
+          },
+          "QueryIntentPostalCode": {
+            "description": "The postal code from query intent",
+            "type": ["null", "string"]
+          },
+          "LocationId": {
+            "description": "The unique identifier for the location where the ad was displayed",
+            "type": ["null", "integer"]
+          },
+          "QueryIntentLocationId": {
+            "description": "The unique identifier for the location from query intent",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all types of conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue generated for all types of conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The overall conversion rate for all types of conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all types of conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all types of conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue generated per conversion for all types of conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of conversions that occurred after a view-through of the ad",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal associated with the ad performance",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal set for ad performance",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of times the ad appeared in the top position on the first page of search results",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of times the ad appeared in the top positions on the search results page",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions for a specific type of conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of qualified conversions for all types of conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified conversions that occurred after a view-through of the ad",
+            "type": ["null", "number"]
+          },
+          "Neighborhood": {
+            "description": "The neighborhood where the ad was displayed",
+            "type": ["null", "string"]
+          },
+          "QueryIntentNeighborhood": {
+            "description": "The neighborhood from query intent",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from conversions that occurred after a view-through of the ad",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "The type of campaign (e.g., Search, Display)",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier for the asset group",
+            "type": ["null", "integer"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["AdGroupId"],
+        ["CampaignId"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["DeviceType"],
+        ["Language"],
+        ["LocationId"],
+        ["QueryIntentLocationId"],
+        ["TimePeriod"],
+        ["TopVsOther"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "user_location_performance_report_daily",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period covered by the report data",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group",
+            "type": ["null", "integer"]
+          },
+          "Country": {
+            "description": "The country where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "State": {
+            "description": "The state where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "MetroArea": {
+            "description": "The metropolitan area where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used in the report",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network of the ad",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position where the ad is displayed",
+            "type": ["null", "number"]
+          },
+          "ProximityTargetLocation": {
+            "description": "The targeted location for proximity",
+            "type": ["null", "string"]
+          },
+          "Radius": {
+            "description": "The radius for proximity targeting",
+            "type": ["null", "integer"]
+          },
+          "Language": {
+            "description": "The language setting of the user",
+            "type": ["null", "string"]
+          },
+          "City": {
+            "description": "The city where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCountry": {
+            "description": "The query intent country",
+            "type": ["null", "string"]
+          },
+          "QueryIntentState": {
+            "description": "The query intent state",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCity": {
+            "description": "The query intent city",
+            "type": ["null", "string"]
+          },
+          "QueryIntentDMA": {
+            "description": "The query intent Designated Market Area",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type of the bid",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type of the delivered item",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Indicates if the ad is shown at the top or other positions",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists in conversions",
+            "type": ["null", "integer"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist in conversions",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist in conversions",
+            "type": ["null", "number"]
+          },
+          "County": {
+            "description": "The county where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "PostalCode": {
+            "description": "The postal code of the location",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCounty": {
+            "description": "The query intent county",
+            "type": ["null", "string"]
+          },
+          "QueryIntentPostalCode": {
+            "description": "The query intent postal code",
+            "type": ["null", "string"]
+          },
+          "LocationId": {
+            "description": "The unique identifier for the location",
+            "type": ["null", "integer"]
+          },
+          "QueryIntentLocationId": {
+            "description": "The query intent location identifier",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of conversions where the ad was displayed but not clicked",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal associated with the report data",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal associated with the report data",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the absolute top of the page",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the top position",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "Neighborhood": {
+            "description": "The neighborhood where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "QueryIntentNeighborhood": {
+            "description": "The query intent neighborhood",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier for the asset group",
+            "type": ["null", "integer"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["AdGroupId"],
+        ["CampaignId"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["DeviceType"],
+        ["Language"],
+        ["LocationId"],
+        ["QueryIntentLocationId"],
+        ["TimePeriod"],
+        ["TopVsOther"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "user_location_performance_report_weekly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period covered by the report data",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group",
+            "type": ["null", "integer"]
+          },
+          "Country": {
+            "description": "The country where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "State": {
+            "description": "The state where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "MetroArea": {
+            "description": "The metropolitan area where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used in the report",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network of the ad",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position where the ad is displayed",
+            "type": ["null", "number"]
+          },
+          "ProximityTargetLocation": {
+            "description": "The targeted location for proximity",
+            "type": ["null", "string"]
+          },
+          "Radius": {
+            "description": "The radius for proximity targeting",
+            "type": ["null", "integer"]
+          },
+          "Language": {
+            "description": "The language setting of the user",
+            "type": ["null", "string"]
+          },
+          "City": {
+            "description": "The city where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCountry": {
+            "description": "The query intent country",
+            "type": ["null", "string"]
+          },
+          "QueryIntentState": {
+            "description": "The query intent state",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCity": {
+            "description": "The query intent city",
+            "type": ["null", "string"]
+          },
+          "QueryIntentDMA": {
+            "description": "The query intent Designated Market Area",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type of the bid",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type of the delivered item",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Indicates if the ad is shown at the top or other positions",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists in conversions",
+            "type": ["null", "integer"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist in conversions",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist in conversions",
+            "type": ["null", "number"]
+          },
+          "County": {
+            "description": "The county where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "PostalCode": {
+            "description": "The postal code of the location",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCounty": {
+            "description": "The query intent county",
+            "type": ["null", "string"]
+          },
+          "QueryIntentPostalCode": {
+            "description": "The query intent postal code",
+            "type": ["null", "string"]
+          },
+          "LocationId": {
+            "description": "The unique identifier for the location",
+            "type": ["null", "integer"]
+          },
+          "QueryIntentLocationId": {
+            "description": "The query intent location identifier",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of conversions where the ad was displayed but not clicked",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal associated with the report data",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal associated with the report data",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the absolute top of the page",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the top position",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "Neighborhood": {
+            "description": "The neighborhood where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "QueryIntentNeighborhood": {
+            "description": "The query intent neighborhood",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier for the asset group",
+            "type": ["null", "integer"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["AdGroupId"],
+        ["CampaignId"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["DeviceType"],
+        ["Language"],
+        ["LocationId"],
+        ["QueryIntentLocationId"],
+        ["TimePeriod"],
+        ["TopVsOther"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "user_location_performance_report_monthly",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "AccountName": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "AccountNumber": {
+            "description": "The account number",
+            "type": ["null", "string"]
+          },
+          "AccountId": {
+            "description": "The unique identifier for the account",
+            "type": ["null", "integer"]
+          },
+          "TimePeriod": {
+            "description": "The time period covered by the report data",
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "CampaignName": {
+            "description": "The name of the campaign",
+            "type": ["null", "string"]
+          },
+          "CampaignId": {
+            "description": "The unique identifier for the campaign",
+            "type": ["null", "integer"]
+          },
+          "AdGroupName": {
+            "description": "The name of the ad group",
+            "type": ["null", "string"]
+          },
+          "AdGroupId": {
+            "description": "The unique identifier for the ad group",
+            "type": ["null", "integer"]
+          },
+          "Country": {
+            "description": "The country where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "State": {
+            "description": "The state where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "MetroArea": {
+            "description": "The metropolitan area where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "description": "The currency code used in the report",
+            "type": ["null", "string"]
+          },
+          "AdDistribution": {
+            "description": "The distribution network of the ad",
+            "type": ["null", "string"]
+          },
+          "Impressions": {
+            "description": "The total number of impressions",
+            "type": ["null", "integer"]
+          },
+          "Clicks": {
+            "description": "The total number of clicks",
+            "type": ["null", "integer"]
+          },
+          "Ctr": {
+            "description": "The click-through rate",
+            "type": ["null", "number"]
+          },
+          "AverageCpc": {
+            "description": "The average cost per click",
+            "type": ["null", "number"]
+          },
+          "Spend": {
+            "description": "The total amount spent",
+            "type": ["null", "number"]
+          },
+          "AveragePosition": {
+            "description": "The average position where the ad is displayed",
+            "type": ["null", "number"]
+          },
+          "ProximityTargetLocation": {
+            "description": "The targeted location for proximity",
+            "type": ["null", "string"]
+          },
+          "Radius": {
+            "description": "The radius for proximity targeting",
+            "type": ["null", "integer"]
+          },
+          "Language": {
+            "description": "The language setting of the user",
+            "type": ["null", "string"]
+          },
+          "City": {
+            "description": "The city where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCountry": {
+            "description": "The query intent country",
+            "type": ["null", "string"]
+          },
+          "QueryIntentState": {
+            "description": "The query intent state",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCity": {
+            "description": "The query intent city",
+            "type": ["null", "string"]
+          },
+          "QueryIntentDMA": {
+            "description": "The query intent Designated Market Area",
+            "type": ["null", "string"]
+          },
+          "BidMatchType": {
+            "description": "The match type of the bid",
+            "type": ["null", "string"]
+          },
+          "DeliveredMatchType": {
+            "description": "The match type of the delivered item",
+            "type": ["null", "string"]
+          },
+          "Network": {
+            "description": "The network where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "TopVsOther": {
+            "description": "Indicates if the ad is shown at the top or other positions",
+            "type": ["null", "string"]
+          },
+          "DeviceType": {
+            "description": "The type of device where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "DeviceOS": {
+            "description": "The operating system of the device",
+            "type": ["null", "string"]
+          },
+          "Assists": {
+            "description": "The number of assists in conversions",
+            "type": ["null", "integer"]
+          },
+          "Conversions": {
+            "description": "The total number of conversions",
+            "type": ["null", "integer"]
+          },
+          "ConversionRate": {
+            "description": "The conversion rate",
+            "type": ["null", "number"]
+          },
+          "Revenue": {
+            "description": "The total revenue generated",
+            "type": ["null", "number"]
+          },
+          "ReturnOnAdSpend": {
+            "description": "The return on ad spend",
+            "type": ["null", "number"]
+          },
+          "CostPerConversion": {
+            "description": "The cost per conversion",
+            "type": ["null", "number"]
+          },
+          "CostPerAssist": {
+            "description": "The cost per assist in conversions",
+            "type": ["null", "number"]
+          },
+          "RevenuePerConversion": {
+            "description": "The revenue per conversion",
+            "type": ["null", "number"]
+          },
+          "RevenuePerAssist": {
+            "description": "The revenue per assist in conversions",
+            "type": ["null", "number"]
+          },
+          "County": {
+            "description": "The county where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "PostalCode": {
+            "description": "The postal code of the location",
+            "type": ["null", "string"]
+          },
+          "QueryIntentCounty": {
+            "description": "The query intent county",
+            "type": ["null", "string"]
+          },
+          "QueryIntentPostalCode": {
+            "description": "The query intent postal code",
+            "type": ["null", "string"]
+          },
+          "LocationId": {
+            "description": "The unique identifier for the location",
+            "type": ["null", "integer"]
+          },
+          "QueryIntentLocationId": {
+            "description": "The query intent location identifier",
+            "type": ["null", "integer"]
+          },
+          "AllConversions": {
+            "description": "The total number of all conversions",
+            "type": ["null", "integer"]
+          },
+          "AllRevenue": {
+            "description": "The total revenue for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionRate": {
+            "description": "The conversion rate for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllCostPerConversion": {
+            "description": "The cost per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllReturnOnAdSpend": {
+            "description": "The return on ad spend for all conversions",
+            "type": ["null", "number"]
+          },
+          "AllRevenuePerConversion": {
+            "description": "The revenue per conversion for all conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversions": {
+            "description": "The number of conversions where the ad was displayed but not clicked",
+            "type": ["null", "integer"]
+          },
+          "Goal": {
+            "description": "The goal associated with the report data",
+            "type": ["null", "string"]
+          },
+          "GoalType": {
+            "description": "The type of goal associated with the report data",
+            "type": ["null", "string"]
+          },
+          "AbsoluteTopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the absolute top of the page",
+            "type": ["null", "number"]
+          },
+          "TopImpressionRatePercent": {
+            "description": "The percentage of impressions shown at the top position",
+            "type": ["null", "number"]
+          },
+          "AverageCpm": {
+            "description": "The average cost per thousand impressions",
+            "type": ["null", "number"]
+          },
+          "ConversionsQualified": {
+            "description": "The number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "AllConversionsQualified": {
+            "description": "The number of qualified conversions",
+            "type": ["null", "number"]
+          },
+          "ViewThroughConversionsQualified": {
+            "description": "The number of qualified view-through conversions",
+            "type": ["null", "number"]
+          },
+          "Neighborhood": {
+            "description": "The neighborhood where the ad is displayed",
+            "type": ["null", "string"]
+          },
+          "QueryIntentNeighborhood": {
+            "description": "The query intent neighborhood",
+            "type": ["null", "string"]
+          },
+          "ViewThroughRevenue": {
+            "description": "The revenue generated from view-through conversions",
+            "type": ["null", "number"]
+          },
+          "CampaignType": {
+            "description": "The type of the campaign",
+            "type": ["null", "string"]
+          },
+          "AssetGroupId": {
+            "description": "The unique identifier for the asset group",
+            "type": ["null", "integer"]
+          },
+          "AssetGroupName": {
+            "description": "The name of the asset group",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["TimePeriod"],
+      "source_defined_primary_key": [
+        ["AccountId"],
+        ["AdGroupId"],
+        ["CampaignId"],
+        ["DeliveredMatchType"],
+        ["DeviceOS"],
+        ["DeviceType"],
+        ["Language"],
+        ["LocationId"],
+        ["QueryIntentLocationId"],
+        ["TimePeriod"],
+        ["TopVsOther"]
+      ],
+      "is_resumable": true
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-bing-ads/erd/estimated_relationships.json
+++ b/airbyte-integrations/connectors/source-bing-ads/erd/estimated_relationships.json
@@ -1,0 +1,666 @@
+{
+  "streams": [
+    {
+      "name": "accounts",
+      "relations": {
+        "BackUpPaymentInstrumentId": "payment_instruments.Id",
+        "BillToCustomerId": "customers.Id",
+        "LastModifiedByUserId": "users.Id",
+        "ParentCustomerId": "customers.Id",
+        "PaymentMethodId": "payment_methods.Id",
+        "PrimaryUserId": "users.Id",
+        "SalesHouseCustomerId": "customers.Id",
+        "SoldToPaymentInstrumentId": "payment_instruments.Id"
+      }
+    },
+    {
+      "name": "ad_groups",
+      "relations": {
+        "CampaignId": "campaigns.Id",
+        "AccountId": "accounts.Id",
+        "CustomerId": "customers.Id"
+      }
+    },
+    {
+      "name": "ad_group_labels",
+      "relations": {
+        "Account Id": "accounts.Id",
+        "Parent Id": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "app_install_ads",
+      "relations": {
+        "Client Id": "accounts.Id",
+        "Parent Id": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "app_install_ad_labels",
+      "relations": {
+        "Account Id": "accounts.Id",
+        "Parent Id": "app_install_ads.Id"
+      }
+    },
+    {
+      "name": "ads",
+      "relations": {
+        "AdGroupId": "ad_groups.Id",
+        "AccountId": "accounts.Id",
+        "CustomerId": "customers.Id"
+      }
+    },
+    {
+      "name": "budget",
+      "relations": {
+        "Account Id": "accounts.Id",
+        "Client Id": "accounts.Id",
+        "Parent Id": "campaigns.Id"
+      }
+    },
+    {
+      "name": "campaigns",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CustomerId": "customers.Id",
+        "BudgetId": "budget.Budget Id"
+      }
+    },
+    {
+      "name": "budget_summary_report",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "labels",
+      "relations": {
+        "Account Id": "accounts.Id",
+        "Client Id": "accounts.Id"
+      }
+    },
+    {
+      "name": "keyword_labels",
+      "relations": {
+        "Account Id": "accounts.Id",
+        "Parent Id": "keywords.Id"
+      }
+    },
+    {
+      "name": "keywords",
+      "relations": {
+        "Account Id": "accounts.Id",
+        "Client Id": "accounts.Id",
+        "Parent Id": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "campaign_labels",
+      "relations": {
+        "Account Id": "accounts.Id",
+        "Parent Id": "campaigns.Id"
+      }
+    },
+    {
+      "name": "age_gender_audience_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "age_gender_audience_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "age_gender_audience_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "age_gender_audience_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "account_impression_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id"
+      }
+    },
+    {
+      "name": "account_impression_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id"
+      }
+    },
+    {
+      "name": "account_impression_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id"
+      }
+    },
+    {
+      "name": "account_impression_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id"
+      }
+    },
+    {
+      "name": "account_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id"
+      }
+    },
+    {
+      "name": "account_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id"
+      }
+    },
+    {
+      "name": "account_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id"
+      }
+    },
+    {
+      "name": "account_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id"
+      }
+    },
+    {
+      "name": "audience_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "audience_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "audience_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "audience_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "keyword_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "KeywordId": "keywords.Id",
+        "AdId": "ads.Id"
+      }
+    },
+    {
+      "name": "keyword_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "KeywordId": "keywords.Id",
+        "AdId": "ads.Id"
+      }
+    },
+    {
+      "name": "keyword_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "KeywordId": "keywords.Id",
+        "AdId": "ads.Id"
+      }
+    },
+    {
+      "name": "keyword_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "KeywordId": "keywords.Id",
+        "AdId": "ads.Id"
+      }
+    },
+    {
+      "name": "ad_group_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "ad_group_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "ad_group_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "ad_group_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id"
+      }
+    },
+    {
+      "name": "ad_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "AdId": "ads.Id"
+      }
+    },
+    {
+      "name": "ad_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "AdId": "ads.Id"
+      }
+    },
+    {
+      "name": "ad_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "AdId": "ads.Id"
+      }
+    },
+    {
+      "name": "ad_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "AdId": "ads.Id"
+      }
+    },
+    {
+      "name": "ad_group_impression_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "ad_group_impression_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "ad_group_impression_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "ad_group_impression_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "campaign_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "campaign_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "campaign_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "campaign_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "campaign_impression_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "campaign_impression_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "campaign_impression_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "campaign_impression_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "geographic_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "geographic_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "geographic_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "geographic_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "BaseCampaignId": "campaigns.Id"
+      }
+    },
+    {
+      "name": "goals_and_funnels_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "KeywordId": "keywords.Id"
+      }
+    },
+    {
+      "name": "goals_and_funnels_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "KeywordId": "keywords.Id"
+      }
+    },
+    {
+      "name": "goals_and_funnels_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "KeywordId": "keywords.Id"
+      }
+    },
+    {
+      "name": "goals_and_funnels_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "KeywordId": "keywords.Id"
+      }
+    },
+    {
+      "name": "product_dimension_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "AdGroupId": "ad_groups.Id",
+        "CampaignId": "campaigns.Id",
+        "AdId": "ads.Id",
+        "CampaignType": "campaigns.CampaignType",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "product_dimension_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "AdGroupId": "ad_groups.Id",
+        "CampaignId": "campaigns.Id",
+        "AdId": "ads.Id",
+        "CampaignType": "campaigns.CampaignType",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "product_dimension_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "AdGroupId": "ad_groups.Id",
+        "CampaignId": "campaigns.Id",
+        "AdId": "ads.Id",
+        "CampaignType": "campaigns.CampaignType",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "product_dimension_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "AdGroupId": "ad_groups.Id",
+        "CampaignId": "campaigns.Id",
+        "AdId": "ads.Id",
+        "CampaignType": "campaigns.CampaignType",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "product_search_query_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "AdGroupId": "ad_groups.Id",
+        "CampaignId": "campaigns.Id",
+        "AdId": "ads.Id",
+        "CampaignType": "campaigns.CampaignType",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "product_search_query_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "AdGroupId": "ad_groups.Id",
+        "CampaignId": "campaigns.Id",
+        "AdId": "ads.Id",
+        "CampaignType": "campaigns.CampaignType",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "product_search_query_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "AdGroupId": "ad_groups.Id",
+        "CampaignId": "campaigns.Id",
+        "AdId": "ads.Id",
+        "CampaignType": "campaigns.CampaignType",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "product_search_query_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "AdGroupId": "ad_groups.Id",
+        "CampaignId": "campaigns.Id",
+        "AdId": "ads.Id",
+        "CampaignType": "campaigns.CampaignType",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "search_query_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "AdId": "ads.Id",
+        "KeywordId": "keywords.Id"
+      }
+    },
+    {
+      "name": "search_query_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "AdId": "ads.Id",
+        "KeywordId": "keywords.Id"
+      }
+    },
+    {
+      "name": "search_query_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "AdId": "ads.Id",
+        "KeywordId": "keywords.Id"
+      }
+    },
+    {
+      "name": "search_query_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "AdId": "ads.Id",
+        "KeywordId": "keywords.Id"
+      }
+    },
+    {
+      "name": "user_location_performance_report_hourly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "LocationId": "geographic_performance_report_daily.LocationId",
+        "QueryIntentLocationId": "geographic_performance_report_daily.LocationId",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "user_location_performance_report_daily",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "LocationId": "geographic_performance_report_daily.LocationId",
+        "QueryIntentLocationId": "geographic_performance_report_daily.LocationId",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "user_location_performance_report_weekly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "LocationId": "geographic_performance_report_daily.LocationId",
+        "QueryIntentLocationId": "geographic_performance_report_daily.LocationId",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    },
+    {
+      "name": "user_location_performance_report_monthly",
+      "relations": {
+        "AccountId": "accounts.Id",
+        "CampaignId": "campaigns.Id",
+        "AdGroupId": "ad_groups.Id",
+        "LocationId": "geographic_performance_report_daily.LocationId",
+        "QueryIntentLocationId": "geographic_performance_report_daily.LocationId",
+        "AssetGroupId": "asset_groups.Id"
+      }
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-bing-ads/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-bing-ads/erd/source.dbml
@@ -1,0 +1,1711 @@
+Table "accounts" {
+    "Id" number [pk]
+    "AccountFinancialStatus" string
+    "AccountLifeCycleStatus" string
+    "AutoTagType" string
+    "AccountMode" string
+    "ForwardCompatibilityMap" string
+    "PaymentMethodType" string
+    "Language" string
+    "LinkedAgencies" object
+    "TaxInformation" string
+    "CurrencyCode" string
+    "TimeZone" string
+    "BusinessAddress" object
+    "BackUpPaymentInstrumentId" number
+    "BillingThresholdAmount" number
+    "BillToCustomerId" number
+    "LastModifiedByUserId" number
+    "LastModifiedTime" string
+    "Name" string
+    "Number" string
+    "ParentCustomerId" number
+    "PauseReason" number
+    "PaymentMethodId" number
+    "PrimaryUserId" number
+    "SalesHouseCustomerId" number
+    "SoldToPaymentInstrumentId" number
+    "TimeStamp" string
+    "TaxCertificate" object
+}
+
+Table "ad_groups" {
+    "CampaignId" integer
+    "AccountId" integer
+    "CustomerId" integer
+    "AdRotation" object
+    "AudienceAdsBidAdjustment" number
+    "BiddingScheme" object
+    "CpcBid" object
+    "CpvBid" object
+    "CpmBid" object
+    "EndDate" object
+    "FinalUrlSuffix" string
+    "ForwardCompatibilityMap" array
+    "Id" integer [pk]
+    "Language" string
+    "Name" string
+    "Network" string
+    "PrivacyStatus" string
+    "Settings" array
+    "StartDate" object
+    "Status" string
+    "TrackingUrlTemplate" string
+    "UrlCustomParameters" object
+    "AdScheduleUseSearcherTimeZone" boolean
+    "AdGroupType" string
+    "MultimediaAdsBidAdjustment" integer
+}
+
+Table "ad_group_labels" {
+    "Account Id" integer
+    "Ad Group" string
+    "Campaign" string
+    "Client Id" string
+    "Id" integer [pk]
+    "Parent Id" integer
+    "Modified Time" string
+    "Status" string
+}
+
+Table "app_install_ads" {
+    "Ad Group" string
+    "App Id" integer
+    "Campaign" string
+    "Client Id" integer
+    "Custom Parameter" string
+    "Device Preference" string
+    "Editorial Appeal Status" string
+    "Editorial Location" string
+    "Editorial Reason Code" string
+    "Editorial Status" string
+    "Editorial Term" string
+    "Final Url" string
+    "Final Url Suffix" string
+    "Id" integer [pk]
+    "Modified Time" string
+    "Parent Id" integer
+    "Publisher Countries" string
+    "Status" string
+    "Text" string
+    "Title" string
+    "Tracking Template" string
+}
+
+Table "app_install_ad_labels" {
+    "Account Id" integer
+    "Client Id" string
+    "Id" integer [pk]
+    "Parent Id" integer
+    "Modified Time" string
+    "Status" string
+}
+
+Table "ads" {
+    "AdGroupId" integer
+    "AccountId" integer
+    "CustomerId" integer
+    "AdFormatPreference" string
+    "DevicePreference" integer
+    "EditorialStatus" string
+    "BusinessName" string
+    "CallToAction" string
+    "CallToActionLanguage" string
+    "Headline" string
+    "Images" object
+    "Videos" object
+    "LongHeadlines" object
+    "LongHeadline" object
+    "LongHeadlineString" string
+    "Text" string
+    "TextPart2" string
+    "TitlePart1" string
+    "TitlePart2" string
+    "TitlePart3" string
+    "FinalAppUrls" null
+    "FinalMobileUrls" object
+    "FinalUrlSuffix" string
+    "FinalUrls" object
+    "ForwardCompatibilityMap" array
+    "Id" integer [pk]
+    "Status" string
+    "TrackingUrlTemplate" string
+    "Type" string
+    "UrlCustomParameters" object
+    "Descriptions" object
+    "Domain" string
+    "Headlines" object
+    "Path1" string
+    "Path2" string
+}
+
+Table "budget" {
+    "Account Id" integer
+    "Type" string
+    "Status" string
+    "Id" integer [pk]
+    "Parent Id" integer
+    "Client Id" integer
+    "Modified Time" string
+    "Budget Id" integer
+    "Budget Name" string
+    "Budget" number
+    "Budget Type" string
+}
+
+Table "campaigns" {
+    "AccountId" integer
+    "CustomerId" integer
+    "AudienceAdsBidAdjustment" number
+    "BiddingScheme" object
+    "BudgetType" string
+    "MultimediaAdsBidAdjustment" number
+    "DailyBudget" number
+    "ExperimentId" number
+    "FinalUrlSuffix" string
+    "ForwardCompatibilityMap" array
+    "Id" number [pk]
+    "Name" string
+    "Status" string
+    "SubType" string
+    "TimeZone" string
+    "TrackingUrlTemplate" string
+    "UrlCustomParameters" object
+    "CampaignType" string
+    "Settings" object
+    "BudgetId" number
+    "Languages" object
+    "AdScheduleUseSearcherTimeZone" boolean
+}
+
+Table "budget_summary_report" {
+    "AccountName" string
+    "AccountNumber" string
+    "AccountId" integer
+    "CampaignId" integer
+    "CampaignName" string
+    "Date" string [pk]
+    "MonthlyBudget" number
+    "DailySpend" number
+    "MonthToDateSpend" number
+}
+
+Table "labels" {
+    "Account Id" integer
+    "Color" string
+    "Client Id" string
+    "Description" string
+    "Id" integer [pk]
+    "Label" string
+    "Modified Time" string
+    "Status" string
+}
+
+Table "keyword_labels" {
+    "Account Id" integer
+    "Client Id" string
+    "Id" integer [pk]
+    "Parent Id" integer
+    "Modified Time" string
+    "Status" string
+}
+
+Table "keywords" {
+    "Account Id" integer
+    "Id" integer [pk]
+    "Ad Group" string
+    "Bid" string
+    "Bid Strategy Type" string
+    "Campaign" string
+    "Client Id" integer
+    "Custom Parameter" string
+    "Destination Url" string
+    "Modified Time" string
+    "Editorial Appeal Status" string
+    "Editorial Location" string
+    "Editorial Reason Code" string
+    "Editorial Status" string
+    "Editorial Term" string
+    "Final Url" string
+    "Final Url Suffix" string
+    "Inherited Bid Strategy Type" string
+    "Keyword" string
+    "Keyword Relevance" string
+    "Landing Page Relevance" string
+    "Landing Page User Experience" string
+    "Match Type" string
+    "Mobile Final Url" string
+    "Param1" string
+    "Param2" string
+    "Param3" string
+    "Parent Id" string
+    "Publisher Countries" string
+    "Quality Score" string
+    "Status" string
+    "Tracking Template" string
+}
+
+Table "campaign_labels" {
+    "Account Id" integer
+    "Campaign" string
+    "Client Id" string
+    "Id" integer [pk]
+    "Parent Id" integer
+    "Modified Time" string
+    "Status" string
+}
+
+Table "age_gender_audience_report_hourly" {
+    "AccountId" integer
+    "AgeGroup" string
+    "Gender" string
+    "TimePeriod" string
+    "AllConversions" integer
+    "AccountName" string
+    "AccountNumber" string
+    "CampaignName" string
+    "CampaignId" integer
+    "AdGroupName" string
+    "AdGroupId" integer
+    "AdDistribution" string
+    "Impressions" integer
+    "Clicks" integer
+    "Conversions" number
+    "Spend" number
+    "Revenue" number
+    "ExtendedCost" number
+    "Assists" integer
+    "Language" string
+    "AccountStatus" string
+    "CampaignStatus" string
+    "AdGroupStatus" string
+    "BaseCampaignId" string
+    "AllRevenue" number
+    "ViewThroughConversions" integer
+    "Goal" string
+    "GoalType" string
+    "AbsoluteTopImpressionRatePercent" number
+    "TopImpressionRatePercent" number
+    "ConversionsQualified" number
+    "AllConversionsQualified" number
+    "ViewThroughConversionsQualified" number
+    "ViewThroughRevenue" number
+
+    indexes {
+        (AgeGroup, Gender, TimePeriod, AccountId, CampaignId, Language, AdDistribution) [pk]
+    }
+}
+
+Table "account_impression_performance_report_hourly" {
+    "AccountName" string
+    "AccountNumber" string
+    "AccountId" integer
+    "TimePeriod" string
+    "CurrencyCode" string
+    "AdDistribution" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "AverageCpc" number
+    "Spend" number
+    "AveragePosition" number
+    "Conversions" integer
+    "ConversionRate" number
+    "CostPerConversion" number
+    "LowQualityClicks" integer
+    "LowQualityClicksPercent" number
+    "LowQualityImpressions" integer
+    "LowQualityImpressionsPercent" number
+    "LowQualityConversions" integer
+    "LowQualityConversionRate" number
+    "DeviceType" string
+    "PhoneImpressions" integer
+    "PhoneCalls" integer
+    "Ptr" number
+    "Network" string
+    "Assists" integer
+    "Revenue" number
+    "ReturnOnAdSpend" number
+    "CostPerAssist" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+    "AccountStatus" string
+    "LowQualityGeneralClicks" integer
+    "LowQualitySophisticatedClicks" integer
+    "TopImpressionRatePercent" number
+    "AllConversions" integer
+    "AllRevenue" number
+    "AllConversionRate" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "AllRevenuePerConversion" number
+    "ViewThroughConversions" integer
+    "AverageCpm" number
+    "ConversionsQualified" number
+    "LowQualityConversionsQualified" number
+    "AllConversionsQualified" number
+    "ViewThroughConversionsQualified" number
+    "ViewThroughRevenue" number
+    "VideoViews" integer
+    "ViewThroughRate" number
+    "AverageCPV" number
+    "VideoViewsAt25Percent" integer
+    "VideoViewsAt50Percent" integer
+    "VideoViewsAt75Percent" integer
+    "CompletedVideoViews" integer
+    "VideoCompletionRate" number
+    "TotalWatchTimeInMS" integer
+    "AverageWatchTimePerVideoView" number
+    "AverageWatchTimePerImpression" number
+    "Sales" integer
+    "CostPerSale" number
+    "RevenuePerSale" number
+    "Installs" integer
+    "CostPerInstall" number
+    "RevenuePerInstall" number
+}
+
+Table "account_performance_report_hourly" {
+    "AccountId" integer
+    "TimePeriod" string
+    "CurrencyCode" string
+    "AdDistribution" string
+    "DeviceType" string
+    "Network" string
+    "DeliveredMatchType" string
+    "DeviceOS" string
+    "TopVsOther" string
+    "BidMatchType" string
+    "AccountName" string
+    "AccountNumber" string
+    "PhoneImpressions" integer
+    "PhoneCalls" integer
+    "Clicks" integer
+    "Ctr" number
+    "Spend" number
+    "Impressions" integer
+    "CostPerConversion" number
+    "Ptr" number
+    "Assists" integer
+    "ReturnOnAdSpend" number
+    "CostPerAssist" number
+    "AverageCpc" number
+    "AveragePosition" number
+    "AverageCpm" number
+    "Conversions" number
+    "ConversionsQualified" number
+    "ConversionRate" number
+    "LowQualityClicks" integer
+    "LowQualityClicksPercent" number
+    "LowQualityImpressions" integer
+    "LowQualitySophisticatedClicks" integer
+    "LowQualityConversions" integer
+    "LowQualityConversionRate" number
+    "Revenue" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+
+    indexes {
+        (AccountId, TimePeriod, CurrencyCode, AdDistribution, DeviceType, Network, DeliveredMatchType, DeviceOS, TopVsOther, BidMatchType) [pk]
+    }
+}
+
+Table "audience_performance_report_hourly" {
+    "AccountName" string
+    "AccountNumber" string
+    "AccountId" integer
+    "TimePeriod" string
+    "CampaignName" string
+    "CampaignId" integer
+    "AdGroupName" string
+    "AdGroupId" integer
+    "AudienceId" integer
+    "AudienceName" string
+    "AssociationStatus" string
+    "BidAdjustment" number
+    "TargetingSetting" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "AverageCpc" number
+    "Spend" number
+    "AveragePosition" number
+    "Conversions" integer
+    "ConversionRate" number
+    "CostPerConversion" number
+    "Revenue" number
+    "ReturnOnAdSpend" number
+    "RevenuePerConversion" number
+    "AccountStatus" string
+    "CampaignStatus" string
+    "AdGroupStatus" string
+    "AudienceType" string
+    "BaseCampaignId" integer
+    "AllConversions" integer
+    "AllRevenue" number
+    "AllConversionRate" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "AllRevenuePerConversion" number
+    "AssociationId" integer
+    "AssociationLevel" string
+    "ViewThroughConversions" integer
+    "Goal" string
+    "GoalType" string
+    "AbsoluteTopImpressionRatePercent" number
+    "TopImpressionRatePercent" number
+    "AverageCpm" number
+    "ConversionsQualified" number
+    "AllConversionsQualified" number
+    "ViewThroughConversionsQualified" number
+    "ViewThroughRevenue" number
+
+    indexes {
+        (AudienceId, TimePeriod, AccountId, CampaignId, AdGroupId) [pk]
+    }
+}
+
+Table "keyword_performance_report_hourly" {
+    "AccountId" integer
+    "CampaignId" integer
+    "AdGroupId" integer
+    "KeywordId" integer
+    "Keyword" string
+    "AdId" integer
+    "TimePeriod" string
+    "CurrencyCode" string
+    "DeliveredMatchType" string
+    "AdDistribution" string
+    "DeviceType" string
+    "Language" string
+    "Network" string
+    "DeviceOS" string
+    "TopVsOther" string
+    "BidMatchType" string
+    "AccountName" string
+    "CampaignName" string
+    "AdGroupName" string
+    "KeywordStatus" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "CurrentMaxCpc" number
+    "Spend" number
+    "CostPerConversion" number
+    "QualityScore" number
+    "ExpectedCtr" string
+    "AdRelevance" number
+    "LandingPageExperience" number
+    "QualityImpact" number
+    "Assists" integer
+    "ReturnOnAdSpend" number
+    "CostPerAssist" number
+    "CustomParameters" string
+    "FinalAppUrl" string
+    "Mainline1Bid" number
+    "MainlineBid" number
+    "FirstPageBid" number
+    "FinalUrlSuffix" string
+    "ViewThroughConversions" integer
+    "ViewThroughConversionsQualified" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "Conversions" number
+    "ConversionRate" number
+    "ConversionsQualified" number
+    "AverageCpc" number
+    "AveragePosition" number
+    "AverageCpm" number
+    "AllConversions" integer
+    "AllConversionRate" number
+    "AllRevenue" number
+    "AllRevenuePerConversion" number
+    "Revenue" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+    "CampaignStatus" string
+    "TopImpressionRatePercent" number
+    "AdGroupStatus" string
+    "TrackingTemplate" string
+    "BidStrategyType" string
+    "AccountStatus" string
+    "FinalUrl" string
+    "AdType" string
+    "KeywordLabels" string
+    "FinalMobileUrl" string
+    "Goal" string
+    "GoalType" string
+    "AbsoluteTopImpressionRatePercent" number
+    "BaseCampaignId" integer
+    "AccountNumber" string
+    "DestinationUrl" string
+
+    indexes {
+        (AccountId, CampaignId, AdGroupId, KeywordId, AdId, TimePeriod, CurrencyCode, DeliveredMatchType, AdDistribution, DeviceType, Language, Network, DeviceOS, TopVsOther, BidMatchType) [pk]
+    }
+}
+
+Table "keyword_performance_report_daily" {
+    "AccountId" integer
+    "CampaignId" integer
+    "AdGroupId" integer
+    "KeywordId" integer
+    "Keyword" string
+    "AdId" integer
+    "TimePeriod" string
+    "CurrencyCode" string
+    "DeliveredMatchType" string
+    "AdDistribution" string
+    "DeviceType" string
+    "Language" string
+    "Network" string
+    "DeviceOS" string
+    "TopVsOther" string
+    "BidMatchType" string
+    "AccountName" string
+    "CampaignName" string
+    "AdGroupName" string
+    "KeywordStatus" string
+    "HistoricalExpectedCtr" number
+    "HistoricalAdRelevance" number
+    "HistoricalLandingPageExperience" number
+    "HistoricalQualityScore" number
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "CurrentMaxCpc" number
+    "Spend" number
+    "CostPerConversion" number
+    "QualityScore" number
+    "ExpectedCtr" string
+    "AdRelevance" number
+    "LandingPageExperience" number
+    "QualityImpact" number
+    "Assists" integer
+    "ReturnOnAdSpend" number
+    "CostPerAssist" number
+    "CustomParameters" string
+    "FinalAppUrl" string
+    "Mainline1Bid" number
+    "MainlineBid" number
+    "FirstPageBid" number
+    "FinalUrlSuffix" string
+    "ViewThroughConversions" integer
+    "ViewThroughConversionsQualified" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "Conversions" number
+    "ConversionRate" number
+    "ConversionsQualified" number
+    "AverageCpc" number
+    "AveragePosition" number
+    "AverageCpm" number
+    "AllConversions" integer
+    "AllConversionRate" number
+    "AllRevenue" number
+    "AllRevenuePerConversion" number
+    "Revenue" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+    "CampaignStatus" string
+    "TopImpressionRatePercent" number
+    "AdGroupStatus" string
+    "TrackingTemplate" string
+    "BidStrategyType" string
+    "AccountStatus" string
+    "FinalUrl" string
+    "AdType" string
+    "KeywordLabels" string
+    "FinalMobileUrl" string
+    "Goal" string
+    "GoalType" string
+    "AbsoluteTopImpressionRatePercent" number
+    "BaseCampaignId" integer
+    "AccountNumber" string
+    "DestinationUrl" string
+
+    indexes {
+        (AccountId, CampaignId, AdGroupId, KeywordId, AdId, TimePeriod, CurrencyCode, DeliveredMatchType, AdDistribution, DeviceType, Language, Network, DeviceOS, TopVsOther, BidMatchType) [pk]
+    }
+}
+
+Table "ad_group_performance_report_hourly" {
+    "AccountId" integer
+    "CampaignId" integer
+    "AdGroupId" integer
+    "TimePeriod" string
+    "CurrencyCode" string
+    "AdDistribution" string
+    "DeviceType" string
+    "Network" string
+    "DeliveredMatchType" string
+    "DeviceOS" string
+    "TopVsOther" string
+    "BidMatchType" string
+    "Language" string
+    "AccountName" string
+    "CampaignName" string
+    "CampaignType" string
+    "AdGroupName" string
+    "AdGroupType" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "Spend" number
+    "CostPerConversion" number
+    "QualityScore" number
+    "ExpectedCtr" string
+    "AdRelevance" number
+    "LandingPageExperience" number
+    "PhoneImpressions" integer
+    "PhoneCalls" integer
+    "Ptr" number
+    "Assists" integer
+    "CostPerAssist" number
+    "CustomParameters" string
+    "FinalUrlSuffix" string
+    "ViewThroughConversions" integer
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "AllConversions" integer
+    "AllConversionRate" number
+    "AllRevenue" number
+    "AllRevenuePerConversion" number
+    "AverageCpc" number
+    "AveragePosition" number
+    "AverageCpm" number
+    "Conversions" number
+    "ConversionRate" number
+    "ConversionsQualified" number
+    "Revenue" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+
+    indexes {
+        (AccountId, CampaignId, AdGroupId, TimePeriod, CurrencyCode, AdDistribution, DeviceType, Network, DeliveredMatchType, DeviceOS, TopVsOther, BidMatchType, Language) [pk]
+    }
+}
+
+Table "ad_performance_report_hourly" {
+    "AccountId" integer
+    "CampaignId" integer
+    "AdGroupId" integer
+    "AdId" integer
+    "TimePeriod" string
+    "CurrencyCode" string
+    "AdDistribution" string
+    "DeviceType" string
+    "Language" string
+    "Network" string
+    "DeviceOS" string
+    "TopVsOther" string
+    "BidMatchType" string
+    "DeliveredMatchType" string
+    "AccountName" string
+    "CampaignName" string
+    "CampaignType" string
+    "AdGroupName" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "Spend" number
+    "CostPerConversion" number
+    "DestinationUrl" string
+    "Assists" integer
+    "ReturnOnAdSpend" number
+    "CostPerAssist" number
+    "CustomParameters" string
+    "FinalAppUrl" string
+    "AdDescription" string
+    "AdDescription2" string
+    "ViewThroughConversions" integer
+    "ViewThroughConversionsQualified" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "Conversions" number
+    "ConversionRate" number
+    "ConversionsQualified" number
+    "AverageCpc" number
+    "AveragePosition" number
+    "AverageCpm" number
+    "AllConversions" integer
+    "AllConversionRate" number
+    "AllRevenue" number
+    "AllRevenuePerConversion" number
+    "Revenue" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+
+    indexes {
+        (AccountId, CampaignId, AdGroupId, AdId, TimePeriod, CurrencyCode, AdDistribution, DeviceType, Language, Network, DeviceOS, TopVsOther, BidMatchType, DeliveredMatchType) [pk]
+    }
+}
+
+Table "ad_group_impression_performance_report_hourly" {
+    "AccountName" string
+    "AccountNumber" string
+    "AccountId" integer
+    "TimePeriod" string
+    "Status" string
+    "CampaignName" string
+    "CampaignId" integer
+    "AdGroupName" string
+    "AdGroupId" integer
+    "CurrencyCode" string
+    "AdDistribution" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "AverageCpc" number
+    "Spend" number
+    "AveragePosition" number
+    "Conversions" integer
+    "ConversionRate" number
+    "CostPerConversion" number
+    "DeviceType" string
+    "Language" string
+    "QualityScore" integer
+    "ExpectedCtr" number
+    "AdRelevance" integer
+    "LandingPageExperience" integer
+    "PhoneImpressions" integer
+    "PhoneCalls" integer
+    "Ptr" number
+    "Network" string
+    "Assists" integer
+    "Revenue" number
+    "ReturnOnAdSpend" number
+    "CostPerAssist" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+    "TrackingTemplate" string
+    "CustomParameters" string
+    "AccountStatus" string
+    "CampaignStatus" string
+    "AdGroupLabels" string
+    "FinalUrlSuffix" string
+    "CampaignType" string
+    "TopImpressionSharePercent" number
+    "AbsoluteTopImpressionRatePercent" number
+    "TopImpressionRatePercent" number
+    "BaseCampaignId" integer
+    "AllConversions" integer
+    "AllRevenue" number
+    "AllConversionRate" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "AllRevenuePerConversion" number
+    "ViewThroughConversions" integer
+    "AdGroupType" string
+    "AverageCpm" number
+    "ConversionsQualified" number
+    "AllConversionsQualified" number
+    "ViewThroughConversionsQualified" number
+    "ViewThroughRevenue" number
+    "VideoViews" integer
+    "ViewThroughRate" number
+    "AverageCPV" number
+    "VideoViewsAt25Percent" integer
+    "VideoViewsAt50Percent" integer
+    "VideoViewsAt75Percent" integer
+    "CompletedVideoViews" integer
+    "VideoCompletionRate" number
+    "TotalWatchTimeInMS" integer
+    "AverageWatchTimePerVideoView" number
+    "AverageWatchTimePerImpression" number
+    "Sales" integer
+    "CostPerSale" number
+    "RevenuePerSale" number
+    "Installs" integer
+    "CostPerInstall" number
+    "RevenuePerInstall" number
+
+    indexes {
+        (TimePeriod, Network, DeviceType) [pk]
+    }
+}
+
+Table "campaign_performance_report_hourly" {
+    "AccountId" integer
+    "CampaignId" integer
+    "TimePeriod" string
+    "CurrencyCode" string
+    "AdDistribution" string
+    "DeviceType" string
+    "Network" string
+    "DeliveredMatchType" string
+    "DeviceOS" string
+    "TopVsOther" string
+    "BidMatchType" string
+    "AccountName" string
+    "CampaignName" string
+    "CampaignType" string
+    "CampaignStatus" string
+    "CampaignLabels" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "Spend" number
+    "CostPerConversion" number
+    "QualityScore" number
+    "AdRelevance" number
+    "LandingPageExperience" number
+    "PhoneImpressions" integer
+    "PhoneCalls" integer
+    "Ptr" number
+    "Assists" integer
+    "ReturnOnAdSpend" number
+    "CostPerAssist" number
+    "CustomParameters" string
+    "ViewThroughConversions" integer
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "AllConversions" integer
+    "ConversionsQualified" number
+    "AllConversionRate" number
+    "AllRevenue" number
+    "AllRevenuePerConversion" number
+    "AverageCpc" number
+    "AveragePosition" number
+    "AverageCpm" number
+    "Conversions" number
+    "ConversionRate" number
+    "LowQualityClicks" integer
+    "LowQualityClicksPercent" number
+    "LowQualityImpressions" integer
+    "LowQualitySophisticatedClicks" integer
+    "LowQualityConversions" integer
+    "LowQualityConversionRate" number
+    "Revenue" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+    "BudgetName" string
+    "BudgetStatus" string
+    "BudgetAssociationStatus" string
+
+    indexes {
+        (AccountId, CampaignId, TimePeriod, CurrencyCode, AdDistribution, DeviceType, Network, DeliveredMatchType, DeviceOS, TopVsOther, BidMatchType) [pk]
+    }
+}
+
+Table "campaign_impression_performance_report_hourly" {
+    "AccountName" string
+    "AccountNumber" string
+    "AccountId" integer
+    "TimePeriod" string
+    "CampaignStatus" string
+    "CampaignName" string
+    "CampaignId" integer
+    "CurrencyCode" string
+    "AdDistribution" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "AverageCpc" number
+    "Spend" number
+    "AveragePosition" number
+    "Conversions" integer
+    "ConversionRate" number
+    "CostPerConversion" number
+    "LowQualityClicks" integer
+    "LowQualityClicksPercent" number
+    "LowQualityImpressions" integer
+    "LowQualityImpressionsPercent" number
+    "LowQualityConversions" integer
+    "LowQualityConversionRate" number
+    "DeviceType" string
+    "QualityScore" number
+    "ExpectedCtr" string
+    "AdRelevance" number
+    "LandingPageExperience" number
+    "PhoneImpressions" integer
+    "PhoneCalls" integer
+    "Ptr" number
+    "Network" string
+    "Assists" integer
+    "Revenue" number
+    "ReturnOnAdSpend" number
+    "CostPerAssist" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+    "TrackingTemplate" string
+    "CustomParameters" string
+    "AccountStatus" string
+    "LowQualityGeneralClicks" integer
+    "LowQualitySophisticatedClicks" integer
+    "CampaignLabels" string
+    "FinalUrlSuffix" string
+    "CampaignType" string
+    "AbsoluteTopImpressionRatePercent" number
+    "TopImpressionRatePercent" number
+    "BaseCampaignId" integer
+    "AllConversions" integer
+    "AllRevenue" number
+    "AllConversionRate" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "AllRevenuePerConversion" number
+    "ViewThroughConversions" integer
+    "AverageCpm" number
+    "ConversionsQualified" number
+    "LowQualityConversionsQualified" number
+    "AllConversionsQualified" number
+    "ViewThroughConversionsQualified" number
+    "ViewThroughRevenue" number
+    "VideoViews" integer
+    "ViewThroughRate" number
+    "AverageCPV" number
+    "VideoViewsAt25Percent" integer
+    "VideoViewsAt50Percent" integer
+    "VideoViewsAt75Percent" integer
+    "CompletedVideoViews" integer
+    "VideoCompletionRate" number
+    "TotalWatchTimeInMS" integer
+    "AverageWatchTimePerVideoView" number
+    "AverageWatchTimePerImpression" number
+    "Sales" integer
+    "CostPerSale" number
+    "RevenuePerSale" number
+    "Installs" integer
+    "CostPerInstall" number
+    "RevenuePerInstall" number
+}
+
+Table "geographic_performance_report_hourly" {
+    "AccountId" integer
+    "CampaignId" integer
+    "AdGroupId" integer
+    "TimePeriod" string
+    "AccountNumber" string
+    "Country" string
+    "State" string
+    "MetroArea" string
+    "City" string
+    "ProximityTargetLocation" string
+    "Radius" string
+    "LocationType" string
+    "MostSpecificLocation" string
+    "AccountStatus" string
+    "CampaignStatus" string
+    "AdGroupStatus" string
+    "County" string
+    "PostalCode" string
+    "LocationId" string
+    "BaseCampaignId" string
+    "Goal" string
+    "GoalType" string
+    "AbsoluteTopImpressionRatePercent" number
+    "TopImpressionRatePercent" string
+    "AllConversionsQualified" string
+    "Neighborhood" string
+    "ViewThroughRevenue" string
+    "CampaignType" string
+    "AssetGroupId" string
+    "AssetGroupName" string
+    "AssetGroupStatus" string
+    "CurrencyCode" string
+    "DeliveredMatchType" string
+    "AdDistribution" string
+    "DeviceType" string
+    "Language" string
+    "Network" string
+    "DeviceOS" string
+    "TopVsOther" string
+    "BidMatchType" string
+    "AccountName" string
+    "CampaignName" string
+    "AdGroupName" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "Spend" number
+    "CostPerConversion" number
+    "Assists" integer
+    "ReturnOnAdSpend" number
+    "CostPerAssist" number
+    "ViewThroughConversions" integer
+    "ViewThroughConversionsQualified" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "Conversions" number
+    "ConversionRate" number
+    "ConversionsQualified" number
+    "AverageCpc" number
+    "AveragePosition" number
+    "AverageCpm" number
+    "AllConversions" integer
+    "AllConversionRate" number
+    "AllRevenue" number
+    "AllRevenuePerConversion" number
+    "Revenue" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+}
+
+Table "goals_and_funnels_report_hourly" {
+    "AccountName" string
+    "AccountNumber" string
+    "AccountId" string
+    "TimePeriod" string
+    "CampaignName" string
+    "CampaignId" integer
+    "AdGroupName" string
+    "AdGroupId" integer
+    "Keyword" string
+    "KeywordId" integer
+    "Goal" string
+    "AllConversions" integer
+    "Assists" integer
+    "AllRevenue" number
+    "GoalId" integer
+    "DeviceType" string
+    "DeviceOS" string
+    "AccountStatus" string
+    "CampaignStatus" string
+    "AdGroupStatus" string
+    "KeywordStatus" string
+    "GoalType" string
+    "ViewThroughConversions" integer
+    "AllConversionsQualified" number
+    "ViewThroughConversionsQualified" number
+    "ViewThroughRevenue" number
+
+    indexes {
+        (GoalId, TimePeriod, AccountId, CampaignId, DeviceType, DeviceOS, AdGroupId) [pk]
+    }
+}
+
+Table "product_dimension_performance_report_hourly" {
+    "AccountId" integer
+    "TimePeriod" string
+    "AccountName" string
+    "AccountNumber" string
+    "AdGroupName" string
+    "AdGroupId" integer
+    "CampaignStatus" string
+    "AccountStatus" string
+    "AdGroupStatus" string
+    "Network" string
+    "AdId" integer
+    "CampaignId" integer
+    "CampaignName" string
+    "CurrencyCode" string
+    "DeviceType" string
+    "Language" string
+    "MerchantProductId" string
+    "Title" string
+    "Condition" string
+    "Brand" string
+    "Price" number
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "AverageCpc" number
+    "Spend" number
+    "Conversions" integer
+    "ConversionRate" number
+    "Revenue" number
+    "RevenuePerConversion" number
+    "SellerName" string
+    "OfferLanguage" string
+    "CountryOfSale" string
+    "AdStatus" string
+    "AdDistribution" string
+    "ClickTypeId" string
+    "TotalClicksOnAdElements" number
+    "ClickType" string
+    "ReturnOnAdSpend" number
+    "BidStrategyType" string
+    "LocalStoreCode" string
+    "StoreId" string
+    "AssistedClicks" string
+    "AssistedConversions" string
+    "AllConversions" integer
+    "AllRevenue" number
+    "AllConversionRate" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "AllRevenuePerConversion" number
+    "CostPerConversion" number
+    "ViewThroughConversions" integer
+    "Goal" string
+    "GoalType" string
+    "ProductBought" string
+    "QuantityBought" string
+    "AverageCpm" number
+    "ConversionsQualified" number
+    "AssistedConversionsQualified" string
+    "ViewThroughConversionsQualified" number
+    "ProductBoughtTitle" string
+    "GTIN" string
+    "MPN" string
+    "ViewThroughRevenue" number
+    "Sales" integer
+    "CostPerSale" number
+    "RevenuePerSale" number
+    "Installs" integer
+    "CostPerInstall" number
+    "RevenuePerInstall" number
+    "CampaignType" string
+    "AssetGroupId" string
+    "AssetGroupName" string
+    "AssetGroupStatus" string
+    "CustomLabel0" string
+    "CustomLabel1" string
+    "CustomLabel2" string
+    "CustomLabel3" string
+    "CustomLabel4" string
+    "ProductType1" string
+    "ProductType2" string
+    "ProductType3" string
+    "ProductType4" string
+    "ProductType5" string
+}
+
+Table "product_search_query_performance_report_hourly" {
+    "TimePeriod" string
+    "AccountId" integer
+    "AccountNumber" string
+    "AccountName" string
+    "AdId" integer
+    "AdGroupId" integer
+    "AdGroupName" string
+    "CampaignId" integer
+    "CampaignName" string
+    "DestinationUrl" string
+    "DeviceType" string
+    "DeviceOS" string
+    "Language" string
+    "SearchQuery" string
+    "Network" string
+    "MerchantProductId" string
+    "Title" string
+    "ClickTypeId" string
+    "TotalClicksOnAdElements" number
+    "ClickType" string
+    "AdGroupCriterionId" string
+    "ProductGroup" string
+    "PartitionType" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "AverageCpc" number
+    "Spend" number
+    "Conversions" integer
+    "ConversionRate" number
+    "Assists" integer
+    "CostPerAssist" number
+    "Revenue" number
+    "CostPerConversion" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+    "CustomerId" integer
+    "CustomerName" string
+    "AssistedImpressions" integer
+    "AssistedClicks" integer
+    "AssistedConversions" integer
+    "AllConversions" integer
+    "AllRevenue" number
+    "AllConversionRate" number
+    "AllCostPerConversion" number
+    "AllRevenuePerConversion" number
+    "Goal" string
+    "GoalType" string
+    "AbsoluteTopImpressionRatePercent" number
+    "AverageCpm" number
+    "ConversionsQualified" number
+    "AssistedConversionsQualified" number
+    "AllConversionsQualified" number
+    "CampaignType" string
+    "AssetGroupId" integer
+    "AssetGroupName" string
+
+    indexes {
+        (AccountId, TimePeriod, CampaignId, AdId, AdGroupId, SearchQuery, DeviceType, DeviceOS, Language, Network) [pk]
+    }
+}
+
+Table "search_query_performance_report_hourly" {
+    "AccountName" string
+    "AccountNumber" string
+    "AccountId" integer
+    "TimePeriod" string
+    "CampaignName" string
+    "CampaignId" integer
+    "AdGroupName" string
+    "AdGroupId" integer
+    "AdId" integer
+    "AdType" string
+    "DestinationUrl" string
+    "BidMatchType" string
+    "DeliveredMatchType" string
+    "CampaignStatus" string
+    "AdStatus" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "AverageCpc" number
+    "Spend" number
+    "AveragePosition" number
+    "SearchQuery" string
+    "Keyword" string
+    "AdGroupCriterionId" string
+    "Conversions" integer
+    "ConversionRate" number
+    "CostPerConversion" number
+    "Language" string
+    "KeywordId" integer
+    "Network" string
+    "TopVsOther" string
+    "DeviceType" string
+    "DeviceOS" string
+    "Assists" integer
+    "Revenue" number
+    "ReturnOnAdSpend" number
+    "CostPerAssist" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+    "AccountStatus" string
+    "AdGroupStatus" string
+    "KeywordStatus" string
+    "CampaignType" string
+    "CustomerId" integer
+    "CustomerName" string
+    "AllConversions" integer
+    "AllRevenue" number
+    "AllConversionRate" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "AllRevenuePerConversion" number
+    "Goal" string
+    "GoalType" string
+    "AbsoluteTopImpressionRatePercent" number
+    "TopImpressionRatePercent" number
+    "AverageCpm" number
+    "ConversionsQualified" number
+    "AllConversionsQualified" number
+
+    indexes {
+        (SearchQuery, Keyword, TimePeriod, AccountId, CampaignId, Language, DeliveredMatchType, DeviceType, DeviceOS, TopVsOther) [pk]
+    }
+}
+
+Table "user_location_performance_report_hourly" {
+    "AccountName" string
+    "AccountNumber" string
+    "AccountId" integer
+    "TimePeriod" string
+    "CampaignName" string
+    "CampaignId" integer
+    "AdGroupName" string
+    "AdGroupId" integer
+    "Country" string
+    "State" string
+    "MetroArea" string
+    "CurrencyCode" string
+    "AdDistribution" string
+    "Impressions" integer
+    "Clicks" integer
+    "Ctr" number
+    "AverageCpc" number
+    "Spend" number
+    "AveragePosition" number
+    "ProximityTargetLocation" string
+    "Radius" integer
+    "Language" string
+    "City" string
+    "QueryIntentCountry" string
+    "QueryIntentState" string
+    "QueryIntentCity" string
+    "QueryIntentDMA" string
+    "BidMatchType" string
+    "DeliveredMatchType" string
+    "Network" string
+    "TopVsOther" string
+    "DeviceType" string
+    "DeviceOS" string
+    "Assists" integer
+    "Conversions" integer
+    "ConversionRate" number
+    "Revenue" number
+    "ReturnOnAdSpend" number
+    "CostPerConversion" number
+    "CostPerAssist" number
+    "RevenuePerConversion" number
+    "RevenuePerAssist" number
+    "County" string
+    "PostalCode" string
+    "QueryIntentCounty" string
+    "QueryIntentPostalCode" string
+    "LocationId" integer
+    "QueryIntentLocationId" integer
+    "AllConversions" integer
+    "AllRevenue" number
+    "AllConversionRate" number
+    "AllCostPerConversion" number
+    "AllReturnOnAdSpend" number
+    "AllRevenuePerConversion" number
+    "ViewThroughConversions" integer
+    "Goal" string
+    "GoalType" string
+    "AbsoluteTopImpressionRatePercent" number
+    "TopImpressionRatePercent" number
+    "AverageCpm" number
+    "ConversionsQualified" number
+    "AllConversionsQualified" number
+    "ViewThroughConversionsQualified" number
+    "Neighborhood" string
+    "QueryIntentNeighborhood" string
+    "ViewThroughRevenue" number
+    "CampaignType" string
+    "AssetGroupId" integer
+    "AssetGroupName" string
+
+    indexes {
+        (AccountId, AdGroupId, CampaignId, DeliveredMatchType, DeviceOS, DeviceType, Language, LocationId, QueryIntentLocationId, TimePeriod, TopVsOther) [pk]
+    }
+}
+
+Ref {
+    "ad_groups"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "ad_groups"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "ad_group_labels"."Account Id" <> "accounts"."Id"
+}
+
+Ref {
+    "ad_group_labels"."Parent Id" <> "ad_groups"."Id"
+}
+
+Ref {
+    "app_install_ads"."Client Id" <> "accounts"."Id"
+}
+
+Ref {
+    "app_install_ads"."Parent Id" <> "ad_groups"."Id"
+}
+
+Ref {
+    "app_install_ad_labels"."Account Id" <> "accounts"."Id"
+}
+
+Ref {
+    "app_install_ad_labels"."Parent Id" <> "app_install_ads"."Id"
+}
+
+Ref {
+    "ads"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "ads"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "budget"."Account Id" <> "accounts"."Id"
+}
+
+Ref {
+    "budget"."Client Id" <> "accounts"."Id"
+}
+
+Ref {
+    "budget"."Parent Id" <> "campaigns"."Id"
+}
+
+Ref {
+    "campaigns"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "campaigns"."BudgetId" <> "budget"."Budget Id"
+}
+
+Ref {
+    "budget_summary_report"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "budget_summary_report"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "labels"."Account Id" <> "accounts"."Id"
+}
+
+Ref {
+    "labels"."Client Id" <> "accounts"."Id"
+}
+
+Ref {
+    "keyword_labels"."Account Id" <> "accounts"."Id"
+}
+
+Ref {
+    "keyword_labels"."Parent Id" <> "keywords"."Id"
+}
+
+Ref {
+    "keywords"."Account Id" <> "accounts"."Id"
+}
+
+Ref {
+    "keywords"."Client Id" <> "accounts"."Id"
+}
+
+Ref {
+    "keywords"."Parent Id" <> "ad_groups"."Id"
+}
+
+Ref {
+    "campaign_labels"."Account Id" <> "accounts"."Id"
+}
+
+Ref {
+    "campaign_labels"."Parent Id" <> "campaigns"."Id"
+}
+
+Ref {
+    "age_gender_audience_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "age_gender_audience_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "age_gender_audience_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "account_impression_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "account_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "audience_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "audience_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "audience_performance_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "keyword_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "keyword_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "keyword_performance_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "keyword_performance_report_hourly"."KeywordId" <> "keywords"."Id"
+}
+
+Ref {
+    "keyword_performance_report_hourly"."AdId" <> "ads"."Id"
+}
+
+Ref {
+    "keyword_performance_report_daily"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "keyword_performance_report_daily"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "keyword_performance_report_daily"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "keyword_performance_report_daily"."KeywordId" <> "keywords"."Id"
+}
+
+Ref {
+    "keyword_performance_report_daily"."AdId" <> "ads"."Id"
+}
+
+Ref {
+    "ad_group_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "ad_group_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "ad_group_performance_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "ad_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "ad_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "ad_performance_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "ad_performance_report_hourly"."AdId" <> "ads"."Id"
+}
+
+Ref {
+    "ad_group_impression_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "ad_group_impression_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "ad_group_impression_performance_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "ad_group_impression_performance_report_hourly"."BaseCampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "campaign_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "campaign_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "campaign_impression_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "campaign_impression_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "campaign_impression_performance_report_hourly"."BaseCampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "geographic_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "geographic_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "geographic_performance_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "geographic_performance_report_hourly"."BaseCampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "goals_and_funnels_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "goals_and_funnels_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "goals_and_funnels_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "goals_and_funnels_report_hourly"."KeywordId" <> "keywords"."Id"
+}
+
+Ref {
+    "product_dimension_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "product_dimension_performance_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "product_dimension_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "product_dimension_performance_report_hourly"."AdId" <> "ads"."Id"
+}
+
+Ref {
+    "product_dimension_performance_report_hourly"."CampaignType" <> "campaigns"."CampaignType"
+}
+
+Ref {
+    "product_search_query_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "product_search_query_performance_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "product_search_query_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "product_search_query_performance_report_hourly"."AdId" <> "ads"."Id"
+}
+
+Ref {
+    "product_search_query_performance_report_hourly"."CampaignType" <> "campaigns"."CampaignType"
+}
+
+Ref {
+    "search_query_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "search_query_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "search_query_performance_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}
+
+Ref {
+    "search_query_performance_report_hourly"."AdId" <> "ads"."Id"
+}
+
+Ref {
+    "search_query_performance_report_hourly"."KeywordId" <> "keywords"."Id"
+}
+
+Ref {
+    "user_location_performance_report_hourly"."AccountId" <> "accounts"."Id"
+}
+
+Ref {
+    "user_location_performance_report_hourly"."CampaignId" <> "campaigns"."Id"
+}
+
+Ref {
+    "user_location_performance_report_hourly"."AdGroupId" <> "ad_groups"."Id"
+}

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -19,6 +19,7 @@ data:
   dockerImageTag: 2.7.3
   dockerRepository: airbyte/source-bing-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/bing-ads
+  erdUrl: https://dbdocs.io/airbyteio/source-bing-ads?view=relationships
   githubIssueLabel: source-bing-ads
   icon: bingads.svg
   license: MIT


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/9173 for source-bing-ads

## How
By running `airbyte-ci --name=source-bing-ads generate-erd`

The publish has been done as part of the airbyte-ci command executed locally.

## User Impact
ERD is now available on https://dbdocs.io/airbyteio/source-bing-ads

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌

