### PR TITLE
[ISSUE 9173] add ERD files for source-shopify

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-shopify/erd/discovered_catalog.json
@@ -1,0 +1,10609 @@
+{
+  "streams": [
+    {
+      "name": "abandoned_checkouts",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "note_attributes": {
+            "description": "Additional notes or attributes associated with the checkout",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of each note attribute",
+              "type": ["null", "object"],
+              "properties": {
+                "name": {
+                  "description": "Name of the attribute",
+                  "type": ["null", "string"]
+                },
+                "value": {
+                  "description": "Value of the attribute",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "location_id": {
+            "description": "ID of the location",
+            "type": ["null", "integer"]
+          },
+          "buyer_accepts_marketing": {
+            "description": "Indicates if the buyer accepts marketing",
+            "type": ["null", "boolean"]
+          },
+          "currency": {
+            "description": "Currency used for the checkout",
+            "type": ["null", "string"]
+          },
+          "completed_at": {
+            "description": "Date and time when the checkout was completed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "token": {
+            "description": "Token associated with the checkout",
+            "type": ["null", "string"]
+          },
+          "billing_address": {
+            "description": "Information about the billing address associated with the checkout",
+            "type": ["null", "object"],
+            "properties": {
+              "phone": {
+                "description": "Phone number associated with the billing address",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "Country of the customer's billing address",
+                "type": ["null", "string"]
+              },
+              "first_name": {
+                "description": "First name of the customer",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Full name associated with the billing address",
+                "type": ["null", "string"]
+              },
+              "latitude": {
+                "description": "Latitude coordinate of the billing address",
+                "type": ["null", "number"]
+              },
+              "zip": {
+                "description": "Zip code of the customer's billing address",
+                "type": ["null", "string"]
+              },
+              "last_name": {
+                "description": "Last name of the customer",
+                "type": ["null", "string"]
+              },
+              "province": {
+                "description": "State or province of the customer's billing address",
+                "type": ["null", "string"]
+              },
+              "address2": {
+                "description": "Second line of the customer's billing address",
+                "type": ["null", "string"]
+              },
+              "address1": {
+                "description": "First line of the customer's billing address",
+                "type": ["null", "string"]
+              },
+              "country_code": {
+                "description": "Country code of the customer's billing address",
+                "type": ["null", "string"]
+              },
+              "city": {
+                "description": "City of the customer's billing address",
+                "type": ["null", "string"]
+              },
+              "company": {
+                "description": "Company name in the billing address",
+                "type": ["null", "string"]
+              },
+              "province_code": {
+                "description": "State or province code of the customer's billing address",
+                "type": ["null", "string"]
+              },
+              "longitude": {
+                "description": "Longitude coordinate of the billing address",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "email": {
+            "description": "Customer's email",
+            "type": ["null", "string"]
+          },
+          "discount_codes": {
+            "description": "List of discount codes applied to the checkout",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of each discount code",
+              "type": ["null", "object"],
+              "properties": {
+                "type": {
+                  "description": "Type of the discount",
+                  "type": ["null", "string"]
+                },
+                "amount": {
+                  "description": "Amount of the discount",
+                  "type": ["null", "string"]
+                },
+                "code": {
+                  "description": "Discount code used",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "customer_locale": {
+            "description": "Locale of the customer",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "Date and time when the checkout was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "Date and time of last checkout update",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "gateway": {
+            "description": "Payment gateway used",
+            "type": ["null", "string"]
+          },
+          "referring_site": {
+            "description": "Site that referred the customer",
+            "type": ["null", "string"]
+          },
+          "source_identifier": {
+            "description": "Identifier of the source",
+            "type": ["null", "string"]
+          },
+          "total_weight": {
+            "description": "Total weight of all line items",
+            "type": ["null", "integer"]
+          },
+          "tax_lines": {
+            "description": "List of tax lines associated with the checkout",
+            "items": {
+              "description": "Details of each tax line",
+              "properties": {
+                "price_set": {
+                  "description": "Price details of the tax line",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "description": "Tax amount in the shop's currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "Amount in shop currency",
+                          "type": ["null", "number"]
+                        },
+                        "currency_code": {
+                          "description": "Currency code in shop currency",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "presentment_money": {
+                      "description": "Tax amount in the currency of presentation",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "Amount in presentment currency",
+                          "type": ["null", "number"]
+                        },
+                        "currency_code": {
+                          "description": "Currency code in presentment currency",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    }
+                  }
+                },
+                "price": {
+                  "description": "Price of the tax line",
+                  "type": ["null", "number"]
+                },
+                "title": {
+                  "description": "Title of the tax",
+                  "type": ["null", "string"]
+                },
+                "rate": {
+                  "description": "Tax rate",
+                  "type": ["null", "number"]
+                },
+                "compare_at": {
+                  "description": "Comparison price of the tax",
+                  "type": ["null", "string"]
+                },
+                "position": {
+                  "description": "Position of the tax line",
+                  "type": ["null", "integer"]
+                },
+                "source": {
+                  "description": "Source of the tax",
+                  "type": ["null", "string"]
+                },
+                "zone": {
+                  "description": "Tax zone",
+                  "type": ["null", "string"]
+                }
+              },
+              "type": ["null", "object"]
+            },
+            "type": ["null", "array"]
+          },
+          "total_line_items_price": {
+            "description": "Total price of all line items",
+            "type": ["null", "number"]
+          },
+          "closed_at": {
+            "description": "Date and time when the checkout was closed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "device_id": {
+            "description": "ID of the device used for checkout",
+            "type": ["null", "integer"]
+          },
+          "phone": {
+            "description": "Customer's phone number",
+            "type": ["null", "string"]
+          },
+          "source_name": {
+            "description": "Name of the source",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "ID of the checkout",
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "description": "Name of the checkout",
+            "type": ["null", "string"]
+          },
+          "total_tax": {
+            "description": "Total tax amount",
+            "type": ["null", "number"]
+          },
+          "subtotal_price": {
+            "description": "Subtotal price of the checkout",
+            "type": ["null", "number"]
+          },
+          "line_items": {
+            "description": "List of purchased items in the checkout",
+            "items": {
+              "description": "Details of each purchased item",
+              "properties": {
+                "sku": {
+                  "description": "SKU of the product",
+                  "type": ["null", "string"]
+                },
+                "grams": {
+                  "description": "Weight in grams",
+                  "type": ["null", "number"]
+                },
+                "price": {
+                  "description": "Price of the line item",
+                  "type": ["null", "string"]
+                },
+                "title": {
+                  "description": "Title of the line item",
+                  "type": ["null", "string"]
+                },
+                "vendor": {
+                  "description": "Vendor of the product",
+                  "type": ["null", "string"]
+                },
+                "quantity": {
+                  "description": "Quantity of the product",
+                  "type": ["null", "integer"]
+                },
+                "product_id": {
+                  "description": "ID of the product in the line item",
+                  "type": ["null", "integer"]
+                },
+                "variant_id": {
+                  "description": "ID of the product variant",
+                  "type": ["null", "integer"]
+                },
+                "variant_title": {
+                  "description": "Title of the product variant",
+                  "type": ["null", "string"]
+                },
+                "requires_shipping": {
+                  "description": "Indicates if shipping is required",
+                  "type": ["null", "boolean"]
+                },
+                "fulfillment_service": {
+                  "description": "Service used for fulfillment",
+                  "type": ["null", "string"]
+                }
+              },
+              "type": ["null", "object"]
+            },
+            "type": ["null", "array"]
+          },
+          "source_url": {
+            "description": "URL of the source",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "URL of the shop",
+            "type": ["null", "string"]
+          },
+          "total_discounts": {
+            "description": "Total discounts applied",
+            "type": ["null", "number"]
+          },
+          "note": {
+            "description": "Checkout note",
+            "type": ["null", "string"]
+          },
+          "presentment_currency": {
+            "description": "Currency used for presentation",
+            "type": ["null", "string"]
+          },
+          "shipping_lines": {
+            "description": "List of shipping methods selected for the checkout",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of each selected shipping method",
+              "type": ["null", "object"],
+              "properties": {
+                "applied_discounts": {
+                  "description": "List of applied discounts",
+                  "type": ["null", "array"],
+                  "items": { "type": ["null", "string"] }
+                },
+                "phone": {
+                  "description": "Phone number associated with the shipping line",
+                  "type": ["null", "string"]
+                },
+                "validation_context": {
+                  "description": "Validation context for the shipping line",
+                  "type": ["null", "string"]
+                },
+                "id": {
+                  "description": "ID of the shipping line",
+                  "type": ["null", "string"]
+                },
+                "carrier_identifier": {
+                  "description": "Identifier of the carrier",
+                  "type": ["null", "string"]
+                },
+                "api_client_id": {
+                  "description": "ID of the API client",
+                  "type": ["null", "integer"]
+                },
+                "price": {
+                  "description": "Price of the shipping line",
+                  "type": ["null", "number"]
+                },
+                "requested_fulfillment_service_id": {
+                  "description": "ID of the requested fulfillment service",
+                  "type": ["null", "string"]
+                },
+                "title": {
+                  "description": "Title of the shipping line",
+                  "type": ["null", "string"]
+                },
+                "code": {
+                  "description": "Code of the shipping line",
+                  "type": ["null", "string"]
+                },
+                "tax_lines": {
+                  "description": "List of tax lines associated with the shipping method",
+                  "items": {
+                    "description": "Details of each tax line",
+                    "properties": {
+                      "price_set": {
+                        "description": "Price details of the tax line",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "Tax amount in the shop's currency",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount in shop currency",
+                                "type": ["null", "number"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code in shop currency",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          },
+                          "presentment_money": {
+                            "description": "Tax amount in the currency of presentation",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount in presentment currency",
+                                "type": ["null", "number"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code in presentment currency",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "price": {
+                        "description": "Price of the tax line",
+                        "type": ["null", "number"]
+                      },
+                      "title": {
+                        "description": "Title of the tax",
+                        "type": ["null", "string"]
+                      },
+                      "rate": {
+                        "description": "Tax rate",
+                        "type": ["null", "number"],
+                        "multipleOf": 1e-10
+                      },
+                      "compare_at": {
+                        "description": "Comparison price",
+                        "type": ["null", "string"]
+                      },
+                      "position": {
+                        "description": "Position of the tax line",
+                        "type": ["null", "integer"]
+                      },
+                      "source": {
+                        "description": "Source of the tax",
+                        "type": ["null", "string"]
+                      },
+                      "zone": {
+                        "description": "Tax zone",
+                        "type": ["null", "string"]
+                      }
+                    },
+                    "type": ["null", "object"]
+                  },
+                  "type": ["null", "array"]
+                },
+                "carrier_service_id": {
+                  "description": "ID of the carrier service",
+                  "type": ["null", "integer"]
+                },
+                "delivery_category": {
+                  "description": "Category of delivery",
+                  "type": ["null", "string"]
+                },
+                "markup": {
+                  "description": "Markup on the shipping line",
+                  "type": ["null", "string"]
+                },
+                "source": {
+                  "description": "Source of the shipping line",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "user_id": {
+            "description": "ID of the user associated with the checkout",
+            "type": ["null", "integer"]
+          },
+          "source": {
+            "description": "Source of the checkout",
+            "type": ["null", "string"]
+          },
+          "shipping_address": {
+            "description": "Information about the shipping address for the checkout",
+            "type": ["null", "object"],
+            "properties": {
+              "phone": {
+                "description": "Phone number associated with the shipping address",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "Country of the customer's shipping address",
+                "type": ["null", "string"]
+              },
+              "first_name": {
+                "description": "First name of the customer",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Full name associated with the shipping address",
+                "type": ["null", "string"]
+              },
+              "latitude": {
+                "description": "Latitude coordinate of the shipping address",
+                "type": ["null", "number"]
+              },
+              "zip": {
+                "description": "Zip code of the customer's shipping address",
+                "type": ["null", "string"]
+              },
+              "last_name": {
+                "description": "Last name of the customer",
+                "type": ["null", "string"]
+              },
+              "province": {
+                "description": "State or province of the customer's shipping address",
+                "type": ["null", "string"]
+              },
+              "address2": {
+                "description": "Second line of the customer's shipping address",
+                "type": ["null", "string"]
+              },
+              "address1": {
+                "description": "First line of the customer's shipping address",
+                "type": ["null", "string"]
+              },
+              "country_code": {
+                "description": "Country code of the customer's shipping address",
+                "type": ["null", "string"]
+              },
+              "city": {
+                "description": "City of the customer's shipping address",
+                "type": ["null", "string"]
+              },
+              "company": {
+                "description": "Company name in the shipping address",
+                "type": ["null", "string"]
+              },
+              "province_code": {
+                "description": "State or province code of the customer's shipping address",
+                "type": ["null", "string"]
+              },
+              "longitude": {
+                "description": "Longitude coordinate of the shipping address",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "abandoned_checkout_url": {
+            "description": "The URL to access the abandoned checkout",
+            "type": ["null", "string"]
+          },
+          "landing_site": {
+            "description": "URL of the landing site",
+            "type": ["null", "string"]
+          },
+          "customer": {
+            "description": "Details of the customer who initiated the checkout",
+            "type": "object",
+            "properties": {
+              "last_order_name": {
+                "description": "Name of the customer's last order",
+                "type": ["null", "string"]
+              },
+              "currency": {
+                "description": "Currency used for the customer",
+                "type": ["null", "string"]
+              },
+              "email": {
+                "description": "Email of the customer",
+                "type": ["null", "string"]
+              },
+              "multipass_identifier": {
+                "description": "Identifier for multipass login",
+                "type": ["null", "string"]
+              },
+              "default_address": {
+                "description": "Default shipping address of the customer",
+                "type": ["null", "object"],
+                "properties": {
+                  "city": {
+                    "description": "City of the customer's default address",
+                    "type": ["null", "string"]
+                  },
+                  "address1": {
+                    "description": "First line of the customer's default address",
+                    "type": ["null", "string"]
+                  },
+                  "zip": {
+                    "description": "Zip code of the customer's default address",
+                    "type": ["null", "string"]
+                  },
+                  "id": {
+                    "description": "Address ID",
+                    "type": ["null", "integer"]
+                  },
+                  "country_name": {
+                    "description": "Country name of the customer's default address",
+                    "type": ["null", "string"]
+                  },
+                  "province": {
+                    "description": "State or province of the customer's default address",
+                    "type": ["null", "string"]
+                  },
+                  "phone": {
+                    "description": "Phone number associated with the default address",
+                    "type": ["null", "string"]
+                  },
+                  "country": {
+                    "description": "Country of the customer's default address",
+                    "type": ["null", "string"]
+                  },
+                  "first_name": {
+                    "description": "First name of the customer",
+                    "type": ["null", "string"]
+                  },
+                  "customer_id": {
+                    "description": "ID of the customer",
+                    "type": ["null", "integer"]
+                  },
+                  "default": {
+                    "description": "Indicates if it's the default address for the customer",
+                    "type": ["null", "boolean"]
+                  },
+                  "last_name": {
+                    "description": "Last name of the customer",
+                    "type": ["null", "string"]
+                  },
+                  "country_code": {
+                    "description": "Country code of the customer's default address",
+                    "type": ["null", "string"]
+                  },
+                  "name": {
+                    "description": "Full name associated with the default address",
+                    "type": ["null", "string"]
+                  },
+                  "province_code": {
+                    "description": "State or province code of the customer's default address",
+                    "type": ["null", "string"]
+                  },
+                  "address2": {
+                    "description": "Second line of the customer's default address",
+                    "type": ["null", "string"]
+                  },
+                  "company": {
+                    "description": "Company name in the default address",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "orders_count": {
+                "description": "Number of orders made by the customer",
+                "type": ["null", "integer"]
+              },
+              "state": {
+                "description": "State of the customer",
+                "type": ["null", "string"]
+              },
+              "verified_email": {
+                "description": "Indicates if the email is verified",
+                "type": ["null", "boolean"]
+              },
+              "total_spent": {
+                "description": "Total amount spent by the customer",
+                "type": ["null", "number"]
+              },
+              "last_order_id": {
+                "description": "ID of the customer's last order",
+                "type": ["null", "integer"]
+              },
+              "first_name": {
+                "description": "First name of the customer",
+                "type": ["null", "string"]
+              },
+              "updated_at": {
+                "description": "Date and time of last customer update",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "note": {
+                "description": "Customer note",
+                "type": ["null", "string"]
+              },
+              "phone": {
+                "description": "Phone number associated with the customer",
+                "type": ["null", "string"]
+              },
+              "admin_graphql_api_id": {
+                "description": "GraphQL ID of the customer",
+                "type": ["null", "string"]
+              },
+              "addresses": {
+                "description": "List of addresses associated with the customer",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Individual address details",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "city": {
+                      "description": "City of the customer's address",
+                      "type": ["null", "string"]
+                    },
+                    "address1": {
+                      "description": "First line of the customer's address",
+                      "type": ["null", "string"]
+                    },
+                    "zip": {
+                      "description": "Zip code of the customer's address",
+                      "type": ["null", "string"]
+                    },
+                    "id": {
+                      "description": "Address ID",
+                      "type": ["null", "integer"]
+                    },
+                    "country_name": {
+                      "description": "Country name of the customer's address",
+                      "type": ["null", "string"]
+                    },
+                    "province": {
+                      "description": "State or province of the customer's address",
+                      "type": ["null", "string"]
+                    },
+                    "phone": {
+                      "description": "Phone number associated with the address",
+                      "type": ["null", "string"]
+                    },
+                    "country": {
+                      "description": "Country of the customer's address",
+                      "type": ["null", "string"]
+                    },
+                    "first_name": {
+                      "description": "First name of the customer",
+                      "type": ["null", "string"]
+                    },
+                    "customer_id": {
+                      "description": "ID of the customer",
+                      "type": ["null", "integer"]
+                    },
+                    "default": {
+                      "description": "Indicates if it's the default address for the customer",
+                      "type": ["null", "boolean"]
+                    },
+                    "last_name": {
+                      "description": "Last name of the customer",
+                      "type": ["null", "string"]
+                    },
+                    "country_code": {
+                      "description": "Country code of the customer's address",
+                      "type": ["null", "string"]
+                    },
+                    "name": {
+                      "description": "Full name associated with the address",
+                      "type": ["null", "string"]
+                    },
+                    "province_code": {
+                      "description": "State or province code of the customer's address",
+                      "type": ["null", "string"]
+                    },
+                    "address2": {
+                      "description": "Second line of the customer's address",
+                      "type": ["null", "string"]
+                    },
+                    "company": {
+                      "description": "Company name in the address",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              },
+              "last_name": {
+                "description": "Last name of the customer",
+                "type": ["null", "string"]
+              },
+              "tags": {
+                "description": "Tags associated with the customer",
+                "type": ["null", "string"]
+              },
+              "tax_exemptions": {
+                "description": "Any tax exemptions applicable to the customer",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "List of tax exemptions",
+                  "type": ["null", "string"]
+                }
+              },
+              "id": {
+                "description": "ID of the customer",
+                "type": ["null", "integer"]
+              },
+              "accepts_marketing": {
+                "description": "Indicates if the customer accepts marketing",
+                "type": ["null", "boolean"]
+              },
+              "accepts_marketing_updated_at": {
+                "description": "Date and time of last update to marketing acceptance",
+                "anyOf": [
+                  { "type": "string", "format": "date-time" },
+                  { "type": "string" },
+                  { "type": "null" }
+                ]
+              },
+              "created_at": {
+                "description": "Date and time when the customer was created",
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          },
+          "total_price": {
+            "description": "Total price of the checkout",
+            "type": ["null", "number"]
+          },
+          "cart_token": {
+            "description": "Token associated with the cart",
+            "type": ["null", "string"]
+          },
+          "taxes_included": {
+            "description": "Indicates if taxes are included in prices",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "articles",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the article",
+            "type": ["null", "integer"]
+          },
+          "title": {
+            "description": "The title of the article",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when the article was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "body_html": {
+            "description": "The HTML content of the article body",
+            "type": ["null", "string"]
+          },
+          "blog_id": {
+            "description": "The unique identifier of the blog to which the article belongs",
+            "type": ["null", "integer"]
+          },
+          "author": {
+            "description": "The name of the author of the article",
+            "type": ["null", "string"]
+          },
+          "user_id": {
+            "description": "The unique identifier of the user who created the article",
+            "type": ["null", "string"]
+          },
+          "published_at": {
+            "description": "The date and time when the article was published",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the article was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "summary_html": {
+            "description": "A summary or excerpt of the article content in HTML format",
+            "type": ["null", "string"]
+          },
+          "template_suffix": {
+            "description": "The suffix of the template used for the article",
+            "type": ["null", "string"]
+          },
+          "handle": {
+            "description": "The unique URL path segment for the article",
+            "type": ["null", "string"]
+          },
+          "tags": {
+            "description": "Tags associated with the article",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier of the article in the GraphQL Admin API",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the article is published",
+            "type": ["null", "string"]
+          },
+          "deleted_at": {
+            "description": "The date and time when the article was deleted",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "deleted_message": {
+            "description": "Message related to the deletion of the article",
+            "type": ["null", "string"]
+          },
+          "deleted_description": {
+            "description": "Description of the reason for article deletion",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["id"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "balance_transactions",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the balance transaction.",
+            "type": "integer"
+          },
+          "type": {
+            "description": "The type of transaction.",
+            "type": ["null", "string"]
+          },
+          "test": {
+            "description": "Flag indicating if the transaction is a test transaction.",
+            "type": ["null", "boolean"]
+          },
+          "payout_id": {
+            "description": "The identifier of the associated payout.",
+            "type": ["null", "integer"]
+          },
+          "payout_status": {
+            "description": "The status of the payout associated with this transaction.",
+            "type": ["null", "string"]
+          },
+          "payoucurrencyt_status": {
+            "description": "Indicates the status of the payout for the currency in which the transaction occurred.",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The amount of the transaction in the specified currency.",
+            "type": ["null", "number"]
+          },
+          "fee": {
+            "description": "The fee associated with the transaction.",
+            "type": ["null", "number"]
+          },
+          "net": {
+            "description": "The final amount received after deducting fees.",
+            "type": ["null", "number"]
+          },
+          "source_id": {
+            "description": "The identifier of the source related to the transaction.",
+            "type": ["null", "integer"]
+          },
+          "source_type": {
+            "description": "The type of source for the transaction.",
+            "type": ["null", "string"]
+          },
+          "source_order_transaction_id": {
+            "description": "The transaction identifier within the order.",
+            "type": ["null", "integer"]
+          },
+          "source_order_id": {
+            "description": "The identifier of the order related to the transaction.",
+            "type": ["null", "integer"]
+          },
+          "processed_at": {
+            "description": "The date and time when the transaction was processed.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "shop_url": {
+            "description": "The URL of the shop related to the transaction.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["id"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "blogs",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "commentable": {
+            "description": "Indicates whether comments are allowed on the blog.",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when the blog was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "feedburner": {
+            "description": "The Feedburner date for the blog.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "feedburner_location": {
+            "description": "The location information related to Feedburner.",
+            "type": ["null", "integer"]
+          },
+          "handle": {
+            "description": "The unique handle used in the blog's URL.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier for the blog.",
+            "type": ["null", "integer"]
+          },
+          "tags": {
+            "description": "Tags associated with the blog.",
+            "type": ["null", "string"]
+          },
+          "template_suffix": {
+            "description": "The template suffix used in the blog's layout.",
+            "type": ["null", "string"]
+          },
+          "title": {
+            "description": "The title of the blog.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the blog was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the blog within the admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop associated with the blog.",
+            "type": ["null", "string"]
+          },
+          "deleted_at": {
+            "description": "The date and time when the blog was deleted, if applicable.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "deleted_message": {
+            "description": "A message associated with the deletion of the blog.",
+            "type": ["null", "string"]
+          },
+          "deleted_description": {
+            "description": "A description of the reason for deleting the blog.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["id"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "collections",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the collection.",
+            "type": ["null", "integer"]
+          },
+          "handle": {
+            "description": "A unique URL-friendly string that represents the collection.",
+            "type": ["null", "string"]
+          },
+          "title": {
+            "description": "The title or name of the collection.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The datetime when the collection was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "body_html": {
+            "description": "The HTML content describing the collection.",
+            "type": ["null", "string"]
+          },
+          "published_at": {
+            "description": "The datetime when the collection was published.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sort_order": {
+            "description": "The order in which the collection should be sorted.",
+            "type": ["null", "string"]
+          },
+          "template_suffix": {
+            "description": "The name of the template that is used to render the collection.",
+            "type": ["null", "string"]
+          },
+          "products_count": {
+            "description": "The number of products within the collection.",
+            "type": ["null", "integer"]
+          },
+          "collection_type": {
+            "description": "The type or category of the collection.",
+            "type": ["null", "string"]
+          },
+          "published_scope": {
+            "description": "The visibility of the collection to customers.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the collection in the Admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the collection belongs.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "collects",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the collect.",
+            "type": ["null", "integer"]
+          },
+          "collection_id": {
+            "description": "The unique identifier for the collection.",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the collect was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "position": {
+            "description": "The position of the product in the collection.",
+            "type": ["null", "integer"]
+          },
+          "product_id": {
+            "description": "The unique identifier of the product.",
+            "type": ["null", "integer"]
+          },
+          "sort_value": {
+            "description": "The value used to sort the products in the collection.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop associated with the collect.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the collect was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["id"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "custom_collections",
+      "json_schema": {
+        "properties": {
+          "handle": {
+            "description": "The unique URL-friendly string that identifies the custom collection.",
+            "type": ["null", "string"]
+          },
+          "sort_order": {
+            "description": "The order in which the custom collection should be displayed.",
+            "type": ["null", "string"]
+          },
+          "body_html": {
+            "description": "The full description of the custom collection for display purposes.",
+            "type": ["null", "string"]
+          },
+          "title": {
+            "description": "The title of the custom collection.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier of the custom collection.",
+            "type": ["null", "integer"]
+          },
+          "published_scope": {
+            "description": "The scope where the custom collection is published (global or web).",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier of the custom collection accessible via GraphQL Admin API.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the custom collection was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "image": {
+            "description": "Represents the image associated with the custom collection if available.",
+            "properties": {
+              "alt": {
+                "description": "The alternative text description of the image.",
+                "type": ["null", "string"]
+              },
+              "src": {
+                "description": "The URL of the image.",
+                "type": ["null", "string"]
+              },
+              "width": {
+                "description": "The width of the image in pixels.",
+                "type": ["null", "integer"]
+              },
+              "created_at": {
+                "description": "The date and time when the image was created.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "height": {
+                "description": "The height of the image in pixels.",
+                "type": ["null", "integer"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "published_at": {
+            "description": "The date and time when the custom collection was published.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "template_suffix": {
+            "description": "The template suffix for the custom collection's URL.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the custom collection belongs.",
+            "type": ["null", "string"]
+          },
+          "deleted_at": {
+            "description": "The date and time when the custom collection was deleted.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "deleted_message": {
+            "description": "Any additional message related to the deletion of the custom collection.",
+            "type": ["null", "string"]
+          },
+          "deleted_description": {
+            "description": "The description of why the custom collection was deleted.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "customer_journey_summary",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "order_id": {
+            "description": "The id of the order.",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the order was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the order was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "customer_journey_summary": {
+            "description": "Represents a customer's visiting activities on a shop's online store.",
+            "type": ["null", "object"],
+            "properties": {
+              "ready": {
+                "description": "Whether the attributed sessions for the order have been created yet.",
+                "type": ["null", "boolean"]
+              },
+              "moments_count": {
+                "description": "The total number of customer moments associated with this order. Returns null if the order is still in the process of being attributed.",
+                "type": ["null", "object"],
+                "properties": {
+                  "count": {
+                    "description": "Count of elements.",
+                    "type": ["null", "integer"]
+                  },
+                  "precision": {
+                    "description": "Precision of count, how exact is the value.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "customer_order_index": {
+                "description": "The position of the current order within the customer's order history. Test orders aren't included.",
+                "type": ["null", "integer"]
+              },
+              "days_to_conversion": {
+                "description": "The number of days between the first session and the order creation date. The first session represents the first session since the last order, or the first session within the 30 day attribution window, if more than 30 days have passed since the last order.",
+                "type": ["null", "integer"]
+              },
+              "first_visit": {
+                "description": "The customer's first session going into the shop.",
+                "type": ["null", "object"],
+                "properties": {
+                  "id": {
+                    "description": "A globally-unique ID.",
+                    "type": ["null", "integer"]
+                  },
+                  "landing_page": {
+                    "description": "URL of the first page the customer landed on for the session.",
+                    "type": ["null", "string"]
+                  },
+                  "landing_page_html": {
+                    "description": "Landing page information with URL linked in HTML. For example, the first page the customer visited was",
+                    "type": ["null", "string"]
+                  },
+                  "occurred_at": {
+                    "description": "The date and time when the customer's session occurred.",
+                    "type": ["null", "string"],
+                    "format": "date-time"
+                  },
+                  "referral_code": {
+                    "description": "Marketing referral code from the link that the customer clicked to visit the store.",
+                    "type": ["null", "string"]
+                  },
+                  "referrer_url": {
+                    "description": "Webpage where the customer clicked a link that sent them to the online store.",
+                    "type": ["null", "string"]
+                  },
+                  "source": {
+                    "description": "Source from which the customer visited the store, such as a platform (Facebook, Google), email, direct, a website domain, QR code, or unknown.",
+                    "type": ["null", "string"]
+                  },
+                  "source_type": {
+                    "description": "Type of marketing tactic.",
+                    "type": ["null", "string"]
+                  },
+                  "source_description": {
+                    "description": "Describes the source explicitly for first or last session.",
+                    "type": ["null", "string"]
+                  },
+                  "utm_parameters": {
+                    "description": "A set of UTM parameters gathered from the URL parameters of the referrer.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "campaign": {
+                        "description": "The name of a marketing campaign.",
+                        "type": ["null", "string"]
+                      },
+                      "content": {
+                        "description": "Identifies specific content in a marketing campaign. Used to differentiate between similar content or links in a marketing campaign to determine which is the most effective.",
+                        "type": ["null", "string"]
+                      },
+                      "medium": {
+                        "description": "The medium of a marketing campaign, such as a banner or email newsletter.",
+                        "type": ["null", "string"]
+                      },
+                      "source": {
+                        "description": "The source of traffic to the merchant's store, such as Google or an email newsletter.",
+                        "type": ["null", "string"]
+                      },
+                      "term": {
+                        "description": "Paid search terms used by a marketing campaign.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "admin_graphql_api_id": {
+                    "description": "Unique identifier for the customer in the Admin GraphQL API.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "last_visit": {
+                "description": "The last session before an order is made.",
+                "type": ["null", "object"],
+                "properties": {
+                  "id": {
+                    "description": "A globally-unique ID.",
+                    "type": ["null", "integer"]
+                  },
+                  "landing_page": {
+                    "description": "URL of the first page the customer landed on for the session.",
+                    "type": ["null", "string"]
+                  },
+                  "landing_page_html": {
+                    "description": "Landing page information with URL linked in HTML. For example, the first page the customer visited was",
+                    "type": ["null", "string"]
+                  },
+                  "occurred_at": {
+                    "description": "The date and time when the customer's session occurred.",
+                    "type": ["null", "string"],
+                    "format": "date-time"
+                  },
+                  "referral_code": {
+                    "description": "Marketing referral code from the link that the customer clicked to visit the store.",
+                    "type": ["null", "string"]
+                  },
+                  "referrer_url": {
+                    "description": "Webpage where the customer clicked a link that sent them to the online store.",
+                    "type": ["null", "string"]
+                  },
+                  "source": {
+                    "description": "Source from which the customer visited the store, such as a platform (Facebook, Google), email, direct, a website domain, QR code, or unknown.",
+                    "type": ["null", "string"]
+                  },
+                  "source_type": {
+                    "description": "Type of marketing tactic.",
+                    "type": ["null", "string"]
+                  },
+                  "source_description": {
+                    "description": "Describes the source explicitly for first or last session.",
+                    "type": ["null", "string"]
+                  },
+                  "utm_parameters": {
+                    "description": "A set of UTM parameters gathered from the URL parameters of the referrer.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "campaign": {
+                        "description": "The name of a marketing campaign.",
+                        "type": ["null", "string"]
+                      },
+                      "content": {
+                        "description": "Identifies specific content in a marketing campaign. Used to differentiate between similar content or links in a marketing campaign to determine which is the most effective.",
+                        "type": ["null", "string"]
+                      },
+                      "medium": {
+                        "description": "The medium of a marketing campaign, such as a banner or email newsletter.",
+                        "type": ["null", "string"]
+                      },
+                      "source": {
+                        "description": "The source of traffic to the merchant's store, such as Google or an email newsletter.",
+                        "type": ["null", "string"]
+                      },
+                      "term": {
+                        "description": "Paid search terms used by a marketing campaign.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "admin_graphql_api_id": {
+                    "description": "Unique identifier for the customer in the Admin GraphQL API.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "admin_graphql_api_id": {
+            "description": "Unique identifier for the customer in the Admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop associated with this customer saved search.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["order_id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "customers",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "last_order_name": {
+            "description": "Name of the customer's last order.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "Currency associated with the customer.",
+            "type": ["null", "string"]
+          },
+          "email": {
+            "description": "Customer's email address.",
+            "type": ["null", "string"]
+          },
+          "multipass_identifier": {
+            "description": "Multipass identifier for the customer.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "URL of the customer's associated shop.",
+            "type": ["null", "string"]
+          },
+          "default_address": {
+            "description": "Customer's default address",
+            "type": ["null", "object"],
+            "properties": {
+              "city": {
+                "description": "City where the customer's default address is located.",
+                "type": ["null", "string"]
+              },
+              "address1": {
+                "description": "First line of customer's default address.",
+                "type": ["null", "string"]
+              },
+              "zip": {
+                "description": "Postal or ZIP code of the customer's default address.",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "Unique identifier for the default address.",
+                "type": ["null", "integer"]
+              },
+              "country_name": {
+                "description": "Name of the country for the customer's default address.",
+                "type": ["null", "string"]
+              },
+              "province": {
+                "description": "Province or state where the customer's default address is located.",
+                "type": ["null", "string"]
+              },
+              "phone": {
+                "description": "Customer's phone number associated with the default address.",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "Country of the customer's default address.",
+                "type": ["null", "string"]
+              },
+              "first_name": {
+                "description": "Customer's first name associated with the default address.",
+                "type": ["null", "string"]
+              },
+              "customer_id": {
+                "description": "Unique identifier for the customer.",
+                "type": ["null", "integer"]
+              },
+              "default": {
+                "description": "Indicates if this is the default address for the customer.",
+                "type": ["null", "boolean"]
+              },
+              "last_name": {
+                "description": "Customer's last name associated with the default address.",
+                "type": ["null", "string"]
+              },
+              "country_code": {
+                "description": "Country code of the customer's default address.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Full name associated with the default address.",
+                "type": ["null", "string"]
+              },
+              "province_code": {
+                "description": "Province or state code of the customer's default address.",
+                "type": ["null", "string"]
+              },
+              "address2": {
+                "description": "Second line of customer's default address.",
+                "type": ["null", "string"]
+              },
+              "company": {
+                "description": "Customer's company name associated with the default address.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "email_marketing_consent": {
+            "description": "Indicates if the customer has consented to receive marketing emails",
+            "type": ["null", "object"],
+            "properties": {
+              "consent_updated_at": {
+                "description": "Timestamp when the email marketing consent was last updated.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "opt_in_level": {
+                "description": "Level of opt-in for email marketing.",
+                "type": ["null", "string"]
+              },
+              "state": {
+                "description": "Current state of email marketing consent.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "orders_count": {
+            "description": "Total number of orders placed by the customer.",
+            "type": ["null", "integer"]
+          },
+          "state": {
+            "description": "Current state or status of the customer.",
+            "type": ["null", "string"]
+          },
+          "verified_email": {
+            "description": "Indicates if the customer's email address has been verified.",
+            "type": ["null", "boolean"]
+          },
+          "total_spent": {
+            "description": "Total amount spent by the customer.",
+            "type": ["null", "number"]
+          },
+          "last_order_id": {
+            "description": "Unique identifier for the customer's last order.",
+            "type": ["null", "integer"]
+          },
+          "first_name": {
+            "description": "Customer's first name.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "Timestamp when the customer data was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "note": {
+            "description": "Additional notes or comments related to the customer.",
+            "type": ["null", "string"]
+          },
+          "phone": {
+            "description": "Customer's phone number.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "Unique identifier for the customer in the Admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "addresses": {
+            "description": "List of addresses associated with the customer",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "city": {
+                  "description": "City where the customer is located.",
+                  "type": ["null", "string"]
+                },
+                "address1": {
+                  "description": "First line of customer's address.",
+                  "type": ["null", "string"]
+                },
+                "zip": {
+                  "description": "Postal or ZIP code of the customer's address.",
+                  "type": ["null", "string"]
+                },
+                "id": {
+                  "description": "Unique identifier for the address.",
+                  "type": ["null", "integer"]
+                },
+                "country_name": {
+                  "description": "Name of the customer's country.",
+                  "type": ["null", "string"]
+                },
+                "province": {
+                  "description": "Province or state where the customer is located.",
+                  "type": ["null", "string"]
+                },
+                "phone": {
+                  "description": "Customer's phone number.",
+                  "type": ["null", "string"]
+                },
+                "country": {
+                  "description": "Customer's country.",
+                  "type": ["null", "string"]
+                },
+                "first_name": {
+                  "description": "Customer's first name.",
+                  "type": ["null", "string"]
+                },
+                "customer_id": {
+                  "description": "Unique identifier for the customer.",
+                  "type": ["null", "integer"]
+                },
+                "default": {
+                  "description": "Indicates if this address is the default address for the customer.",
+                  "type": ["null", "boolean"]
+                },
+                "last_name": {
+                  "description": "Customer's last name.",
+                  "type": ["null", "string"]
+                },
+                "country_code": {
+                  "description": "Country code of the customer's country.",
+                  "type": ["null", "string"]
+                },
+                "name": {
+                  "description": "Full name associated with the address.",
+                  "type": ["null", "string"]
+                },
+                "province_code": {
+                  "description": "Province or state code.",
+                  "type": ["null", "string"]
+                },
+                "address2": {
+                  "description": "Second line of customer's address.",
+                  "type": ["null", "string"]
+                },
+                "company": {
+                  "description": "Customer's company name.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "last_name": {
+            "description": "Customer's last name.",
+            "type": ["null", "string"]
+          },
+          "tags": {
+            "description": "Tags associated with the customer for categorization.",
+            "type": ["null", "string"]
+          },
+          "tax_exempt": {
+            "description": "Indicates if the customer is tax exempt.",
+            "type": ["null", "boolean"]
+          },
+          "id": {
+            "description": "Unique identifier for the customer.",
+            "type": ["null", "integer"]
+          },
+          "accepts_marketing": {
+            "description": "Indicates if the customer has agreed to receive marketing materials.",
+            "type": ["null", "boolean"]
+          },
+          "accepts_marketing_updated_at": {
+            "description": "Timestamp when the marketing consent status was last updated.",
+            "anyOf": [
+              { "type": "string", "format": "date-time" },
+              { "type": "string" },
+              { "type": "null" }
+            ]
+          },
+          "created_at": {
+            "description": "Timestamp when the customer was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sms_marketing_consent": {
+            "description": "Indicates if the customer has consented to receive marketing SMS messages",
+            "type": ["null", "object"],
+            "properties": {
+              "consent_collected_from": {
+                "description": "Source from which SMS marketing consent was collected.",
+                "type": ["null", "string"]
+              },
+              "consent_updated_at": {
+                "description": "Timestamp when the SMS marketing consent was last updated.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "opt_in_level": {
+                "description": "Level of opt-in for SMS marketing.",
+                "type": ["null", "string"]
+              },
+              "state": {
+                "description": "Current state of SMS marketing consent.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "tax_exemptions": {
+            "description": "Information about tax exemptions for the customer.",
+            "type": ["null", "string"]
+          },
+          "marketing_opt_in_level": {
+            "description": "Level of opt-in for marketing activities.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "discount_codes",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the discount code",
+            "type": ["null", "integer"]
+          },
+          "price_rule_id": {
+            "description": "The identifier of the price rule associated with the discount code",
+            "type": ["null", "integer"]
+          },
+          "code": {
+            "description": "The discount code that customers can use during checkout to apply the discount",
+            "type": ["null", "string"]
+          },
+          "usage_count": {
+            "description": "The number of times the discount code has been used by customers",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the discount code was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "createdBy": {
+            "description": "The application that created the discount reedem code.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "id": { "type": ["null", "string"] },
+              "title": { "type": ["null", "string"] }
+            }
+          },
+          "updated_at": {
+            "description": "The date and time when the discount code was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "summary": {
+            "description": "A brief summary or description of the discount code",
+            "type": ["null", "string"]
+          },
+          "discount_type": {
+            "description": "The type of discount applied by the discount code, such as a percentage or fixed amount off",
+            "type": ["null", "string"]
+          },
+          "typename": {
+            "description": "The typename of the discount",
+            "type": ["null", "string"]
+          },
+          "starts_at": {
+            "description": "The date and time when the discount code is activated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "ends_at": {
+            "description": "The date and time when the discount code is deactivated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "status": {
+            "description": "The status of the Discount",
+            "type": ["null", "string"]
+          },
+          "title": {
+            "description": "The title of the discount.",
+            "type": ["null", "string"]
+          },
+          "usage_limit": {
+            "description": "The maximum number of times that the discount can be used.",
+            "type": ["null", "integer"]
+          },
+          "applies_once_per_customer": {
+            "description": "Whether the discount can be applied only once per customer.",
+            "type": ["null", "boolean"]
+          },
+          "async_usage_count": {
+            "description": "The number of times that the discount has been used.",
+            "type": ["null", "integer"]
+          },
+          "codes_count": {
+            "description": "The number of redeem codes for the discount.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "count": {
+                "description": "The count of elements.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "total_sales": {
+            "description": "The total sales from orders where the discount was used.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "amount": { "type": ["null", "number"] },
+              "currency_code": { "type": ["null", "string"] }
+            }
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the discount code in the Shopify Admin GraphQL API",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the discount code is applicable",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "disputes",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the dispute",
+            "type": ["null", "integer"]
+          },
+          "order_id": {
+            "description": "The identifier of the order associated with the dispute",
+            "type": ["null", "integer"]
+          },
+          "type": {
+            "description": "The type of dispute (e.g., chargeback, refund request)",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency in which the dispute amount is represented",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The disputed amount in the currency specified",
+            "type": ["null", "string"]
+          },
+          "reason": {
+            "description": "The reason provided for the dispute",
+            "type": ["null", "string"]
+          },
+          "network_reason_code": {
+            "description": "The reason code provided by the network for the dispute",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "The current status of the dispute",
+            "type": ["null", "string"]
+          },
+          "initiated_at": {
+            "description": "The date and time when the dispute was initiated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "evidence_due_by": {
+            "description": "The date by which evidence needs to be submitted for the dispute",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "evidence_sent_on": {
+            "description": "The date when evidence was sent for the dispute",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "finalized_on": {
+            "description": "The date when the dispute was finalized",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["id"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "draft_orders",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "Unique identifier of the draft order",
+            "type": ["null", "integer"]
+          },
+          "note": {
+            "description": "Additional notes or comments related to the draft order",
+            "type": ["null", "string"]
+          },
+          "email": {
+            "description": "Email address associated with the draft order",
+            "type": ["null", "string"]
+          },
+          "taxes_included": {
+            "description": "Indicates if taxes are included in the prices",
+            "type": ["null", "boolean"]
+          },
+          "currency": {
+            "description": "Currency used for the draft order",
+            "type": ["null", "string"]
+          },
+          "invoice_sent_at": {
+            "description": "Timestamp when the invoice was sent",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "created_at": {
+            "description": "Timestamp when the draft order was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "Timestamp when the draft order was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "tax_exempt": {
+            "description": "Indicates if the draft order is tax exempt",
+            "type": ["null", "boolean"]
+          },
+          "completed_at": {
+            "description": "Timestamp when the draft order was completed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "name": {
+            "description": "Name of the draft order",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "Status of the draft order",
+            "type": ["null", "string"]
+          },
+          "line_items": {
+            "description": "Items included in the draft order",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "Unique identifier of the line item",
+                  "type": ["null", "integer"]
+                },
+                "variant_id": {
+                  "description": "Unique identifier of the variant associated with the line item",
+                  "type": ["null", "integer"]
+                },
+                "product_id": {
+                  "description": "Unique identifier of the product associated with the line item",
+                  "type": ["null", "integer"]
+                },
+                "title": {
+                  "description": "Title of the line item",
+                  "type": ["null", "string"]
+                },
+                "variant_title": {
+                  "description": "Title of the variant associated with the line item",
+                  "type": ["null", "string"]
+                },
+                "sku": {
+                  "description": "Stock Keeping Unit (SKU) of the line item",
+                  "type": ["null", "string"]
+                },
+                "vendor": {
+                  "description": "Vendor of the product associated with the line item",
+                  "type": ["null", "string"]
+                },
+                "quantity": {
+                  "description": "Quantity of the line item",
+                  "type": ["null", "integer"]
+                },
+                "requires_shipping": {
+                  "description": "Indicates if the line item requires shipping",
+                  "type": ["null", "boolean"]
+                },
+                "taxable": {
+                  "description": "Indicates if the line item is taxable",
+                  "type": ["null", "boolean"]
+                },
+                "gift_card": {
+                  "description": "Indicates if the line item is a gift card",
+                  "type": ["null", "boolean"]
+                },
+                "fulfillment_service": {
+                  "description": "Service used for fulfillment of the line item",
+                  "type": ["null", "string"]
+                },
+                "grams": {
+                  "description": "Weight in grams of the line item",
+                  "type": ["null", "number"]
+                },
+                "tax_lines": {
+                  "description": "Tax information related to the line item",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "price": {
+                        "description": "Amount of tax for the line item",
+                        "type": ["null", "number"]
+                      },
+                      "rate": {
+                        "description": "Tax rate applied",
+                        "type": ["null", "number"]
+                      },
+                      "title": {
+                        "description": "Title of the tax",
+                        "type": ["null", "string"]
+                      },
+                      "price_set": {
+                        "description": "Information about the price set for tax",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "Money information in the shop's currency",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount of money",
+                                "type": ["null", "number"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          },
+                          "presentment_money": {
+                            "description": "Money information in the presentment currency",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount of money",
+                                "type": ["null", "number"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "applied_discount": {
+                  "description": "Details of any discount applied to the line item",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "description": {
+                      "description": "Description of the discount applied to the line item",
+                      "type": ["null", "string"]
+                    },
+                    "value": {
+                      "description": "The value of the discount applied to the line item",
+                      "type": ["null", "string"]
+                    },
+                    "title": {
+                      "description": "Title of the discount applied to the line item",
+                      "type": ["null", "string"]
+                    },
+                    "amount": {
+                      "description": "The amount of the discount applied to the line item",
+                      "type": ["null", "string"]
+                    },
+                    "value_type": {
+                      "description": "Type of the value in the discount applied to the line item",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "name": {
+                  "description": "Name of the line item",
+                  "type": ["null", "string"]
+                },
+                "properties": {
+                  "description": "Additional properties associated with the line item",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the property",
+                        "type": ["null", "string"]
+                      },
+                      "value": {
+                        "description": "Value of the property",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                },
+                "custom": {
+                  "description": "Custom information related to the line item",
+                  "type": ["null", "boolean"]
+                },
+                "price": {
+                  "description": "Price of the line item",
+                  "type": ["null", "number"]
+                },
+                "admin_graphql_api_id": {
+                  "description": "The unique identifier of the line item in the Shopify Admin GraphQL API",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "shipping_address": {
+            "description": "The shipping address associated with the draft order",
+            "properties": {
+              "phone": {
+                "description": "Phone number associated with the shipping address",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "Country of the shipping address",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Full name in the shipping address",
+                "type": ["null", "string"]
+              },
+              "address1": {
+                "description": "First line of the shipping address",
+                "type": ["null", "string"]
+              },
+              "longitude": {
+                "description": "Longitude coordinate of the shipping address",
+                "type": ["null", "number"]
+              },
+              "address2": {
+                "description": "Second line of the shipping address",
+                "type": ["null", "string"]
+              },
+              "last_name": {
+                "description": "Last name in the shipping address",
+                "type": ["null", "string"]
+              },
+              "first_name": {
+                "description": "First name in the shipping address",
+                "type": ["null", "string"]
+              },
+              "province": {
+                "description": "Province of the shipping address",
+                "type": ["null", "string"]
+              },
+              "city": {
+                "description": "City of the shipping address",
+                "type": ["null", "string"]
+              },
+              "company": {
+                "description": "Company name in the shipping address",
+                "type": ["null", "string"]
+              },
+              "latitude": {
+                "description": "Latitude coordinate of the shipping address",
+                "type": ["null", "number"]
+              },
+              "country_code": {
+                "description": "Country code of the shipping address",
+                "type": ["null", "string"]
+              },
+              "province_code": {
+                "description": "Province code of the shipping address",
+                "type": ["null", "string"]
+              },
+              "zip": {
+                "description": "ZIP or postal code of the shipping address",
+                "type": ["null", "string"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "billing_address": {
+            "description": "The billing address associated with the draft order",
+            "properties": {
+              "phone": {
+                "description": "Phone number associated with the billing address",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "Country of the billing address",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Full name in the billing address",
+                "type": ["null", "string"]
+              },
+              "address1": {
+                "description": "First line of the billing address",
+                "type": ["null", "string"]
+              },
+              "longitude": {
+                "description": "Longitude coordinate of the billing address",
+                "type": ["null", "number"]
+              },
+              "address2": {
+                "description": "Second line of the billing address",
+                "type": ["null", "string"]
+              },
+              "last_name": {
+                "description": "Last name in the billing address",
+                "type": ["null", "string"]
+              },
+              "first_name": {
+                "description": "First name in the billing address",
+                "type": ["null", "string"]
+              },
+              "province": {
+                "description": "Province of the billing address",
+                "type": ["null", "string"]
+              },
+              "city": {
+                "description": "City of the billing address",
+                "type": ["null", "string"]
+              },
+              "company": {
+                "description": "Company name in the billing address",
+                "type": ["null", "string"]
+              },
+              "latitude": {
+                "description": "Latitude coordinate of the billing address",
+                "type": ["null", "number"]
+              },
+              "country_code": {
+                "description": "Country code of the billing address",
+                "type": ["null", "string"]
+              },
+              "province_code": {
+                "description": "Province code of the billing address",
+                "type": ["null", "string"]
+              },
+              "zip": {
+                "description": "ZIP or postal code of the billing address",
+                "type": ["null", "string"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "invoice_url": {
+            "description": "URL for the invoice related to the draft order",
+            "type": ["null", "string"]
+          },
+          "applied_discount": {
+            "description": "Details of any discount applied to the draft order",
+            "type": ["null", "object"],
+            "properties": {
+              "description": {
+                "description": "Description of the discount applied",
+                "type": ["null", "string"]
+              },
+              "value": {
+                "description": "The value of the discount",
+                "type": ["null", "string"]
+              },
+              "title": {
+                "description": "Title of the discount",
+                "type": ["null", "string"]
+              },
+              "amount": {
+                "description": "The amount of the discount applied",
+                "type": ["null", "string"]
+              },
+              "value_type": {
+                "description": "Type of the value in the discount",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "order_id": {
+            "description": "Unique identifier of the order associated with the draft order",
+            "type": ["null", "integer"]
+          },
+          "payment_terms": {
+            "description": "Terms of payment for the draft order",
+            "type": ["null", "string"]
+          },
+          "po_number": {
+            "description": "Purchase order number associated with the draft order",
+            "type": ["null", "string"]
+          },
+          "shipping_line": {
+            "description": "Details of the shipping service and cost associated with the draft order",
+            "properties": {
+              "price": {
+                "description": "Price of the shipping service",
+                "type": ["null", "number"]
+              },
+              "title": {
+                "description": "Title of the shipping service",
+                "type": ["null", "string"]
+              },
+              "custom": {
+                "description": "Custom information related to the shipping line",
+                "type": ["null", "boolean"]
+              },
+              "handle": {
+                "description": "Identifier for the shipping line",
+                "type": ["null", "string"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "tax_lines": {
+            "description": "Tax information related to the draft order",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "price": {
+                  "description": "Amount of tax for the draft order",
+                  "type": ["null", "number"]
+                },
+                "rate": {
+                  "description": "Tax rate applied",
+                  "type": ["null", "number"]
+                },
+                "title": {
+                  "description": "Title of the tax",
+                  "type": ["null", "string"]
+                },
+                "price_set": {
+                  "description": "Information about the price set for tax",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "description": "Money information in the shop's currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "Amount of money",
+                          "type": ["null", "number"]
+                        },
+                        "currency_code": {
+                          "description": "Currency code",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "presentment_money": {
+                      "description": "Money information in the presentment currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "Amount of money",
+                          "type": ["null", "number"]
+                        },
+                        "currency_code": {
+                          "description": "Currency code",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "tags": {
+            "description": "Tags associated with the draft order",
+            "type": ["null", "string"]
+          },
+          "note_attributes": {
+            "description": "Additional attributes or notes associated with the draft order",
+            "items": {
+              "properties": {
+                "name": {
+                  "description": "Name of the attribute or note",
+                  "type": ["null", "string"]
+                },
+                "value": {
+                  "description": "Value of the attribute or note",
+                  "type": ["null", "string"]
+                }
+              },
+              "type": ["null", "object"]
+            },
+            "type": ["null", "array"]
+          },
+          "total_price": {
+            "description": "Total price of the draft order",
+            "type": ["null", "string"]
+          },
+          "subtotal_price": {
+            "description": "Subtotal price of the draft order",
+            "type": ["null", "string"]
+          },
+          "total_tax": {
+            "description": "Total tax amount for the draft order",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier of the draft order in the Shopify Admin GraphQL API",
+            "type": ["null", "string"]
+          },
+          "customer": {
+            "description": "Details of the customer associated with the draft order",
+            "type": ["null", "object"],
+            "properties": {
+              "id": {
+                "description": "Unique identifier of the customer",
+                "type": ["null", "integer"]
+              },
+              "email": {
+                "description": "Email address of the customer",
+                "type": ["null", "string"]
+              },
+              "accepts_marketing": {
+                "description": "Indicates if the customer accepts marketing",
+                "type": ["null", "boolean"]
+              },
+              "created_at": {
+                "description": "Timestamp when the customer was created",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "updated_at": {
+                "description": "Timestamp when the customer record was last updated",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_name": {
+                "description": "First name of the customer",
+                "type": ["null", "string"]
+              },
+              "last_name": {
+                "description": "Last name of the customer",
+                "type": ["null", "string"]
+              },
+              "orders_count": {
+                "description": "Total number of orders made by the customer",
+                "type": ["null", "integer"]
+              },
+              "state": {
+                "description": "State of the customer",
+                "type": ["null", "string"]
+              },
+              "total_spent": {
+                "description": "Total amount spent by the customer",
+                "type": ["null", "number"]
+              },
+              "last_order_id": {
+                "description": "Unique identifier of the last order made by the customer",
+                "type": ["null", "integer"]
+              },
+              "note": {
+                "description": "Notes or comments about the customer",
+                "type": ["null", "string"]
+              },
+              "verified_email": {
+                "description": "Indicates if the email address of the customer is verified",
+                "type": ["null", "boolean"]
+              },
+              "multipass_identifier": {
+                "description": "Multipass identifier associated with the customer",
+                "type": ["null", "string"]
+              },
+              "tax_exempt": {
+                "description": "Indicates if the customer is tax exempt",
+                "type": ["null", "boolean"]
+              },
+              "phone": {
+                "description": "Phone number associated with the customer",
+                "type": ["null", "string"]
+              },
+              "tags": {
+                "description": "Tags associated with the customer",
+                "type": ["null", "string"]
+              },
+              "last_order_name": {
+                "description": "Name of the last order made by the customer",
+                "type": ["null", "string"]
+              },
+              "currency": {
+                "description": "Currency used for the customer",
+                "type": ["null", "string"]
+              },
+              "accepts_marketing_updated_at": {
+                "description": "Timestamp when marketing acceptance was last updated",
+                "type": ["null", "string"]
+              },
+              "marketing_opt_in_level": {
+                "description": "Level of marketing opt-in for the customer",
+                "type": ["null", "string"]
+              },
+              "tax_exemptions": {
+                "description": "List of tax exemptions for the customer",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "admin_graphql_api_id": {
+                "description": "The unique identifier of the customer in the Shopify Admin GraphQL API",
+                "type": ["null", "string"]
+              },
+              "default_address": {
+                "description": "Default address of the customer",
+                "type": ["null", "object"],
+                "properties": {
+                  "id": {
+                    "description": "Unique identifier of the default address",
+                    "type": ["null", "integer"]
+                  },
+                  "customer_id": {
+                    "description": "The unique identifier of the customer associated with the address",
+                    "type": ["null", "integer"]
+                  },
+                  "first_name": {
+                    "description": "First name in the default address",
+                    "type": ["null", "string"]
+                  },
+                  "last_name": {
+                    "description": "Last name in the default address",
+                    "type": ["null", "string"]
+                  },
+                  "company": {
+                    "description": "Company name in the default address",
+                    "type": ["null", "string"]
+                  },
+                  "address1": {
+                    "description": "First line of the default address",
+                    "type": ["null", "string"]
+                  },
+                  "address2": {
+                    "description": "Second line of the default address",
+                    "type": ["null", "string"]
+                  },
+                  "city": {
+                    "description": "City of the default address",
+                    "type": ["null", "string"]
+                  },
+                  "province": {
+                    "description": "Province of the default address",
+                    "type": ["null", "string"]
+                  },
+                  "country": {
+                    "description": "Country of the default address",
+                    "type": ["null", "string"]
+                  },
+                  "zip": {
+                    "description": "ZIP or postal code of the default address",
+                    "type": ["null", "string"]
+                  },
+                  "phone": {
+                    "description": "Phone number associated with the default address",
+                    "type": ["null", "string"]
+                  },
+                  "name": {
+                    "description": "Full name in the default address",
+                    "type": ["null", "string"]
+                  },
+                  "province_code": {
+                    "description": "Province code of the default address",
+                    "type": ["null", "string"]
+                  },
+                  "country_code": {
+                    "description": "Country code of the default address",
+                    "type": ["null", "string"]
+                  },
+                  "country_name": {
+                    "description": "Name of the country in the default address",
+                    "type": ["null", "string"]
+                  },
+                  "default": {
+                    "description": "Indicates if this is the default address for the customer",
+                    "type": ["null", "boolean"]
+                  }
+                }
+              }
+            }
+          },
+          "shop_url": {
+            "description": "URL of the shop related to the draft order",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "fulfillment_orders",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "assigned_location_id": {
+            "description": "The unique identifier of the assigned location",
+            "type": ["null", "integer"]
+          },
+          "channel_id": {
+            "description": "The ID of the channel that created an order",
+            "type": ["null", "string"]
+          },
+          "destination": {
+            "description": "Details of the destination where the order is to be fulfilled",
+            "type": ["null", "object"],
+            "properties": {
+              "id": {
+                "description": "The unique identifier of the destination",
+                "type": ["null", "integer"]
+              },
+              "address1": {
+                "description": "The primary address of the destination",
+                "type": ["null", "string"]
+              },
+              "address2": {
+                "description": "The secondary address of the destination",
+                "type": ["null", "string"]
+              },
+              "city": {
+                "description": "The city of the destination",
+                "type": ["null", "string"]
+              },
+              "company": {
+                "description": "The name of the company at the destination",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "The country of the destination",
+                "type": ["null", "string"]
+              },
+              "email": {
+                "description": "The email address of the recipient at the destination",
+                "type": ["null", "string"]
+              },
+              "first_name": {
+                "description": "The first name of the recipient at the destination",
+                "type": ["null", "string"]
+              },
+              "last_name": {
+                "description": "The last name of the recipient at the destination",
+                "type": ["null", "string"]
+              },
+              "phone": {
+                "description": "The phone number of the recipient at the destination",
+                "type": ["null", "string"]
+              },
+              "province": {
+                "description": "The province of the destination",
+                "type": ["null", "string"]
+              },
+              "zip": {
+                "description": "The postal code of the destination",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "delivery_method": {
+            "description": "Details of the delivery method for the fulfillment order",
+            "type": ["null", "object"],
+            "properties": {
+              "id": {
+                "description": "The unique identifier of the delivery method",
+                "type": ["null", "integer"]
+              },
+              "method_type": {
+                "description": "The type of delivery method",
+                "type": ["null", "string"]
+              },
+              "min_delivery_date_time": {
+                "description": "The minimum expected delivery date and time",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "max_delivery_date_time": {
+                "description": "The maximum expected delivery date and time",
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          },
+          "fulfilled_at": {
+            "description": "The date and time when the fulfillment was completed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "fulfill_at": {
+            "description": "The date and time when the fulfillment is scheduled to occur",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "fulfill_by": {
+            "description": "The deadline by which the fulfillment must be completed",
+            "type": ["null", "string"]
+          },
+          "international_duties": {
+            "description": "Details of any international duties associated with the fulfillment order",
+            "type": ["null", "string"]
+          },
+          "fulfillment_holds": {
+            "description": "Details of any holds on the fulfillment",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "reason": {
+                  "description": "The reason for the hold on the fulfillment",
+                  "type": ["null", "string"]
+                },
+                "reason_notes": {
+                  "description": "Additional notes regarding the hold on the fulfillment",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "id": {
+            "description": "The unique identifier of the fulfillment order",
+            "type": ["null", "integer"]
+          },
+          "line_items": {
+            "description": "Details of the line items in the fulfillment order",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "The unique identifier of the line item",
+                  "type": ["null", "integer"]
+                },
+                "shop_id": {
+                  "description": "The identifier of the shop where the line item belongs",
+                  "type": ["null", "integer"]
+                },
+                "fulfillment_order_id": {
+                  "description": "The identifier of the fulfillment order",
+                  "type": ["null", "integer"]
+                },
+                "line_item_id": {
+                  "description": "The identifier of the line item in the order",
+                  "type": ["null", "integer"]
+                },
+                "inventory_item_id": {
+                  "description": "The identifier of the inventory item associated with the line item",
+                  "type": ["null", "integer"]
+                },
+                "quantity": {
+                  "description": "The quantity of the line item",
+                  "type": ["null", "integer"]
+                },
+                "fulfillable_quantity": {
+                  "description": "The quantity that can be fulfilled",
+                  "type": ["null", "integer"]
+                },
+                "variant_id": {
+                  "description": "The identifier of the product variant",
+                  "type": ["null", "integer"]
+                }
+              }
+            }
+          },
+          "order_id": {
+            "description": "The identifier of the order associated with the fulfillment",
+            "type": ["null", "integer"]
+          },
+          "request_status": {
+            "description": "The status of any requests associated with the fulfillment order",
+            "type": ["null", "string"]
+          },
+          "shop_id": {
+            "description": "The identifier of the shop that created the fulfillment order",
+            "type": ["null", "integer"]
+          },
+          "status": {
+            "description": "The current status of the fulfillment order",
+            "type": ["null", "string"]
+          },
+          "supported_actions": {
+            "description": "Actions supported for the fulfillment order",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "action": {
+                  "description": "The type of action supported",
+                  "type": ["null", "string"]
+                },
+                "external_url": {
+                  "description": "The external URL associated with the action",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "merchant_requests": {
+            "description": "Details of any requests made by the merchant regarding the fulfillment order",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "The unique identifier of the merchant request",
+                  "type": ["null", "integer"]
+                },
+                "message": {
+                  "description": "The message included with the merchant request",
+                  "type": ["null", "string"]
+                },
+                "kind": {
+                  "description": "The type of request made by the merchant",
+                  "type": ["null", "string"]
+                },
+                "request_options": {
+                  "description": "Additional options provided with the merchant request",
+                  "type": ["null", "object"],
+                  "additionalProperties": true,
+                  "properties": {
+                    "notify_customer": {
+                      "description": "Whether to notify the customer regarding the request",
+                      "type": ["null", "boolean"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "assigned_location": {
+            "description": "The location to which the fulfillment order is assigned",
+            "type": ["null", "object"],
+            "properties": {
+              "address1": {
+                "description": "The primary address of the assigned location",
+                "type": ["null", "string"]
+              },
+              "address2": {
+                "description": "The secondary address of the assigned location",
+                "type": ["null", "string"]
+              },
+              "city": {
+                "description": "The city of the assigned location",
+                "type": ["null", "string"]
+              },
+              "country_code": {
+                "description": "The country code of the assigned location",
+                "type": ["null", "string"]
+              },
+              "location_id": {
+                "description": "The unique identifier of the assigned location",
+                "type": ["null", "integer"]
+              },
+              "name": {
+                "description": "The name of the assigned location",
+                "type": ["null", "string"]
+              },
+              "phone": {
+                "description": "The phone number of the assigned location",
+                "type": ["null", "string"]
+              },
+              "province": {
+                "description": "The province of the assigned location",
+                "type": ["null", "string"]
+              },
+              "zip": {
+                "description": "The postal code of the assigned location",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "shop_url": {
+            "description": "The URL of the shop associated with the fulfillment order",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when the fulfillment order was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the fulfillment order was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier of the fulfillment order in the Admin GraphQL API",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "fulfillments",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "admin_graphql_api_id": {
+            "description": "The unique identifier of the resource in the Admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when the fulfillment was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "id": {
+            "description": "The unique identifier of the fulfillment.",
+            "type": ["null", "integer"]
+          },
+          "location_id": {
+            "description": "The location identifier where the fulfillment takes place.",
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "description": "The name of the fulfillment.",
+            "type": ["null", "string"]
+          },
+          "notify_customer": {
+            "description": "Indicates if the customer should be notified about the fulfillment.",
+            "type": ["null", "boolean"]
+          },
+          "order_id": {
+            "description": "The unique identifier of the order associated with the fulfillment.",
+            "type": ["null", "integer"]
+          },
+          "origin_address": {
+            "description": "Address information for the origin of the fulfillment",
+            "type": ["null", "object"],
+            "properties": {
+              "address1": {
+                "description": "The first line of the origin address.",
+                "type": "string"
+              },
+              "address2": {
+                "description": "The second line of the origin address.",
+                "type": "string"
+              },
+              "city": {
+                "description": "The city of the origin address.",
+                "type": "string"
+              },
+              "country_code": {
+                "description": "The country code of the origin address.",
+                "type": "string"
+              },
+              "province_code": {
+                "description": "The province code of the origin address.",
+                "type": "string"
+              },
+              "zip": {
+                "description": "The postal/ZIP code of the origin address.",
+                "type": "string"
+              }
+            }
+          },
+          "receipt": {
+            "description": "Receipt details for the fulfillment",
+            "type": ["null", "object"],
+            "properties": {
+              "testcase": {
+                "description": "Indicates if the fulfillment is a test case.",
+                "type": ["null", "boolean"]
+              },
+              "authorization": {
+                "description": "The authorization information associated with the fulfillment.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "service": {
+            "description": "The service used for the fulfillment.",
+            "type": ["null", "string"]
+          },
+          "shipment_status": {
+            "description": "The status of the shipment.",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "The status of the fulfillment.",
+            "type": ["null", "string"]
+          },
+          "tracking_company": {
+            "description": "The company responsible for tracking the shipment.",
+            "type": ["null", "string"]
+          },
+          "tracking_numbers": {
+            "description": "Tracking numbers associated with the fulfillment",
+            "type": ["null", "array"],
+            "items": {
+              "description": "List of tracking numbers associated with the shipment.",
+              "type": ["null", "string"]
+            }
+          },
+          "tracking_urls": {
+            "description": "Tracking URLs for tracking the fulfillment",
+            "type": ["null", "array"],
+            "items": {
+              "description": "List of tracking URLs associated with the shipment.",
+              "type": ["null", "string"]
+            }
+          },
+          "tracking_url": {
+            "description": "The tracking URL of the shipment.",
+            "type": ["null", "string"]
+          },
+          "tracking_number": {
+            "description": "The tracking number of the shipment.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the fulfillment was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "variant_inventory_management": {
+            "description": "The inventory management method for the variant.",
+            "type": ["null", "string"]
+          },
+          "line_items": {
+            "description": "Information about line items included in the fulfillment",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "The unique identifier of the line item.",
+                  "type": ["null", "integer"]
+                },
+                "variant_id": {
+                  "description": "The unique identifier of the associated variant.",
+                  "type": ["null", "integer"]
+                },
+                "title": {
+                  "description": "The title of the line item.",
+                  "type": ["null", "string"]
+                },
+                "quantity": {
+                  "description": "The quantity of the line item.",
+                  "type": ["null", "integer"]
+                },
+                "price": {
+                  "description": "The price of the line item.",
+                  "type": ["null", "string"]
+                },
+                "price_set": {
+                  "description": "Set of prices for the line item",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "description": "Price in shop's currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "The amount of the line item price in the shop currency.",
+                          "type": ["null", "number"]
+                        },
+                        "currency_code": {
+                          "description": "The currency code of the line item price.",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "presentment_money": {
+                      "description": "Price in presentment currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "The amount of the line item price in the presentment currency.",
+                          "type": ["null", "number"]
+                        },
+                        "currency_code": {
+                          "description": "The currency code of the line item price.",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    }
+                  }
+                },
+                "grams": {
+                  "description": "The weight of the line item in grams.",
+                  "type": ["null", "number"]
+                },
+                "sku": {
+                  "description": "The SKU of the line item.",
+                  "type": ["null", "string"]
+                },
+                "variant_title": {
+                  "description": "The title of the variant associated with the line item.",
+                  "type": ["null", "string"]
+                },
+                "vendor": {
+                  "description": "The vendor of the product associated with the line item.",
+                  "type": ["null", "string"]
+                },
+                "fulfillment_service": {
+                  "description": "The service used for fulfillment.",
+                  "type": ["null", "string"]
+                },
+                "product_id": {
+                  "description": "The unique identifier of the associated product.",
+                  "type": ["null", "integer"]
+                },
+                "requires_shipping": {
+                  "description": "Indicates if the line item requires shipping.",
+                  "type": ["null", "boolean"]
+                },
+                "taxable": {
+                  "description": "Indicates if the line item is taxable.",
+                  "type": ["null", "boolean"]
+                },
+                "gift_card": {
+                  "description": "Indicates if the line item is a gift card.",
+                  "type": ["null", "boolean"]
+                },
+                "name": {
+                  "description": "The name of the line item.",
+                  "type": ["null", "string"]
+                },
+                "variant_inventory_management": {
+                  "description": "The inventory management method for the variant.",
+                  "type": ["null", "string"]
+                },
+                "properties": {
+                  "description": "Other properties related to the line item",
+                  "type": ["null", "array"],
+                  "items": {
+                    "description": "Additional properties associated with the line item.",
+                    "type": ["null", "string"]
+                  }
+                },
+                "product_exists": {
+                  "description": "Indicates if the product associated with the line item exists.",
+                  "type": ["null", "boolean"]
+                },
+                "fulfillable_quantity": {
+                  "description": "The quantity that can be fulfilled.",
+                  "type": ["null", "integer"]
+                },
+                "total_discount": {
+                  "description": "The total discount applied to the line item.",
+                  "type": ["null", "string"]
+                },
+                "total_discount_set": {
+                  "description": "Set of total discounts for the line item",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "description": "Total discount amount in shop's currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "The amount of total discount in the shop currency.",
+                          "type": ["null", "number"]
+                        },
+                        "currency_code": {
+                          "description": "The currency code of the total discount amount.",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "presentment_money": {
+                      "description": "Total discount amount in presentment currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "The amount of total discount in the presentment currency.",
+                          "type": ["null", "number"]
+                        },
+                        "currency_code": {
+                          "description": "The currency code of the total discount amount.",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    }
+                  }
+                },
+                "fulfillment_status": {
+                  "description": "The status of the fulfillment.",
+                  "type": ["null", "string"]
+                },
+                "fulfillment_line_item_id": {
+                  "description": "The unique identifier of the fulfillment line item.",
+                  "type": ["null", "integer"]
+                },
+                "tax_lines": {
+                  "description": "Tax lines related to the line item",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "channel_liable": {
+                        "description": "Indicates if the channel is liable for the tax.",
+                        "type": ["null", "boolean"]
+                      },
+                      "price": {
+                        "description": "The price of the tax line.",
+                        "type": ["null", "number"]
+                      },
+                      "price_set": {
+                        "description": "Set of prices for tax lines",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "The tax line price in the shop currency.",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "number"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          },
+                          "presentment_money": {
+                            "description": "The tax line price in the presentment currency.",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "number"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      },
+                      "rate": {
+                        "description": "The tax rate.",
+                        "type": ["null", "number"]
+                      },
+                      "title": {
+                        "description": "The title of the tax line.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                },
+                "duties": {
+                  "description": "Information about duties associated with the line item",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": {
+                        "description": "The unique identifier of the duty.",
+                        "type": ["null", "string"]
+                      },
+                      "harmonized_system_code": {
+                        "description": "The harmonized system code for duty calculation.",
+                        "type": ["null", "string"]
+                      },
+                      "country_code_of_origin": {
+                        "description": "The country code of origin for duty calculation.",
+                        "type": ["null", "string"]
+                      },
+                      "shop_money": {
+                        "description": "Duties amount in shop's currency",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "amount": {
+                            "description": "The amount of duty in the shop currency.",
+                            "type": ["null", "string"]
+                          },
+                          "currency_code": {
+                            "description": "The currency code of the duty amount.",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "presentment_money": {
+                        "description": "Duties amount in presentment currency",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "amount": {
+                            "description": "The amount of duty in the presentment currency.",
+                            "type": ["null", "string"]
+                          },
+                          "currency_code": {
+                            "description": "The currency code of the duty amount.",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "tax_lines": {
+                        "description": "Tax lines related to duties",
+                        "type": ["null", "array"],
+                        "items": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "title": {
+                              "description": "The title of the tax line.",
+                              "type": ["null", "string"]
+                            },
+                            "price": {
+                              "description": "The price of the tax line.",
+                              "type": ["null", "string"]
+                            },
+                            "rate": {
+                              "description": "The tax rate.",
+                              "type": ["null", "number"]
+                            },
+                            "price_set": {
+                              "description": "Set of prices for tax lines",
+                              "type": ["null", "object"],
+                              "properties": {
+                                "shop_money": {
+                                  "description": "The tax line price in the shop currency.",
+                                  "type": ["null", "object"],
+                                  "properties": {
+                                    "amount": { "type": ["null", "string"] },
+                                    "currency_code": {
+                                      "type": ["null", "string"]
+                                    }
+                                  }
+                                },
+                                "presentment_money": {
+                                  "description": "The tax line price in the presentment currency.",
+                                  "type": ["null", "object"],
+                                  "properties": {
+                                    "amount": { "type": ["null", "string"] },
+                                    "currency_code": {
+                                      "type": ["null", "string"]
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "channel_liable": {
+                              "description": "Indicates if the channel is liable for the tax.",
+                              "type": ["null", "boolean"]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "discount_allocations": {
+                  "description": "List of discount allocations associated with the line item",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": {
+                        "description": "The unique identifier of the discount allocation.",
+                        "type": ["null", "string"]
+                      },
+                      "amount": {
+                        "description": "The amount of discount allocation.",
+                        "type": ["null", "string"]
+                      },
+                      "description": {
+                        "description": "The description of the discount allocation.",
+                        "type": ["null", "string"]
+                      },
+                      "created_at": {
+                        "description": "The date and time when the discount allocation was created.",
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "discount_application_index": {
+                        "description": "The index of the discount application.",
+                        "type": ["null", "number"]
+                      },
+                      "amount_set": {
+                        "description": "Set of amounts for discount allocations",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "The discount allocation amount in the shop currency.",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "string"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          },
+                          "presentment_money": {
+                            "description": "The discount allocation amount in the presentment currency.",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "string"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      },
+                      "application_type": {
+                        "description": "The type of discount application.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                },
+                "admin_graphql_api_id": {
+                  "description": "The unique identifier of the line item in the Admin GraphQL API.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "duties": {
+            "description": "Information about duties associated with the fulfillment",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "The unique identifier of the duty.",
+                  "type": ["null", "string"]
+                },
+                "harmonized_system_code": {
+                  "description": "The harmonized system code for duty calculation.",
+                  "type": ["null", "string"]
+                },
+                "country_code_of_origin": {
+                  "description": "The country code of origin for duty calculation.",
+                  "type": ["null", "string"]
+                },
+                "shop_money": {
+                  "description": "Duties amount in shop's currency",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "amount": {
+                      "description": "The amount of duty in the shop currency.",
+                      "type": ["null", "string"]
+                    },
+                    "currency_code": {
+                      "description": "The currency code of the duty amount.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "presentment_money": {
+                  "description": "Duties amount in presentment currency",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "amount": {
+                      "description": "The amount of duty in the presentment currency.",
+                      "type": ["null", "string"]
+                    },
+                    "currency_code": {
+                      "description": "The currency code of the duty amount.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "tax_lines": {
+                  "description": "Tax lines related to duties",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "title": {
+                        "description": "The title of the tax line.",
+                        "type": ["null", "string"]
+                      },
+                      "price": {
+                        "description": "The price of the tax line.",
+                        "type": ["null", "string"]
+                      },
+                      "rate": {
+                        "description": "The tax rate.",
+                        "type": ["null", "number"]
+                      },
+                      "price_set": {
+                        "description": "Set of prices for tax lines",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "The tax line price in the shop currency.",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "string"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          },
+                          "presentment_money": {
+                            "description": "The tax line price in the presentment currency.",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "string"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      },
+                      "channel_liable": {
+                        "description": "Indicates if the channel is liable for the tax.",
+                        "type": ["null", "boolean"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "shop_url": {
+            "description": "The URL of the shop associated with the fulfillment.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "inventory_items",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the inventory item",
+            "type": ["null", "integer"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the inventory item in the admin GraphQL API",
+            "type": ["null", "string"]
+          },
+          "cost": {
+            "description": "The cost of the inventory item",
+            "type": ["null", "number"]
+          },
+          "currency_code": {
+            "description": "Currency of the money",
+            "type": ["null", "string"]
+          },
+          "country_code_of_origin": {
+            "description": "The country code indicating the origin of the inventory item",
+            "type": ["null", "string"]
+          },
+          "country_harmonized_system_codes": {
+            "description": "The harmonized system codes associated with the inventory item",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "duplicate_sku_count": {
+            "description": "The number of inventory items that share the same SKU with this item",
+            "type": ["null", "integer"]
+          },
+          "harmonized_system_code": {
+            "description": "The harmonized system code for the inventory item",
+            "type": ["null", "string"]
+          },
+          "province_code_of_origin": {
+            "description": "The province code indicating the origin of the inventory item",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the inventory item was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "created_at": {
+            "description": "The date and time when the inventory item was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sku": {
+            "description": "The stock keeping unit (SKU) of the inventory item",
+            "type": ["null", "string"]
+          },
+          "tracked": {
+            "description": "Flag indicating if the inventory item is tracked",
+            "type": ["null", "boolean"]
+          },
+          "requires_shipping": {
+            "description": "Flag indicating if the inventory item requires shipping",
+            "type": ["null", "boolean"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the inventory item belongs",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "inventory_levels",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the inventory level.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the inventory levels in GraphQL format.",
+            "type": ["null", "string"]
+          },
+          "available": {
+            "description": "The quantity of items available for sale in the inventory.",
+            "type": ["null", "integer"]
+          },
+          "can_deactivate": {
+            "description": "Whether the inventory items associated with the inventory level can be deactivated.",
+            "type": ["null", "boolean"]
+          },
+          "created_at": {
+            "description": "The date and time when the inventory level was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "inventory_history_url": {
+            "description": "The URL that points to the inventory history for the item.",
+            "type": ["null", "string"]
+          },
+          "locations_count": {
+            "description": "The number of locations where this inventory item is stocked.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "count": {
+                "description": "The count of elements.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "deactivation_alert": {
+            "description": "Describes either the impact of deactivating the inventory level, or why the inventory level can't be deactivated.",
+            "type": ["null", "string"]
+          },
+          "inventory_item_id": {
+            "description": "The unique identifier for the associated inventory item.",
+            "type": ["null", "integer"]
+          },
+          "location_id": {
+            "description": "The unique identifier for the location related to the inventory level.",
+            "type": ["null", "integer"]
+          },
+          "updated_at": {
+            "description": "The date and time when the inventory level was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the inventory belongs.",
+            "type": ["null", "string"]
+          },
+          "quantities": {
+            "description": "The quantities of items available for sale in the inventory.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "integer"] },
+                "name": { "type": ["null", "string"] },
+                "quantity": { "type": ["null", "integer"] },
+                "updatedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "admin_graphql_api_id": { "type": ["null", "string"] }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "locations",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "active": {
+            "description": "Indicates if the location is currently active or not.",
+            "type": ["null", "boolean"]
+          },
+          "address1": {
+            "description": "The first line of the location's address.",
+            "type": ["null", "string"]
+          },
+          "address2": {
+            "description": "The second line of the location's address.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The Admin GraphQL API ID of the location.",
+            "type": ["null", "string"]
+          },
+          "city": {
+            "description": "The city where the location is based.",
+            "type": ["null", "string"]
+          },
+          "country": {
+            "description": "The full name of the country where the location is located.",
+            "type": ["null", "string"]
+          },
+          "country_code": {
+            "description": "The ISO country code of the location.",
+            "type": ["null", "string"]
+          },
+          "country_name": {
+            "description": "The name of the country where the location is located.",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when the location was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "id": {
+            "description": "The unique identifier of the location.",
+            "type": ["null", "integer"]
+          },
+          "legacy": {
+            "description": "Indicates if the location is a legacy location or not.",
+            "type": ["null", "boolean"]
+          },
+          "name": {
+            "description": "The name of the location.",
+            "type": ["null", "string"]
+          },
+          "phone": {
+            "description": "The phone number associated with the location.",
+            "type": ["null", "string"]
+          },
+          "province": {
+            "description": "The full name of the province or state where the location is located.",
+            "type": ["null", "string"]
+          },
+          "province_code": {
+            "description": "The ISO code of the province or state where the location is located.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the location was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "zip": {
+            "description": "The postal or ZIP code of the location.",
+            "type": ["null", "string"]
+          },
+          "localized_country_name": {
+            "description": "The localized name of the country where the location is located.",
+            "type": ["null", "string"]
+          },
+          "localized_province_name": {
+            "description": "The localized name of the province or state of the location.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop associated with the location.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_articles",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the metafield",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace under which the metafield is defined",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key or identifier used to access the metafield",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The actual value stored in the metafield",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The type of value stored in the metafield (e.g., single, array)",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description or details of the metafield",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The unique identifier of the resource that owns the metafield",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The type or resource that owns the metafield (e.g., Article, Product)",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The data type of the metafield's value (e.g., string, integer)",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier of the metafield in the GraphQL Admin API",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop linked to the metafield",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_blogs",
+      "json_schema": {
+        "properties": {
+          "owner_id": {
+            "description": "The unique identifier of the owner associated with the metafield data",
+            "type": ["null", "integer"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the metafield data in the Admin GraphQL API",
+            "type": ["null", "string"]
+          },
+          "owner_resource": {
+            "description": "The resource type of the owner associated with the metafield data",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The data type of the value stored in the metafield",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key associated with the metafield data",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield data was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "id": {
+            "description": "The unique identifier for the metafield data",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace of the metafield data",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the metafield data",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The value of the metafield data",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield data was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the metafield data belongs",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The type of data stored in the metafield",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_collections",
+      "json_schema": {
+        "properties": {
+          "owner_id": {
+            "description": "The ID of the owner associated with the metafield collection",
+            "type": ["null", "integer"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the metafield collection in the Admin GraphQL API",
+            "type": ["null", "string"]
+          },
+          "owner_resource": {
+            "description": "The resource type of the owner associated with the metafield collection",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The type of the value in the metafield collection",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key associated with the metafield collection",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield collection was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "id": {
+            "description": "The unique identifier for the metafield collection",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace for the metafield collection",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the metafield collection",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The value of the metafield collection",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield collection was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "shop_url": {
+            "description": "The URL of the shop related to the metafield collection",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The type of the metafield collection",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_customers",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the metafield.",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace in which the metafield is defined.",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key or title that identifies the metafield.",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The actual value of the metafield.",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The type of value stored in the metafield (e.g., string, integer, boolean).",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description or additional information about the metafield.",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The unique identifier of the resource owner associated with the metafield.",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The resource type of the owner (e.g., Customer, Product) of the metafield.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The data type of the metafield value.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the metafield accessible via the Admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop associated with the metafield.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_draft_orders",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the metafield draft order.",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace of the metafield draft order.",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key associated with the metafield draft order.",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The value of the metafield draft order.",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The data type of the value of the metafield draft order.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The textual description of the metafield draft order.",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The unique identifier of the owner (e.g., shop) associated with the metafield draft order.",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield draft order was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield draft order was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The type of owner resource (e.g., shop) associated with the metafield draft order.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The type of the metafield draft order.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier of the metafield draft order within the admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop to which the metafield draft order belongs.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_locations",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the metafield",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace of the metafield",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key or name of the metafield",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The actual value of the metafield",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The data type of the metafield value",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the metafield",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The unique identifier of the resource that owns the metafield",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The type of resource that owns the metafield",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The type of the metafield value",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the metafield in the Shopify GraphQL Admin API",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the metafield is associated",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_orders",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the metafield record.",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The area or group to which the metafield belongs.",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The name that identifies the metafield.",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The actual value of the metafield.",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The type of data stored in the metafield value.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "Additional information or notes about the metafield.",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The unique identifier of the resource that owns the metafield.",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The type of resource that owns the metafield.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The data type of the metafield value.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the metafield in the Admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the Shopify shop associated with the metafield.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_pages",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "A unique identifier for the metafield.",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace for the metafield, used to group related metafields together.",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key or name of the metafield.",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The actual value stored in the metafield.",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The data type of the value stored in the metafield (e.g., string, integer).",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description or purpose of the metafield.",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The ID of the resource (e.g., product, order) that owns the metafield.",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The type of resource (e.g., product, order) that owns the metafield.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The data type of the value stored in the metafield (e.g., string, integer).",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "A unique identifier for the metafield within Shopify's GraphQL Admin API.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the metafield is associated.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_product_images",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "The unique ID of the metafield.",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace of the metafield.",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key that identifies the metafield.",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The actual value stored in the metafield.",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The type of the value stored in the metafield.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the metafield.",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The ID of the owner of the metafield.",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The type of resource that owns the metafield.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The data type of the value stored in the metafield.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The admin GraphQL API ID of the metafield.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the metafield belongs.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_products",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "A unique identifier for the metafield.",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace for the metafield, helping to group related metafields together.",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key or name that identifies the metafield.",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The actual value of the metafield based on its type.",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "A representation of the type of the value (for example, 'string' or 'integer').",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the metafield, providing additional information.",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The unique identifier of the resource that owns the metafield.",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time the metafield was created in ISO 8601 format.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time the metafield was last updated in ISO 8601 format.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The type of resource that owns the metafield, such as 'product' or 'collection'.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The type of the metafield value, such as 'string', 'integer', 'json_string', etc.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "A unique identifier for the metafield used in the Shopify Admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The shop URL where the metafield is associated with.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_product_variants",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the metafield",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace for grouping metafields",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key associated with the metafield for identifying purposes",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The actual value of the metafield",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The type that the value of the metafield represents (e.g., URL, text)",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the metafield content",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The unique identifier of the entity that owns the metafield",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The resource type that owns the metafield (e.g., product, variant)",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The data type of the metafield value (e.g., string, integer)",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the metafield in the GraphQL Admin API",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the metafield is associated",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_shops",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the metafield.",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The namespace to which the metafield belongs.",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key that identifies the metafield.",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The actual value stored in the metafield.",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The data type of the value stored in the metafield.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The additional information about the metafield.",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The unique identifier of the owner resource linked to this metafield.",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The type of resource that owns the metafield.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The type of data stored in the metafield.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the admin GraphQL API of the shop.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop to which the metafield is associated.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "metafield_smart_collections",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the metafield.",
+            "type": ["null", "integer"]
+          },
+          "namespace": {
+            "description": "The container for a set of metafields. Typically corresponds to a section of the store.",
+            "type": ["null", "string"]
+          },
+          "key": {
+            "description": "The key or name associated with the metafield.",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The actual value of the metafield.",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The type of value stored in the metafield (e.g., string, integer, json_string).",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The detailed description of the metafield data.",
+            "type": ["null", "string"]
+          },
+          "owner_id": {
+            "description": "The ID of the resource to which the metafield is attached.",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the metafield was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the metafield was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "owner_resource": {
+            "description": "The resource type (e.g., Product, Collection) to which the metafield is attached.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The data type of the metafield value (e.g., string, integer).",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the metafield in the GraphQL admin API.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the metafield belongs.",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "order_agreements",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "A globally-unique Order ID",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time when the order was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the order was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "admin_graphql_api_id": {
+            "description": "The original order id reference for the shopify api",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "URL of the shop where the order was placed.",
+            "type": ["null", "string"]
+          },
+          "agreements": {
+            "description": "A list of sales agreements associated with the order.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "The unique ID for the agreement.",
+                  "type": ["null", "integer"]
+                },
+                "happened_at": {
+                  "description": "The date and time at which the agreement occured.",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "reason": {
+                  "description": "The reason the agremeent was created.",
+                  "type": ["null", "string"]
+                },
+                "sales": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "quantity": {
+                        "description": "The number of units either ordered or intended to be returned.",
+                        "type": ["null", "integer"]
+                      },
+                      "id": {
+                        "description": "The unique ID for the sale.",
+                        "type": ["null", "integer"]
+                      },
+                      "action_type": {
+                        "description": "The type of order action that the sale represents.",
+                        "type": ["null", "string"]
+                      },
+                      "line_type": {
+                        "description": "The line type assocated with the sale.",
+                        "type": ["null", "string"]
+                      },
+                      "total_amount": {
+                        "description": "The total sale amount after taxes and discounts.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "Amount in shop currency.",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Decimal money amount.",
+                                "type": ["null", "number"]
+                              },
+                              "currency_code": {
+                                "description": "Currency of the money.",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "total_discount_amount_after_taxes": {
+                        "description": "The total discounts allocated to the sale after taxes.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "Amount in shop currency.",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Decimal money amount.",
+                                "type": ["null", "number"]
+                              },
+                              "currency_code": {
+                                "description": "Currency of the money.",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "total_discount_amount_before_taxes": {
+                        "description": "The total discounts allocated to the sale before taxes.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "Amount in shop currency.",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Decimal money amount.",
+                                "type": ["null", "number"]
+                              },
+                              "currency_code": {
+                                "description": "Currency of the money.",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "total_tax_amount": {
+                        "description": "The total amount of taxes for the sale.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "Amount in shop currency.",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Decimal money amount.",
+                                "type": ["null", "number"]
+                              },
+                              "currency_code": {
+                                "description": "Currency of the money.",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "line_item": {
+                        "description": "The line item for the associated sale.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "id": {
+                            "description": "A globally-unique line item ID.",
+                            "type": ["null", "integer"]
+                          },
+                          "admin_graphql_api_id": {
+                            "description": "The original agreement-sales-related line item id reference for the shopify api",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "admin_graphql_api_id": {
+                        "description": "The original agreement-related sale id reference for the shopify api",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                },
+                "admin_graphql_api_id": {
+                  "description": "The original agreement id reference for the shopify api",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "order_refunds",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "order_id": {
+            "description": "ID of the original order for which the refund was issued",
+            "type": ["null", "integer"]
+          },
+          "restock": {
+            "description": "Indicates if the refund involves restocking items",
+            "type": ["null", "boolean"]
+          },
+          "order_adjustments": {
+            "description": "Adjustments made to the original order as part of the refund",
+            "items": {
+              "properties": {
+                "order_id": {
+                  "description": "ID of the original order related to the adjustment",
+                  "type": ["null", "integer"]
+                },
+                "tax_amount": {
+                  "description": "Amount of tax associated with the adjustment",
+                  "type": ["null", "string"]
+                },
+                "refund_id": {
+                  "description": "ID of the refund associated with the adjustment",
+                  "type": ["null", "integer"]
+                },
+                "amount": {
+                  "description": "Amount of the adjustment",
+                  "type": ["null", "string"]
+                },
+                "kind": {
+                  "description": "Type of adjustment",
+                  "type": ["null", "string"]
+                },
+                "id": {
+                  "description": "Unique identifier for the adjustment",
+                  "type": ["null", "integer"]
+                },
+                "reason": {
+                  "description": "Reason for the adjustment",
+                  "type": ["null", "string"]
+                }
+              },
+              "type": ["null", "object"]
+            },
+            "type": ["null", "array"]
+          },
+          "processed_at": {
+            "description": "Date and time when the refund was processed",
+            "type": ["null", "string"]
+          },
+          "user_id": {
+            "description": "ID of the user who initiated the refund",
+            "type": ["null", "integer"]
+          },
+          "note": {
+            "description": "Any additional notes or comments regarding the refund",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier for the order refund resource",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "Date and time when the order refund was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "admin_graphql_api_id": {
+            "description": "ID of the Shopify API resource",
+            "type": ["null", "string"]
+          },
+          "duties": {
+            "description": "Information about any duties associated with the refund",
+            "type": ["null", "string"]
+          },
+          "refund_line_items": {
+            "description": "Line items included in the refund",
+            "type": ["null", "array"],
+            "items": {
+              "properties": {
+                "location_id": {
+                  "description": "ID of the location related to the refund",
+                  "type": ["null", "integer"]
+                },
+                "subtotal_set": {
+                  "description": "Details of the subtotal amount",
+                  "properties": {
+                    "shop_money": {
+                      "description": "Subtotal amount in the shop's currency",
+                      "properties": {
+                        "currency_code": { "type": ["null", "string"] },
+                        "amount": { "type": ["null", "number"] }
+                      },
+                      "type": ["null", "object"]
+                    },
+                    "presentment_money": {
+                      "description": "Subtotal amount in the currency presented to the customer",
+                      "properties": {
+                        "currency_code": { "type": ["null", "string"] },
+                        "amount": { "type": ["null", "number"] }
+                      },
+                      "type": ["null", "object"]
+                    }
+                  },
+                  "type": ["null", "object"]
+                },
+                "total_tax_set": {
+                  "description": "Details of the total tax amount",
+                  "properties": {
+                    "shop_money": {
+                      "description": "Total tax amount in the shop's currency",
+                      "properties": {
+                        "currency_code": { "type": ["null", "string"] },
+                        "amount": { "type": ["null", "number"] }
+                      },
+                      "type": ["null", "object"]
+                    },
+                    "presentment_money": {
+                      "description": "Total tax amount in the currency presented to the customer",
+                      "properties": {
+                        "currency_code": { "type": ["null", "string"] },
+                        "amount": { "type": ["null", "number"] }
+                      },
+                      "type": ["null", "object"]
+                    }
+                  },
+                  "type": ["null", "object"]
+                },
+                "line_item_id": {
+                  "description": "ID of the original line item being refunded",
+                  "type": ["null", "integer"]
+                },
+                "total_tax": {
+                  "description": "Total tax amount for the line item",
+                  "type": ["null", "number"]
+                },
+                "quantity": {
+                  "description": "Quantity being refunded",
+                  "type": ["null", "integer"]
+                },
+                "id": {
+                  "description": "Unique identifier for the refund line item",
+                  "type": ["null", "integer"]
+                },
+                "line_item": {
+                  "description": "Information about the original line item being refunded",
+                  "properties": {
+                    "gift_card": {
+                      "description": "Indicates if the line item is a gift card",
+                      "type": ["null", "boolean"]
+                    },
+                    "price": {
+                      "description": "Price of the product after taxes",
+                      "type": ["null", "number"]
+                    },
+                    "tax_lines": {
+                      "description": "Tax details associated with the line item",
+                      "type": ["null", "array"],
+                      "items": {
+                        "properties": {
+                          "price_set": {
+                            "description": "Details of the tax price",
+                            "properties": {
+                              "shop_money": {
+                                "description": "Tax price in the shop's currency",
+                                "properties": {
+                                  "currency_code": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "amount": { "type": ["null", "number"] }
+                                },
+                                "type": ["null", "object"]
+                              },
+                              "presentment_money": {
+                                "description": "Tax price in the currency presented to the customer",
+                                "properties": {
+                                  "currency_code": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "amount": { "type": ["null", "number"] }
+                                },
+                                "type": ["null", "object"]
+                              }
+                            },
+                            "type": ["null", "object"]
+                          },
+                          "price": {
+                            "description": "Price of the tax",
+                            "type": ["null", "number"]
+                          },
+                          "title": {
+                            "description": "Title of the tax",
+                            "type": ["null", "string"]
+                          },
+                          "rate": {
+                            "description": "Tax rate applied",
+                            "type": ["null", "number"]
+                          },
+                          "channel_liable": {
+                            "description": "Indicates if the channel is liable for the tax",
+                            "type": ["null", "boolean"]
+                          }
+                        },
+                        "type": ["null", "object"]
+                      }
+                    },
+                    "fulfillment_service": {
+                      "description": "Service responsible for fulfilling the item",
+                      "type": ["null", "string"]
+                    },
+                    "sku": {
+                      "description": "Stock Keeping Unit for the product",
+                      "type": ["null", "string"]
+                    },
+                    "fulfillment_status": {
+                      "description": "Status of fulfillment for the line item",
+                      "type": ["null", "string"]
+                    },
+                    "properties": {
+                      "description": "Additional properties of the line item",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "string"] }
+                    },
+                    "quantity": {
+                      "description": "Quantity of the line item",
+                      "type": ["null", "integer"]
+                    },
+                    "variant_id": {
+                      "description": "ID of the variant associated with the product",
+                      "type": ["null", "integer"]
+                    },
+                    "grams": {
+                      "description": "Weight of the line item",
+                      "type": ["null", "integer"]
+                    },
+                    "requires_shipping": {
+                      "description": "Indicates if the product requires shipping",
+                      "type": ["null", "boolean"]
+                    },
+                    "vendor": {
+                      "description": "Vendor of the product",
+                      "type": ["null", "string"]
+                    },
+                    "price_set": {
+                      "description": "Details of the price after taxes",
+                      "properties": {
+                        "shop_money": {
+                          "description": "Price after taxes in the shop's currency",
+                          "properties": {
+                            "currency_code": { "type": ["null", "string"] },
+                            "amount": { "type": ["null", "number"] }
+                          },
+                          "type": ["null", "object"]
+                        },
+                        "presentment_money": {
+                          "description": "Price after taxes in the currency presented to the customer",
+                          "properties": {
+                            "currency_code": { "type": ["null", "string"] },
+                            "amount": { "type": ["null", "number"] }
+                          },
+                          "type": ["null", "object"]
+                        }
+                      },
+                      "type": ["null", "object"]
+                    },
+                    "variant_inventory_management": {
+                      "description": "Manages the inventory for the variant",
+                      "type": ["null", "string"]
+                    },
+                    "pre_tax_price": {
+                      "description": "Price of the product before taxes",
+                      "type": ["null", "number"]
+                    },
+                    "variant_title": {
+                      "description": "Title of the variant",
+                      "type": ["null", "string"]
+                    },
+                    "total_discount_set": {
+                      "description": "Details of the total discount",
+                      "properties": {
+                        "shop_money": {
+                          "description": "Total discount in the shop's currency",
+                          "properties": {
+                            "currency_code": { "type": ["null", "string"] },
+                            "amount": { "type": ["null", "number"] }
+                          },
+                          "type": ["null", "object"]
+                        },
+                        "presentment_money": {
+                          "description": "Total discount in the currency presented to the customer",
+                          "properties": {
+                            "currency_code": { "type": ["null", "string"] },
+                            "amount": { "type": ["null", "number"] }
+                          },
+                          "type": ["null", "object"]
+                        }
+                      },
+                      "type": ["null", "object"]
+                    },
+                    "discount_allocations": {
+                      "description": "Discounts applied to the line item",
+                      "type": ["null", "array"],
+                      "items": {
+                        "properties": {
+                          "amount": {
+                            "description": "Amount of the discount",
+                            "type": ["null", "number"]
+                          },
+                          "amount_set": {
+                            "description": "Details of the discount amount",
+                            "properties": {
+                              "shop_money": {
+                                "description": "Amount in the shop's currency",
+                                "properties": {
+                                  "currency_code": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "amount": { "type": ["null", "number"] }
+                                },
+                                "type": ["null", "object"]
+                              },
+                              "presentment_money": {
+                                "description": "Amount in the currency presented to the customer",
+                                "properties": {
+                                  "currency_code": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "amount": { "type": ["null", "number"] }
+                                },
+                                "type": ["null", "object"]
+                              }
+                            },
+                            "type": ["null", "object"]
+                          },
+                          "discount_application_index": {
+                            "description": "Index of the discount application",
+                            "type": ["null", "integer"]
+                          }
+                        },
+                        "type": ["null", "object"]
+                      }
+                    },
+                    "pre_tax_price_set": {
+                      "description": "Details of the pre-tax price",
+                      "properties": {
+                        "shop_money": {
+                          "description": "Pre-tax price in the shop's currency",
+                          "properties": {
+                            "currency_code": { "type": ["null", "string"] },
+                            "amount": { "type": ["null", "number"] }
+                          },
+                          "type": ["null", "object"]
+                        },
+                        "presentment_money": {
+                          "description": "Pre-tax price in the currency presented to the customer",
+                          "properties": {
+                            "currency_code": { "type": ["null", "string"] },
+                            "amount": { "type": ["null", "number"] }
+                          },
+                          "type": ["null", "object"]
+                        }
+                      },
+                      "type": ["null", "object"]
+                    },
+                    "fulfillable_quantity": {
+                      "description": "Quantity that can be fulfilled",
+                      "type": ["null", "integer"]
+                    },
+                    "id": {
+                      "description": "Unique identifier for the line item",
+                      "type": ["null", "integer"]
+                    },
+                    "admin_graphql_api_id": {
+                      "description": "ID of the original line item in Shopify API",
+                      "type": ["null", "string"]
+                    },
+                    "total_discount": {
+                      "description": "Total discount applied to the line item",
+                      "type": ["null", "number"]
+                    },
+                    "name": {
+                      "description": "Name of the product",
+                      "type": ["null", "string"]
+                    },
+                    "product_exists": {
+                      "description": "Indicates if the product exists",
+                      "type": ["null", "boolean"]
+                    },
+                    "taxable": {
+                      "description": "Indicates if the product is taxable",
+                      "type": ["null", "boolean"]
+                    },
+                    "product_id": {
+                      "description": "ID of the associated product",
+                      "type": ["null", "integer"]
+                    },
+                    "title": {
+                      "description": "Title of the line item",
+                      "type": ["null", "string"]
+                    },
+                    "duties": {
+                      "description": "Information about any duties associated with the line item",
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["null", "object"],
+                        "additionalProperties": true,
+                        "properties": {
+                          "duty_id": {
+                            "description": "ID of the duty",
+                            "type": ["null", "integer"]
+                          },
+                          "amount_set": {
+                            "description": "Details of the duty amount",
+                            "properties": {
+                              "shop_money": {
+                                "description": "Amount in the shop's currency",
+                                "properties": {
+                                  "currency_code": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "amount": { "type": ["null", "number"] }
+                                },
+                                "type": ["null", "object"]
+                              },
+                              "presentment_money": {
+                                "description": "Amount in the currency presented to the customer",
+                                "properties": {
+                                  "currency_code": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "amount": { "type": ["null", "number"] }
+                                },
+                                "type": ["null", "object"]
+                              }
+                            },
+                            "type": ["null", "object"]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "type": ["null", "object"]
+                },
+                "subtotal": {
+                  "description": "Subtotal amount for the line item",
+                  "type": ["null", "number"]
+                },
+                "restock_type": {
+                  "description": "Type of restocking for the line item",
+                  "type": ["null", "string"]
+                }
+              },
+              "type": ["null", "object"]
+            }
+          },
+          "return": {
+            "description": "Details of the return associated with the refund",
+            "type": ["null", "object"],
+            "properties": {
+              "admin_graphql_api_id": {
+                "description": "ID of the return resource in Shopify API",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "Unique identifier for the return",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "transactions": {
+            "description": "Payment transactions related to the refund",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "Unique identifier for the transaction",
+                  "type": ["null", "integer"]
+                },
+                "admin_graphql_api_id": {
+                  "description": "ID of the transaction resource in Shopify API",
+                  "type": ["null", "string"]
+                },
+                "amount": {
+                  "description": "Amount of the transaction",
+                  "type": ["null", "string"]
+                },
+                "authorization": {
+                  "description": "Authorization details for the transaction",
+                  "type": ["null", "string"]
+                },
+                "created_at": {
+                  "description": "Date and time when the transaction was created",
+                  "type": ["null", "string"]
+                },
+                "currency": {
+                  "description": "Currency used for the transaction",
+                  "type": ["null", "string"]
+                },
+                "device_id": {
+                  "description": "ID of the device used for the transaction",
+                  "type": ["null", "integer"]
+                },
+                "error_code": {
+                  "description": "Error code associated with the transaction",
+                  "type": ["null", "string"]
+                },
+                "gateway": {
+                  "description": "Payment gateway used for the transaction",
+                  "type": ["null", "string"]
+                },
+                "kind": {
+                  "description": "Type of transaction",
+                  "type": ["null", "string"]
+                },
+                "location_id": {
+                  "description": "ID of the location where the transaction occurred",
+                  "type": ["null", "integer"]
+                },
+                "message": {
+                  "description": "Message related to the transaction",
+                  "type": ["null", "string"]
+                },
+                "order_id": {
+                  "description": "ID of the order related to the transaction",
+                  "type": ["null", "integer"]
+                },
+                "parent_id": {
+                  "description": "ID of the parent transaction, if applicable",
+                  "type": ["null", "integer"]
+                },
+                "processed_at": {
+                  "description": "Date and time when the transaction was processed",
+                  "type": ["null", "string"]
+                },
+                "receipt": {
+                  "description": "Details of the receipt for the transaction",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "paid_amount": {
+                      "description": "Amount paid in the receipt",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "source_name": {
+                  "description": "Name of the payment source",
+                  "type": ["null", "string"]
+                },
+                "status": {
+                  "description": "Status of the transaction",
+                  "type": ["null", "string"]
+                },
+                "test": {
+                  "description": "Indicates if the transaction is a test",
+                  "type": ["null", "boolean"]
+                },
+                "user_id": {
+                  "description": "ID of the user associated with the transaction",
+                  "type": ["null", "integer"]
+                },
+                "payment_details": {
+                  "description": "Details about the payment for the transaction",
+                  "type": ["null", "object"],
+                  "additionalProperties": true,
+                  "properties": {
+                    "avs_result_code": {
+                      "description": "AVS result code for the payment",
+                      "type": ["null", "string"]
+                    },
+                    "buyer_action_info": {
+                      "description": "Information about buyer's actions during payment",
+                      "type": ["null", "string"]
+                    },
+                    "credit_card_bin": {
+                      "description": "BIN number of the credit card",
+                      "type": ["null", "string"]
+                    },
+                    "credit_card_company": {
+                      "description": "Company associated with the credit card",
+                      "type": ["null", "string"]
+                    },
+                    "credit_card_expiration_month": {
+                      "description": "Expiration month of the credit card",
+                      "type": ["null", "integer"]
+                    },
+                    "credit_card_expiration_year": {
+                      "description": "Expiration year of the credit card",
+                      "type": ["null", "integer"]
+                    },
+                    "credit_card_name": {
+                      "description": "Name on the credit card",
+                      "type": ["null", "string"]
+                    },
+                    "credit_card_number": {
+                      "description": "Masked credit card number",
+                      "type": ["null", "string"]
+                    },
+                    "credit_card_wallet": {
+                      "description": "Information about the credit card wallet used",
+                      "type": ["null", "string"]
+                    },
+                    "cvv_result_code": {
+                      "description": "CVV result code for the payment",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "payment_id": {
+                  "description": "ID of the payment associated with the transaction",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "shop_url": {
+            "description": "URL of the shop where the refund was processed",
+            "type": ["null", "string"]
+          },
+          "total_duties_set": {
+            "description": "Details of the total duties amount",
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "description": "Total duties amount in the shop's currency",
+                "type": ["null", "object"],
+                "properties": {
+                  "currency_code": { "type": ["null", "string"] },
+                  "amount": { "type": ["null", "number"] }
+                }
+              },
+              "presentment_money": {
+                "description": "Total duties amount in the currency presented to the customer",
+                "type": ["null", "object"],
+                "properties": {
+                  "currency_code": { "type": ["null", "string"] },
+                  "amount": { "type": ["null", "number"] }
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "order_risks",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the order risk entry.",
+            "type": ["null", "integer"]
+          },
+          "order_id": {
+            "description": "The identifier of the order to which the risk is related.",
+            "type": ["null", "integer"]
+          },
+          "checkout_id": {
+            "description": "The unique identifier of the checkout associated with the order.",
+            "type": ["null", "integer"]
+          },
+          "source": {
+            "description": "Source of the risk notification.",
+            "type": ["null", "string"]
+          },
+          "score": {
+            "description": "Numerical score indicating the level of risk.",
+            "type": ["null", "number"]
+          },
+          "recommendation": {
+            "description": "Suggested action to mitigate the risk.",
+            "type": ["null", "string"]
+          },
+          "display": {
+            "description": "Flag to determine if the risk should be displayed to the merchant.",
+            "type": ["null", "boolean"]
+          },
+          "cause_cancel": {
+            "description": "Reason indicating why the order is at risk of cancellation.",
+            "type": ["null", "boolean"]
+          },
+          "message": {
+            "description": "Description of the risk associated with the order.",
+            "type": ["null", "string"]
+          },
+          "merchant_message": {
+            "description": "Message shown to the merchant regarding the risk.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The original id reference for the shopify api",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the order and the risk was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "assessments": {
+            "description": "The risk assessments for an order.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "additionalProperties": true,
+              "properties": {
+                "risk_level": {
+                  "description": "The likelihood that the order is fraudulent, based on this risk assessment",
+                  "type": ["null", "string"]
+                },
+                "facts": {
+                  "description": "Optional facts used to describe the risk assessment",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "description": {
+                        "description": "A description of the risk fact",
+                        "type": ["null", "string"]
+                      },
+                      "sentiment": {
+                        "description": "Indicates whether the fact is a negative, neutral or positive contributor with regards to risk",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                },
+                "provider": {
+                  "description": "The app that provided the assessment, null if the assessment was provided by Shopify",
+                  "type": ["null", "object"],
+                  "additionalProperties": true,
+                  "properties": {
+                    "features": {
+                      "description": "A list of app features that are shown in the Shopify App Store listing.",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "string"] }
+                    },
+                    "description": {
+                      "description": "Description of the app",
+                      "type": ["null", "string"]
+                    },
+                    "handle": {
+                      "description": "Handle of the app",
+                      "type": ["null", "string"]
+                    },
+                    "embedded": {
+                      "description": "Whether the app uses the Embedded App SDK",
+                      "type": ["null", "boolean"]
+                    },
+                    "title": {
+                      "description": "Name of the app",
+                      "type": ["null", "string"]
+                    },
+                    "published": {
+                      "description": "Whether the app is published to the Shopify App Store",
+                      "type": ["null", "boolean"]
+                    },
+                    "developer_name": {
+                      "description": "The name of the app developer",
+                      "type": ["null", "string"]
+                    },
+                    "developer_type": {
+                      "description": "The type of app developer",
+                      "type": ["null", "string"]
+                    },
+                    "app_store_app_url": {
+                      "description": "App store page URL of the app",
+                      "type": ["null", "string"]
+                    },
+                    "install_url": {
+                      "description": "Webpage where you can install the app",
+                      "type": ["null", "string"]
+                    },
+                    "app_store_developer_url": {
+                      "description": "App store page URL of the developer who created the app",
+                      "type": ["null", "string"]
+                    },
+                    "is_post_purchase_app_in_use": {
+                      "description": "Whether the app is the post purchase app in use",
+                      "type": ["null", "boolean"]
+                    },
+                    "previously_installed": {
+                      "description": "Whether the app was previously installed on the current shop",
+                      "type": ["null", "boolean"]
+                    },
+                    "pricing_details_summary": {
+                      "description": "Summary of the app pricing details",
+                      "type": ["null", "string"]
+                    },
+                    "pricing_details": {
+                      "description": "Detailed information about the app pricing",
+                      "type": ["null", "string"]
+                    },
+                    "privacy_policy_url": {
+                      "description": "Link to app privacy policy",
+                      "type": ["null", "string"]
+                    },
+                    "public_category": {
+                      "description": "The public category for the app",
+                      "type": ["null", "string"]
+                    },
+                    "uninstall_message": {
+                      "description": "Message that appears when the app is uninstalled",
+                      "type": ["null", "string"]
+                    },
+                    "webhook_api_version": {
+                      "description": "The webhook API version for the app",
+                      "type": ["null", "string"]
+                    },
+                    "shopify_developed": {
+                      "description": "Whether the app was developed by Shopify",
+                      "type": ["null", "boolean"]
+                    },
+                    "provider_id": {
+                      "description": "A globally-unique provider ID, represented as integer",
+                      "type": ["null", "integer"]
+                    },
+                    "failed_requirements": {
+                      "description": "Requirements that must be met before the app can be installed",
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["null", "object"],
+                        "additionalProperties": true,
+                        "properties": {
+                          "action": {
+                            "description": "Action to be taken to resolve a failed requirement, including URL link",
+                            "type": ["null", "object"],
+                            "additionalProperties": true,
+                            "properties": {
+                              "action_id": {
+                                "description": "The unique identifier of the navigation item",
+                                "type": ["null", "string"]
+                              },
+                              "title": {
+                                "description": "The name of the navigation item",
+                                "type": ["null", "string"]
+                              },
+                              "url": {
+                                "description": "The URL of the page that the navigation item links to",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          },
+                          "message": {
+                            "description": "A concise set of copy strings to be displayed to merchants, to guide them in resolving problems your app encounters when trying to make use of their Shop and its resources",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      }
+                    },
+                    "feedback": {
+                      "description": "Feedback from this app about the store",
+                      "type": ["null", "object"],
+                      "additionalProperties": true,
+                      "properties": {
+                        "link": {
+                          "description": "A link to where merchants can resolve errors",
+                          "type": ["null", "object"],
+                          "additionalProperties": true,
+                          "properties": {
+                            "label": {
+                              "description": "A context-sensitive label for the link",
+                              "type": ["null", "string"]
+                            },
+                            "url": {
+                              "description": "The URL that the link visits",
+                              "type": ["null", "string"]
+                            }
+                          }
+                        },
+                        "messages": {
+                          "description": "The feedback message presented to the merchant",
+                          "type": ["null", "array"],
+                          "items": {
+                            "type": ["null", "object"],
+                            "additionalProperties": true,
+                            "properties": {
+                              "field": {
+                                "description": "The path to the input field that caused the error",
+                                "type": ["null", "string"]
+                              },
+                              "message": {
+                                "description": "The error message",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "admin_graphql_api_id": {
+                      "description": "A globally-unique provider ID",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "shop_url": {
+            "description": "URL of the shop where the order was placed.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "orders",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the order",
+            "type": ["null", "integer"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier of the order in the GraphQL Admin API",
+            "type": ["null", "string"]
+          },
+          "app_id": {
+            "description": "The ID of the app that created the order",
+            "type": ["null", "integer"]
+          },
+          "browser_ip": {
+            "description": "The IP address of the customer's browser",
+            "type": ["null", "string"]
+          },
+          "buyer_accepts_marketing": {
+            "description": "Indicates if the customer has agreed to receive marketing emails",
+            "type": ["null", "boolean"]
+          },
+          "cancel_reason": {
+            "description": "The reason provided if the order was canceled",
+            "type": ["null", "string"]
+          },
+          "cancelled_at": {
+            "description": "The date and time when the order was canceled",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "cart_token": {
+            "description": "Token representing the cart associated with the order",
+            "type": ["null", "string"]
+          },
+          "checkout_id": {
+            "description": "The ID of the checkout that processed the order",
+            "type": ["null", "integer"]
+          },
+          "checkout_token": {
+            "description": "Token representing the checkout associated with the order",
+            "type": ["null", "string"]
+          },
+          "client_details": {
+            "type": ["null", "object"],
+            "properties": {
+              "accept_language": { "type": ["null", "string"] },
+              "browser_height": { "type": ["null", "integer"] },
+              "browser_ip": { "type": ["null", "string"] },
+              "browser_width": { "type": ["null", "integer"] },
+              "session_hash": { "type": ["null", "string"] },
+              "user_agent": { "type": ["null", "string"] }
+            }
+          },
+          "closed_at": {
+            "description": "The date and time when the order was closed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "company": {
+            "description": "The name of the company associated with the order",
+            "type": ["null", "string"]
+          },
+          "confirmed": {
+            "description": "Indicates if the order has been confirmed",
+            "type": ["null", "boolean"]
+          },
+          "confirmation_number": {
+            "description": "The unique number for confirming the order",
+            "type": ["null", "string"]
+          },
+          "contact_email": {
+            "description": "The email address for order-related contacts",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when the order was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "currency": {
+            "description": "The currency used for the order",
+            "type": ["null", "string"]
+          },
+          "current_subtotal_price": {
+            "description": "The current subtotal price of the order",
+            "type": ["null", "number"]
+          },
+          "current_subtotal_price_set": {
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "current_total_discounts": {
+            "description": "The current total discounts applied to the order",
+            "type": ["null", "number"]
+          },
+          "current_total_discounts_set": {
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "current_total_duties_set": {
+            "description": "The current total duties set for the order",
+            "type": ["null", "string"]
+          },
+          "current_total_price": {
+            "description": "The current total price of the order",
+            "type": ["null", "number"]
+          },
+          "current_total_price_set": {
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "current_total_tax": {
+            "description": "The current total tax amount for the order",
+            "type": ["null", "number"]
+          },
+          "current_total_tax_set": {
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "current_total_additional_fees_set": {
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "customer_locale": {
+            "description": "The locale of the customer",
+            "type": ["null", "string"]
+          },
+          "device_id": {
+            "description": "The ID of the device used to place the order",
+            "type": ["null", "string"]
+          },
+          "discount_applications": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "type": { "type": ["null", "string"] },
+                "title": { "type": ["null", "string"] },
+                "description": { "type": ["null", "string"] },
+                "value": { "type": ["null", "string"] },
+                "value_type": { "type": ["null", "string"] },
+                "allocation_method": { "type": ["null", "string"] },
+                "target_selection": { "type": ["null", "string"] },
+                "target_type": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "discount_codes": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "code": { "type": ["null", "string"] },
+                "amount": { "type": ["null", "string"] },
+                "type": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "email": {
+            "description": "The email address of the customer",
+            "type": ["null", "string"]
+          },
+          "estimated_taxes": {
+            "description": "Estimated taxes for the order",
+            "type": ["null", "boolean"]
+          },
+          "financial_status": {
+            "description": "The financial status of the order",
+            "type": ["null", "string"]
+          },
+          "fulfillment_status": {
+            "description": "The fulfillment status of the order",
+            "type": ["null", "string"]
+          },
+          "landing_site": {
+            "description": "The landing site of the order",
+            "type": ["null", "string"]
+          },
+          "landing_site_ref": {
+            "description": "Reference for the landing site of the order",
+            "type": ["null", "string"]
+          },
+          "location_id": {
+            "description": "The location ID associated with the order",
+            "type": ["null", "integer"]
+          },
+          "merchant_of_record_app_id": {
+            "description": "The app ID of the merchant of record",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name of the order",
+            "type": ["null", "string"]
+          },
+          "note": {
+            "description": "Additional notes related to the order",
+            "type": ["null", "string"]
+          },
+          "note_attributes": {
+            "description": "Custom note attributes associated with the order",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "name": {
+                  "description": "Name of the note attribute",
+                  "type": ["null", "string"]
+                },
+                "value": {
+                  "description": "Value of the note attribute",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "number": {
+            "description": "The order number",
+            "type": ["null", "integer"]
+          },
+          "order_number": {
+            "description": "The unique number assigned to the order",
+            "type": ["null", "integer"]
+          },
+          "order_status_url": {
+            "description": "URL to check the status of the order",
+            "type": ["null", "string"]
+          },
+          "original_total_duties_set": {
+            "description": "The original total duties set for the order",
+            "type": ["null", "string"]
+          },
+          "original_total_additional_fees_set": {
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "payment_gateway_names": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "payment_terms": {
+            "description": "The terms of payment for the order",
+            "type": ["null", "string"]
+          },
+          "phone": {
+            "description": "The phone number of the customer",
+            "type": ["null", "string"]
+          },
+          "presentment_currency": {
+            "description": "The currency used for presenting the order",
+            "type": ["null", "string"]
+          },
+          "processed_at": {
+            "description": "The date and time when the order was processed",
+            "type": ["null", "string"]
+          },
+          "po_number": {
+            "description": "The purchase order number",
+            "type": ["null", "string"]
+          },
+          "reference": {
+            "description": "Reference associated with the order",
+            "type": ["null", "string"]
+          },
+          "referring_site": {
+            "description": "The referring site of the order",
+            "type": ["null", "string"]
+          },
+          "source_identifier": {
+            "description": "Identifier for the order's source",
+            "type": ["null", "string"]
+          },
+          "source_name": {
+            "description": "Name of the order's source",
+            "type": ["null", "string"]
+          },
+          "source_url": {
+            "description": "URL of the order's source",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "URL of the shop associated with the order",
+            "type": ["null", "string"]
+          },
+          "subtotal_price": {
+            "description": "The subtotal price of the order",
+            "type": ["null", "number"]
+          },
+          "subtotal_price_set": {
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "tags": {
+            "description": "Tags associated with the order",
+            "type": ["null", "string"]
+          },
+          "tax_exempt": {
+            "description": "Indicates if the order is tax exempt",
+            "type": ["null", "boolean"]
+          },
+          "tax_lines": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "channel_liable": { "type": ["null", "boolean"] },
+                "price": { "type": ["null", "number"] },
+                "rate": { "type": ["null", "number"] },
+                "title": { "type": ["null", "string"] },
+                "price_set": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "number"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    },
+                    "presentment_money": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "number"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "taxes_included": {
+            "description": "Indicates if taxes are included in the prices",
+            "type": ["null", "boolean"]
+          },
+          "test": {
+            "description": "Indicates if the order is a test order",
+            "type": ["null", "boolean"]
+          },
+          "token": {
+            "description": "Token associated with the order",
+            "type": ["null", "string"]
+          },
+          "total_discounts": {
+            "description": "The total amount of discounts applied to the order",
+            "type": ["null", "number"]
+          },
+          "total_discounts_set": {
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "total_line_items_price": {
+            "description": "The total price of all line items in the order",
+            "type": ["null", "number"]
+          },
+          "total_line_items_price_set": {
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "total_outstanding": {
+            "description": "The total outstanding amount for the order",
+            "type": ["null", "number"]
+          },
+          "total_price": {
+            "description": "The total price of the order",
+            "type": ["null", "number"]
+          },
+          "total_price_set": {
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": { "type": ["null", "number"] },
+                  "currency_code": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "total_price_usd": {
+            "description": "The total price of the order in USD",
+            "type": ["null", "number"]
+          },
+          "total_shipping_price_set": {
+            "description": "The details of the total shipping price for the order.",
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": {
+                    "description": "The total shipping amount in shop currency",
+                    "type": ["null", "number"]
+                  },
+                  "currency_code": {
+                    "description": "The currency code for the total shipping price in shop currency",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": {
+                    "description": "The total shipping amount in presentment currency",
+                    "type": ["null", "number"]
+                  },
+                  "currency_code": {
+                    "description": "The currency code for the total shipping price",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "total_tax": {
+            "description": "The total tax amount for the order",
+            "type": ["null", "number"]
+          },
+          "total_tax_set": {
+            "description": "The details of the total tax applied to the order.",
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": {
+                    "description": "The total tax amount in shop currency",
+                    "type": ["null", "number"]
+                  },
+                  "currency_code": {
+                    "description": "The currency code for the total tax amount in shop currency",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "presentment_money": {
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": {
+                    "description": "The total tax amount in presentment currency",
+                    "type": ["null", "number"]
+                  },
+                  "currency_code": {
+                    "description": "The currency code for the total tax amount",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "total_tip_received": {
+            "description": "The total tip amount received, if any",
+            "type": ["null", "number"]
+          },
+          "total_weight": {
+            "description": "The total weight of all items in the order",
+            "type": ["null", "integer"]
+          },
+          "updated_at": {
+            "description": "The date and time when the order was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "user_id": {
+            "description": "The unique identifier of the user associated with the order",
+            "type": ["null", "number"]
+          },
+          "billing_address": {
+            "type": ["null", "object"],
+            "properties": {
+              "first_name": { "type": ["null", "string"] },
+              "address1": { "type": ["null", "string"] },
+              "phone": { "type": ["null", "string"] },
+              "city": { "type": ["null", "string"] },
+              "zip": { "type": ["null", "string"] },
+              "province": { "type": ["null", "string"] },
+              "country": { "type": ["null", "string"] },
+              "last_name": { "type": ["null", "string"] },
+              "address2": { "type": ["null", "string"] },
+              "company": { "type": ["null", "string"] },
+              "latitude": { "type": ["null", "number"] },
+              "longitude": { "type": ["null", "number"] },
+              "name": { "type": ["null", "string"] },
+              "country_code": { "type": ["null", "string"] },
+              "province_code": { "type": ["null", "string"] }
+            }
+          },
+          "customer": {
+            "type": ["null", "object"],
+            "properties": {
+              "id": { "type": ["null", "integer"] },
+              "email": { "type": ["null", "string"] },
+              "accepts_marketing": { "type": ["null", "boolean"] },
+              "created_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "updated_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_name": { "type": ["null", "string"] },
+              "last_name": { "type": ["null", "string"] },
+              "orders_count": { "type": ["null", "integer"] },
+              "state": { "type": ["null", "string"] },
+              "total_spent": { "type": ["null", "number"] },
+              "last_order_id": { "type": ["null", "integer"] },
+              "note": { "type": ["null", "string"] },
+              "verified_email": { "type": ["null", "boolean"] },
+              "multipass_identifier": { "type": ["null", "string"] },
+              "tax_exempt": { "type": ["null", "boolean"] },
+              "phone": { "type": ["null", "string"] },
+              "tags": { "type": ["null", "string"] },
+              "last_order_name": { "type": ["null", "string"] },
+              "currency": { "type": ["null", "string"] },
+              "accepts_marketing_updated_at": { "type": ["null", "string"] },
+              "marketing_opt_in_level": { "type": ["null", "string"] },
+              "admin_graphql_api_id": { "type": ["null", "string"] },
+              "default_address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "id": { "type": ["null", "integer"] },
+                  "customer_id": { "type": ["null", "integer"] },
+                  "first_name": { "type": ["null", "string"] },
+                  "last_name": { "type": ["null", "string"] },
+                  "company": { "type": ["null", "string"] },
+                  "address1": { "type": ["null", "string"] },
+                  "address2": { "type": ["null", "string"] },
+                  "city": { "type": ["null", "string"] },
+                  "province": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "zip": { "type": ["null", "string"] },
+                  "phone": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "province_code": { "type": ["null", "string"] },
+                  "country_code": { "type": ["null", "string"] },
+                  "country_name": { "type": ["null", "string"] },
+                  "default": { "type": ["null", "boolean"] }
+                }
+              },
+              "email_marketing_consent": {
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "state": { "type": ["null", "string"] },
+                  "opt_in_level": { "type": ["null", "string"] },
+                  "consent_updated_at": {
+                    "type": ["null", "string"],
+                    "format": "date-time"
+                  },
+                  "consent_collected_from": { "type": ["null", "string"] }
+                }
+              },
+              "sms_marketing_consent": {
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "state": { "type": ["null", "string"] },
+                  "opt_in_level": { "type": ["null", "string"] },
+                  "consent_updated_at": {
+                    "type": ["null", "string"],
+                    "format": "date-time"
+                  },
+                  "consent_collected_from": { "type": ["null", "string"] }
+                }
+              },
+              "tax_exemptions": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "discount_allocations": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "string"] },
+                "amount": { "type": ["null", "string"] },
+                "description": { "type": ["null", "string"] },
+                "created_at": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "discount_application_index": { "type": ["null", "number"] },
+                "amount_set": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "string"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    },
+                    "presentment_money": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "string"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    }
+                  }
+                },
+                "application_type": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "fulfillments": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "integer"] },
+                "admin_graphql_api_id": { "type": ["null", "string"] },
+                "created_at": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "location_id": { "type": ["null", "integer"] },
+                "name": { "type": ["null", "string"] },
+                "order_id": { "type": ["null", "integer"] },
+                "receipt": { "type": ["null", "object"] },
+                "service": { "type": ["null", "string"] },
+                "shipment_status": { "type": ["null", "string"] },
+                "status": { "type": ["null", "string"] },
+                "tracking_company": { "type": ["null", "string"] },
+                "tracking_number": { "type": ["null", "string"] },
+                "tracking_numbers": {
+                  "type": ["null", "array"],
+                  "items": { "type": ["null", "string"] }
+                },
+                "tracking_url": { "type": ["null", "string"] },
+                "tracking_urls": {
+                  "type": ["null", "array"],
+                  "items": { "type": ["null", "string"] }
+                },
+                "updated_at": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "line_items": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": { "type": ["null", "integer"] },
+                      "admin_graphql_api_id": { "type": ["null", "string"] },
+                      "destination_location": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "id": { "type": ["null", "integer"] },
+                          "country_code": { "type": ["null", "string"] },
+                          "province_code": { "type": ["null", "string"] },
+                          "name": { "type": ["null", "string"] },
+                          "address1": { "type": ["null", "string"] },
+                          "address2": { "type": ["null", "string"] },
+                          "city": { "type": ["null", "string"] },
+                          "zip": { "type": ["null", "string"] }
+                        }
+                      },
+                      "fulfillable_quantity": { "type": ["null", "integer"] },
+                      "fulfillment_service": { "type": ["null", "string"] },
+                      "fulfillment_status": { "type": ["null", "string"] },
+                      "gift_card": { "type": ["null", "boolean"] },
+                      "grams": { "type": ["null", "integer"] },
+                      "name": { "type": ["null", "string"] },
+                      "origin_location": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "id": { "type": ["null", "integer"] },
+                          "country_code": { "type": ["null", "string"] },
+                          "province_code": { "type": ["null", "string"] },
+                          "name": { "type": ["null", "string"] },
+                          "address1": { "type": ["null", "string"] },
+                          "address2": { "type": ["null", "string"] },
+                          "city": { "type": ["null", "string"] },
+                          "zip": { "type": ["null", "string"] }
+                        }
+                      },
+                      "price": { "type": ["null", "number"] },
+                      "price_set": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "number"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          },
+                          "presentment_money": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "number"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      },
+                      "pre_tax_price": { "type": ["null", "number"] },
+                      "product_exists": { "type": ["null", "boolean"] },
+                      "product_id": { "type": ["null", "integer"] },
+                      "properties": {
+                        "type": ["null", "array"],
+                        "items": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "name": { "type": ["null", "string"] },
+                            "value": { "type": ["null", "string"] }
+                          }
+                        }
+                      },
+                      "quantity": { "type": ["null", "integer"] },
+                      "requires_shipping": { "type": ["null", "boolean"] },
+                      "sku": { "type": ["null", "string"] },
+                      "taxable": { "type": ["null", "boolean"] },
+                      "title": { "type": ["null", "string"] },
+                      "total_discount": { "type": ["null", "number"] },
+                      "total_discount_set": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "number"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          },
+                          "presentment_money": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "number"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      },
+                      "variant_id": { "type": ["null", "integer"] },
+                      "variant_inventory_management": {
+                        "type": ["null", "string"]
+                      },
+                      "variant_title": { "type": ["null", "string"] },
+                      "vendor": { "type": ["null", "string"] },
+                      "tax_lines": {
+                        "type": ["null", "array"],
+                        "items": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "channel_liable": { "type": ["null", "boolean"] },
+                            "price": { "type": ["null", "number"] },
+                            "price_set": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "shop_money": {
+                                  "type": ["null", "object"],
+                                  "properties": {
+                                    "amount": { "type": ["null", "number"] },
+                                    "currency_code": {
+                                      "type": ["null", "string"]
+                                    }
+                                  }
+                                },
+                                "presentment_money": {
+                                  "type": ["null", "object"],
+                                  "properties": {
+                                    "amount": { "type": ["null", "number"] },
+                                    "currency_code": {
+                                      "type": ["null", "string"]
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "rate": { "type": ["null", "number"] },
+                            "title": { "type": ["null", "string"] }
+                          }
+                        }
+                      },
+                      "duties": {
+                        "type": ["null", "array"],
+                        "items": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "id": { "type": ["null", "string"] },
+                            "harmonized_system_code": {
+                              "type": ["null", "string"]
+                            },
+                            "country_code_of_origin": {
+                              "type": ["null", "string"]
+                            },
+                            "shop_money": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "amount": { "type": ["null", "string"] },
+                                "currency_code": { "type": ["null", "string"] }
+                              }
+                            },
+                            "presentment_money": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "amount": { "type": ["null", "string"] },
+                                "currency_code": { "type": ["null", "string"] }
+                              }
+                            },
+                            "tax_lines": {
+                              "type": ["null", "array"],
+                              "items": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "title": { "type": ["null", "string"] },
+                                  "price": { "type": ["null", "string"] },
+                                  "rate": { "type": ["null", "number"] },
+                                  "price_set": {
+                                    "type": ["null", "object"],
+                                    "properties": {
+                                      "shop_money": {
+                                        "type": ["null", "object"],
+                                        "properties": {
+                                          "amount": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "currency_code": {
+                                            "type": ["null", "string"]
+                                          }
+                                        }
+                                      },
+                                      "presentment_money": {
+                                        "type": ["null", "object"],
+                                        "properties": {
+                                          "amount": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "currency_code": {
+                                            "type": ["null", "string"]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "channel_liable": {
+                                    "type": ["null", "boolean"]
+                                  }
+                                }
+                              }
+                            },
+                            "admin_graphql_api_id": {
+                              "type": ["null", "string"]
+                            }
+                          }
+                        }
+                      },
+                      "discount_allocations": {
+                        "type": ["null", "array"],
+                        "items": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "id": { "type": ["null", "string"] },
+                            "amount": { "type": ["null", "string"] },
+                            "description": { "type": ["null", "string"] },
+                            "created_at": {
+                              "type": ["null", "string"],
+                              "format": "date-time"
+                            },
+                            "discount_application_index": {
+                              "type": ["null", "number"]
+                            },
+                            "amount_set": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "shop_money": {
+                                  "type": ["null", "object"],
+                                  "properties": {
+                                    "amount": { "type": ["null", "string"] },
+                                    "currency_code": {
+                                      "type": ["null", "string"]
+                                    }
+                                  }
+                                },
+                                "presentment_money": {
+                                  "type": ["null", "object"],
+                                  "properties": {
+                                    "amount": { "type": ["null", "string"] },
+                                    "currency_code": {
+                                      "type": ["null", "string"]
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "application_type": { "type": ["null", "string"] }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "origin_address": {
+                  "type": ["null", "object"],
+                  "additionalProperties": true,
+                  "properties": {
+                    "address1": { "type": ["null", "string"] },
+                    "address2": { "type": ["null", "string"] },
+                    "city": { "type": ["null", "string"] },
+                    "country_code": { "type": ["null", "string"] },
+                    "province_code": { "type": ["null", "string"] },
+                    "zip": { "type": ["null", "string"] }
+                  }
+                }
+              }
+            }
+          },
+          "line_items": {
+            "description": "Details of the products within an order",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "Unique identifier for the item",
+                  "type": ["null", "integer"]
+                },
+                "admin_graphql_api_id": {
+                  "description": "Unique identifier for the item",
+                  "type": ["null", "string"]
+                },
+                "destination_location": {
+                  "description": "Destination address of the item",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": {
+                      "description": "Unique identifier for the location",
+                      "type": ["null", "integer"]
+                    },
+                    "country_code": {
+                      "description": "Country code of the address",
+                      "type": ["null", "string"]
+                    },
+                    "province_code": {
+                      "description": "Province code of the address",
+                      "type": ["null", "string"]
+                    },
+                    "name": {
+                      "description": "Name of the location",
+                      "type": ["null", "string"]
+                    },
+                    "address1": {
+                      "description": "First line of address",
+                      "type": ["null", "string"]
+                    },
+                    "address2": {
+                      "description": "Second line of address",
+                      "type": ["null", "string"]
+                    },
+                    "city": {
+                      "description": "City of the address",
+                      "type": ["null", "string"]
+                    },
+                    "zip": {
+                      "description": "Zip code of the address",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "fulfillable_quantity": {
+                  "description": "Quantity that is fulfillable",
+                  "type": ["null", "integer"]
+                },
+                "fulfillment_service": {
+                  "description": "Service used for fulfillment",
+                  "type": ["null", "string"]
+                },
+                "fulfillment_status": {
+                  "description": "Status of fulfillment",
+                  "type": ["null", "string"]
+                },
+                "gift_card": {
+                  "description": "Whether the item is a gift card",
+                  "type": ["null", "boolean"]
+                },
+                "grams": {
+                  "description": "Weight in grams",
+                  "type": ["null", "integer"]
+                },
+                "name": {
+                  "description": "Name of the item",
+                  "type": ["null", "string"]
+                },
+                "origin_location": {
+                  "description": "Origin address of the item",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": {
+                      "description": "Unique identifier for the location",
+                      "type": ["null", "integer"]
+                    },
+                    "country_code": {
+                      "description": "Country code of the address",
+                      "type": ["null", "string"]
+                    },
+                    "province_code": {
+                      "description": "Province code of the address",
+                      "type": ["null", "string"]
+                    },
+                    "name": {
+                      "description": "Name of the location",
+                      "type": ["null", "string"]
+                    },
+                    "address1": {
+                      "description": "First line of address",
+                      "type": ["null", "string"]
+                    },
+                    "address2": {
+                      "description": "Second line of address",
+                      "type": ["null", "string"]
+                    },
+                    "city": {
+                      "description": "City of the address",
+                      "type": ["null", "string"]
+                    },
+                    "zip": {
+                      "description": "Zip code of the address",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "price": {
+                  "description": "Price of the item",
+                  "type": ["null", "number"]
+                },
+                "price_set": {
+                  "description": "Details of the item price",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "description": "Item price in shop currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "number"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    },
+                    "presentment_money": {
+                      "description": "Item price in presentment currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "number"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    }
+                  }
+                },
+                "pre_tax_price": {
+                  "description": "Price before tax",
+                  "type": ["null", "number"]
+                },
+                "product_exists": {
+                  "description": "Whether the product exists",
+                  "type": ["null", "boolean"]
+                },
+                "product_id": {
+                  "description": "Identifier for the product",
+                  "type": ["null", "integer"]
+                },
+                "properties": {
+                  "description": "Any additional properties associated with the item",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the property",
+                        "type": ["null", "string"]
+                      },
+                      "value": {
+                        "description": "Value of the property",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                },
+                "quantity": {
+                  "description": "Quantity of the item",
+                  "type": ["null", "integer"]
+                },
+                "requires_shipping": {
+                  "description": "Whether shipping is required",
+                  "type": ["null", "boolean"]
+                },
+                "sku": {
+                  "description": "Stock keeping unit of the item",
+                  "type": ["null", "string"]
+                },
+                "taxable": {
+                  "description": "Whether the item is taxable",
+                  "type": ["null", "boolean"]
+                },
+                "title": {
+                  "description": "Title of the item",
+                  "type": ["null", "string"]
+                },
+                "total_discount": {
+                  "description": "Total discount applied to the item",
+                  "type": ["null", "number"]
+                },
+                "total_discount_set": {
+                  "description": "Details of the total discount applied to the item",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "description": "Total discount amount in shop currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "number"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    },
+                    "presentment_money": {
+                      "description": "Total discount amount in presentment currency",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "number"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    }
+                  }
+                },
+                "variant_id": {
+                  "description": "Identifier for the variant of the item",
+                  "type": ["null", "integer"]
+                },
+                "variant_inventory_management": {
+                  "description": "Inventory management type for the variant",
+                  "type": ["null", "string"]
+                },
+                "variant_title": {
+                  "description": "Title of the variant",
+                  "type": ["null", "string"]
+                },
+                "vendor": {
+                  "description": "Vendor of the item",
+                  "type": ["null", "string"]
+                },
+                "tax_lines": {
+                  "description": "Details of tax lines associated with the item",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "channel_liable": {
+                        "description": "Whether the channel is liable for the tax",
+                        "type": ["null", "boolean"]
+                      },
+                      "price": {
+                        "description": "Price of the tax",
+                        "type": ["null", "number"]
+                      },
+                      "price_set": {
+                        "description": "Details of the tax price",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "Tax price in shop currency",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "number"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          },
+                          "presentment_money": {
+                            "description": "Tax price in presentment currency",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "number"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      },
+                      "rate": {
+                        "description": "Tax rate",
+                        "type": ["null", "number"]
+                      },
+                      "title": {
+                        "description": "Title of the tax",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                },
+                "duties": {
+                  "description": "Details of any duties associated with the item",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": {
+                        "description": "Unique identifier for the duty",
+                        "type": ["null", "string"]
+                      },
+                      "harmonized_system_code": {
+                        "description": "Harmonized system code for the duty",
+                        "type": ["null", "string"]
+                      },
+                      "country_code_of_origin": {
+                        "description": "Country code of origin for the duty",
+                        "type": ["null", "string"]
+                      },
+                      "shop_money": {
+                        "description": "Duty amount in shop currency",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "amount": {
+                            "description": "Duty amount",
+                            "type": ["null", "string"]
+                          },
+                          "currency_code": {
+                            "description": "Currency code of the duty amount",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "presentment_money": {
+                        "description": "Duty amount in presentment currency",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "amount": {
+                            "description": "Duty amount",
+                            "type": ["null", "string"]
+                          },
+                          "currency_code": {
+                            "description": "Currency code of the duty amount",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "tax_lines": {
+                        "description": "Details of tax lines associated with the duty",
+                        "type": ["null", "array"],
+                        "items": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "title": {
+                              "description": "Title of the tax",
+                              "type": ["null", "string"]
+                            },
+                            "price": {
+                              "description": "Price of the tax",
+                              "type": ["null", "string"]
+                            },
+                            "rate": {
+                              "description": "Tax rate",
+                              "type": ["null", "number"]
+                            },
+                            "price_set": {
+                              "description": "Details of the tax price",
+                              "type": ["null", "object"],
+                              "properties": {
+                                "shop_money": {
+                                  "description": "Tax price in shop currency",
+                                  "type": ["null", "object"],
+                                  "properties": {
+                                    "amount": { "type": ["null", "string"] },
+                                    "currency_code": {
+                                      "type": ["null", "string"]
+                                    }
+                                  }
+                                },
+                                "presentment_money": {
+                                  "description": "Tax price in presentment currency",
+                                  "type": ["null", "object"],
+                                  "properties": {
+                                    "amount": { "type": ["null", "string"] },
+                                    "currency_code": {
+                                      "type": ["null", "string"]
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "channel_liable": {
+                              "description": "Whether the channel is liable for the tax",
+                              "type": ["null", "boolean"]
+                            }
+                          }
+                        }
+                      },
+                      "admin_graphql_api_id": {
+                        "description": "Unique identifier for the duty",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                },
+                "discount_allocations": {
+                  "description": "Details of any discounts applied to the item",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": {
+                        "description": "Unique identifier for the discount",
+                        "type": ["null", "string"]
+                      },
+                      "amount": {
+                        "description": "Amount of the discount",
+                        "type": ["null", "string"]
+                      },
+                      "description": {
+                        "description": "Description of the discount",
+                        "type": ["null", "string"]
+                      },
+                      "created_at": {
+                        "description": "Timestamp of when the discount was created",
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "discount_application_index": {
+                        "description": "Index of the discount application",
+                        "type": ["null", "number"]
+                      },
+                      "amount_set": {
+                        "description": "Details of the discount amount",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "Discount amount in shop currency",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "string"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          },
+                          "presentment_money": {
+                            "description": "Discount amount in presentment currency",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "string"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      },
+                      "application_type": {
+                        "description": "Type of application of the discount",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "refunds": {
+            "description": "Information about the refunds associated with the order",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "Unique ID of the refund",
+                  "type": ["null", "integer"]
+                },
+                "admin_graphql_api_id": {
+                  "description": "Unique ID of the refund in the GraphQL Admin API",
+                  "type": ["null", "string"]
+                },
+                "created_at": {
+                  "description": "Timestamp for when the refund was created",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "note": {
+                  "description": "Additional note associated with the refund",
+                  "type": ["null", "string"]
+                },
+                "order_id": {
+                  "description": "ID of the order for which the refund is created",
+                  "type": ["null", "integer"]
+                },
+                "processed_at": {
+                  "description": "Timestamp for when the refund was processed",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "restock": {
+                  "description": "Indicates if restocking is required",
+                  "type": ["null", "boolean"]
+                },
+                "user_id": {
+                  "description": "ID of the user associated with the refund",
+                  "type": ["null", "integer"]
+                },
+                "order_adjustments": {
+                  "description": "Adjustments made to the order related to the refund",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "amount": {
+                        "description": "Amount of the adjustment",
+                        "type": ["null", "string"]
+                      },
+                      "amount_set": {
+                        "description": "Set of amounts for the adjustment",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "presentment_money": {
+                            "description": "Presentment amount of adjustment",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount in presentment currency",
+                                "type": ["null", "string"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code for presentment amount",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          },
+                          "shop_money": {
+                            "description": "Shop amount of adjustment",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount in shop currency",
+                                "type": ["null", "string"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code for shop amount",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "id": {
+                        "description": "Unique ID of the adjustment",
+                        "type": ["null", "integer"]
+                      },
+                      "kind": {
+                        "description": "Type of adjustment",
+                        "type": ["null", "string"]
+                      },
+                      "order_id": {
+                        "description": "ID of the order associated with the adjustment",
+                        "type": ["null", "integer"]
+                      },
+                      "reason": {
+                        "description": "Reason for the adjustment",
+                        "type": ["null", "string"]
+                      },
+                      "refund_id": {
+                        "description": "ID of the refund associated with the adjustment",
+                        "type": ["null", "integer"]
+                      },
+                      "tax_amount": {
+                        "description": "Tax amount of the adjustment",
+                        "type": ["null", "string"]
+                      },
+                      "tax_amount_set": {
+                        "description": "Set of tax amounts for the adjustment",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "presentment_money": {
+                            "description": "Presentment tax amount of the adjustment",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount in presentment currency",
+                                "type": ["null", "string"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code for presentment amount",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          },
+                          "shop_money": {
+                            "description": "Shop tax amount of the adjustment",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount in shop currency",
+                                "type": ["null", "string"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code for shop amount",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "transactions": {
+                  "description": "Information about transactions related to the refund",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": {
+                        "description": "Unique ID of the transaction",
+                        "type": ["null", "integer"]
+                      },
+                      "admin_graphql_api_id": {
+                        "description": "Unique ID of the transaction in the GraphQL Admin API",
+                        "type": ["null", "string"]
+                      },
+                      "amount": {
+                        "description": "Amount of the transaction",
+                        "type": ["null", "string"]
+                      },
+                      "authorization": {
+                        "description": "Authorization code of the transaction",
+                        "type": ["null", "string"]
+                      },
+                      "created_at": {
+                        "description": "Timestamp for when the transaction was created",
+                        "type": ["null", "string"]
+                      },
+                      "currency": {
+                        "description": "Currency of the transaction",
+                        "type": ["null", "string"]
+                      },
+                      "device_id": {
+                        "description": "ID of the device used for the transaction",
+                        "type": ["null", "integer"]
+                      },
+                      "error_code": {
+                        "description": "Error code of the transaction",
+                        "type": ["null", "string"]
+                      },
+                      "gateway": {
+                        "description": "Payment gateway used for the transaction",
+                        "type": ["null", "string"]
+                      },
+                      "kind": {
+                        "description": "Type of transaction",
+                        "type": ["null", "string"]
+                      },
+                      "location_id": {
+                        "description": "ID of the location",
+                        "type": ["null", "integer"]
+                      },
+                      "message": {
+                        "description": "Message related to the transaction",
+                        "type": ["null", "string"]
+                      },
+                      "order_id": {
+                        "description": "ID of the order associated with the transaction",
+                        "type": ["null", "integer"]
+                      },
+                      "parent_id": {
+                        "description": "ID of the parent transaction",
+                        "type": ["null", "integer"]
+                      },
+                      "processed_at": {
+                        "description": "Timestamp for when the transaction was processed",
+                        "type": ["null", "string"]
+                      },
+                      "receipt": {
+                        "description": "Receipt information for the transaction",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "paid_amount": {
+                            "description": "Amount paid",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "source_name": {
+                        "description": "Name of the transaction source",
+                        "type": ["null", "string"]
+                      },
+                      "status": {
+                        "description": "Status of the transaction",
+                        "type": ["null", "string"]
+                      },
+                      "test": {
+                        "description": "Indicates if the transaction is a test",
+                        "type": ["null", "boolean"]
+                      },
+                      "user_id": {
+                        "description": "ID of the user associated with the transaction",
+                        "type": ["null", "integer"]
+                      },
+                      "payment_details": {
+                        "description": "Details about the payment",
+                        "type": ["null", "object"],
+                        "additionalProperties": true,
+                        "properties": {
+                          "avs_result_code": {
+                            "description": "AVS (Address Verification System) result code",
+                            "type": ["null", "string"]
+                          },
+                          "buyer_action_info": {
+                            "description": "Additional info on buyer action",
+                            "type": ["null", "string"]
+                          },
+                          "credit_card_bin": {
+                            "description": "BIN (Bank Identification Number) of the credit card",
+                            "type": ["null", "string"]
+                          },
+                          "credit_card_company": {
+                            "description": "Company of the credit card",
+                            "type": ["null", "string"]
+                          },
+                          "credit_card_expiration_month": {
+                            "description": "Expiration month of the credit card",
+                            "type": ["null", "integer"]
+                          },
+                          "credit_card_expiration_year": {
+                            "description": "Expiration year of the credit card",
+                            "type": ["null", "integer"]
+                          },
+                          "credit_card_name": {
+                            "description": "Name on the credit card",
+                            "type": ["null", "string"]
+                          },
+                          "credit_card_number": {
+                            "description": "Number of the credit card",
+                            "type": ["null", "string"]
+                          },
+                          "credit_card_wallet": {
+                            "description": "Wallet used for the credit card",
+                            "type": ["null", "string"]
+                          },
+                          "cvv_result_code": {
+                            "description": "CVV (Card Verification Value) result code",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "payment_id": {
+                        "description": "ID of the payment",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                },
+                "refund_line_items": {
+                  "description": "Information about the line items included in the refund",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": {
+                        "description": "Unique ID of the refund line item",
+                        "type": ["null", "integer"]
+                      },
+                      "line_item_id": {
+                        "description": "ID of the line item included in the refund",
+                        "type": ["null", "integer"]
+                      },
+                      "location_id": {
+                        "description": "ID of the location",
+                        "type": ["null", "integer"]
+                      },
+                      "quantity": {
+                        "description": "Quantity of the line item included in the refund",
+                        "type": ["null", "integer"]
+                      },
+                      "restock_type": {
+                        "description": "Type of restocking",
+                        "type": ["null", "string"]
+                      },
+                      "subtotal": {
+                        "description": "Subtotal of the line item included in the refund",
+                        "type": ["null", "number"]
+                      },
+                      "subtotal_set": {
+                        "description": "Set of subtotals for the line item included in the refund",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "Shop subtotal of the line item",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount in shop currency",
+                                "type": ["null", "string"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code for shop amount",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          },
+                          "presentment_money": {
+                            "description": "Presentment subtotal of the line item",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount in presentment currency",
+                                "type": ["null", "string"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code for presentment amount",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "total_tax": {
+                        "description": "Total tax for the line item included in the refund",
+                        "type": ["null", "number"]
+                      },
+                      "total_tax_set": {
+                        "description": "Set of total taxes for the line item included in the refund",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "description": "Shop total tax of the line item",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount in shop currency",
+                                "type": ["null", "string"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code for shop amount",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          },
+                          "presentment_money": {
+                            "description": "Presentment total tax of the line item",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": {
+                                "description": "Amount in presentment currency",
+                                "type": ["null", "string"]
+                              },
+                              "currency_code": {
+                                "description": "Currency code for presentment amount",
+                                "type": ["null", "string"]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "line_item": {
+                        "description": "Information about the line item in the refund",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "id": {
+                            "description": "Unique ID of the line item",
+                            "type": ["null", "integer"]
+                          },
+                          "admin_graphql_api_id": {
+                            "description": "Unique ID of the line item in the GraphQL Admin API",
+                            "type": ["null", "string"]
+                          },
+                          "fulfillable_quantity": {
+                            "description": "Quantity fulfillable for the line item",
+                            "type": ["null", "integer"]
+                          },
+                          "fulfillment_service": {
+                            "description": "Service responsible for fulfillment",
+                            "type": ["null", "string"]
+                          },
+                          "fulfillment_status": {
+                            "description": "Status of fulfillment",
+                            "type": ["null", "string"]
+                          },
+                          "gift_card": {
+                            "description": "Indicates if line item is a gift card",
+                            "type": ["null", "boolean"]
+                          },
+                          "grams": {
+                            "description": "Weight of the line item in grams",
+                            "type": ["null", "number"]
+                          },
+                          "name": {
+                            "description": "Name of the line item",
+                            "type": ["null", "string"]
+                          },
+                          "price": {
+                            "description": "Price of the line item",
+                            "type": ["null", "string"]
+                          },
+                          "price_set": {
+                            "description": "Set of prices for the line item",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "shop_money": {
+                                "description": "Shop price of the line item",
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "amount": {
+                                    "description": "Amount in shop currency",
+                                    "type": ["null", "string"]
+                                  },
+                                  "currency_code": {
+                                    "description": "Currency code for shop amount",
+                                    "type": ["null", "string"]
+                                  }
+                                }
+                              },
+                              "presentment_money": {
+                                "description": "Presentment price of the line item",
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "amount": {
+                                    "description": "Amount in presentment currency",
+                                    "type": ["null", "string"]
+                                  },
+                                  "currency_code": {
+                                    "description": "Currency code for presentment amount",
+                                    "type": ["null", "string"]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "product_exists": {
+                            "description": "Indicates if the product for the line item exists",
+                            "type": ["null", "boolean"]
+                          },
+                          "product_id": {
+                            "description": "ID of the associated product",
+                            "type": ["null", "integer"]
+                          },
+                          "properties": {
+                            "description": "Additional properties of the line item",
+                            "type": ["null", "array"],
+                            "items": { "type": ["null", "string"] }
+                          },
+                          "quantity": {
+                            "description": "Quantity of the line item",
+                            "type": ["null", "integer"]
+                          },
+                          "requires_shipping": {
+                            "description": "Indicates if shipping is required for the line item",
+                            "type": ["null", "boolean"]
+                          },
+                          "sku": {
+                            "description": "Stock keeping unit of the line item",
+                            "type": ["null", "string"]
+                          },
+                          "taxable": {
+                            "description": "Indicates if the line item is taxable",
+                            "type": ["null", "boolean"]
+                          },
+                          "title": {
+                            "description": "Title of the line item",
+                            "type": ["null", "string"]
+                          },
+                          "total_discount": {
+                            "description": "Total discount applied to the line item",
+                            "type": ["null", "string"]
+                          },
+                          "total_discount_set": {
+                            "description": "Set of total discounts for the line item",
+                            "type": ["null", "object"],
+                            "properties": {
+                              "shop_money": {
+                                "description": "Shop total discount of the line item",
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "amount": {
+                                    "description": "Amount in shop currency",
+                                    "type": ["null", "string"]
+                                  },
+                                  "currency_code": {
+                                    "description": "Currency code for shop amount",
+                                    "type": ["null", "string"]
+                                  }
+                                }
+                              },
+                              "presentment_money": {
+                                "description": "Presentment total discount of the line item",
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "amount": {
+                                    "description": "Amount in presentment currency",
+                                    "type": ["null", "string"]
+                                  },
+                                  "currency_code": {
+                                    "description": "Currency code for presentment amount",
+                                    "type": ["null", "string"]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "variant_id": {
+                            "description": "ID of the variant associated with the line item",
+                            "type": ["null", "integer"]
+                          },
+                          "variant_inventory_management": {
+                            "description": "Type of inventory management for the variant",
+                            "type": ["null", "string"]
+                          },
+                          "variant_title": {
+                            "description": "Title of the variant associated with the line item",
+                            "type": ["null", "string"]
+                          },
+                          "vendor": {
+                            "description": "Vendor of the line item",
+                            "type": ["null", "string"]
+                          },
+                          "tax_lines": {
+                            "description": "Information about tax applied to the line item",
+                            "type": ["null", "array"],
+                            "items": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "channel_liable": {
+                                  "description": "Indicates if the channel is liable for the tax",
+                                  "type": ["null", "boolean"]
+                                },
+                                "price": {
+                                  "description": "Tax price applied to the line item",
+                                  "type": ["null", "string"]
+                                },
+                                "price_set": {
+                                  "description": "Set of tax prices for the line item",
+                                  "type": ["null", "object"],
+                                  "properties": {
+                                    "shop_money": {
+                                      "description": "Shop tax price of the line item",
+                                      "type": ["null", "object"],
+                                      "properties": {
+                                        "amount": {
+                                          "description": "Amount in shop currency",
+                                          "type": ["null", "string"]
+                                        },
+                                        "currency_code": {
+                                          "description": "Currency code for shop amount",
+                                          "type": ["null", "string"]
+                                        }
+                                      }
+                                    },
+                                    "presentment_money": {
+                                      "description": "Presentment tax price of the line item",
+                                      "type": ["null", "object"],
+                                      "properties": {
+                                        "amount": {
+                                          "description": "Amount in presentment currency",
+                                          "type": ["null", "string"]
+                                        },
+                                        "currency_code": {
+                                          "description": "Currency code for presentment amount",
+                                          "type": ["null", "string"]
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "rate": {
+                                  "description": "Tax rate applied to the line item",
+                                  "type": ["null", "number"]
+                                },
+                                "title": {
+                                  "description": "Title of the tax applied",
+                                  "type": ["null", "string"]
+                                }
+                              }
+                            }
+                          },
+                          "discount_allocations": {
+                            "description": "Allocations of discounts for the line item",
+                            "type": ["null", "array"],
+                            "items": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "amount": {
+                                  "description": "Amount of the discount",
+                                  "type": ["null", "string"]
+                                },
+                                "amount_set": {
+                                  "description": "Set of amounts for the discount allocation",
+                                  "type": ["null", "object"],
+                                  "properties": {
+                                    "shop_money": {
+                                      "description": "Shop amount of the discount allocation",
+                                      "type": ["null", "object"],
+                                      "properties": {
+                                        "amount": {
+                                          "description": "Amount in shop currency",
+                                          "type": ["null", "string"]
+                                        },
+                                        "currency_code": {
+                                          "description": "Currency code for shop amount",
+                                          "type": ["null", "string"]
+                                        }
+                                      }
+                                    },
+                                    "presentment_money": {
+                                      "description": "Presentment amount of the discount allocation",
+                                      "type": ["null", "object"],
+                                      "properties": {
+                                        "amount": {
+                                          "description": "Amount in presentment currency",
+                                          "type": ["null", "string"]
+                                        },
+                                        "currency_code": {
+                                          "description": "Currency code for presentment amount",
+                                          "type": ["null", "string"]
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "discount_application_index": {
+                                  "description": "Index of the discount application",
+                                  "type": ["null", "number"]
+                                }
+                              }
+                            }
+                          },
+                          "duties": {
+                            "description": "Information about duties of the line item",
+                            "type": ["null", "array"],
+                            "items": {
+                              "type": ["null", "object"],
+                              "additionalProperties": true,
+                              "properties": {
+                                "duty_id": {
+                                  "description": "ID of the duty",
+                                  "type": ["null", "integer"]
+                                },
+                                "amount_set": {
+                                  "description": "Set of amounts for the duties of the line item",
+                                  "properties": {
+                                    "shop_money": {
+                                      "description": "Shop amount of duty for the line item",
+                                      "properties": {
+                                        "currency_code": {
+                                          "description": "Currency code for shop amount",
+                                          "type": ["null", "string"]
+                                        },
+                                        "amount": {
+                                          "description": "Amount in shop currency",
+                                          "type": ["null", "number"]
+                                        }
+                                      },
+                                      "type": ["null", "object"]
+                                    },
+                                    "presentment_money": {
+                                      "description": "Presentment amount of duty for the line item",
+                                      "properties": {
+                                        "currency_code": {
+                                          "description": "Currency code for presentment amount",
+                                          "type": ["null", "string"]
+                                        },
+                                        "amount": {
+                                          "description": "Amount in presentment currency",
+                                          "type": ["null", "number"]
+                                        }
+                                      },
+                                      "type": ["null", "object"]
+                                    }
+                                  },
+                                  "type": ["null", "object"]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "duties": {
+                  "description": "Information about duties for the refund",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "duty_id": {
+                        "description": "ID of the duty",
+                        "type": ["null", "integer"]
+                      },
+                      "amount_set": {
+                        "description": "Set of amounts for duties",
+                        "properties": {
+                          "shop_money": {
+                            "description": "Shop amount of duty",
+                            "properties": {
+                              "currency_code": {
+                                "description": "Currency code for shop amount",
+                                "type": ["null", "string"]
+                              },
+                              "amount": {
+                                "description": "Amount in shop currency",
+                                "type": ["null", "number"]
+                              }
+                            },
+                            "type": ["null", "object"]
+                          },
+                          "presentment_money": {
+                            "description": "Presentment amount of duty",
+                            "properties": {
+                              "currency_code": {
+                                "description": "Currency code for presentment amount",
+                                "type": ["null", "string"]
+                              },
+                              "amount": {
+                                "description": "Amount in presentment currency",
+                                "type": ["null", "number"]
+                              }
+                            },
+                            "type": ["null", "object"]
+                          }
+                        },
+                        "type": ["null", "object"]
+                      }
+                    }
+                  }
+                },
+                "total_duties_set": {
+                  "description": "Set of total duties for the order",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "description": "Shop total duties",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "currency_code": {
+                          "description": "Currency code for shop amount",
+                          "type": ["null", "string"]
+                        },
+                        "amount": {
+                          "description": "Amount in shop currency",
+                          "type": ["null", "number"]
+                        }
+                      }
+                    },
+                    "presentment_money": {
+                      "description": "Presentment total duties",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "currency_code": {
+                          "description": "Currency code for presentment amount",
+                          "type": ["null", "string"]
+                        },
+                        "amount": {
+                          "description": "Amount in presentment currency",
+                          "type": ["null", "number"]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "shipping_address": {
+            "type": ["null", "object"],
+            "properties": {
+              "first_name": { "type": ["null", "string"] },
+              "address1": { "type": ["null", "string"] },
+              "phone": { "type": ["null", "string"] },
+              "city": { "type": ["null", "string"] },
+              "zip": { "type": ["null", "string"] },
+              "province": { "type": ["null", "string"] },
+              "country": { "type": ["null", "string"] },
+              "last_name": { "type": ["null", "string"] },
+              "address2": { "type": ["null", "string"] },
+              "company": { "type": ["null", "string"] },
+              "latitude": { "type": ["null", "number"] },
+              "longitude": { "type": ["null", "number"] },
+              "name": { "type": ["null", "string"] },
+              "country_code": { "type": ["null", "string"] },
+              "province_code": { "type": ["null", "string"] }
+            }
+          },
+          "shipping_lines": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "integer"] },
+                "carrier_identifier": { "type": ["null", "string"] },
+                "code": { "type": ["null", "string"] },
+                "discounted_price": { "type": ["null", "number"] },
+                "discounted_price_set": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "number"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    },
+                    "presentment_money": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "number"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    }
+                  }
+                },
+                "phone": { "type": ["null", "string"] },
+                "price": { "type": ["null", "number"] },
+                "price_set": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "shop_money": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "number"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    },
+                    "presentment_money": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": { "type": ["null", "number"] },
+                        "currency_code": { "type": ["null", "string"] }
+                      }
+                    }
+                  }
+                },
+                "requested_fulfillment_service_id": {
+                  "type": ["null", "string"]
+                },
+                "source": { "type": ["null", "string"] },
+                "title": { "type": ["null", "string"] },
+                "tax_lines": { "type": ["null", "array"] },
+                "discount_allocations": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": { "type": ["null", "string"] },
+                      "amount": { "type": ["null", "string"] },
+                      "description": { "type": ["null", "string"] },
+                      "created_at": {
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "discount_application_index": {
+                        "type": ["null", "number"]
+                      },
+                      "amount_set": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "shop_money": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "string"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          },
+                          "presentment_money": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "amount": { "type": ["null", "string"] },
+                              "currency_code": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      },
+                      "application_type": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "deleted_at": {
+            "description": "The date and time when the order was deleted",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "deleted_message": {
+            "description": "Message provided when the order was deleted",
+            "type": ["null", "string"]
+          },
+          "deleted_description": {
+            "description": "Description provided when the order was deleted",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "pages",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "author": {
+            "description": "The author of the page.",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the page in the Admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "body_html": {
+            "description": "The HTML content of the page.",
+            "body_html": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The timestamp when the page was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "handle": {
+            "description": "The unique URL path segment for the page.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier for the page.",
+            "type": ["null", "integer"]
+          },
+          "published_at": {
+            "description": "The timestamp when the page was published.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "shop_id": {
+            "description": "The ID of the shop to which the page belongs.",
+            "type": ["null", "integer"]
+          },
+          "template_suffix": {
+            "description": "The suffix of the liquid template used for the page.",
+            "type": ["null", "string"]
+          },
+          "title": {
+            "description": "The title of the page.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The timestamp when the page was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "shop_url": {
+            "description": "The URL of the shop associated with the page.",
+            "type": ["null", "string"]
+          },
+          "deleted_at": {
+            "description": "The timestamp when the page was deleted.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "deleted_message": {
+            "description": "Message indicating why the page was deleted.",
+            "type": ["null", "string"]
+          },
+          "deleted_description": {
+            "description": "Description of the reason for deletion of the page.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "price_rules",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "allocation_method": {
+            "description": "The method used to allocate the discount",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the price rule in the GraphQL Admin API",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when the price rule was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "customer_segment_prerequisite_ids": {
+            "description": "An array of customer segment IDs as prerequisites for the discount",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "updated_at": {
+            "description": "The date and time when the price rule was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "customer_selection": {
+            "description": "The customer selection criteria for the discount",
+            "type": ["null", "string"]
+          },
+          "ends_at": {
+            "description": "The date and time when the discount ends",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "entitled_collection_ids": {
+            "description": "An array of collection IDs entitled to the discount",
+            "items": { "type": ["null", "integer"] },
+            "type": ["null", "array"]
+          },
+          "entitled_country_ids": {
+            "description": "An array of country IDs entitled to the discount",
+            "items": { "type": ["null", "integer"] },
+            "type": ["null", "array"]
+          },
+          "entitled_product_ids": {
+            "description": "An array of product IDs entitled to the discount",
+            "items": { "type": ["null", "integer"] },
+            "type": ["null", "array"]
+          },
+          "entitled_variant_ids": {
+            "description": "An array of variant IDs entitled to the discount",
+            "items": { "type": ["null", "integer"] },
+            "type": ["null", "array"]
+          },
+          "id": {
+            "description": "The unique identifier for the price rule",
+            "type": ["null", "integer"]
+          },
+          "once_per_customer": {
+            "description": "Whether the discount can only be applied once per customer",
+            "type": ["null", "boolean"]
+          },
+          "prerequisite_customer_ids": {
+            "description": "An array of customer IDs required as prerequisites for the discount",
+            "items": { "type": ["null", "number"] },
+            "type": ["null", "array"]
+          },
+          "prerequisite_quantity_range": {
+            "description": "The required quantity range for the discount",
+            "properties": {
+              "greater_than_or_equal_to": {
+                "description": "The minimum quantity required for the discount",
+                "type": ["null", "integer"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "prerequisite_saved_search_ids": {
+            "description": "An array of saved search IDs that act as prerequisites for the discount",
+            "items": { "type": ["null", "integer"] },
+            "type": ["null", "array"]
+          },
+          "prerequisite_shipping_price_range": {
+            "description": "The maximum shipping price required for the discount",
+            "properties": {
+              "less_than_or_equal_to": {
+                "description": "The maximum shipping price allowed for the discount",
+                "type": ["null", "number"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "prerequisite_subtotal_range": {
+            "description": "The required subtotal range for the discount",
+            "properties": {
+              "greater_than_or_equal_to": {
+                "description": "The minimum subtotal required for the discount",
+                "type": ["null", "string"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "prerequisite_to_entitlement_purchase": {
+            "description": "The amount required for a purchase to be entitled to the discount",
+            "properties": {
+              "prerequisite_amount": {
+                "description": "The required amount for entitlement to the discount",
+                "type": ["null", "number"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "starts_at": {
+            "description": "The date and time when the discount starts",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "target_selection": {
+            "description": "The target selection criteria for the discount",
+            "type": ["null", "string"]
+          },
+          "target_type": {
+            "description": "The type of target for the discount",
+            "type": ["null", "string"]
+          },
+          "title": {
+            "description": "The title of the price rule",
+            "type": ["null", "string"]
+          },
+          "usage_limit": {
+            "description": "The limit on the total number of times the discount can be used",
+            "type": ["null", "integer"]
+          },
+          "prerequisite_product_ids": {
+            "description": "An array of product IDs required as prerequisites for the discount",
+            "items": { "type": ["null", "integer"] },
+            "type": ["null", "array"]
+          },
+          "prerequisite_variant_ids": {
+            "description": "An array of variant IDs required as prerequisites for the discount",
+            "items": { "type": ["null", "integer"] },
+            "type": ["null", "array"]
+          },
+          "prerequisite_collection_ids": {
+            "description": "An array of collection IDs required as prerequisites for the discount",
+            "items": { "type": ["null", "integer"] },
+            "type": ["null", "array"]
+          },
+          "value": {
+            "description": "The value of the discount",
+            "type": ["null", "string"]
+          },
+          "value_type": {
+            "description": "The type of value for the discount",
+            "type": ["null", "string"]
+          },
+          "prerequisite_to_entitlement_quantity_ratio": {
+            "description": "The quantity ratio required for entitlement to the discount",
+            "properties": {
+              "prerequisite_quantity": {
+                "description": "The quantity required as prerequisites for the discount",
+                "type": ["null", "integer"]
+              },
+              "entitled_quantity": {
+                "description": "The quantity entitled to the discount",
+                "type": ["null", "integer"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "allocation_limit": {
+            "description": "The maximum number of times the discount can be applied",
+            "type": ["null", "integer"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the price rule is applied",
+            "type": ["null", "string"]
+          },
+          "deleted_at": {
+            "description": "The date and time when the price rule was deleted",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "deleted_message": {
+            "description": "Message displayed when the price rule is deleted",
+            "type": ["null", "string"]
+          },
+          "deleted_description": {
+            "description": "Description of why the price rule was deleted",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "product_images",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "created_at": {
+            "description": "Date and time when the image was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "id": {
+            "description": "Unique identifier for the image",
+            "type": ["null", "integer"]
+          },
+          "position": {
+            "description": "Position order of the image relative to other images of the same product",
+            "type": ["null", "integer"]
+          },
+          "product_id": {
+            "description": "Unique identifier of the product associated with the image",
+            "type": ["null", "integer"]
+          },
+          "variant_ids": {
+            "description": "Array of unique identifiers for the product variants associated with the image",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "src": {
+            "description": "URL of the image",
+            "type": ["null", "string"]
+          },
+          "width": {
+            "description": "Width of the image in pixels",
+            "type": ["null", "integer"]
+          },
+          "height": {
+            "description": "Height of the image in pixels",
+            "type": ["null", "integer"]
+          },
+          "updated_at": {
+            "description": "Date and time when the image was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "admin_graphql_api_id": {
+            "description": "Unique identifier for the image in the Admin GraphQL API",
+            "type": ["null", "string"]
+          },
+          "alt": {
+            "description": "Alternative text description of the image for accessibility",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "URL of the shop where the image is hosted",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "products",
+      "json_schema": {
+        "type": ["object", "null"],
+        "additionalProperties": true,
+        "properties": {
+          "published_at": {
+            "description": "The date and time when the product was published.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "created_at": {
+            "description": "The date and time when the product was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "published_scope": {
+            "description": "The scope of where the product is available for purchase.",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "The status of the product.",
+            "type": ["null", "string"]
+          },
+          "vendor": {
+            "description": "The vendor or manufacturer of the product.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the product was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "body_html": {
+            "description": "The HTML description of the product.",
+            "type": ["null", "string"]
+          },
+          "product_type": {
+            "description": "The type or category of the product.",
+            "type": ["null", "string"]
+          },
+          "tags": {
+            "description": "Tags associated with the product.",
+            "type": ["null", "string"]
+          },
+          "options": {
+            "description": "Represents different customizable options available for the product.",
+            "type": ["null", "array"],
+            "items": {
+              "properties": {
+                "name": {
+                  "description": "The name of the product option.",
+                  "type": ["null", "string"]
+                },
+                "product_id": {
+                  "description": "The unique identifier of the product.",
+                  "type": ["null", "integer"]
+                },
+                "values": {
+                  "description": "Possible values that can be selected for each option.",
+                  "type": ["null", "array"],
+                  "items": {
+                    "description": "List of values associated with the product option.",
+                    "type": ["null", "string"]
+                  }
+                },
+                "id": {
+                  "description": "The unique identifier of the product option.",
+                  "type": ["null", "integer"]
+                },
+                "position": {
+                  "description": "The position of the product option.",
+                  "type": ["null", "integer"]
+                }
+              },
+              "type": ["null", "object"]
+            }
+          },
+          "image": {
+            "description": "Represents the main product image linked to one or more variants.",
+            "properties": {
+              "updated_at": {
+                "description": "The date and time when the image was last updated.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "created_at": {
+                "description": "The date and time when the image was created.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "variant_ids": {
+                "description": "Array of variant IDs associated with this image.",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "List of variant IDs associated with the image.",
+                  "type": ["null", "integer"]
+                }
+              },
+              "height": {
+                "description": "The height of the image.",
+                "type": ["null", "integer"]
+              },
+              "alt": {
+                "description": "The alternative text for the image.",
+                "type": ["null", "string"]
+              },
+              "src": {
+                "description": "The URL of the image source.",
+                "type": ["null", "string"]
+              },
+              "position": {
+                "description": "The position of the image.",
+                "type": ["null", "integer"]
+              },
+              "id": {
+                "description": "The unique identifier of the image.",
+                "type": ["null", "integer"]
+              },
+              "admin_graphql_api_id": {
+                "description": "The unique identifier of the image in the Admin GraphQL API.",
+                "type": ["null", "string"]
+              },
+              "width": {
+                "description": "The width of the image.",
+                "type": ["null", "integer"]
+              },
+              "product_id": {
+                "description": "The unique identifier of the product associated with the image.",
+                "type": ["null", "integer"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "handle": {
+            "description": "The human-readable URL for the product.",
+            "type": ["null", "string"]
+          },
+          "images": {
+            "description": "Represents a collection of additional images related to the product.",
+            "type": ["null", "array"],
+            "items": {
+              "properties": {
+                "updated_at": {
+                  "description": "The date and time when the image was last updated.",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "created_at": {
+                  "description": "The date and time when the image was created.",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "variant_ids": {
+                  "description": "Array of variant IDs associated with each image.",
+                  "type": ["null", "array"],
+                  "items": {
+                    "description": "List of variant IDs associated with the image.",
+                    "type": ["null", "integer"]
+                  }
+                },
+                "height": {
+                  "description": "The height of the image.",
+                  "type": ["null", "integer"]
+                },
+                "alt": {
+                  "description": "The alternative text for the image.",
+                  "type": ["null", "string"]
+                },
+                "src": {
+                  "description": "The URL of the image source.",
+                  "type": ["null", "string"]
+                },
+                "position": {
+                  "description": "The position of the image.",
+                  "type": ["null", "integer"]
+                },
+                "id": {
+                  "description": "The unique identifier of the image.",
+                  "type": ["null", "integer"]
+                },
+                "admin_graphql_api_id": {
+                  "description": "The unique identifier of the image in the Admin GraphQL API.",
+                  "type": ["null", "string"]
+                },
+                "width": {
+                  "description": "The width of the image.",
+                  "type": ["null", "integer"]
+                },
+                "product_id": {
+                  "description": "The unique identifier of the product associated with the image.",
+                  "type": ["null", "integer"]
+                }
+              },
+              "type": ["null", "object"]
+            }
+          },
+          "template_suffix": {
+            "description": "The template suffix used for the product.",
+            "type": ["null", "string"]
+          },
+          "title": {
+            "description": "The title of the product.",
+            "type": ["null", "string"]
+          },
+          "variants": {
+            "description": "Represents different versions or variations of the product.",
+            "type": ["null", "array"],
+            "items": {
+              "properties": {
+                "barcode": {
+                  "description": "The barcode of the variant.",
+                  "type": ["null", "string"]
+                },
+                "tax_code": {
+                  "description": "The tax code for the variant.",
+                  "type": ["null", "string"]
+                },
+                "created_at": {
+                  "description": "The date and time when the variant was created.",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "weight_unit": {
+                  "description": "The unit of weight for the variant.",
+                  "type": ["null", "string"]
+                },
+                "id": {
+                  "description": "The unique identifier of the variant.",
+                  "type": ["null", "integer"]
+                },
+                "position": {
+                  "description": "The position of the variant.",
+                  "type": ["null", "integer"]
+                },
+                "price": {
+                  "description": "The price of the variant.",
+                  "type": ["null", "number"]
+                },
+                "image_id": {
+                  "description": "The unique identifier of the image associated with the variant.",
+                  "type": ["null", "integer"]
+                },
+                "inventory_policy": {
+                  "description": "The inventory policy for the variant.",
+                  "type": ["null", "string"]
+                },
+                "sku": {
+                  "description": "The stock keeping unit (SKU) of the variant.",
+                  "type": ["null", "string"]
+                },
+                "inventory_item_id": {
+                  "description": "The unique identifier of the inventory item associated with the variant.",
+                  "type": ["null", "integer"]
+                },
+                "fulfillment_service": {
+                  "description": "The fulfillment service for the variant.",
+                  "type": ["null", "string"]
+                },
+                "title": {
+                  "description": "The title of the variant.",
+                  "type": ["null", "string"]
+                },
+                "weight": {
+                  "description": "The weight of the variant.",
+                  "type": ["null", "number"]
+                },
+                "inventory_management": {
+                  "description": "The management method for the variant inventory.",
+                  "type": ["null", "string"]
+                },
+                "taxable": {
+                  "description": "Indicates if the variant is taxable.",
+                  "type": ["null", "boolean"]
+                },
+                "admin_graphql_api_id": {
+                  "description": "The unique identifier of the variant in the Admin GraphQL API.",
+                  "type": ["null", "string"]
+                },
+                "option1": {
+                  "description": "The value of option 1 for the variant.",
+                  "type": ["null", "string"]
+                },
+                "compare_at_price": {
+                  "description": "The original price of the product before any discounts.",
+                  "type": ["null", "number"]
+                },
+                "updated_at": {
+                  "description": "The date and time when the variant was last updated.",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "option2": {
+                  "description": "The value of option 2 for the variant.",
+                  "type": ["null", "string"]
+                },
+                "old_inventory_quantity": {
+                  "description": "The previous quantity of the variant before change.",
+                  "type": ["null", "integer"]
+                },
+                "presentment_prices": {
+                  "description": "Prices displayed to customers in different currencies or formats.",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "price": {
+                        "description": "The price of the product variant.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "amount": {
+                            "description": "The price amount.",
+                            "type": ["null", "number"]
+                          },
+                          "currency_code": {
+                            "description": "The currency code of the price.",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "compare_at_price": {
+                        "description": "The compare at price in different currencies.",
+                        "type": ["null", "number"]
+                      }
+                    }
+                  }
+                },
+                "requires_shipping": {
+                  "description": "Indicates if the variant requires shipping.",
+                  "type": ["null", "boolean"]
+                },
+                "inventory_quantity": {
+                  "description": "The available quantity of the variant.",
+                  "type": ["null", "integer"]
+                },
+                "grams": {
+                  "description": "The weight of the variant in grams.",
+                  "type": ["null", "integer"]
+                },
+                "option3": {
+                  "description": "The value of option 3 for the variant.",
+                  "type": ["null", "string"]
+                },
+                "product_id": {
+                  "description": "The unique identifier of the product associated with the variant.",
+                  "type": ["null", "integer"]
+                }
+              },
+              "type": ["null", "object"]
+            }
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier of the product in the Admin GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier of the product.",
+            "type": ["null", "integer"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the product is listed.",
+            "type": ["null", "string"]
+          },
+          "deleted_at": {
+            "description": "The date and time when the product was deleted.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "deleted_message": {
+            "description": "Message related to the deletion of the product.",
+            "type": ["null", "string"]
+          },
+          "deleted_description": {
+            "description": "Description of the reason for deletion.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The product's description.",
+            "type": ["null", "string"]
+          },
+          "description_html": {
+            "description": "The product's description in HTML format.",
+            "type": ["null", "string"]
+          },
+          "is_gift_card": {
+            "description": "Indicates whether the product is a gift card.",
+            "type": ["null", "boolean"]
+          },
+          "legacy_resource_id": {
+            "description": "The legacy resource ID of the product.",
+            "type": ["null", "string"]
+          },
+          "media_count": {
+            "description": "The total count of media (images/videos) associated with the product.",
+            "type": ["null", "integer"]
+          },
+          "online_store_preview_url": {
+            "description": "The URL for previewing the product on the online store.",
+            "type": ["null", "string"]
+          },
+          "online_store_url": {
+            "description": "The URL of the product on the online store.",
+            "type": ["null", "string"]
+          },
+          "total_inventory": {
+            "description": "The total inventory count of the product.",
+            "type": ["null", "integer"]
+          },
+          "total_variants": {
+            "description": "The total number of variants available for the product.",
+            "type": ["null", "integer"]
+          },
+          "tracks_inventory": {
+            "description": "Indicates whether inventory tracking is enabled for the product.",
+            "type": ["null", "boolean"]
+          },
+          "has_only_default_variant": {
+            "description": "Whether the product has only a single variant with the default option and value.",
+            "type": ["null", "boolean"]
+          },
+          "has_out_of_stock_variants": {
+            "description": "Whether the product has out of stock variants.",
+            "type": ["null", "boolean"]
+          },
+          "requires_sellin_plan": {
+            "description": "Whether the product can only be purchased with a selling plan (subscription)",
+            "type": ["null", "boolean"]
+          },
+          "price_range_v2": {
+            "description": "The price range of the product with prices formatted as decimals.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "max_variant_price": {
+                "description": "The highest variant's price.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "amount": {
+                    "description": "Decimal money amount.",
+                    "type": ["null", "number"]
+                  },
+                  "currency_code": {
+                    "description": "Currency of the money.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "min_variant_price": {
+                "description": "The lowest variant's price.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "amount": {
+                    "description": "Decimal money amount.",
+                    "type": ["null", "number"]
+                  },
+                  "currency_code": {
+                    "description": "Currency of the money.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "featured_image": {
+            "description": "The featured image for the product.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "alt_text": {
+                "description": "A word or phrase to share the nature or contents of an image.",
+                "type": ["null", "string"]
+              },
+              "height": {
+                "description": "The original height of the image in pixels. Returns null if the image isn't hosted by Shopify.",
+                "type": ["null", "integer"]
+              },
+              "id": {
+                "description": "A unique ID for the image.",
+                "type": ["null", "string"]
+              },
+              "url": {
+                "description": "The location of the image as a URL.",
+                "type": ["null", "string"]
+              },
+              "width": {
+                "description": "The original width of the image in pixels. Returns null if the image isn't hosted by Shopify.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "seo": {
+            "description": "SEO information of the product.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "description": {
+                "description": "SEO Description.",
+                "type": ["null", "string"]
+              },
+              "title": {
+                "description": "SEO Title.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "featured_media": {
+            "description": "The featured media for the product.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "alt": {
+                "description": "A word or phrase to share the nature or contents of a media.",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "A globally-unique ID.",
+                "type": ["null", "string"]
+              },
+              "media_content_type": {
+                "description": "The media content type.",
+                "type": ["null", "string"]
+              },
+              "status": {
+                "description": "Current status of the media.",
+                "type": ["null", "string"]
+              },
+              "preview": {
+                "description": "The preview image for the media.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "status": {
+                    "description": "Current status of the preview image.",
+                    "type": ["null", "string"]
+                  },
+                  "image": {
+                    "description": "The preview image for the media. Returns 'null' until status is 'READY'",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "id": {
+                        "description": "A unique ID for the image.",
+                        "type": ["null", "string"]
+                      },
+                      "alt_text": {
+                        "description": "A word or phrase to share the nature or contents of an image.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              },
+              "media_errors": {
+                "description": "Any errors which have occurred on the media.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "additionalProperties": true,
+                  "properties": {
+                    "code": {
+                      "description": "Code representing the type of error.",
+                      "type": ["null", "string"]
+                    },
+                    "details": {
+                      "description": "Additional details regarding the error.",
+                      "type": ["null", "string"]
+                    },
+                    "message": {
+                      "description": "Translated error message.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              },
+              "media_warnings": {
+                "description": "The warnings attached to the media.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "additionalProperties": true,
+                  "properties": {
+                    "code": {
+                      "description": "The code representing the type of warning.",
+                      "type": ["null", "string"]
+                    },
+                    "message": {
+                      "description": "Translated warning message.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "feedback": {
+            "description": "Information about the product that's provided through resource feedback.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "details": {
+                "description": "List of AppFeedback detailing issues regarding a resource.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "app": {
+                    "description": "The application associated to the feedback.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "id": {
+                        "description": "A globally-unique ID.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "link": {
+                    "description": "A link to where merchants can resolve errors.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "url": {
+                        "description": "The URL that the link visits.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "messages": {
+                    "description": "The feedback message presented to the merchant.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "field": {
+                        "description": "The path to the input field that caused the error.",
+                        "type": ["null", "string"]
+                      },
+                      "message": {
+                        "description": "The error message.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              },
+              "summary": {
+                "description": "Summary of resource feedback pertaining to the resource.",
+                "type": ["null", "string"]
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "products_graph_ql",
+      "json_schema": {
+        "$schema": "http://json-schema.org/schema#",
+        "properties": {
+          "createdAt": {
+            "description": "The date and time when the product was created.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The product's description.",
+            "type": "string"
+          },
+          "descriptionHtml": {
+            "description": "The product's description in HTML format.",
+            "type": "string"
+          },
+          "handle": {
+            "description": "The unique URL-friendly handle of the product.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique identifier of the product.",
+            "type": "string"
+          },
+          "isGiftCard": {
+            "description": "Indicates whether the product is a gift card.",
+            "type": "boolean"
+          },
+          "legacyResourceId": {
+            "description": "The legacy resource ID of the product.",
+            "type": "string"
+          },
+          "mediaCount": {
+            "description": "The total count of media (images/videos) associated with the product.",
+            "type": "integer"
+          },
+          "onlineStorePreviewUrl": {
+            "description": "The URL for previewing the product on the online store.",
+            "type": "string"
+          },
+          "onlineStoreUrl": {
+            "description": "The URL of the product on the online store.",
+            "type": ["null", "string"]
+          },
+          "options": {
+            "description": "Represents various options available for the product",
+            "items": {
+              "properties": {
+                "id": {
+                  "description": "The unique identifier of the option.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the option.",
+                  "type": "string"
+                },
+                "position": {
+                  "description": "The position of the option.",
+                  "type": "integer"
+                },
+                "values": {
+                  "description": "Contains the different values for the options",
+                  "items": {
+                    "description": "The possible values for the option.",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "productType": {
+            "description": "The type or category of the product.",
+            "type": "string"
+          },
+          "publishedAt": {
+            "description": "The date and time when the product was published.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the product is listed.",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the product.",
+            "type": "string"
+          },
+          "tags": {
+            "description": "Contains tags associated with the product",
+            "items": {
+              "description": "The tags associated with the product.",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": {
+            "description": "The title or name of the product.",
+            "type": "string"
+          },
+          "totalInventory": {
+            "description": "The total inventory count of the product.",
+            "type": "integer"
+          },
+          "totalVariants": {
+            "description": "The total number of variants available for the product.",
+            "type": "integer"
+          },
+          "tracksInventory": {
+            "description": "Indicates whether inventory tracking is enabled for the product.",
+            "type": "boolean"
+          },
+          "updatedAt": {
+            "description": "The date and time when the product was last updated.",
+            "type": "string"
+          },
+          "vendor": {
+            "description": "The vendor or manufacturer of the product.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "product_variants",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the variant",
+            "type": ["null", "integer"]
+          },
+          "product_id": {
+            "description": "The unique identifier for the product associated with the variant",
+            "type": ["null", "integer"]
+          },
+          "title": {
+            "description": "The title of the variant",
+            "type": ["null", "string"]
+          },
+          "price": {
+            "description": "The price of the variant",
+            "type": ["null", "number"]
+          },
+          "sku": {
+            "description": "The unique SKU (stock keeping unit) of the variant",
+            "type": ["null", "string"]
+          },
+          "position": {
+            "description": "The position of the variant in the product's list of variants",
+            "type": ["null", "integer"]
+          },
+          "inventory_policy": {
+            "description": "The inventory policy for the variant",
+            "type": ["null", "string"]
+          },
+          "compare_at_price": {
+            "description": "The original price of the variant before any discount",
+            "type": ["null", "string"]
+          },
+          "fulfillment_service": {
+            "description": "The fulfillment service for the variant",
+            "type": ["null", "string"]
+          },
+          "inventory_management": {
+            "description": "The method used to manage inventory for the variant",
+            "type": ["null", "string"]
+          },
+          "option1": {
+            "description": "The value for option 1 of the variant",
+            "type": ["null", "string"]
+          },
+          "option2": {
+            "description": "The value for option 2 of the variant",
+            "type": ["null", "string"]
+          },
+          "option3": {
+            "description": "The value for option 3 of the variant",
+            "type": ["null", "string"]
+          },
+          "options": {
+            "description": "List of product options applied to the variant.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "name": {
+                  "description": "The product option\u2019s name.",
+                  "type": ["null", "string"]
+                },
+                "value": {
+                  "description": "The product option\u2019s value.",
+                  "type": ["null", "string"]
+                },
+                "option_value": {
+                  "description": "The product option\u2019s value object.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": {
+                      "description": "A globally-unique ID.",
+                      "type": ["null", "string"]
+                    },
+                    "name": {
+                      "description": "The name of the product option value.",
+                      "type": ["null", "string"]
+                    },
+                    "has_variants": {
+                      "description": "Whether the product option value has any linked variants.",
+                      "type": ["null", "boolean"]
+                    },
+                    "swatch": {
+                      "description": "The swatch associated with the product option value.",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "color": {
+                          "description": "The color representation of the swatch.",
+                          "type": ["null", "string"]
+                        },
+                        "image": {
+                          "description": "An image representation of the swatch.",
+                          "type": ["null", "object"],
+                          "properties": {
+                            "id": {
+                              "description": "A globally-unique ID of an image representation of the swatch.",
+                              "type": ["null", "string"]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "created_at": {
+            "description": "The date and time when the variant was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the variant was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "taxable": {
+            "description": "Indicates whether taxes are applied to the variant",
+            "type": ["null", "boolean"]
+          },
+          "barcode": {
+            "description": "The barcode associated with the variant",
+            "type": ["null", "string"]
+          },
+          "grams": {
+            "description": "The weight of the variant in grams",
+            "type": ["null", "integer"]
+          },
+          "image_id": {
+            "description": "The unique identifier for the image associated with the variant",
+            "type": ["null", "integer"]
+          },
+          "weight": {
+            "description": "The weight of the variant",
+            "type": ["null", "number"]
+          },
+          "weight_unit": {
+            "description": "The unit of measurement for the weight of the variant",
+            "type": ["null", "string"]
+          },
+          "inventory_item_id": {
+            "description": "The unique identifier for the inventory item associated with the variant",
+            "type": ["null", "integer"]
+          },
+          "inventory_quantity": {
+            "description": "The current inventory quantity for the variant",
+            "type": ["null", "integer"]
+          },
+          "old_inventory_quantity": {
+            "description": "The previous inventory quantity for the variant",
+            "type": ["null", "integer"]
+          },
+          "presentment_prices": {
+            "description": "The prices of the variant for presentation in different currencies",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "price": {
+                  "description": "The price of the variant in a different currency",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "amount": {
+                      "description": "The amount of the price",
+                      "type": ["null", "number"]
+                    },
+                    "currency_code": {
+                      "description": "The currency code of the price",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "compare_at_price": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "amount": {
+                      "description": "The amount of the price",
+                      "type": ["null", "number"]
+                    },
+                    "currency_code": {
+                      "description": "The currency code of the price",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "requires_shipping": {
+            "description": "Indicates whether the variant requires shipping",
+            "type": ["null", "boolean"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the variant used by the GraphQL Admin API",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the variant is listed",
+            "type": ["null", "string"]
+          },
+          "available_for_sale": {
+            "description": "Whether the product variant is available for sale.",
+            "type": ["null", "boolean"]
+          },
+          "display_name": {
+            "description": "Display name of the variant, based on product's title + variant's title.",
+            "type": ["null", "string"]
+          },
+          "tax_code": {
+            "description": "The tax code for the product variant.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "shop",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "address1": {
+            "description": "The first line of the shop's address",
+            "type": ["null", "string"]
+          },
+          "address2": {
+            "description": "The second line of the shop's address",
+            "type": ["null", "string"]
+          },
+          "auto_configure_tax_inclusivity": {
+            "description": "Flag indicating if taxes are automatically configured to be inclusive",
+            "type": ["null", "string"]
+          },
+          "checkout_api_supported": {
+            "description": "Flag indicating if the shop supports the checkout API",
+            "type": ["null", "boolean"]
+          },
+          "city": {
+            "description": "The city where the shop is located",
+            "type": ["null", "string"]
+          },
+          "country": {
+            "description": "The country where the shop is located",
+            "type": ["null", "string"]
+          },
+          "country_code": {
+            "description": "The country code of the shop's location",
+            "type": ["null", "string"]
+          },
+          "country_name": {
+            "description": "The name of the country where the shop is located",
+            "type": ["null", "string"]
+          },
+          "county_taxes": {
+            "description": "Flag indicating if county taxes are applicable",
+            "type": ["null", "boolean"]
+          },
+          "created_at": {
+            "description": "The date and time when the shop was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "customer_email": {
+            "description": "The email address of the shop's customer support",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency used in the shop",
+            "type": ["null", "string"]
+          },
+          "domain": {
+            "description": "The domain of the shop",
+            "type": ["null", "string"]
+          },
+          "enabled_presentment_currencies": {
+            "description": "The list of currencies enabled for presenting prices",
+            "items": { "type": ["null", "string"] },
+            "type": ["null", "array"]
+          },
+          "eligible_for_card_reader_giveaway": {
+            "description": "Flag indicating if the shop is eligible for a card reader giveaway",
+            "type": ["null", "boolean"]
+          },
+          "eligible_for_payments": {
+            "description": "Flag indicating if the shop is eligible to receive payments",
+            "type": ["null", "boolean"]
+          },
+          "email": {
+            "description": "The email address associated with the shop",
+            "type": ["null", "string"]
+          },
+          "finances": {
+            "description": "Financial information related to the shop",
+            "type": ["null", "boolean"]
+          },
+          "force_ssl": {
+            "description": "Flag indicating if SSL is enforced for the shop",
+            "type": ["null", "boolean"]
+          },
+          "google_apps_domain": {
+            "description": "The Google Apps domain associated with the shop",
+            "type": ["null", "string"]
+          },
+          "google_apps_login_enabled": {
+            "description": "Flag indicating if Google Apps login is enabled for the shop",
+            "type": ["null", "boolean"]
+          },
+          "has_discounts": {
+            "description": "Flag indicating if the shop offers discounts",
+            "type": ["null", "boolean"]
+          },
+          "has_gift_cards": {
+            "description": "Flag indicating if the shop offers gift cards",
+            "type": ["null", "boolean"]
+          },
+          "has_storefront": {
+            "description": "Flag indicating if the shop has a visible storefront",
+            "type": ["null", "boolean"]
+          },
+          "iana_timezone": {
+            "description": "The IANA timezone of the shop",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier of the shop",
+            "type": ["null", "integer"]
+          },
+          "latitude": {
+            "description": "The latitude coordinate of the shop's location",
+            "type": ["null", "number"]
+          },
+          "longitude": {
+            "description": "The longitude coordinate of the shop's location",
+            "type": ["null", "number"]
+          },
+          "marketing_sms_consent_enabled_at_checkout": {
+            "description": "Flag indicating if SMS marketing consent is enabled at checkout",
+            "type": ["null", "boolean"]
+          },
+          "money_format": {
+            "description": "The format used for displaying money",
+            "type": ["null", "string"]
+          },
+          "money_in_emails_format": {
+            "description": "The format used for displaying money in emails",
+            "type": ["null", "string"]
+          },
+          "money_with_currency_format": {
+            "description": "The format used for displaying money with currency",
+            "type": ["null", "string"]
+          },
+          "money_with_currency_in_emails_format": {
+            "description": "The format used for displaying money with currency in emails",
+            "type": ["null", "string"]
+          },
+          "multi_location_enabled": {
+            "description": "Flag indicating if multi-location is enabled for the shop",
+            "type": ["null", "boolean"]
+          },
+          "myshopify_domain": {
+            "description": "The MyShopify domain of the shop",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name of the shop",
+            "type": ["null", "string"]
+          },
+          "password_enabled": {
+            "description": "Flag indicating if password login is enabled for the shop",
+            "type": ["null", "boolean"]
+          },
+          "phone": {
+            "description": "The phone number associated with the shop",
+            "type": ["null", "string"]
+          },
+          "plan_display_name": {
+            "description": "The display name of the plan the shop is on",
+            "type": ["null", "string"]
+          },
+          "pre_launch_enabled": {
+            "description": "Flag indicating if pre-launch settings are enabled",
+            "type": ["null", "boolean"]
+          },
+          "cookie_consent_level": {
+            "description": "The level of cookie consent set for the shop",
+            "type": ["null", "string"]
+          },
+          "plan_name": {
+            "description": "The name of the plan the shop is on",
+            "type": ["null", "string"]
+          },
+          "primary_locale": {
+            "description": "The primary locale set for the shop",
+            "type": ["null", "string"]
+          },
+          "primary_location_id": {
+            "description": "The ID of the primary location of the shop",
+            "type": ["null", "integer"]
+          },
+          "province": {
+            "description": "The province or state where the shop is located",
+            "type": ["null", "string"]
+          },
+          "province_code": {
+            "description": "The code representing the province or state of the shop's location",
+            "type": ["null", "string"]
+          },
+          "requires_extra_payments_agreement": {
+            "description": "Flag indicating if an extra payments agreement is required",
+            "type": ["null", "boolean"]
+          },
+          "setup_required": {
+            "description": "Flag indicating if setup is required for the shop",
+            "type": ["null", "boolean"]
+          },
+          "shop_owner": {
+            "description": "The owner of the shop",
+            "type": ["null", "string"]
+          },
+          "source": {
+            "description": "The source of the shop data",
+            "type": ["null", "string"]
+          },
+          "taxes_included": {
+            "description": "Flag indicating if taxes are included in prices",
+            "type": ["null", "boolean"]
+          },
+          "tax_shipping": {
+            "description": "Flag indicating if taxes are applicable to shipping",
+            "type": ["null", "boolean"]
+          },
+          "timezone": {
+            "description": "The timezone of the shop",
+            "type": ["null", "string"]
+          },
+          "transactional_sms_disabled": {
+            "description": "Flag indicating if transactional SMS is disabled",
+            "type": ["null", "boolean"]
+          },
+          "updated_at": {
+            "description": "The date and time when the shop was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "visitor_tracking_consent_preference": {
+            "description": "The visitor tracking consent preference set for the shop",
+            "type": ["null", "string"]
+          },
+          "weight_unit": {
+            "description": "The unit used for measuring weight",
+            "type": ["null", "string"]
+          },
+          "zip": {
+            "description": "The ZIP or postal code of the shop's location",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "smart_collections",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the smart collection",
+            "type": ["null", "integer"]
+          },
+          "handle": {
+            "description": "The human-friendly URL for the collection",
+            "type": ["null", "string"]
+          },
+          "title": {
+            "description": "The title or name of the smart collection",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the collection was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "body_html": {
+            "description": "The description or details of the smart collection",
+            "type": ["null", "string"]
+          },
+          "published_at": {
+            "description": "The date and time when the collection was published",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sort_order": {
+            "description": "The order in which the collection is displayed",
+            "type": ["null", "string"]
+          },
+          "template_suffix": {
+            "description": "The suffix added to the collection template filename",
+            "type": ["null", "string"]
+          },
+          "disjunctive": {
+            "description": "Indicates whether the collection uses disjunctive filtering",
+            "type": ["null", "boolean"]
+          },
+          "rules": {
+            "description": "The filtering rules that determine which products are included in the collection",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "published_scope": {
+            "description": "The visibility of the collection to different sales channels",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "The unique identifier for the collection in the GraphQL Admin API",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the smart collection belongs",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "tender_transactions",
+      "json_schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the tender transaction.",
+            "type": ["null", "integer"]
+          },
+          "order_id": {
+            "description": "The identifier of the order associated with the transaction.",
+            "type": ["null", "integer"]
+          },
+          "amount": {
+            "description": "The transaction amount in the specified currency.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency in which the transaction amount is stated.",
+            "type": ["null", "string"]
+          },
+          "user_id": {
+            "description": "Unique identifier of the user associated with the transaction.",
+            "type": ["null", "integer"]
+          },
+          "test": {
+            "description": "Flag indicating whether the transaction was done in a testing environment.",
+            "type": ["null", "boolean"]
+          },
+          "processed_at": {
+            "description": "The date and time when the transaction was processed.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "remote_reference": {
+            "description": "Reference to an external system for the transaction.",
+            "type": ["null", "string"]
+          },
+          "payment_details": {
+            "description": "Details about the payment made for the transaction.",
+            "type": ["null", "object"],
+            "properties": {
+              "credit_card_number": {
+                "description": "The masked credit card number used for payment.",
+                "type": ["null", "string"]
+              },
+              "credit_card_company": {
+                "description": "The company associated with the credit card used for payment.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "payment_method": {
+            "description": "The method used for payment, e.g., credit card, PayPal, etc.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop where the transaction took place.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["processed_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "transactions",
+      "json_schema": {
+        "properties": {
+          "error_code": {
+            "description": "Error code associated with the transaction",
+            "type": ["null", "string"]
+          },
+          "device_id": {
+            "description": "ID of the device used to process the transaction",
+            "type": ["null", "integer"]
+          },
+          "user_id": {
+            "description": "ID of the user associated with the transaction",
+            "type": ["null", "integer"]
+          },
+          "parent_id": {
+            "description": "ID of the parent transaction if applicable",
+            "type": ["null", "integer"]
+          },
+          "test": {
+            "description": "Flag to indicate if the transaction is a test transaction",
+            "type": ["null", "boolean"]
+          },
+          "kind": {
+            "description": "Type of transaction",
+            "type": ["null", "string"]
+          },
+          "order_id": {
+            "description": "ID of the order associated with the transaction",
+            "type": ["null", "integer"]
+          },
+          "amount": {
+            "description": "The amount of the transaction",
+            "type": ["null", "number"]
+          },
+          "amount_set": {
+            "description": "The amount and currency of the transaction in shop",
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "description": "Amount in the shop currency",
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": {
+                    "description": "Amount in the shop currency",
+                    "type": ["null", "number"]
+                  },
+                  "currency": {
+                    "description": "Currency of the shop amount",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "fees": {
+            "description": "The transaction fees charged on the order transaction. Only present for Shopify Payments transactions.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "additionalProperties": true,
+              "properties": {
+                "id": {
+                  "description": "A globally-unique ID.",
+                  "type": ["null", "string"]
+                },
+                "admin_graphql_api_id": {
+                  "description": "Unique identifier for the resource in the GraphQL Admin API",
+                  "type": ["null", "string"]
+                },
+                "rate": {
+                  "description": "Percentage charge.",
+                  "type": ["null", "number"]
+                },
+                "type": {
+                  "description": "Name of the type of fee.",
+                  "type": ["null", "string"]
+                },
+                "flat_fee_name": {
+                  "description": "Name of the credit card flat fee.",
+                  "type": ["null", "string"]
+                },
+                "rate_name": {
+                  "description": "Percentage charge.",
+                  "type": ["null", "string"]
+                },
+                "amount": {
+                  "description": "Amount in the shop currency",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "amount": {
+                      "description": "Amount in the shop currency",
+                      "type": ["null", "number"]
+                    },
+                    "currency": {
+                      "description": "Currency of the shop amount",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "flat_fee": {
+                  "description": "Amount in the shop currency",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "amount": {
+                      "description": "Amount in the shop currency",
+                      "type": ["null", "number"]
+                    },
+                    "currency": {
+                      "description": "Currency of the shop amount",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "tax_amount": {
+                  "description": "Amount in the shop currency",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "amount": {
+                      "description": "Amount in the shop currency",
+                      "type": ["null", "number"]
+                    },
+                    "currency": {
+                      "description": "Currency of the shop amount",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "authorization": {
+            "description": "Authorization code for the transaction",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "Currency of the transaction",
+            "type": ["null", "string"]
+          },
+          "source_name": {
+            "description": "Name of the source that initiated the transaction",
+            "type": ["null", "string"]
+          },
+          "message": {
+            "description": "Additional message or notes regarding the transaction",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier of the transaction",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "Date and time when the transaction was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "status": {
+            "description": "Status of the transaction",
+            "type": ["null", "string"]
+          },
+          "total_unsettled_set": {
+            "description": "Total unsettled amount of the transaction",
+            "type": ["null", "object"],
+            "properties": {
+              "shop_money": {
+                "description": "Amount in the shop currency",
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": {
+                    "description": "Amount in the shop currency",
+                    "type": ["null", "number"]
+                  },
+                  "currency_code": {
+                    "description": "Currency code of the shop amount",
+                    "type": ["null", "string"]
+                  },
+                  "currency": {
+                    "description": "Currency of the shop amount",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "presentment_money": {
+                "description": "Amount in the presentment currency",
+                "type": ["null", "object"],
+                "properties": {
+                  "amount": {
+                    "description": "Amount in the currency for presentation purposes",
+                    "type": ["null", "number"]
+                  },
+                  "currency_code": {
+                    "description": "Currency code of the presentment amount",
+                    "type": ["null", "string"]
+                  },
+                  "currency": {
+                    "description": "Currency of the presentment amount",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "payment_id": {
+            "description": "ID of the payment associated with the transaction",
+            "type": ["null", "string"]
+          },
+          "payment_details": {
+            "description": "Details of the payment transaction",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "avs_result_code": {
+                "description": "Code indicating the AVS (Address Verification Service) result",
+                "type": ["null", "string"]
+              },
+              "buyer_action_info": {
+                "description": "Information about any buyer actions associated with the payment",
+                "type": ["null", "string"]
+              },
+              "credit_card_bin": {
+                "description": "First few digits of the credit card number",
+                "type": ["null", "string"]
+              },
+              "credit_card_company": {
+                "description": "Name of the credit card company",
+                "type": ["null", "string"]
+              },
+              "credit_card_expiration_month": {
+                "description": "Expiration month of the credit card",
+                "type": ["null", "integer"]
+              },
+              "credit_card_expiration_year": {
+                "description": "Expiration year of the credit card",
+                "type": ["null", "integer"]
+              },
+              "credit_card_name": {
+                "description": "Name on the credit card",
+                "type": ["null", "string"]
+              },
+              "credit_card_number": {
+                "description": "Full credit card number",
+                "type": ["null", "string"]
+              },
+              "credit_card_wallet": {
+                "description": "Information about the digital wallet used for payment",
+                "type": ["null", "string"]
+              },
+              "cvv_result_code": {
+                "description": "Code indicating the CVV (Card Verification Value) result",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "processed_at": {
+            "description": "Date and time when the transaction was processed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "gateway": {
+            "description": "Payment gateway used for the transaction",
+            "type": ["null", "string"]
+          },
+          "admin_graphql_api_id": {
+            "description": "Unique identifier for the resource in the GraphQL Admin API",
+            "type": ["null", "string"]
+          },
+          "receipt": {
+            "description": "Receipt information related to the transaction",
+            "oneOf": [
+              {
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "fee_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                  },
+                  "gross_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                  },
+                  "tax_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                  }
+                }
+              },
+              { "type": ["null", "string"] }
+            ]
+          },
+          "location_id": {
+            "description": "ID of the location where the transaction took place",
+            "type": ["null", "integer"]
+          },
+          "accountNumber": {
+            "description": "The masked account number associated with the payment method.",
+            "type": ["null", "integer"]
+          },
+          "formattedGateway": {
+            "description": "The human-readable payment gateway name used to process the transaction.",
+            "type": ["null", "string"]
+          },
+          "manuallyCapturable": {
+            "description": "Whether the transaction can be manually captured.",
+            "type": ["null", "boolean"]
+          },
+          "shop_url": {
+            "description": "URL of the shop where the transaction occurred",
+            "type": ["null", "string"]
+          }
+        },
+        "additionalProperties": true,
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "customer_saved_search",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "created_at": {
+            "description": "The date and time when the customer saved search was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "id": {
+            "description": "The unique identifier for the customer saved search.",
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "description": "The name given to the customer saved search.",
+            "type": ["null", "string"]
+          },
+          "query": {
+            "description": "The search query string or parameters used for this saved search.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop associated with this customer saved search.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the customer saved search was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["id"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "customer_address",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "address1": {
+            "description": "The first line of the customer's street address.",
+            "type": ["null", "string"]
+          },
+          "address2": {
+            "description": "The second line of the customer's street address.",
+            "type": ["null", "string"]
+          },
+          "city": {
+            "description": "The city where the customer resides.",
+            "type": ["null", "string"]
+          },
+          "country": {
+            "description": "The full name of the country associated with the address.",
+            "type": ["null", "string"]
+          },
+          "country_code": {
+            "description": "The ISO 3166-1 alpha-2 country code of the address country.",
+            "type": ["null", "string"]
+          },
+          "country_name": {
+            "description": "The name of the country associated with the address.",
+            "type": ["null", "string"]
+          },
+          "company": {
+            "description": "The company name associated with the customer's address.",
+            "type": ["null", "string"]
+          },
+          "customer_id": {
+            "description": "The unique identifier of the customer to whom the address belongs.",
+            "type": ["null", "integer"]
+          },
+          "first_name": {
+            "description": "The first name of the customer.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier of the address.",
+            "type": ["null", "integer"]
+          },
+          "last_name": {
+            "description": "The last name of the customer.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The full name of the customer associated with the address.",
+            "type": ["null", "string"]
+          },
+          "phone": {
+            "description": "The phone number associated with the address.",
+            "type": ["null", "string"]
+          },
+          "province": {
+            "description": "The region or state where the customer resides.",
+            "type": ["null", "string"]
+          },
+          "province_code": {
+            "description": "The code or abbreviation of the region or state.",
+            "type": ["null", "string"]
+          },
+          "zip": {
+            "description": "The postal code or ZIP code of the address.",
+            "type": ["null", "string"]
+          },
+          "default": {
+            "description": "Indicates whether this is the default address for the customer.",
+            "type": ["null", "boolean"]
+          },
+          "shop_url": {
+            "description": "The URL of the shop associated with the customer's address.",
+            "type": ["null", "string"]
+          },
+          "updated_at": {
+            "description": "The date and time when the address was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["id"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "countries",
+      "json_schema": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "code": {
+            "description": "ISO country code.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier for the country.",
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "description": "Name of the country.",
+            "type": ["null", "string"]
+          },
+          "provinces": {
+            "description": "Array of provinces or states within the country.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "code": {
+                  "description": "Province or state code.",
+                  "type": ["null", "string"]
+                },
+                "country_id": {
+                  "description": "Unique identifier of the country the province belongs to.",
+                  "type": ["null", "integer"]
+                },
+                "id": {
+                  "description": "Unique identifier for the province.",
+                  "type": ["null", "integer"]
+                },
+                "name": {
+                  "description": "Name of the province.",
+                  "type": ["null", "string"]
+                },
+                "tax": {
+                  "description": "Tax information for the province.",
+                  "type": ["null", "number"]
+                },
+                "tax_name": {
+                  "description": "Name of the tax applicable for the province.",
+                  "type": ["null", "string"]
+                },
+                "tax_type": {
+                  "description": "Type of tax (e.g., sales tax, VAT) applicable in the province.",
+                  "type": ["null", "string"]
+                },
+                "tax_percentage": {
+                  "description": "Percentage value of tax applicable in the province.",
+                  "type": ["null", "number"]
+                }
+              }
+            }
+          },
+          "tax": {
+            "description": "Overall tax information for the country.",
+            "type": ["null", "number"]
+          },
+          "tax_name": {
+            "description": "Name of the tax applicable for the country.",
+            "type": ["null", "string"]
+          },
+          "shop_url": {
+            "description": "URL for the shop related to this country.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-shopify/erd/estimated_relationships.json
+++ b/airbyte-integrations/connectors/source-shopify/erd/estimated_relationships.json
@@ -1,0 +1,282 @@
+{
+  "streams": [
+    {
+      "name": "abandoned_checkouts",
+      "relations": {
+        "location_id": "locations.id",
+        "user_id": "customers.id"
+      }
+    },
+    {
+      "name": "articles",
+      "relations": {
+        "blog_id": "blogs.id",
+        "user_id": "customers.id"
+      }
+    },
+    {
+      "name": "balance_transactions",
+      "relations": {
+        "payout_id": "payouts.id",
+        "source_id": "sources.id"
+      }
+    },
+    {
+      "name": "blogs",
+      "relations": {}
+    },
+    {
+      "name": "collections",
+      "relations": {}
+    },
+    {
+      "name": "collects",
+      "relations": {
+        "collection_id": "collections.id",
+        "product_id": "products.id"
+      }
+    },
+    {
+      "name": "custom_collections",
+      "relations": {}
+    },
+    {
+      "name": "customer_journey_summary",
+      "relations": {
+        "order_id": "orders.id"
+      }
+    },
+    {
+      "name": "customers",
+      "relations": {
+        "last_order_id": "orders.id"
+      }
+    },
+    {
+      "name": "discount_codes",
+      "relations": {
+        "price_rule_id": "price_rules.id"
+      }
+    },
+    {
+      "name": "disputes",
+      "relations": {
+        "order_id": "orders.id"
+      }
+    },
+    {
+      "name": "draft_orders",
+      "relations": {
+        "order_id": "orders.id"
+      }
+    },
+    {
+      "name": "fulfillment_orders",
+      "relations": {
+        "assigned_location_id": "locations.id",
+        "order_id": "orders.id",
+        "shop_id": "shop.id"
+      }
+    },
+    {
+      "name": "fulfillments",
+      "relations": {
+        "location_id": "locations.id",
+        "order_id": "orders.id"
+      }
+    },
+    {
+      "name": "inventory_items",
+      "relations": {}
+    },
+    {
+      "name": "inventory_levels",
+      "relations": {
+        "inventory_item_id": "inventory_items.id",
+        "location_id": "locations.id"
+      }
+    },
+    {
+      "name": "locations",
+      "relations": {}
+    },
+    {
+      "name": "metafield_articles",
+      "relations": {
+        "owner_id": "articles.id"
+      }
+    },
+    {
+      "name": "metafield_blogs",
+      "relations": {
+        "owner_id": "blogs.id"
+      }
+    },
+    {
+      "name": "metafield_collections",
+      "relations": {
+        "owner_id": "collections.id"
+      }
+    },
+    {
+      "name": "metafield_customers",
+      "relations": {
+        "owner_id": "customers.id"
+      }
+    },
+    {
+      "name": "metafield_draft_orders",
+      "relations": {
+        "owner_id": "draft_orders.id"
+      }
+    },
+    {
+      "name": "metafield_locations",
+      "relations": {
+        "owner_id": "locations.id"
+      }
+    },
+    {
+      "name": "metafield_orders",
+      "relations": {
+        "owner_id": "orders.id"
+      }
+    },
+    {
+      "name": "metafield_pages",
+      "relations": {
+        "owner_id": "pages.id"
+      }
+    },
+    {
+      "name": "metafield_product_images",
+      "relations": {
+        "owner_id": "product_images.id"
+      }
+    },
+    {
+      "name": "metafield_products",
+      "relations": {
+        "owner_id": "products.id"
+      }
+    },
+    {
+      "name": "metafield_product_variants",
+      "relations": {
+        "owner_id": "product_variants.id"
+      }
+    },
+    {
+      "name": "metafield_shops",
+      "relations": {
+        "owner_id": "shop.id"
+      }
+    },
+    {
+      "name": "metafield_smart_collections",
+      "relations": {
+        "owner_id": "smart_collections.id"
+      }
+    },
+    {
+      "name": "order_agreements",
+      "relations": {
+        "id": "orders.id"
+      }
+    },
+    {
+      "name": "order_refunds",
+      "relations": {
+        "order_id": "orders.id",
+        "user_id": "customers.id"
+      }
+    },
+    {
+      "name": "order_risks",
+      "relations": {
+        "order_id": "orders.id",
+        "checkout_id": "abandoned_checkouts.id"
+      }
+    },
+    {
+      "name": "orders",
+      "relations": {
+        "app_id": "apps.id",
+        "checkout_id": "abandoned_checkouts.id",
+        "location_id": "locations.id",
+        "user_id": "customers.id"
+      }
+    },
+    {
+      "name": "pages",
+      "relations": {
+        "shop_id": "shop.id"
+      }
+    },
+    {
+      "name": "price_rules",
+      "relations": {}
+    },
+    {
+      "name": "product_images",
+      "relations": {
+        "product_id": "products.id"
+      }
+    },
+    {
+      "name": "products",
+      "relations": {}
+    },
+    {
+      "name": "products_graph_ql",
+      "relations": {}
+    },
+    {
+      "name": "product_variants",
+      "relations": {
+        "product_id": "products.id",
+        "inventory_item_id": "inventory_items.id"
+      }
+    },
+    {
+      "name": "shop",
+      "relations": {
+        "primary_location_id": "locations.id"
+      }
+    },
+    {
+      "name": "smart_collections",
+      "relations": {}
+    },
+    {
+      "name": "tender_transactions",
+      "relations": {
+        "order_id": "orders.id",
+        "user_id": "customers.id"
+      }
+    },
+    {
+      "name": "transactions",
+      "relations": {
+        "order_id": "orders.id",
+        "user_id": "customers.id",
+        "parent_id": "transactions.id",
+        "location_id": "locations.id"
+      }
+    },
+    {
+      "name": "customer_saved_search",
+      "relations": {}
+    },
+    {
+      "name": "customer_address",
+      "relations": {
+        "customer_id": "customers.id"
+      }
+    },
+    {
+      "name": "countries",
+      "relations": {}
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-shopify/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-shopify/erd/source.dbml
@@ -1,0 +1,1254 @@
+Table "abandoned_checkouts" {
+    "note_attributes" array
+    "location_id" integer
+    "buyer_accepts_marketing" boolean
+    "currency" string
+    "completed_at" string
+    "token" string
+    "billing_address" object
+    "email" string
+    "discount_codes" array
+    "customer_locale" string
+    "created_at" string
+    "updated_at" string
+    "gateway" string
+    "referring_site" string
+    "source_identifier" string
+    "total_weight" integer
+    "tax_lines" array
+    "total_line_items_price" number
+    "closed_at" string
+    "device_id" integer
+    "phone" string
+    "source_name" string
+    "id" integer [pk]
+    "name" string
+    "total_tax" number
+    "subtotal_price" number
+    "line_items" array
+    "source_url" string
+    "shop_url" string
+    "total_discounts" number
+    "note" string
+    "presentment_currency" string
+    "shipping_lines" array
+    "user_id" integer
+    "source" string
+    "shipping_address" object
+    "abandoned_checkout_url" string
+    "landing_site" string
+    "customer" object
+    "total_price" number
+    "cart_token" string
+    "taxes_included" boolean
+}
+
+Table "articles" {
+    "id" integer [pk]
+    "title" string
+    "created_at" string
+    "body_html" string
+    "blog_id" integer
+    "author" string
+    "user_id" string
+    "published_at" string
+    "updated_at" string
+    "summary_html" string
+    "template_suffix" string
+    "handle" string
+    "tags" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+    "deleted_at" string
+    "deleted_message" string
+    "deleted_description" string
+}
+
+Table "balance_transactions" {
+    "id" integer [pk]
+    "type" string
+    "test" boolean
+    "payout_id" integer
+    "payout_status" string
+    "payoucurrencyt_status" string
+    "amount" number
+    "fee" number
+    "net" number
+    "source_id" integer
+    "source_type" string
+    "source_order_transaction_id" integer
+    "source_order_id" integer
+    "processed_at" string
+    "shop_url" string
+}
+
+Table "blogs" {
+    "commentable" string
+    "created_at" string
+    "feedburner" string
+    "feedburner_location" integer
+    "handle" string
+    "id" integer [pk]
+    "tags" string
+    "template_suffix" string
+    "title" string
+    "updated_at" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+    "deleted_at" string
+    "deleted_message" string
+    "deleted_description" string
+}
+
+Table "collections" {
+    "id" integer [pk]
+    "handle" string
+    "title" string
+    "updated_at" string
+    "body_html" string
+    "published_at" string
+    "sort_order" string
+    "template_suffix" string
+    "products_count" integer
+    "collection_type" string
+    "published_scope" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "collects" {
+    "id" integer [pk]
+    "collection_id" integer
+    "created_at" string
+    "position" integer
+    "product_id" integer
+    "sort_value" string
+    "shop_url" string
+    "updated_at" string
+}
+
+Table "custom_collections" {
+    "handle" string
+    "sort_order" string
+    "body_html" string
+    "title" string
+    "id" integer [pk]
+    "published_scope" string
+    "admin_graphql_api_id" string
+    "updated_at" string
+    "image" object
+    "published_at" string
+    "template_suffix" string
+    "shop_url" string
+    "deleted_at" string
+    "deleted_message" string
+    "deleted_description" string
+}
+
+Table "customer_journey_summary" {
+    "order_id" integer [pk]
+    "created_at" string
+    "updated_at" string
+    "customer_journey_summary" object
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "customers" {
+    "last_order_name" string
+    "currency" string
+    "email" string
+    "multipass_identifier" string
+    "shop_url" string
+    "default_address" object
+    "email_marketing_consent" object
+    "orders_count" integer
+    "state" string
+    "verified_email" boolean
+    "total_spent" number
+    "last_order_id" integer
+    "first_name" string
+    "updated_at" string
+    "note" string
+    "phone" string
+    "admin_graphql_api_id" string
+    "addresses" array
+    "last_name" string
+    "tags" string
+    "tax_exempt" boolean
+    "id" integer [pk]
+    "accepts_marketing" boolean
+    "created_at" string
+    "sms_marketing_consent" object
+    "tax_exemptions" string
+    "marketing_opt_in_level" string
+}
+
+Table "discount_codes" {
+    "id" integer [pk]
+    "price_rule_id" integer
+    "code" string
+    "usage_count" integer
+    "created_at" string
+    "createdBy" object
+    "updated_at" string
+    "summary" string
+    "discount_type" string
+    "typename" string
+    "starts_at" string
+    "ends_at" string
+    "status" string
+    "title" string
+    "usage_limit" integer
+    "applies_once_per_customer" boolean
+    "async_usage_count" integer
+    "codes_count" object
+    "total_sales" object
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "disputes" {
+    "id" integer [pk]
+    "order_id" integer
+    "type" string
+    "currency" string
+    "amount" string
+    "reason" string
+    "network_reason_code" string
+    "status" string
+    "initiated_at" string
+    "evidence_due_by" string
+    "evidence_sent_on" string
+    "finalized_on" string
+}
+
+Table "draft_orders" {
+    "id" integer [pk]
+    "note" string
+    "email" string
+    "taxes_included" boolean
+    "currency" string
+    "invoice_sent_at" string
+    "created_at" string
+    "updated_at" string
+    "tax_exempt" boolean
+    "completed_at" string
+    "name" string
+    "status" string
+    "line_items" array
+    "shipping_address" object
+    "billing_address" object
+    "invoice_url" string
+    "applied_discount" object
+    "order_id" integer
+    "payment_terms" string
+    "po_number" string
+    "shipping_line" object
+    "tax_lines" array
+    "tags" string
+    "note_attributes" array
+    "total_price" string
+    "subtotal_price" string
+    "total_tax" string
+    "admin_graphql_api_id" string
+    "customer" object
+    "shop_url" string
+}
+
+Table "fulfillment_orders" {
+    "assigned_location_id" integer
+    "channel_id" string
+    "destination" object
+    "delivery_method" object
+    "fulfilled_at" string
+    "fulfill_at" string
+    "fulfill_by" string
+    "international_duties" string
+    "fulfillment_holds" array
+    "id" integer [pk]
+    "line_items" array
+    "order_id" integer
+    "request_status" string
+    "shop_id" integer
+    "status" string
+    "supported_actions" array
+    "merchant_requests" array
+    "assigned_location" object
+    "shop_url" string
+    "created_at" string
+    "updated_at" string
+    "admin_graphql_api_id" string
+}
+
+Table "fulfillments" {
+    "admin_graphql_api_id" string
+    "created_at" string
+    "id" integer [pk]
+    "location_id" integer
+    "name" string
+    "notify_customer" boolean
+    "order_id" integer
+    "origin_address" object
+    "receipt" object
+    "service" string
+    "shipment_status" string
+    "status" string
+    "tracking_company" string
+    "tracking_numbers" array
+    "tracking_urls" array
+    "tracking_url" string
+    "tracking_number" string
+    "updated_at" string
+    "variant_inventory_management" string
+    "line_items" array
+    "duties" array
+    "shop_url" string
+}
+
+Table "inventory_items" {
+    "id" integer [pk]
+    "admin_graphql_api_id" string
+    "cost" number
+    "currency_code" string
+    "country_code_of_origin" string
+    "country_harmonized_system_codes" array
+    "duplicate_sku_count" integer
+    "harmonized_system_code" string
+    "province_code_of_origin" string
+    "updated_at" string
+    "created_at" string
+    "sku" string
+    "tracked" boolean
+    "requires_shipping" boolean
+    "shop_url" string
+}
+
+Table "inventory_levels" {
+    "id" string [pk]
+    "admin_graphql_api_id" string
+    "available" integer
+    "can_deactivate" boolean
+    "created_at" string
+    "inventory_history_url" string
+    "locations_count" object
+    "deactivation_alert" string
+    "inventory_item_id" integer
+    "location_id" integer
+    "updated_at" string
+    "shop_url" string
+    "quantities" array
+}
+
+Table "locations" {
+    "active" boolean
+    "address1" string
+    "address2" string
+    "admin_graphql_api_id" string
+    "city" string
+    "country" string
+    "country_code" string
+    "country_name" string
+    "created_at" string
+    "id" integer [pk]
+    "legacy" boolean
+    "name" string
+    "phone" string
+    "province" string
+    "province_code" string
+    "updated_at" string
+    "zip" string
+    "localized_country_name" string
+    "localized_province_name" string
+    "shop_url" string
+}
+
+Table "metafield_articles" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "metafield_blogs" {
+    "owner_id" integer
+    "admin_graphql_api_id" string
+    "owner_resource" string
+    "value_type" string
+    "key" string
+    "created_at" string
+    "id" integer [pk]
+    "namespace" string
+    "description" string
+    "value" string
+    "updated_at" string
+    "shop_url" string
+    "type" string
+}
+
+Table "metafield_collections" {
+    "owner_id" integer
+    "admin_graphql_api_id" string
+    "owner_resource" string
+    "value_type" string
+    "key" string
+    "created_at" string
+    "id" integer [pk]
+    "namespace" string
+    "description" string
+    "value" string
+    "updated_at" string
+    "shop_url" string
+    "type" string
+}
+
+Table "metafield_customers" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "metafield_draft_orders" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "metafield_locations" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "metafield_orders" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "metafield_pages" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "metafield_product_images" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "metafield_products" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "metafield_product_variants" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "metafield_shops" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "metafield_smart_collections" {
+    "id" integer [pk]
+    "namespace" string
+    "key" string
+    "value" string
+    "value_type" string
+    "description" string
+    "owner_id" integer
+    "created_at" string
+    "updated_at" string
+    "owner_resource" string
+    "type" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "order_agreements" {
+    "id" integer [pk]
+    "created_at" string
+    "updated_at" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+    "agreements" array
+}
+
+Table "order_refunds" {
+    "order_id" integer
+    "restock" boolean
+    "order_adjustments" array
+    "processed_at" string
+    "user_id" integer
+    "note" string
+    "id" integer [pk]
+    "created_at" string
+    "admin_graphql_api_id" string
+    "duties" string
+    "refund_line_items" array
+    "return" object
+    "transactions" array
+    "shop_url" string
+    "total_duties_set" object
+}
+
+Table "order_risks" {
+    "id" integer [pk]
+    "order_id" integer
+    "checkout_id" integer
+    "source" string
+    "score" number
+    "recommendation" string
+    "display" boolean
+    "cause_cancel" boolean
+    "message" string
+    "merchant_message" string
+    "admin_graphql_api_id" string
+    "updated_at" string
+    "assessments" array
+    "shop_url" string
+}
+
+Table "orders" {
+    "id" integer [pk]
+    "admin_graphql_api_id" string
+    "app_id" integer
+    "browser_ip" string
+    "buyer_accepts_marketing" boolean
+    "cancel_reason" string
+    "cancelled_at" string
+    "cart_token" string
+    "checkout_id" integer
+    "checkout_token" string
+    "client_details" object
+    "closed_at" string
+    "company" string
+    "confirmed" boolean
+    "confirmation_number" string
+    "contact_email" string
+    "created_at" string
+    "currency" string
+    "current_subtotal_price" number
+    "current_subtotal_price_set" object
+    "current_total_discounts" number
+    "current_total_discounts_set" object
+    "current_total_duties_set" string
+    "current_total_price" number
+    "current_total_price_set" object
+    "current_total_tax" number
+    "current_total_tax_set" object
+    "current_total_additional_fees_set" object
+    "customer_locale" string
+    "device_id" string
+    "discount_applications" array
+    "discount_codes" array
+    "email" string
+    "estimated_taxes" boolean
+    "financial_status" string
+    "fulfillment_status" string
+    "landing_site" string
+    "landing_site_ref" string
+    "location_id" integer
+    "merchant_of_record_app_id" string
+    "name" string
+    "note" string
+    "note_attributes" array
+    "number" integer
+    "order_number" integer
+    "order_status_url" string
+    "original_total_duties_set" string
+    "original_total_additional_fees_set" object
+    "payment_gateway_names" array
+    "payment_terms" string
+    "phone" string
+    "presentment_currency" string
+    "processed_at" string
+    "po_number" string
+    "reference" string
+    "referring_site" string
+    "source_identifier" string
+    "source_name" string
+    "source_url" string
+    "shop_url" string
+    "subtotal_price" number
+    "subtotal_price_set" object
+    "tags" string
+    "tax_exempt" boolean
+    "tax_lines" array
+    "taxes_included" boolean
+    "test" boolean
+    "token" string
+    "total_discounts" number
+    "total_discounts_set" object
+    "total_line_items_price" number
+    "total_line_items_price_set" object
+    "total_outstanding" number
+    "total_price" number
+    "total_price_set" object
+    "total_price_usd" number
+    "total_shipping_price_set" object
+    "total_tax" number
+    "total_tax_set" object
+    "total_tip_received" number
+    "total_weight" integer
+    "updated_at" string
+    "user_id" number
+    "billing_address" object
+    "customer" object
+    "discount_allocations" array
+    "fulfillments" array
+    "line_items" array
+    "refunds" array
+    "shipping_address" object
+    "shipping_lines" array
+    "deleted_at" string
+    "deleted_message" string
+    "deleted_description" string
+}
+
+Table "pages" {
+    "author" string
+    "admin_graphql_api_id" string
+    "created_at" string
+    "handle" string
+    "id" integer [pk]
+    "published_at" string
+    "shop_id" integer
+    "template_suffix" string
+    "title" string
+    "updated_at" string
+    "shop_url" string
+    "deleted_at" string
+    "deleted_message" string
+    "deleted_description" string
+}
+
+Table "price_rules" {
+    "allocation_method" string
+    "admin_graphql_api_id" string
+    "created_at" string
+    "customer_segment_prerequisite_ids" array
+    "updated_at" string
+    "customer_selection" string
+    "ends_at" string
+    "entitled_collection_ids" array
+    "entitled_country_ids" array
+    "entitled_product_ids" array
+    "entitled_variant_ids" array
+    "id" integer [pk]
+    "once_per_customer" boolean
+    "prerequisite_customer_ids" array
+    "prerequisite_quantity_range" object
+    "prerequisite_saved_search_ids" array
+    "prerequisite_shipping_price_range" object
+    "prerequisite_subtotal_range" object
+    "prerequisite_to_entitlement_purchase" object
+    "starts_at" string
+    "target_selection" string
+    "target_type" string
+    "title" string
+    "usage_limit" integer
+    "prerequisite_product_ids" array
+    "prerequisite_variant_ids" array
+    "prerequisite_collection_ids" array
+    "value" string
+    "value_type" string
+    "prerequisite_to_entitlement_quantity_ratio" object
+    "allocation_limit" integer
+    "shop_url" string
+    "deleted_at" string
+    "deleted_message" string
+    "deleted_description" string
+}
+
+Table "product_images" {
+    "created_at" string
+    "id" integer [pk]
+    "position" integer
+    "product_id" integer
+    "variant_ids" array
+    "src" string
+    "width" integer
+    "height" integer
+    "updated_at" string
+    "admin_graphql_api_id" string
+    "alt" string
+    "shop_url" string
+}
+
+Table "products" {
+    "published_at" string
+    "created_at" string
+    "published_scope" string
+    "status" string
+    "vendor" string
+    "updated_at" string
+    "body_html" string
+    "product_type" string
+    "tags" string
+    "options" array
+    "image" object
+    "handle" string
+    "images" array
+    "template_suffix" string
+    "title" string
+    "variants" array
+    "admin_graphql_api_id" string
+    "id" integer [pk]
+    "shop_url" string
+    "deleted_at" string
+    "deleted_message" string
+    "deleted_description" string
+    "description" string
+    "description_html" string
+    "is_gift_card" boolean
+    "legacy_resource_id" string
+    "media_count" integer
+    "online_store_preview_url" string
+    "online_store_url" string
+    "total_inventory" integer
+    "total_variants" integer
+    "tracks_inventory" boolean
+    "has_only_default_variant" boolean
+    "has_out_of_stock_variants" boolean
+    "requires_sellin_plan" boolean
+    "price_range_v2" object
+    "featured_image" object
+    "seo" object
+    "featured_media" object
+    "feedback" object
+}
+
+Table "products_graph_ql" {
+    "createdAt" string
+    "description" string
+    "descriptionHtml" string
+    "handle" string
+    "id" string [pk]
+    "isGiftCard" boolean
+    "legacyResourceId" string
+    "mediaCount" integer
+    "onlineStorePreviewUrl" string
+    "onlineStoreUrl" string
+    "options" array
+    "productType" string
+    "publishedAt" string
+    "shop_url" string
+    "status" string
+    "tags" array
+    "title" string
+    "totalInventory" integer
+    "totalVariants" integer
+    "tracksInventory" boolean
+    "updatedAt" string
+    "vendor" string
+}
+
+Table "product_variants" {
+    "id" integer [pk]
+    "product_id" integer
+    "title" string
+    "price" number
+    "sku" string
+    "position" integer
+    "inventory_policy" string
+    "compare_at_price" string
+    "fulfillment_service" string
+    "inventory_management" string
+    "option1" string
+    "option2" string
+    "option3" string
+    "options" array
+    "created_at" string
+    "updated_at" string
+    "taxable" boolean
+    "barcode" string
+    "grams" integer
+    "image_id" integer
+    "weight" number
+    "weight_unit" string
+    "inventory_item_id" integer
+    "inventory_quantity" integer
+    "old_inventory_quantity" integer
+    "presentment_prices" array
+    "requires_shipping" boolean
+    "admin_graphql_api_id" string
+    "shop_url" string
+    "available_for_sale" boolean
+    "display_name" string
+    "tax_code" string
+}
+
+Table "shop" {
+    "address1" string
+    "address2" string
+    "auto_configure_tax_inclusivity" string
+    "checkout_api_supported" boolean
+    "city" string
+    "country" string
+    "country_code" string
+    "country_name" string
+    "county_taxes" boolean
+    "created_at" string
+    "customer_email" string
+    "currency" string
+    "domain" string
+    "enabled_presentment_currencies" array
+    "eligible_for_card_reader_giveaway" boolean
+    "eligible_for_payments" boolean
+    "email" string
+    "finances" boolean
+    "force_ssl" boolean
+    "google_apps_domain" string
+    "google_apps_login_enabled" boolean
+    "has_discounts" boolean
+    "has_gift_cards" boolean
+    "has_storefront" boolean
+    "iana_timezone" string
+    "id" integer [pk]
+    "latitude" number
+    "longitude" number
+    "marketing_sms_consent_enabled_at_checkout" boolean
+    "money_format" string
+    "money_in_emails_format" string
+    "money_with_currency_format" string
+    "money_with_currency_in_emails_format" string
+    "multi_location_enabled" boolean
+    "myshopify_domain" string
+    "name" string
+    "password_enabled" boolean
+    "phone" string
+    "plan_display_name" string
+    "pre_launch_enabled" boolean
+    "cookie_consent_level" string
+    "plan_name" string
+    "primary_locale" string
+    "primary_location_id" integer
+    "province" string
+    "province_code" string
+    "requires_extra_payments_agreement" boolean
+    "setup_required" boolean
+    "shop_owner" string
+    "source" string
+    "taxes_included" boolean
+    "tax_shipping" boolean
+    "timezone" string
+    "transactional_sms_disabled" boolean
+    "updated_at" string
+    "visitor_tracking_consent_preference" string
+    "weight_unit" string
+    "zip" string
+    "shop_url" string
+}
+
+Table "smart_collections" {
+    "id" integer [pk]
+    "handle" string
+    "title" string
+    "updated_at" string
+    "body_html" string
+    "published_at" string
+    "sort_order" string
+    "template_suffix" string
+    "disjunctive" boolean
+    "rules" array
+    "published_scope" string
+    "admin_graphql_api_id" string
+    "shop_url" string
+}
+
+Table "tender_transactions" {
+    "id" integer [pk]
+    "order_id" integer
+    "amount" string
+    "currency" string
+    "user_id" integer
+    "test" boolean
+    "processed_at" string
+    "remote_reference" string
+    "payment_details" object
+    "payment_method" string
+    "shop_url" string
+}
+
+Table "transactions" {
+    "error_code" string
+    "device_id" integer
+    "user_id" integer
+    "parent_id" integer
+    "test" boolean
+    "kind" string
+    "order_id" integer
+    "amount" number
+    "amount_set" object
+    "fees" array
+    "authorization" string
+    "currency" string
+    "source_name" string
+    "message" string
+    "id" integer [pk]
+    "created_at" string
+    "status" string
+    "total_unsettled_set" object
+    "payment_id" string
+    "payment_details" object
+    "processed_at" string
+    "gateway" string
+    "admin_graphql_api_id" string
+    "location_id" integer
+    "accountNumber" integer
+    "formattedGateway" string
+    "manuallyCapturable" boolean
+    "shop_url" string
+}
+
+Table "customer_saved_search" {
+    "created_at" string
+    "id" integer [pk]
+    "name" string
+    "query" string
+    "shop_url" string
+    "updated_at" string
+}
+
+Table "customer_address" {
+    "address1" string
+    "address2" string
+    "city" string
+    "country" string
+    "country_code" string
+    "country_name" string
+    "company" string
+    "customer_id" integer
+    "first_name" string
+    "id" integer [pk]
+    "last_name" string
+    "name" string
+    "phone" string
+    "province" string
+    "province_code" string
+    "zip" string
+    "default" boolean
+    "shop_url" string
+    "updated_at" string
+}
+
+Table "countries" {
+    "code" string
+    "id" integer [pk]
+    "name" string
+    "provinces" array
+    "tax" number
+    "tax_name" string
+    "shop_url" string
+}
+
+Ref {
+    "abandoned_checkouts"."location_id" <> "locations"."id"
+}
+
+Ref {
+    "abandoned_checkouts"."user_id" <> "customers"."id"
+}
+
+Ref {
+    "articles"."blog_id" <> "blogs"."id"
+}
+
+Ref {
+    "articles"."user_id" <> "customers"."id"
+}
+
+Ref {
+    "collects"."collection_id" <> "collections"."id"
+}
+
+Ref {
+    "collects"."product_id" <> "products"."id"
+}
+
+Ref {
+    "customer_journey_summary"."order_id" <> "orders"."id"
+}
+
+Ref {
+    "customers"."last_order_id" <> "orders"."id"
+}
+
+Ref {
+    "discount_codes"."price_rule_id" <> "price_rules"."id"
+}
+
+Ref {
+    "disputes"."order_id" <> "orders"."id"
+}
+
+Ref {
+    "draft_orders"."order_id" <> "orders"."id"
+}
+
+Ref {
+    "fulfillment_orders"."assigned_location_id" <> "locations"."id"
+}
+
+Ref {
+    "fulfillment_orders"."order_id" <> "orders"."id"
+}
+
+Ref {
+    "fulfillment_orders"."shop_id" <> "shop"."id"
+}
+
+Ref {
+    "fulfillments"."location_id" <> "locations"."id"
+}
+
+Ref {
+    "fulfillments"."order_id" <> "orders"."id"
+}
+
+Ref {
+    "inventory_levels"."inventory_item_id" <> "inventory_items"."id"
+}
+
+Ref {
+    "inventory_levels"."location_id" <> "locations"."id"
+}
+
+Ref {
+    "metafield_articles"."owner_id" <> "articles"."id"
+}
+
+Ref {
+    "metafield_blogs"."owner_id" <> "blogs"."id"
+}
+
+Ref {
+    "metafield_collections"."owner_id" <> "collections"."id"
+}
+
+Ref {
+    "metafield_customers"."owner_id" <> "customers"."id"
+}
+
+Ref {
+    "metafield_draft_orders"."owner_id" <> "draft_orders"."id"
+}
+
+Ref {
+    "metafield_locations"."owner_id" <> "locations"."id"
+}
+
+Ref {
+    "metafield_orders"."owner_id" <> "orders"."id"
+}
+
+Ref {
+    "metafield_pages"."owner_id" <> "pages"."id"
+}
+
+Ref {
+    "metafield_product_images"."owner_id" <> "product_images"."id"
+}
+
+Ref {
+    "metafield_products"."owner_id" <> "products"."id"
+}
+
+Ref {
+    "metafield_product_variants"."owner_id" <> "product_variants"."id"
+}
+
+Ref {
+    "metafield_shops"."owner_id" <> "shop"."id"
+}
+
+Ref {
+    "metafield_smart_collections"."owner_id" <> "smart_collections"."id"
+}
+
+Ref {
+    "order_agreements"."id" <> "orders"."id"
+}
+
+Ref {
+    "order_refunds"."order_id" <> "orders"."id"
+}
+
+Ref {
+    "order_refunds"."user_id" <> "customers"."id"
+}
+
+Ref {
+    "order_risks"."order_id" <> "orders"."id"
+}
+
+Ref {
+    "order_risks"."checkout_id" <> "abandoned_checkouts"."id"
+}
+
+Ref {
+    "orders"."checkout_id" <> "abandoned_checkouts"."id"
+}
+
+Ref {
+    "orders"."location_id" <> "locations"."id"
+}
+
+Ref {
+    "orders"."user_id" <> "customers"."id"
+}
+
+Ref {
+    "pages"."shop_id" <> "shop"."id"
+}
+
+Ref {
+    "product_images"."product_id" <> "products"."id"
+}
+
+Ref {
+    "product_variants"."product_id" <> "products"."id"
+}
+
+Ref {
+    "product_variants"."inventory_item_id" <> "inventory_items"."id"
+}
+
+Ref {
+    "shop"."primary_location_id" <> "locations"."id"
+}
+
+Ref {
+    "tender_transactions"."order_id" <> "orders"."id"
+}
+
+Ref {
+    "tender_transactions"."user_id" <> "customers"."id"
+}
+
+Ref {
+    "transactions"."order_id" <> "orders"."id"
+}
+
+Ref {
+    "transactions"."user_id" <> "customers"."id"
+}
+
+Ref {
+    "transactions"."parent_id" <> "transactions"."id"
+}
+
+Ref {
+    "transactions"."location_id" <> "locations"."id"
+}
+
+Ref {
+    "customer_address"."customer_id" <> "customers"."id"
+}

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -14,6 +14,7 @@ data:
   dockerImageTag: 2.4.21
   dockerRepository: airbyte/source-shopify
   documentationUrl: https://docs.airbyte.com/integrations/sources/shopify
+  erdUrl: https://dbdocs.io/airbyteio/source-shopify?view=relationships
   githubIssueLabel: source-shopify
   icon: shopify.svg
   license: ELv2


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/9173 for source-shopify

## How
By running `airbyte-ci --name=source-shopify generate-erd`

The publish has been done as part of the airbyte-ci command executed locally.

## User Impact
ERD is now available on https://dbdocs.io/airbyteio/source-shopify

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌

